### PR TITLE
chore: board SSOT A→B→C (writable SSOT, post-merge Done, export+DRIFT-010)

### DIFF
--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -20,6 +20,9 @@ disable-model-invocation: true
 6. Note merge SHA: `gh api repos/.../pulls/<n> -q .merge_commit_sha` (or `gh pr view` if working).
 7. **Record:**  
    `python .ai_infra/scripts/pr/merge.py --pr <id|url> --pipeline default --merge-sha <sha>`  
+   Optional: `--item-id PVTI_…` when known; `--skip-board-sync` to bypass board close.  
+   When `project_ssot.enabled`, this sets the card → **Done** and appends Notes (`Merged: <PR URL> @ <sha>`). Failure is a **warn** only — merge artifact still writes.  
+   Prefer PR body line `- Board-Item: PVTI_…` under Collaboration so find-by-pr can resolve without `--item-id`.  
    (same `--arch-impacting` if used above). Enrich `merge.md` with method + follow-ups.
 8. **Finalize:** `git checkout main`; `python .ai_infra/scripts/pr/finalize.py --branch <branch>`; prune remotes; confirm feature branch gone on origin.
 

--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -6,15 +6,15 @@ disable-model-invocation: true
 
 # PR workflow (maintainer)
 
-**Implementer work** (trackers, slices) uses `.local/index-and-planning/current/*`, `.cursor/agents/implementer.md`, and `.cursor/rules/implementation-workflow-governance.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
+**Implementer work:** when `project_ssot.enabled` + `board_only`, slice status lives on the **GitHub Project** (Entry/Exit continuation). Local `.local/index-and-planning/current/*` is offline fallback only — see ADR-008 and `project-ssot-precedence.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
 
 This skill is the **merge path** only: **review → prepare → merge** (slash skills: `review-pr`, `prepare-pr`, `merge-pr`).
 
 ## Order
 
-1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers changed. When scope is architecture-impacting, run **`enterprise-auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
-2. `prepare-pr` — tracker sync + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
-3. `merge-pr` — `merge.py` check, `gh pr merge`, finalize repo state.
+1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers/board status changed. When scope is architecture-impacting, run **`enterprise-auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
+2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
+3. `merge-pr` — `merge.py` check, `gh pr merge`, `merge.py --merge-sha` (sets board card → Done when SSOT on), finalize repo state.
 
 Per-step detail: `.agents/skills/review-pr/`, `prepare-pr/`, `merge-pr/`.
 

--- a/.agents/skills/prepare-pr/SKILL.md
+++ b/.agents/skills/prepare-pr/SKILL.md
@@ -13,7 +13,7 @@ disable-model-invocation: true
 1. `review.md` exists; clear BLOCKER/IMPORTANT items first.
 2. Alignment files present when required (authored via **`enterprise-auditor`** / `enterprise-architecture-audit` skill; see `advisory-audit-alignment-enforcement.mdc`); no open **P0** unless explicitly accepted.
 3. Fixes **only** in PR scope.
-4. Sync trackers when status changed — **`.local/index-and-planning/current/`**: `session-pointer.md`, `change-index.md`, `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md` when applicable.
+4. Status sync: when `project_ssot.enabled` and `sync_policy: board_only`, update **board Status/Notes only** — do **not** dual-write competing `in_progress` into local trackers. Local `.local/index-and-planning/current/` files are offline fallback / session pointer only. When SSOT is disabled or offline fallback is active, sync trackers as usual (`session-pointer.md`, `change-index.md`, `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md` when applicable).
 5. Run (owner from YAML; **Agent/s** auto-merges trackers + pipeline unless `--agents` set):  
    `python .ai_infra/scripts/pr/prepare.py --pr <id|url> --pipeline default`  
    Same **`--agents-from-session`** behavior as review — see **`pr-workflow/SKILL.md`**.  

--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -49,14 +49,16 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 
 | Agent | Role |
 |-------|------|
-| `implementer` | Slices, code, trackers (or board when `project_ssot.enabled`) |
-| `test-runner` | Module tests, coverage |
-| `verifier` | Evidence checks |
-| `enterprise-auditor` | Architecture audits |
-| `researcher` | Research corpus (local) |
-| `integrator-mas-agent` | Add agents/skills/MCP to infrastructure |
-| `workflow-drift-guard` | Operational drift (plan ↔ tracker ↔ docs) — [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) |
-| `project-board` | Independent-governed board triage (ADR-006); not in default PR pipelines |
+| `implementer` | Slices, code; board Status when `project_ssot.enabled` |
+| `test-runner` | Module tests, coverage; board Exit Status |
+| `verifier` | Evidence checks; board Done / In review |
+| `enterprise-auditor` | Architecture audits; audit card Status + Notes |
+| `researcher` | Research corpus; research card Done when present |
+| `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
+| `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
+| `project-board` | Board triage helper (ADR-006); not in default PR pipelines |
+
+Continuation: every agent Entry reads the Project; Exit updates Status/Notes — [project-board-collaboration.md](../operations/project-board-collaboration.md).
 
 Integration procedure: [mas-infrastructure-integration.md](../operations/mas-infrastructure-integration.md).  
 Drift validation: `make drift-validate` — see [gate-matrix.md](../operations/gate-matrix.md).

--- a/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -46,6 +46,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-007 | P2 | kit-dev | updates-log fresh when git tree dirty |
 | DRIFT-008 | P2 | consumer | Scaffold trackers present |
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
+| DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
 
 **Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`).
 

--- a/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -11,20 +11,26 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 
 ## Decision
 
-1. **`board_only` wins** when `project_ssot.enabled: true` and `sync_policy: board_only`. Agents must not dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
-2. **Offline fallback:** if enabled is false or `gh`/Projects unavailable, use `fallback: local_trackers` with an explicit warning — then resume board sync; never silent dual-write.
-3. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
-4. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
-5. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
-6. **`project-board` agent:** independent-governed helper; not in PR pipelines. Long-term all agents Anchor on `project_ssot`.
-7. **Production port deferred** until demo + implementer Anchor + dual-write drift check + human sign-off. Marketplace kit stays markdown SSOT until then.
+1. **Only writable SSOT:** when `project_ssot.enabled: true` and `sync_policy: board_only`, the GitHub Project is the **only writable** coordination SSOT for backlog, Status, and multi-agent continuation. Agents must not dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
+2. **`board_only` wins** — dual-mirror (local trackers + board both writable) is rejected; it causes worse agent drift (DRIFT-009).
+3. **Offline fallback:** if enabled is false or `gh`/Projects unavailable, use `fallback: local_trackers` with an explicit warning — then resume board sync; never silent dual-write.
+4. **Read-only exports:** optional snapshots (`project export`) may cache board state for audits/ICC later; they **must not** write Status and must never become a competing SSOT.
+5. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
+6. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
+7. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
+8. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
+9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
+10. **Production port deferred** until demo + implementer Anchor + dual-write drift check + human sign-off. Marketplace kit stays markdown SSOT until then.
+11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization — agents never edit these.
 
 ## Consequences
 
 - New CLI module: `.ai_infra/install/cursor_workflow/project_cli.py`
-- Skill: `.cursor/skills/project-board-ssot/SKILL.md`
+- Skill: `.cursor/skills/project-board-ssot/SKILL.md` (Continuation contract + per-agent rights)
+- Ops: `.ai_infra/docs/operations/project-board-collaboration.md`
 - Agent: `.cursor/agents/project-board.md`
-- Drift: DRIFT-009 advisory when board_only and tracker has competing `in_progress` (experiment)
+- Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); workflow-drift-guard **reads and updates** the board on Exit
+- Post-merge Done: Pattern A `merge.py` (not a dedicated agent)
 
 ## References
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (MAS Workflow Kit)
 
 **Last updated:** 2026-07-17 (board SSOT experiment: ADR-008, project-board agent, DRIFT-009)  
-**Product:** MAS Workflow Kit (`mas-workflow-kit`) · CLI: `cursor-workflow` 0.4.0 · **Tests:** 642
+**Product:** MAS Workflow Kit (`mas-workflow-kit`) · CLI: `cursor-workflow` 0.4.0 · **Tests:** 657
 
 ## Shipped (confirmed in repo)
 
@@ -44,7 +44,7 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 642 | `tests/modules/` |
+| Tests | 657 | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -1,0 +1,74 @@
+<!--
+File: project-board-collaboration.md
+Path: .ai_infra/docs/operations/project-board-collaboration.md
+Role: Ops mirror — Project surfaces + per-agent Entry/Exit continuation on the board.
+Used By:
+ - .cursor/skills/project-board-ssot/SKILL.md
+ - .cursor/agents/*.md
+ - AGENTS.md / HANDOFF.md
+Depends On:
+ - github.collaboration.yaml project_ssot
+ - ADR-008
+Notes:
+ - When enabled, every agent reads the Project on Entry and updates Status on Exit.
+-->
+
+# Project board collaboration (agents + humans)
+
+When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project is the only writable SSOT** for backlog, Status, and continuation. Local trackers are offline fallback only; read-only exports never compete with Status. Canonical skill: `.cursor/skills/project-board-ssot/SKILL.md`.
+
+## Continuation (why agents update the board)
+
+| Without board Exit | With board Exit |
+|--------------------|-----------------|
+| Next agent guesses from chat | Next agent lists Ready / In progress / In review |
+| Status drifts from reality | Status column = truth (DRIFT-009 watches dual-write) |
+| Humans cannot see progress | Project UI is the shared dashboard |
+
+**Rule:** Entry = read board. Exit = update Status (and Notes) for the card you touched.
+
+## Surfaces — who may write
+
+| Surface | Human | Agents | GitHub |
+|---------|-------|--------|--------|
+| Card Status | Yes | Yes — every agent Exit | — |
+| Priority / Size | Yes | Triage + own card | — |
+| Create cards | Yes | project-board, implementer, integrator | — |
+| Ready prioritization | **Owner** | Consume; create agreed work | — |
+| Views / workflows / Insights / README / status updates | **Owner only** | Never | Insights auto |
+| Assignee / My items | Yes | Claim = In progress | My items view |
+| PR / audits / secrets | Local | Local | — |
+| Post-merge Status → Done | — | Via `merge.py` (Pattern A) | — |
+| Read-only board export | Consume | `project export` (never writes Status) | — |
+
+## Per-agent Entry / Exit
+
+| Agent | Entry | Exit (board) |
+|-------|-------|--------------|
+| **project-board** | status + list | Full triage; handoff to implementer |
+| **implementer** | status + Ready/claim | →In review / →Done; Notes for next |
+| **test-runner** | status + slice card | →In review or →Done when tests finish |
+| **verifier** | status + related card | →Done or leave In review + Notes |
+| **integrator-mas-agent** | status + claim | →Done on integration card |
+| **enterprise-auditor** | status + audit card | →In review/Done; Notes → artifact paths |
+| **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; cite board in drift-audit; remediation via Notes/Ready handoff — no silent tracker edits |
+| **researcher** | status (+ research card) | Research card →Done + corpus paths in Notes |
+
+## Status path
+
+```text
+Ready → In progress → In review → Done
+```
+
+Handoff: `item_id=PVTI_… · Status=a→b · next=<agent>`
+
+## workflow-drift-guard specifically
+
+1. **Read board first** (`project status`, `list --status in_progress`) so dual-write checks compare board Status vs trackers.
+2. Run `drift validate` (includes DRIFT-009 / DRIFT-010 when board_only; refresh `project export` for DRIFT-010).
+3. Write `.local/workflow-artifacts/drift/*` (evidence stays local).
+4. **Update board:** close the drift-pass card; if dual-write Confirmed, add Notes on the offending card or ask project-board to queue a Ready fix — do not write competing `in_progress` into `work-tracker.md`.
+
+## Human-only
+
+Views, workflows, Insights, Project README, status updates, Ready prioritization, PORT-GATE.

--- a/.ai_infra/docs/operations/token-efficiency.md
+++ b/.ai_infra/docs/operations/token-efficiency.md
@@ -8,12 +8,26 @@ Depends On:
  - .ai_infra/scripts/pr/prepare.py
  - docs/governance/workflow-source-owners.md
 Notes:
- - Pair with session-pointer.md + change-index.md for resume-without-chat.
+ - When project_ssot.enabled: pair with board Status + card Notes for resume-without-chat.
+ - Else: session-pointer.md + change-index.md.
 -->
 
 # Token efficiency (agent contract)
 
 ## Read set (default)
+
+**When `project_ssot.enabled`:**
+
+| Order | Path / command | When |
+|-------|----------------|------|
+| 1 | `python -m cursor_workflow project status` + `project list` | **Every session start** |
+| 2 | Board card body (Acceptance / Rollback / Notes) | Claimed / In progress card |
+| 3 | `.cursor/skills/project-board-ssot/SKILL.md` § Continuation | When mutating Status |
+| 4 | `change-index.md` | Resume mid-slice (thin cache) |
+| 5 | `test-plan.md`, `test-index.md` | When tests change |
+| 6 | `workflow-artifacts/pr/*.md` | Only when phase = review \| prepare \| merge |
+
+**When disabled / offline fallback:**
 
 | Order | Path | When |
 |-------|------|------|
@@ -26,6 +40,15 @@ Notes:
 **Skip:** `.local/generated-data/**`, `history/archive/**`, full `updates-log.md` body, root handoff megadocs unless explicitly tasked.
 
 ## Write set (slice close)
+
+**When board SSOT enabled:**
+
+1. Board Status via `cursor_workflow project set-status` (+ Notes / handoff line)
+2. `change-index.md` — one row per batch  
+3. `history/updates-log.md` — **one line** (no gate dumps)
+4. Do **not** dual-write tracker `in_progress` under `board_only`
+
+**Offline fallback:**
 
 1. `change-index.md` — one row per batch  
 2. `session-pointer.md` — phase, next agent, blockers  

--- a/.ai_infra/docs/operations/workflow-complete.md
+++ b/.ai_infra/docs/operations/workflow-complete.md
@@ -74,15 +74,26 @@ When cutting an RC in a product repo:
 
 This is the **implementation agent** end-of-loop on top of sections **C** and **D** — run it before saying a slice is finished:
 
-1. **`.local/index-and-planning/history/updates-log.md`** — append one top entry (summary, validation, next step; no repeated prepare-gate paste — see **`agent-workflow-procedures.md`**).
-2. **`.local/index-and-planning/current/work-tracker.md`** — resolve task status; keep one primary `in_progress` across the file.
-3. **`test-plan.md` / `test-index.md`** — update when tests or ownership changed.
-4. **`coverage-index.md`** — regenerate after any coverage run that matters for the slice (project-specific tooling; see overlay pack if applicable).
-5. **`implementation-control-center.html`** — under `.local/agents-control-center/dashboards/`; if you add a tracker, update **`../config/pages.json`** and header **Depends On** comments; keep **Coverage** in sync with **`coverage-index.md`**.
-6. **`module-audit.html`** — under `.local/agents-control-center/audits/`; touch only when deliberately refreshing a deep module audit export, not per slice.
-7. **`make drift-validate`** — run before handoff; on P0/P1 findings, hand off to **`workflow-drift-guard`** (`.cursor/agents/workflow-drift-guard.md`).
+**When `project_ssot.enabled` (board-first):**
 
-Canonical detail: **`.local/index-and-planning/current/plan.md`** section **Implementer slice closure (mandatory end-of-loop)**.
+1. **Board Status** — `set-status --to in_review|done`; card Notes name next agent; print handoff line (`item_id=… · Status=… · next=…`).
+2. **`.local/index-and-planning/history/updates-log.md`** — one top entry (no gate dumps).
+3. **`change-index.md`** — one row; do **not** dual-write tracker `in_progress` under `board_only`.
+4. **`test-plan.md` / `test-index.md`** — when tests changed.
+5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); pass `--item-id` or embed `Board-Item: PVTI_…` in the PR body.
+6. **`make drift-validate`** — on P0/P1, hand off to **`workflow-drift-guard`** (reads + updates the board; DRIFT-009/010).
+
+**Offline fallback (project_ssot disabled / no gh):**
+
+1. **`.local/index-and-planning/history/updates-log.md`** — append one top entry.
+2. **`.local/index-and-planning/current/work-tracker.md`** — resolve task status; keep one primary `in_progress`.
+3. **`test-plan.md` / `test-index.md`** — update when tests or ownership changed.
+4. **`coverage-index.md`** — regenerate after any coverage run that matters.
+5. **`implementation-control-center.html`** — under `.local/agents-control-center/dashboards/`; if you add a tracker, update **`../config/pages.json`**.
+6. **`module-audit.html`** — touch only when deliberately refreshing a deep module audit export.
+7. **`make drift-validate`** — hand off to **`workflow-drift-guard`** on P0/P1.
+
+Canonical detail: **`.local/index-and-planning/current/plan.md`** / board card body; skill `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## File retention policy (explicit)
 

--- a/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/.ai_infra/install/cursor_workflow/project_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -348,6 +349,403 @@ def cmd_set_field(args: argparse.Namespace) -> int:
     return 0
 
 
+def _normalize_status(raw: str) -> str:
+    key = str(raw or "").strip().lower().replace(" ", "_").replace("-", "_")
+    if key in ("inprogress",):
+        return "in_progress"
+    if key in ("review",):
+        return "in_review"
+    return key
+
+
+def _item_body(item: dict[str, Any]) -> str:
+    content = item.get("content")
+    if isinstance(content, dict):
+        body = content.get("body")
+        if isinstance(body, str):
+            return body
+    body = item.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def _item_title(item: dict[str, Any]) -> str:
+    title = item.get("title")
+    if isinstance(title, str) and title:
+        return title
+    content = item.get("content")
+    if isinstance(content, dict):
+        t = content.get("title")
+        if isinstance(t, str):
+            return t
+    return ""
+
+
+def fetch_project_items(ssot: dict[str, Any], *, limit: int = 100) -> tuple[list[dict[str, Any]], str | None]:
+    """Return (items, error). Each item keeps gh JSON fields plus normalized helpers."""
+    owner = str(ssot["owner"])
+    number = int(ssot["number"])
+    proc = run_gh(
+        [
+            "project",
+            "item-list",
+            str(number),
+            "--owner",
+            owner,
+            "--format",
+            "json",
+            "--limit",
+            str(limit),
+        ]
+    )
+    if proc.returncode != 0:
+        return [], (proc.stderr or proc.stdout or "gh project item-list failed").strip()
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return [], f"invalid JSON from gh: {exc}"
+    raw = data.get("items") if isinstance(data, dict) else data
+    if not isinstance(raw, list):
+        return [], None
+    items: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict):
+            items.append(item)
+    return items, None
+
+
+def find_item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any] | None:
+    for item in items:
+        if str(item.get("id") or "") == item_id:
+            return item
+    return None
+
+
+def append_notes_to_body(body: str, text: str) -> tuple[str, bool]:
+    """
+    Append text under ## Notes. Returns (new_body, changed).
+    Idempotent when the exact text line is already present.
+    """
+    note_line = text.strip()
+    if not note_line:
+        return body, False
+    if note_line in (body or ""):
+        return body, False
+    body = body or ""
+    marker = "## Notes"
+    if marker in body:
+        # Append after the Notes heading block (before next ## or end).
+        idx = body.find(marker)
+        rest = body[idx + len(marker) :]
+        next_h = rest.find("\n## ")
+        if next_h >= 0:
+            insert_at = idx + len(marker) + next_h
+            new_body = body[:insert_at].rstrip() + f"\n\n- {note_line}\n" + body[insert_at:]
+        else:
+            new_body = body.rstrip() + f"\n\n- {note_line}\n"
+    else:
+        new_body = body.rstrip() + f"\n\n## Notes\n\n- {note_line}\n"
+    return new_body, True
+
+
+def parse_board_item_from_text(text: str) -> str | None:
+    """Extract PVTI_… from a Board-Item: line in PR or card body."""
+    m = re.search(r"(?i)Board-Item:\s*(PVTI_[A-Za-z0-9_-]+)", text or "")
+    return m.group(1) if m else None
+
+
+def find_items_mentioning_pr(
+    items: list[dict[str, Any]],
+    *,
+    pr_number: str,
+    pr_url: str = "",
+) -> list[dict[str, Any]]:
+    """Items whose body/title mention the PR number or URL; prefer in_review/in_progress."""
+    needle_num = str(pr_number).strip().lstrip("#")
+    needles = [n for n in (pr_url, f"#{needle_num}", f"/pull/{needle_num}", needle_num) if n]
+    matches: list[dict[str, Any]] = []
+    for item in items:
+        blob = f"{_item_title(item)}\n{_item_body(item)}"
+        if not any(n and n in blob for n in needles):
+            continue
+        status = _normalize_status(str(item.get("status") or ""))
+        if status in ("in_review", "in_progress", "ready"):
+            matches.append(item)
+        else:
+            matches.append(item)
+    # Prefer in_review then in_progress
+    def rank(it: dict[str, Any]) -> int:
+        s = _normalize_status(str(it.get("status") or ""))
+        return {"in_review": 0, "in_progress": 1, "ready": 2}.get(s, 9)
+
+    matches.sort(key=rank)
+    return matches
+
+
+def resolve_item_id_for_pr(
+    ssot: dict[str, Any],
+    *,
+    pr: str,
+    repo: str | None = None,
+    limit: int = 100,
+) -> tuple[str | None, list[str], str | None]:
+    """
+    Resolve project item id for a PR.
+    Returns (item_id | None, candidate_ids, error | None).
+    Prefers Board-Item in PR body; else body/URL scan of active cards.
+    """
+    pr_ref = str(pr).strip()
+    # Accept URL or number
+    pr_number = pr_ref.rstrip("/").split("/")[-1] if "/" in pr_ref else pr_ref.lstrip("#")
+    repo_flag = repo or str(ssot.get("default_repo") or "")
+    view_args = ["pr", "view", pr_number, "--json", "body,url,number"]
+    if repo_flag:
+        view_args.extend(["--repo", repo_flag])
+    proc = run_gh(view_args)
+    pr_body = ""
+    pr_url = ""
+    if proc.returncode == 0:
+        try:
+            pdata = json.loads(proc.stdout or "{}")
+            pr_body = str(pdata.get("body") or "")
+            pr_url = str(pdata.get("url") or "")
+            if pdata.get("number") is not None:
+                pr_number = str(pdata["number"])
+        except json.JSONDecodeError:
+            pass
+    board_item = parse_board_item_from_text(pr_body)
+    if board_item:
+        return board_item, [board_item], None
+
+    items, err = fetch_project_items(ssot, limit=limit)
+    if err:
+        return None, [], err
+    matches = find_items_mentioning_pr(items, pr_number=pr_number, pr_url=pr_url)
+    ids = [str(m.get("id")) for m in matches if m.get("id")]
+    if len(ids) == 1:
+        return ids[0], ids, None
+    if len(ids) > 1:
+        return None, ids, "ambiguous: multiple project items mention this PR"
+    return None, [], "no project item found for this PR (add Board-Item: PVTI_… to PR body)"
+
+
+def edit_item_body(ssot: dict[str, Any], item_id: str, body: str) -> tuple[bool, str]:
+    project_id = str(ssot["project_id"])
+    proc = run_gh(
+        [
+            "project",
+            "item-edit",
+            "--project-id",
+            project_id,
+            "--id",
+            item_id,
+            "--body",
+            body,
+        ]
+    )
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "gh project item-edit --body failed").strip()
+    return True, "ok"
+
+
+def set_item_status(ssot: dict[str, Any], item_id: str, logical: str) -> tuple[bool, str]:
+    try:
+        option_id = resolve_status_option_id(ssot, logical)
+        field_id = status_field_id(ssot)
+    except KeyError as exc:
+        return False, str(exc)
+    project_id = str(ssot["project_id"])
+    proc = run_gh(
+        [
+            "project",
+            "item-edit",
+            "--project-id",
+            project_id,
+            "--id",
+            item_id,
+            "--field-id",
+            field_id,
+            "--single-select-option-id",
+            option_id,
+        ]
+    )
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "gh project item-edit failed").strip()
+    return True, option_id
+
+
+def build_export_snapshot(ssot: dict[str, Any], items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Read-only snapshot shape for project export / DRIFT-010."""
+    out_items: list[dict[str, Any]] = []
+    for item in items:
+        body = _item_body(item)
+        excerpt = body if len(body) <= 500 else body[:497] + "..."
+        out_items.append(
+            {
+                "id": item.get("id"),
+                "title": _item_title(item),
+                "status": item.get("status"),
+                "status_normalized": _normalize_status(str(item.get("status") or "")),
+                "priority": item.get("priority"),
+                "size": item.get("size"),
+                "body_excerpt": excerpt,
+                "updated_at": item.get("updatedAt") or item.get("updated_at"),
+            }
+        )
+    return {
+        "schema": "project-board-snapshot/v1",
+        "project": {
+            "name": ssot.get("name"),
+            "owner": ssot.get("owner"),
+            "number": ssot.get("number"),
+            "url": ssot.get("url"),
+            "project_id": ssot.get("project_id"),
+            "default_repo": ssot.get("default_repo"),
+        },
+        "items": out_items,
+        "totalCount": len(out_items),
+    }
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project get: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project get: FAIL — {e}", file=sys.stderr)
+        return 2
+    items, err = fetch_project_items(ssot, limit=args.limit)
+    if err:
+        print(f"project get: FAIL — {err}", file=sys.stderr)
+        return 1
+    item = find_item_by_id(items, args.id)
+    if item is None:
+        print(f"project get: FAIL — item not found: {args.id}", file=sys.stderr)
+        return 1
+    payload = {
+        "id": item.get("id"),
+        "title": _item_title(item),
+        "status": item.get("status"),
+        "priority": item.get("priority"),
+        "size": item.get("size"),
+        "body": _item_body(item),
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"id: {payload['id']}")
+        print(f"title: {payload['title']}")
+        print(f"status: {payload['status']}")
+        print(f"priority: {payload['priority']}")
+        print(f"size: {payload['size']}")
+        print("--- body ---")
+        print(payload["body"] or "(empty)")
+    return 0
+
+
+def cmd_append_notes(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project append-notes: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project append-notes: FAIL — {e}", file=sys.stderr)
+        return 2
+    items, err = fetch_project_items(ssot, limit=args.limit)
+    if err:
+        print(f"project append-notes: FAIL — {err}", file=sys.stderr)
+        return 1
+    item = find_item_by_id(items, args.id)
+    if item is None:
+        print(f"project append-notes: FAIL — item not found: {args.id}", file=sys.stderr)
+        return 1
+    body = _item_body(item)
+    new_body, changed = append_notes_to_body(body, args.text)
+    if not changed:
+        print(f"append-notes: {args.id} — already present (idempotent skip)")
+        return 0
+    ok, detail = edit_item_body(ssot, args.id, new_body)
+    if not ok:
+        print(f"project append-notes: FAIL — {detail}", file=sys.stderr)
+        return 1
+    print(f"append-notes: {args.id} — updated")
+    return 0
+
+
+def cmd_find_by_pr(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project find-by-pr: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project find-by-pr: FAIL — {e}", file=sys.stderr)
+        return 2
+    item_id, candidates, err = resolve_item_id_for_pr(
+        ssot, pr=args.pr, repo=args.repo or None, limit=args.limit
+    )
+    payload = {
+        "item_id": item_id,
+        "candidates": candidates,
+        "error": err,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        if item_id:
+            print(item_id)
+        else:
+            print(f"project find-by-pr: FAIL — {err}", file=sys.stderr)
+            if candidates:
+                print("candidates:", ", ".join(candidates), file=sys.stderr)
+            return 1
+    return 0 if item_id else 1
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    """Read-only snapshot — never mutates the board."""
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project export: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project export: FAIL — {e}", file=sys.stderr)
+        return 2
+    items, err = fetch_project_items(ssot, limit=args.limit)
+    if err:
+        print(f"project export: FAIL — {err}", file=sys.stderr)
+        return 1
+    snapshot = build_export_snapshot(ssot, items)
+    text = json.dumps(snapshot, indent=2) + "\n"
+    if args.stdout:
+        print(text, end="")
+        return 0
+    out_path = Path(args.output) if args.output else (
+        root / ".local" / "generated-data" / "project-board-snapshot.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    print(f"Wrote {out_path} ({snapshot['totalCount']} items)")
+    if args.json:
+        print(text, end="")
+    return 0
+
+
 def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     project = sub.add_parser(
         "project",
@@ -393,3 +791,44 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     set_field.add_argument("--field", required=True, choices=("priority", "size"))
     set_field.add_argument("--to", required=True, help="e.g. p1 or s")
     set_field.set_defaults(func=cmd_set_field)
+
+    get_cmd = project_sub.add_parser("get", help="Get one project item by id")
+    get_cmd.add_argument("--directory", type=Path, default=".")
+    get_cmd.add_argument("--id", required=True, help="Project item id (PVTI_…)")
+    get_cmd.add_argument("--limit", type=int, default=100)
+    get_cmd.add_argument("--json", action="store_true")
+    get_cmd.set_defaults(func=cmd_get)
+
+    notes_cmd = project_sub.add_parser(
+        "append-notes", help="Append a line under ## Notes on the card body"
+    )
+    notes_cmd.add_argument("--directory", type=Path, default=".")
+    notes_cmd.add_argument("--id", required=True)
+    notes_cmd.add_argument("--text", required=True)
+    notes_cmd.add_argument("--limit", type=int, default=100)
+    notes_cmd.set_defaults(func=cmd_append_notes)
+
+    find_cmd = project_sub.add_parser(
+        "find-by-pr", help="Resolve project item id from PR (Board-Item or body scan)"
+    )
+    find_cmd.add_argument("--directory", type=Path, default=".")
+    find_cmd.add_argument("--pr", required=True, help="PR number or URL")
+    find_cmd.add_argument("--repo", default="", help="owner/repo (defaults to project_ssot.default_repo)")
+    find_cmd.add_argument("--limit", type=int, default=100)
+    find_cmd.add_argument("--json", action="store_true")
+    find_cmd.set_defaults(func=cmd_find_by_pr)
+
+    export_cmd = project_sub.add_parser(
+        "export", help="Read-only board snapshot (never mutates Status)"
+    )
+    export_cmd.add_argument("--directory", type=Path, default=".")
+    export_cmd.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: .local/generated-data/project-board-snapshot.json)",
+    )
+    export_cmd.add_argument("--limit", type=int, default=100)
+    export_cmd.add_argument("--json", action="store_true", help="Also print JSON to stdout")
+    export_cmd.add_argument("--stdout", action="store_true", help="Print JSON only (no file write)")
+    export_cmd.set_defaults(func=cmd_export)

--- a/.ai_infra/scripts/pr/merge.py
+++ b/.ai_infra/scripts/pr/merge.py
@@ -1,18 +1,20 @@
 """
 File: merge.py
 Path: .ai_infra/scripts/pr/merge.py
-Role: Verifies merge prerequisites and writes merge summary artifact.
+Role: Verifies merge prerequisites and writes merge summary artifact; optional board SSOT close.
 Used By:
  - .agents/skills/merge-pr/SKILL.md
 Depends On:
  - argparse
  - pathlib
  - scripts/pr/local_workflow_paths.py
+ - .ai_infra/install/cursor_workflow/project_cli.py (board sync when project_ssot enabled)
 Notes:
  - This script does not perform git merge; it verifies readiness and logs evidence.
  - Call AFTER gh pr merge with --merge-sha <oid> so the artifact records the correct merge commit.
  - --branch is optional; if omitted the script reads the current git branch.
  - Checks for alignment artifact presence when --arch-impacting flag is set.
+ - When project_ssot is operational, sets card Status → done and appends Notes (non-blocking on failure).
 """
 
 from __future__ import annotations
@@ -23,8 +25,12 @@ import sys
 from pathlib import Path
 
 _PR_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _PR_DIR.parents[2]
+_INSTALL_CW = _REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
 if str(_PR_DIR) not in sys.path:
     sys.path.insert(0, str(_PR_DIR))
+if _INSTALL_CW.is_dir() and str(_INSTALL_CW) not in sys.path:
+    sys.path.insert(0, str(_INSTALL_CW))
 
 from local_workflow_paths import (
     ALIGNMENT_AUDIT_MD,
@@ -67,6 +73,90 @@ def _artifact_matches_pr(file_path: Path, pr_ref: str) -> tuple[bool, str]:
     return True, "ok"
 
 
+def _pr_url(root: Path, pr: str, default_repo: str = "") -> str:
+    """Best-effort PR URL for Notes."""
+    pr_number = pr.rstrip("/").split("/")[-1] if "/" in pr else pr.lstrip("#")
+    if pr.startswith("http"):
+        return pr
+    repo = default_repo
+    if not repo:
+        proc = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            repo = proc.stdout.strip()
+    if repo:
+        return f"https://github.com/{repo}/pull/{pr_number}"
+    return f"PR #{pr_number}"
+
+
+def sync_board_after_merge(
+    *,
+    root: Path,
+    pr: str,
+    merge_sha: str,
+    item_id: str | None = None,
+    skip: bool = False,
+) -> str:
+    """
+    Set project card to done and append merge Notes when project_ssot is operational.
+    Returns a short status line for merge.md. Never raises for board failures.
+    """
+    if skip:
+        return "board sync: skipped (--skip-board-sync)"
+    try:
+        import project_cli
+    except ImportError:
+        return "board sync: skipped (project_cli unavailable)"
+
+    ssot, errs = project_cli.load_project_ssot(root)
+    if errs or ssot is None:
+        return "board sync: skipped (no project_ssot config)"
+    enabled_errs = project_cli.require_enabled(ssot)
+    if enabled_errs:
+        return "board sync: skipped (project_ssot not operational)"
+
+    resolved = item_id
+    candidates: list[str] = []
+    if not resolved:
+        resolved, candidates, find_err = project_cli.resolve_item_id_for_pr(
+            ssot, pr=pr, repo=str(ssot.get("default_repo") or "") or None
+        )
+        if not resolved:
+            detail = find_err or "no item"
+            if candidates:
+                detail += f"; candidates={','.join(candidates)}"
+            print(f"[WARN] board sync: {detail}", file=sys.stderr)
+            return f"board sync: warn — {detail}"
+
+    conventions = ssot.get("conventions") or {}
+    done_logical = str(conventions.get("done_status") or "done")
+    ok, detail = project_cli.set_item_status(ssot, resolved, done_logical)
+    if not ok:
+        print(f"[WARN] board sync set-status failed: {detail}", file=sys.stderr)
+        return f"board sync: warn — set-status failed ({detail})"
+
+    pr_url = _pr_url(root, pr, str(ssot.get("default_repo") or ""))
+    note = f"Merged: {pr_url} @ {merge_sha}"
+    items, list_err = project_cli.fetch_project_items(ssot, limit=100)
+    if list_err:
+        print(f"[WARN] board sync append-notes list failed: {list_err}", file=sys.stderr)
+        return f"board sync: status→{done_logical} on {resolved}; notes warn ({list_err})"
+    item = project_cli.find_item_by_id(items, resolved)
+    body = project_cli._item_body(item) if item else ""
+    new_body, changed = project_cli.append_notes_to_body(body, note)
+    if changed:
+        nok, ndetail = project_cli.edit_item_body(ssot, resolved, new_body)
+        if not nok:
+            print(f"[WARN] board sync append-notes failed: {ndetail}", file=sys.stderr)
+            return f"board sync: status→{done_logical} on {resolved}; notes warn ({ndetail})"
+    print(f"[PASS] board sync: {resolved} → {done_logical}; Notes updated")
+    return f"board sync: {resolved} → {done_logical}; Notes: {note}"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Verify merge readiness and emit merge artifact.")
     parser.add_argument("--pr", required=True, help="PR number or URL")
@@ -98,6 +188,17 @@ def main() -> int:
             "Run prerequisite checks only and do not write workflow merge.md. "
             "Use this for pre-merge validation."
         ),
+    )
+    parser.add_argument(
+        "--item-id",
+        default=None,
+        help="Project item id (PVTI_…) to close after merge; else find-by-pr / Board-Item.",
+    )
+    parser.add_argument(
+        "--skip-board-sync",
+        action="store_true",
+        default=False,
+        help="Do not update GitHub Project Status/Notes after merge.",
     )
     args = parser.parse_args()
 
@@ -155,6 +256,14 @@ def main() -> int:
     merge_sha = args.merge_sha or _head_sha()
     sha_source = "provided" if args.merge_sha else "git HEAD (fallback — prefer passing --merge-sha)"
 
+    board_line = sync_board_after_merge(
+        root=Path.cwd(),
+        pr=args.pr,
+        merge_sha=merge_sha,
+        item_id=args.item_id,
+        skip=args.skip_board_sync,
+    )
+
     merge_file.write_text(
         "\n".join(
             [
@@ -176,9 +285,11 @@ def main() -> int:
                 "## Merge Summary",
                 f"- merge SHA: {merge_sha} ({sha_source})",
                 "- merge execution: completed via gh pr merge",
+                f"- {board_line}",
                 "",
                 "## Agent Notes",
                 "- (agent: add merge method, checks used as evidence, and follow-up work items below)",
+                f"- {board_line}",
             ]
         )
         + "\n",

--- a/.ai_infra/scripts/workflow/drift_checks.py
+++ b/.ai_infra/scripts/workflow/drift_checks.py
@@ -1,7 +1,7 @@
 """
 File: drift_checks.py
 Path: .ai_infra/scripts/workflow/drift_checks.py
-Role: Individual DRIFT-001…008 check functions for workflow drift validation.
+Role: Individual DRIFT-001…010 check functions for workflow drift validation.
 Used By:
  - .ai_infra/scripts/workflow/check_drift.py
 Depends On:
@@ -420,6 +420,215 @@ def check_drift009(paths: DriftPaths) -> CheckResult:
     )
 
 
+def _load_board_snapshot(paths: DriftPaths) -> tuple[dict | None, str]:
+    """Load read-only export if present; else None + reason."""
+    snap = (
+        paths.root
+        / ".local"
+        / "generated-data"
+        / "project-board-snapshot.json"
+    )
+    if not snap.is_file():
+        return None, "no project-board-snapshot.json (run: python -m cursor_workflow project export)"
+    try:
+        import json
+
+        data = json.loads(snap.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return None, f"cannot read snapshot: {exc}"
+    if not isinstance(data, dict):
+        return None, "snapshot is not an object"
+    return data, "ok"
+
+
+def _open_pr_bodies(repo: str) -> tuple[list[dict], str | None]:
+    """Return open PRs as dicts with number, url, body — or error."""
+    import json
+    import subprocess
+
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number,url,body,title",
+        "--limit",
+        "50",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=45, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return [], str(exc)
+    if proc.returncode != 0:
+        return [], (proc.stderr or proc.stdout or "gh pr list failed").strip()
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], f"invalid JSON from gh pr list: {exc}"
+    if not isinstance(data, list):
+        return [], "gh pr list did not return a list"
+    return [p for p in data if isinstance(p, dict)], None
+
+
+def check_drift010(paths: DriftPaths) -> CheckResult:
+    """
+    Advisory: board Status vs open PRs / stale In progress (board_only).
+    Uses read-only snapshot when present; skips offline without failing P0.
+    """
+    collab = paths.root / ".local" / "user_settings" / "github.collaboration.yaml"
+    if not collab.is_file():
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="no github.collaboration.yaml — skipped",
+        )
+    try:
+        import yaml
+    except ImportError:
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="PyYAML missing — skipped",
+        )
+    try:
+        data = yaml.safe_load(collab.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=False,
+            detail=f"cannot parse collab YAML: {exc}",
+        )
+    ssot = data.get("project_ssot") if isinstance(data, dict) else None
+    if not isinstance(ssot, dict) or not ssot.get("enabled"):
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="project_ssot disabled or absent — skipped",
+        )
+    policy = str(ssot.get("sync_policy") or "")
+    if policy != "board_only":
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"sync_policy={policy!r} — board/PR check skipped",
+        )
+
+    snapshot, snap_detail = _load_board_snapshot(paths)
+    if snapshot is None:
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"skipped — {snap_detail}",
+        )
+
+    items = snapshot.get("items") if isinstance(snapshot.get("items"), list) else []
+    repo = str(ssot.get("default_repo") or "")
+    if not repo:
+        proj = snapshot.get("project") if isinstance(snapshot.get("project"), dict) else {}
+        repo = str(proj.get("default_repo") or "")
+
+    open_prs: list[dict] = []
+    pr_err: str | None = None
+    if repo:
+        open_prs, pr_err = _open_pr_bodies(repo)
+        if pr_err:
+            return CheckResult(
+                check_id="DRIFT-010",
+                severity=Severity.P1,
+                passed=True,
+                detail=f"skipped — cannot list open PRs: {pr_err}",
+            )
+
+    # Build set of Board-Item ids referenced by open PRs + PR numbers mentioned
+    open_item_ids: set[str] = set()
+    open_pr_nums: set[str] = set()
+    for pr in open_prs:
+        open_pr_nums.add(str(pr.get("number") or ""))
+        body = str(pr.get("body") or "")
+        m = re.search(r"(?i)Board-Item:\s*(PVTI_[A-Za-z0-9_-]+)", body)
+        if m:
+            open_item_ids.add(m.group(1))
+
+    findings: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id") or "")
+        status = str(
+            item.get("status_normalized")
+            or str(item.get("status") or "").strip().lower().replace(" ", "_")
+        )
+        title = str(item.get("title") or item_id)
+        excerpt = str(item.get("body_excerpt") or "")
+
+        if status == "in_review":
+            # In review should have an open PR referencing this item or mentioning the card
+            linked = item_id in open_item_ids
+            mentioned = any(
+                f"/pull/{n}" in excerpt or f"#{n}" in excerpt for n in open_pr_nums if n
+            )
+            if open_prs and not linked and not mentioned:
+                # Also OK if any open PR body mentions this item id
+                if not any(item_id and item_id in str(p.get("body") or "") for p in open_prs):
+                    findings.append(f"in_review without open PR: {title} ({item_id})")
+
+        if status == "in_progress":
+            # Stale if no open PR references this card and Notes lack a recent handoff marker
+            linked = item_id in open_item_ids
+            has_pr_mention = any(
+                f"/pull/{n}" in excerpt or f"#{n}" in excerpt for n in open_pr_nums if n
+            )
+            if open_prs is not None and repo and not linked and not has_pr_mention:
+                # Soft stale signal: In progress with no PR link when repo has open PRs elsewhere
+                # Only flag when there are open PRs in the repo but none tied to this card —
+                # and excerpt has no "next=" handoff (still actively worked mid-slice is OK).
+                if "next=" not in excerpt.lower() and "Merged:" not in excerpt:
+                    # Don't flag every In progress — only when excerpt looks abandoned (empty Notes)
+                    if not excerpt.strip() or excerpt.strip() in ("...", "(TBD)"):
+                        findings.append(
+                            f"stale in_progress (empty Notes, no open PR link): {title} ({item_id})"
+                        )
+
+    # Merged-but-not-Done is hard without merged PR list; use Notes heuristic:
+    # if Status still in_review/in_progress but body has Merged: line → drift
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = str(
+            item.get("status_normalized")
+            or str(item.get("status") or "").strip().lower().replace(" ", "_")
+        )
+        excerpt = str(item.get("body_excerpt") or "")
+        if status in ("in_review", "in_progress") and "Merged:" in excerpt:
+            findings.append(
+                f"merged-but-not-done: {item.get('title')} ({item.get('id')})"
+            )
+
+    if not findings:
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="board Status vs open PRs — no mismatches",
+        )
+    return CheckResult(
+        check_id="DRIFT-010",
+        severity=Severity.P1,
+        passed=False,
+        detail="; ".join(findings[:5]) + (f" (+{len(findings) - 5} more)" if len(findings) > 5 else ""),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_drift001,
     check_drift002,
@@ -430,6 +639,7 @@ KIT_DEV_CHECKS = (
     check_drift007,
     check_drift008,
     check_drift009,
+    check_drift010,
 )
 
 CONSUMER_CHECKS = (

--- a/.cursor/agents/enterprise-auditor.md
+++ b/.cursor/agents/enterprise-auditor.md
@@ -8,9 +8,11 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice; else `session-pointer.md` + `change-index.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice (claim/create audit card if missing); else `session-pointer.md` + `change-index.md`.
 
-**Exit:** Update alignment artifacts + `change-index.md`; one line in `updates-log.md`. Optionally set board Status to `in_review`/`done` for the audit card. **Dashboard:** ICC still reads `.local/workflow-artifacts/` — list required sync actions in `enterprise-audit-actions.md` for **implementer** (prefer board Status over dual-writing trackers when `board_only`).
+**Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+
+**Board rights:** Status + Notes on **audit card** required on Exit. No Priority reshuffle; no Project views/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -16,10 +16,12 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Exit (board-first when enabled):**
 
-1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open) or `--to done` (slice closed).
+1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed). Put next agent in card Notes when handing off.
 2. Append `change-index.md`; one line in `history/updates-log.md`.
 3. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-4. Say *prepare gates green* — do not paste full `GATES`.
+4. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+
+**Board rights:** claim Ready→In progress; In review on PR; Done on close; Priority/Size on **own** card; may create slice cards. **Exit Status update is mandatory** for continuation. Do **not** edit Project views/workflows/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 

--- a/.cursor/agents/integrator-mas-agent.md
+++ b/.cursor/agents/integrator-mas-agent.md
@@ -14,9 +14,11 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Else `session-pointer.md` then integration skill.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card. Else `session-pointer.md` then integration skill.
 
-**Exit:** Board Status for the integration card when enabled; append `change-index.md` (Agent: `integrator-mas-agent`); one line in `updates-log.md`. No dual-write under `board_only`. Run verification commands; say outcomes — do not paste full gate lists.
+**Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+
+**Board rights:** Create integration cards; claim→Done; fields on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## Read first (evidence before edits)
 

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -8,9 +8,11 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 ## Anchor (mandatory)
 
-**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/project-board-ssot/SKILL.md`. Run `python -m cursor_workflow project status`.
+**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/project-board-ssot/SKILL.md`. Run `python -m cursor_workflow project status` + `project list`.
 
-**Exit:** Board Status updated via CLI; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+**Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+
+**Board rights:** Full triage — create cards; any Status; Priority/Size. Own Ready queue hygiene so other agents can claim. Never edit Project views/workflows/README/Insights. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## Role
 

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -8,9 +8,11 @@ description: Optional local research corpus; hard-stop on product code without e
 
 ## Anchor (mandatory)
 
-**Entry:** When coordinating with implement slices: if `project_ssot.enabled` note board card context via `project status`; else `session-pointer.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
 
-**Exit:** Research-only — update research corpus indexes; do not mutate board Status or `session-pointer` unless user expands scope.
+**Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
+
+**Board rights:** Always **read** board when enabled. **Update** only your research card on Exit. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -8,9 +8,11 @@ description: Module-focused tests, regressions, coverage.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card; else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
 
-**Exit:** Board Status via CLI when enabled (`in_review`/`done` as appropriate); update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write of tracker SSOT under `board_only`.
+**Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+
+**Board rights:** Stay on the slice card; Exit Status update required for continuation. Priority/Size only on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -8,9 +8,11 @@ description: Claims vs evidence; minimal high-signal checks.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card; else `session-pointer.md`. Always read claims to verify against evidence.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card (read Notes for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
 
-**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review`); update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+
+**Board rights:** Confirm Done or leave In review + Notes. Do **not** create cards or reshuffle Priority. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.

--- a/.cursor/agents/workflow-drift-guard.md
+++ b/.cursor/agents/workflow-drift-guard.md
@@ -8,24 +8,27 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (board vs tracker dual-write context); else `session-pointer.md`.
+**Entry:** If `project_ssot.enabled` → **must** `python -m cursor_workflow project status` and `project list --status in_progress` (board vs tracker dual-write context; cite board Status in findings). Else `session-pointer.md`.
 
-**Exit:** Write drift artifacts only; one line in `updates-log.md` when audit completes. Do **not** auto-edit `plan.md` or `work-tracker.md`. Do not invent board Status changes unless the user asks.
+**Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+
+**Board rights:** **Read** board every pass. **Update** Status on the drift-pass card when finished. Remediation = Notes / Ready handoff, not silent tracker writes. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** when project SSOT enabled).
-3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog.
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** when project SSOT enabled; prefer a fresh `project export` snapshot for DRIFT-010).
+3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
 4. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
 5. Do not duplicate governance, integrate, or enterprise-auditor scope (ADR-007 / ADR-008).
 
 ## Read first
 
 - `.cursor/skills/workflow-drift-audit/SKILL.md` — full protocol
+- `.cursor/skills/project-board-ssot/SKILL.md` — when `project_ssot.enabled`
 - `.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md`
 - `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md` (when project_ssot enabled)
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only for context; fallback SSOT)
+- Fallback only: `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only)
 
 ## Write (mandatory)
 
@@ -34,14 +37,14 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Handoff format
 
-Profile • P0/P1/P2 counts • artifact paths • blockers • suggested next agent (implementer / verifier)
+drift profile • P0/P1/P2 counts • board Status cited • item_id (if any) · next=project-board|implementer|…
 
 ## MCP integration
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | `workflow_drift_validate`, trackers — prefer over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `workflow-kit` | Trackers/gates — prefer scripts |
+| External | See `.cursor/mcp.registry.yaml` | Only if listed for this agent |
 
 Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -5,11 +5,14 @@ alwaysApply: true
 
 # Project SSOT precedence (experiment)
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is backlog/status SSOT.
-- Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md`). Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009 guards dual-write).
+- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
+- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+- **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
+- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- PR Pattern A (`prepare.py` GATES), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `HANDOFF.md`.
+- PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
+- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
+- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
-- Keep this file out of marketplace `payload/.cursor/rules/` until production port (install via `overlays/rules/` copy into `.cursor/rules/` only).

--- a/.cursor/skills/enterprise-architecture-audit/SKILL.md
+++ b/.cursor/skills/enterprise-architecture-audit/SKILL.md
@@ -84,7 +84,7 @@ Evidence-Standard: repository + user context only
 
 **Downstream agents:**
 
-- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items into `work-tracker.md` (one primary `in_progress` task). Follow `.cursor/skills/implementation-execution-loop/SKILL.md`.
+- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items onto **board Ready cards** when `project_ssot.enabled` (Acceptance/Rollback in body); else `work-tracker.md` (one primary `in_progress`). Follow `.cursor/skills/implementation-execution-loop/SKILL.md` + `project-board-ssot` Continuation contract.
 - **Alignment / maintainer:** if findings are doc-policy-roadmap drift, also record P0/P1 items per `.ai_infra/docs/roadmap/alignment-audit-schema.md` in `.local/workflow-artifacts/alignment/alignment-audit.md` and `alignment-todos.md` (advisory).
 - **Module map depth:** optionally run `.cursor/skills/audit-module-map/SKILL.md` for `module-map` / HTML export; cite those paths as evidence in the enterprise report.
 

--- a/.cursor/skills/implementation-execution-loop/SKILL.md
+++ b/.cursor/skills/implementation-execution-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-execution-loop
-description: Disciplined implementation slices with tracker updates and handoff.
+description: Disciplined implementation slices with board SSOT continuation and Pattern A gates.
 ---
 
 # Implementation execution loop
@@ -11,7 +11,7 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Inputs
 
-- **When `project_ssot.enabled`:** `.local/user_settings/github.collaboration.yaml` + `.cursor/skills/project-board-ssot/SKILL.md` + board card (Acceptance/Rollback in body)
+- **When `project_ssot.enabled`:** `.local/user_settings/github.collaboration.yaml` + `.cursor/skills/project-board-ssot/SKILL.md` (§ Continuation contract) + board card (Acceptance/Rollback/Notes in body)
 - **Fallback:** `.local/index-and-planning/current/plan.md`, `work-tracker.md`, `session-pointer.md`
 - Project `docs/architecture/` (stub under `.local/.../current/` if present)
 - Test trackers when tests change: `test-plan.md`, `test-index.md`
@@ -21,12 +21,12 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 ## Steps
 
 1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`set-status --to in_progress`). Else read plan + tracker; one task `in_progress` locally.
-2. Document acceptance + rollback on **card body** (or `plan.md` if fallback).
+2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
-6. **Close:** board `set-status --to in_review|done` when SSOT enabled; do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts.
+6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · next=…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
 ## Output
 
-Slice • item_id (if board) • modules/files • gates outcome • blockers • next step
+Slice • item_id • Status before→after • modules/files • gates outcome • blockers • next agent

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -6,63 +6,133 @@ description: Drive GitHub Project SSOT via project_ssot YAML and cursor_workflow
 <!--
 File: SKILL.md
 Path: .cursor/skills/project-board-ssot/SKILL.md
-Role: Procedural skill for board-first backlog/status using project_ssot settings.
+Role: Procedural skill for board-first backlog/status + multi-agent continuation on the Project.
 Used By:
  - .cursor/agents/project-board.md
- - implementer and other agents when project_ssot.enabled
+ - All kit agents when project_ssot.enabled
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:
  - Pattern A: one CLI command per action; no dual-write of work-tracker when board_only.
+ - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
 -->
 
 # Project board SSOT
 
 ## Goal
 
-Use the GitHub Project configured in **`project_ssot`** (`.local/user_settings/github.collaboration.yaml`) as backlog/status SSOT. Prefer CLI over inventing `gh` flags.
+When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Project as the **only writable SSOT** for backlog, Status, and multi-agent continuation. Prefer CLI over inventing `gh` flags. Local trackers are offline fallback only; read-only exports never compete with board Status.
 
 **Agent:** `.cursor/agents/project-board.md`  
+**Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
 **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+
+## Continuation contract (all agents — non-negotiable when enabled)
+
+Work is **indexed on the Project**, not in chat alone.
+
+| Phase | Required |
+|-------|----------|
+| **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
+| **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Print handoff line. |
+| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. |
+
+Handoff line (chat + optional card Notes):
+
+```text
+item_id=PVTI_… · title=… · Status=before→after · next=implementer|verifier|test-runner|…
+```
 
 ## When to use
 
-- Triage Ready / P0–P1 work from the shared board
-- Create DraftIssue cards with Acceptance / Rollback / Notes
-- Move Status (Ready → In progress → In review → Done)
-- Set Priority or Size from YAML option ids
+- Any session where `project_ssot.enabled: true`
+- Triage, create, claim, Priority/Size, Status transitions
+- Multi-agent handoffs (implementer → test-runner → verifier, etc.)
 
 ## Evidence contract
 
 - Cite CLI output or `gh project` JSON for claims.
-- Label **Unknown** when board unreachable.
+- Label **Unknown** when board unreachable → then `fallback: local_trackers` only.
 
-## Procedure
+## Collaboration
+
+### Human vs agent vs GitHub
+
+| Surface | Human | Agents | Derived |
+|---------|-------|--------|---------|
+| Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
+| Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
+| Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
+| My items | Assign in UI | Claim = Status In progress (assignee CLI TBD) | View filter |
+| PR gates, audits, secrets | Local | Local (`local_only`) | — |
+
+### Rules
+
+1. One primary **In progress** per assignee — do not steal others'.
+2. Pull from **Ready** or continue your In progress.
+3. Acceptance / Rollback / Notes on **card body** = continuation index.
+4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
+5. Humans own views, workflows, README, Insights, status updates.
+6. Read-only `project export` (if used) never writes Status.
+7. Post-merge Done is Pattern A (`merge.py`), not a dedicated agent.
+
+### Per-agent rights (what / when / where)
+
+| Agent | Entry (read board) | Exit (must update board) | Local writes |
+|-------|--------------------|--------------------------|--------------|
+| **project-board** | status + list | create/move any Status; Priority/Size; hand off to implementer | change-index, updates-log |
+| **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
+| **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
+| **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
+| **integrator-mas-agent** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
+| **enterprise-auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
+| **workflow-drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to project-board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
+| **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |
+
+### Status path
+
+```text
+Ready → In progress → In review → Done
+```
+
+| Moment | Actor | CLI |
+|--------|-------|-----|
+| Start work | implementer / integrator / test-runner / project-board | `set-status --to in_progress` |
+| PR open / peer handoff | implementer | `set-status --to in_review` |
+| Part verified closed | implementer / verifier / test-runner | `set-status --to done` |
+| Drift / audit pass closed | drift-guard / auditor | `set-status --to done` (their card) |
+| Queue triage | project-board or human | create / set-status / set-field |
+
+## Procedure (CLI)
 
 1. **Status:** `python -m cursor_workflow project status --directory .`
-   - Exit 2 / disabled → use local trackers only (`fallback: local_trackers`); do not invent board ids.
-2. **List queue:** `python -m cursor_workflow project list --status ready --directory .`
-3. **Claim:** `python -m cursor_workflow project set-status --id PVTI_… --to in_progress --directory .`
-   - Respect `conventions.one_in_progress_per_assignee` (do not steal others' In progress).
-4. **Create:** `python -m cursor_workflow project create --title "…" [--body "…"] --directory .`
-5. **Priority/Size:** `python -m cursor_workflow project set-field --id PVTI_… --field priority --to p1 --directory .`
-6. **Close:** `python -m cursor_workflow project set-status --id PVTI_… --to done --directory .` (or `in_review` when PR open)
-7. **Verify:** re-run `project list` or `gh project item-list` — Status matches intent.
+2. **List:** `python -m cursor_workflow project list [--status ready|in_progress|in_review] --directory .`
+3. **Claim:** `set-status --id PVTI_… --to in_progress`
+4. **Create:** `project create --title "…" [--body "…"]`
+5. **Fields:** `set-field --id … --field priority|size --to …`
+6. **Close / handoff:** `set-status --to in_review|done`
+7. **Verify:** `project list` matches intent + handoff line printed
 
 ## Dual-write ban
 
-When `sync_policy: board_only`, do **not** also mark the same slice `in_progress` in `work-tracker.md` as competing SSOT. PR artifacts / audits stay local (`local_only`).
+When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local (`local_only`).
 
 ## Exit criteria
 
-- [ ] `project status` shows `operational: True` (or explicit fallback)
-- [ ] Status change confirmed on the board
-- [ ] No dual-write of tracker SSOT
+- [ ] Entry read board (or explicit offline fallback)
+- [ ] Exit updated Status (or Notes + next agent if still In progress)
+- [ ] Handoff line printed when another agent continues
+- [ ] No dual-write; no edits to Project views/workflows/README/Insights
 
 ## Anti-patterns
 
-- Hardcoding field/option ids instead of reading YAML
-- Bypassing `prepare.py` gates
-- Adding this flow to production `mas-workflow-kit` without port gate
+- Chat-only completion with stale board Status
+- Hardcoding field/option ids
+- Reshuffling Ready/P0 without human or project-board ask
+- Editing Project views, workflows, Insights, or status updates
+- Dual-write board + tracker under `board_only`
+- Port to production kit without PORT-GATE

--- a/.cursor/skills/workflow-drift-audit/SKILL.md
+++ b/.cursor/skills/workflow-drift-audit/SKILL.md
@@ -19,20 +19,23 @@ Notes:
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
+Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
 
 ## When
 
 - Substantive implementer slice closure (recommended)
 - Optional pre-review drift pass before PR workflow
 - After tracker or handoff doc edits
+- When `project_ssot.enabled` — every pass should include board Status evidence
 
 ## Steps
 
-1. **Script first:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer` (no agent required before the script). Include **DRIFT-009** when `project_ssot` board_only is enabled (ADR-008).
-2. Capture profile, check IDs, severities, and details from output.
-3. Write artifacts under `.local/workflow-artifacts/drift/` only.
-4. Do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+3. Capture profile, check IDs, severities, and details from output.
+4. Write artifacts under `.local/workflow-artifacts/drift/` only.
+5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to project-board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+6. Print handoff line with `item_id` when applicable.
 
 ## Evidence contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 **MAS Workflow Kit** (`mas-workflow-kit`) — universal, installable infrastructure for multi-agent development workflows. Agents call **one script command** per maintainer action; `GATES` are hardcoded in `.ai_infra/scripts/pr/prepare.py` (customize once at install). This is **not** a product application repo unless you add overlays.
 
-**This sibling experiment (`mas-workflow-kit-project-ssot`):** when `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true`, the **GitHub Project** is backlog/status SSOT. Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md`, ADR-008, `overlays/rules/project-ssot-precedence.mdc`). Local trackers are offline fallback only — no dual-write under `board_only`. Read [`HANDOFF.md`](HANDOFF.md) first.
+**This sibling experiment (`mas-workflow-kit-project-ssot`):** when `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project** is the **only writable SSOT** for backlog, Status, and multi-agent continuation. Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md` § Collaboration, ADR-008, `overlays/rules/project-ssot-precedence.mdc`). Ops mirror: `.ai_infra/docs/operations/project-board-collaboration.md`. Local trackers are offline fallback only; read-only exports never compete with board Status — no dual-write under `board_only`. Read [`HANDOFF.md`](HANDOFF.md) first.
 
 ## First reads (onboarding)
 
@@ -40,12 +40,14 @@ Abbreviations: [`.ai_infra/docs/operations/abbreviations-notepad.md`](.ai_infra/
 
 **Resume every session:**
 
-1. If `project_ssot.enabled` → `python -m cursor_workflow project status` → board list/claim (`.cursor/skills/project-board-ssot/SKILL.md`).
+1. If `project_ssot.enabled` → `python -m cursor_workflow project status` → board list/claim (`.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract). Read card Notes for prior handoffs.
 2. Else → `.local/index-and-planning/current/session-pointer.md` → `plan.md` → `work-tracker.md`.
+
+**After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`.
 
 Token contract: [`.ai_infra/docs/operations/token-efficiency.md`](.ai_infra/docs/operations/token-efficiency.md).
 
-Sequence: `plan → interfaces → implementation → tests → evidence → docs update` (plan may live on the board card body when SSOT enabled).
+Sequence: `plan → interfaces → implementation → tests → evidence → docs update` (plan lives on the **board card body** when SSOT enabled).
 
 Full handoff checklist: [`.ai_infra/docs/operations/workflow-complete.md`](.ai_infra/docs/operations/workflow-complete.md) (esp. §F).
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -34,7 +34,7 @@ Notes:
 
 ## 1. Goal (north star)
 
-**Hypothesis (updated):** Collaborators and agents use a **GitHub Project** as the **single source of truth** for backlog, slice status, and handoffs — **replacing** local tracker markdown under `.local/index-and-planning/current/` (`session-pointer.md`, `plan.md`, `work-tracker.md`, and related tracker writes).
+**Hypothesis (clarified):** Collaborators and agents treat the configured **GitHub Project** as the **only writable SSOT** for backlog, Status, and multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only`. Every agent **reads the board on Entry** and **updates Status and Notes on Exit**; card body indexes handoffs — not chat alone. Local trackers are **offline fallback only**; PR gates, audits, secrets stay local. Optional **read-only** exports may cache snapshots but must never compete with board Status.
 
 **Why:**
 
@@ -48,18 +48,19 @@ Notes:
 
 | Keep | Why |
 |------|-----|
-| PR Pattern A (`prepare.py` GATES, review/prep/merge scripts) | Merge readiness is code-side |
+| PR Pattern A (`prepare.py` GATES, review/prep/merge scripts) | Merge readiness is code-side; post-merge card → Done is Pattern A (`merge.py`) |
 | Commit/PR attribution (`owner`, trailers, pipelines) | Already in collab YAML |
 | `.venv`, secrets, coverage dumps | Machine-local |
-| Optional offline fallback | If no `project` scope / no `gh` — degrade to local trackers temporarily |
+| Offline fallback trackers | If no `project` scope / no `gh` — **resume-only** local trackers; never a second writer under `board_only` |
+| Read-only board export (optional) | Snapshot cache for audits/ICC later — never writes Status |
 
-**Non-goal (this experiment):** Do **not** rewrite production `mas-workflow-kit` `main` until this sibling proves the model. Marketplace `v0.4.0` consumers stay on markdown SSOT until an explicit port.
+**Non-goal (this experiment):** Do **not** rewrite production `mas-workflow-kit` `main` until this sibling proves the model. Marketplace `v0.4.0` consumers stay on markdown SSOT until an explicit port. Do **not** dual-mirror local trackers + board “for safety.”
 
 **Success looks like:**
 
 1. Agents **create** and **load** tasks from the configured Project (not from `work-tracker.md`).
-2. Agent Anchors read `project_ssot` from collab YAML → board; exit updates card Status (and links Issue/PR when useful).
-3. Humans follow progress **only** on the Project UI; local tracker markdown is deprecated or unused.
+2. Agent Anchors read `project_ssot` from collab YAML → board; Exit updates card Status and Notes (continuation contract).
+3. Humans follow progress **only** on the Project UI; local tracker markdown is **offline fallback only** (not a writable SSOT under `board_only`).
 4. Clear auth (`project` scopes) + settings onboarding for every collaborator who opts in.
 5. Rollback = abandon this sibling repo; production kit unchanged.
 
@@ -304,12 +305,13 @@ Do **not** run production marketplace publish from this repo.
 
 | Question | Notes |
 |----------|-------|
-| Board-only vs dual mirror? | **Board wins.** Offline fallback only; no dual writers. |
+| Board-only vs dual mirror? | **Board wins — only writable SSOT.** Offline fallback only; no dual writers “for safety.” |
 | DraftIssue vs real Issues? | Drafts OK for smoke; Issues better for PR linking. |
 | Consumer installs? | Projects opt-in until production port. |
 | Offline / no `gh`? | `fallback: local_trackers` then resume board sync. |
 | Card → which repo? | Convention: Repository field or body path; default = this experiment repo. |
-| Control Center dashboards? | **Deferred.** ICC today reads `.local/` markdown only — no board tab until a later export/tab slice (EA-010). Humans follow Project #3 UI for backlog/status. |
+| Control Center dashboards? | **Deferred (EA-010).** Read-only `project export` may land first; ICC panel that *reads* the export is future — never a second writer. Humans follow Project #3 UI for backlog/status. |
+| Who updates the Project? | **Every agent** Entry=read board; Exit=update Status/Notes. Post-merge Done = Pattern A (`merge.py`). Rights: `project-board-ssot` skill § Continuation; ops `project-board-collaboration.md`. **You:** views, workflows, Insights, README, status updates, Ready prioritization. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | **Production kit (do not break)** | [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) |
 | **Agent handoff (READ FIRST)** | [HANDOFF.md](./HANDOFF.md) |
 
-**Experiment agents (8):** `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `researcher`, `integrator-mas-agent`, `workflow-drift-guard`, `project-board` — see [AGENTS.md](./AGENTS.md). Board CLI: `python -m cursor_workflow project …`.
+**Experiment agents (8):** `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `researcher`, `integrator-mas-agent`, `workflow-drift-guard`, `project-board` — see [AGENTS.md](./AGENTS.md). Board CLI: `python -m cursor_workflow project …`. **Continuation:** every agent reads the Project on Entry and updates Status/Notes on Exit ([project-board-collaboration.md](.ai_infra/docs/operations/project-board-collaboration.md)).
 
 This repository is an isolated sibling sandbox. If the experiment fails, abandon this repo; leave marketplace `mas-workflow-kit` on markdown SSOT.
 

--- a/agents/enterprise-auditor.md
+++ b/agents/enterprise-auditor.md
@@ -8,9 +8,11 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice; else `session-pointer.md` + `change-index.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice (claim/create audit card if missing); else `session-pointer.md` + `change-index.md`.
 
-**Exit:** Update alignment artifacts + `change-index.md`; one line in `updates-log.md`. Optionally set board Status to `in_review`/`done` for the audit card. **Dashboard:** ICC still reads `.local/workflow-artifacts/` — list required sync actions in `enterprise-audit-actions.md` for **implementer** (prefer board Status over dual-writing trackers when `board_only`).
+**Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+
+**Board rights:** Status + Notes on **audit card** required on Exit. No Priority reshuffle; no Project views/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -16,10 +16,12 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Exit (board-first when enabled):**
 
-1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open) or `--to done` (slice closed).
+1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed). Put next agent in card Notes when handing off.
 2. Append `change-index.md`; one line in `history/updates-log.md`.
 3. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-4. Say *prepare gates green* — do not paste full `GATES`.
+4. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+
+**Board rights:** claim Ready→In progress; In review on PR; Done on close; Priority/Size on **own** card; may create slice cards. **Exit Status update is mandatory** for continuation. Do **not** edit Project views/workflows/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 

--- a/agents/integrator-mas-agent.md
+++ b/agents/integrator-mas-agent.md
@@ -14,9 +14,11 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Else `session-pointer.md` then integration skill.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card. Else `session-pointer.md` then integration skill.
 
-**Exit:** Board Status for the integration card when enabled; append `change-index.md` (Agent: `integrator-mas-agent`); one line in `updates-log.md`. No dual-write under `board_only`. Run verification commands; say outcomes — do not paste full gate lists.
+**Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+
+**Board rights:** Create integration cards; claim→Done; fields on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## Read first (evidence before edits)
 

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -8,9 +8,11 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 ## Anchor (mandatory)
 
-**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/project-board-ssot/SKILL.md`. Run `python -m cursor_workflow project status`.
+**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/project-board-ssot/SKILL.md`. Run `python -m cursor_workflow project status` + `project list`.
 
-**Exit:** Board Status updated via CLI; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+**Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+
+**Board rights:** Full triage — create cards; any Status; Priority/Size. Own Ready queue hygiene so other agents can claim. Never edit Project views/workflows/README/Insights. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## Role
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -8,9 +8,11 @@ description: Optional local research corpus; hard-stop on product code without e
 
 ## Anchor (mandatory)
 
-**Entry:** When coordinating with implement slices: if `project_ssot.enabled` note board card context via `project status`; else `session-pointer.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
 
-**Exit:** Research-only — update research corpus indexes; do not mutate board Status or `session-pointer` unless user expands scope.
+**Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
+
+**Board rights:** Always **read** board when enabled. **Update** only your research card on Exit. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -8,9 +8,11 @@ description: Module-focused tests, regressions, coverage.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card; else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
 
-**Exit:** Board Status via CLI when enabled (`in_review`/`done` as appropriate); update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write of tracker SSOT under `board_only`.
+**Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+
+**Board rights:** Stay on the slice card; Exit Status update required for continuation. Priority/Size only on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -8,9 +8,11 @@ description: Claims vs evidence; minimal high-signal checks.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card; else `session-pointer.md`. Always read claims to verify against evidence.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card (read Notes for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
 
-**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review`); update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+
+**Board rights:** Confirm Done or leave In review + Notes. Do **not** create cards or reshuffle Priority. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.

--- a/agents/workflow-drift-guard.md
+++ b/agents/workflow-drift-guard.md
@@ -8,24 +8,27 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (board vs tracker dual-write context); else `session-pointer.md`.
+**Entry:** If `project_ssot.enabled` → **must** `python -m cursor_workflow project status` and `project list --status in_progress` (board vs tracker dual-write context; cite board Status in findings). Else `session-pointer.md`.
 
-**Exit:** Write drift artifacts only; one line in `updates-log.md` when audit completes. Do **not** auto-edit `plan.md` or `work-tracker.md`. Do not invent board Status changes unless the user asks.
+**Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+
+**Board rights:** **Read** board every pass. **Update** Status on the drift-pass card when finished. Remediation = Notes / Ready handoff, not silent tracker writes. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** when project SSOT enabled).
-3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog.
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** when project SSOT enabled; prefer a fresh `project export` snapshot for DRIFT-010).
+3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
 4. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
 5. Do not duplicate governance, integrate, or enterprise-auditor scope (ADR-007 / ADR-008).
 
 ## Read first
 
 - `.cursor/skills/workflow-drift-audit/SKILL.md` — full protocol
+- `.cursor/skills/project-board-ssot/SKILL.md` — when `project_ssot.enabled`
 - `.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md`
 - `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md` (when project_ssot enabled)
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only for context; fallback SSOT)
+- Fallback only: `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only)
 
 ## Write (mandatory)
 
@@ -34,14 +37,14 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Handoff format
 
-Profile • P0/P1/P2 counts • artifact paths • blockers • suggested next agent (implementer / verifier)
+drift profile • P0/P1/P2 counts • board Status cited • item_id (if any) · next=project-board|implementer|…
 
 ## MCP integration
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | `workflow_drift_validate`, trackers — prefer over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `workflow-kit` | Trackers/gates — prefer scripts |
+| External | See `.cursor/mcp.registry.yaml` | Only if listed for this agent |
 
 Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -5,11 +5,14 @@ alwaysApply: true
 
 # Project SSOT precedence (experiment)
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is backlog/status SSOT.
-- Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md`). Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009 guards dual-write).
+- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
+- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+- **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
+- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- PR Pattern A (`prepare.py` GATES), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `HANDOFF.md`.
+- PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
+- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
+- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
-- Keep this file out of marketplace `payload/.cursor/rules/` until production port (install via `overlays/rules/` copy into `.cursor/rules/` only).

--- a/payload/.agents/skills/merge-pr/SKILL.md
+++ b/payload/.agents/skills/merge-pr/SKILL.md
@@ -20,6 +20,9 @@ disable-model-invocation: true
 6. Note merge SHA: `gh api repos/.../pulls/<n> -q .merge_commit_sha` (or `gh pr view` if working).
 7. **Record:**  
    `python .ai_infra/scripts/pr/merge.py --pr <id|url> --pipeline default --merge-sha <sha>`  
+   Optional: `--item-id PVTI_…` when known; `--skip-board-sync` to bypass board close.  
+   When `project_ssot.enabled`, this sets the card → **Done** and appends Notes (`Merged: <PR URL> @ <sha>`). Failure is a **warn** only — merge artifact still writes.  
+   Prefer PR body line `- Board-Item: PVTI_…` under Collaboration so find-by-pr can resolve without `--item-id`.  
    (same `--arch-impacting` if used above). Enrich `merge.md` with method + follow-ups.
 8. **Finalize:** `git checkout main`; `python .ai_infra/scripts/pr/finalize.py --branch <branch>`; prune remotes; confirm feature branch gone on origin.
 

--- a/payload/.agents/skills/pr-workflow/SKILL.md
+++ b/payload/.agents/skills/pr-workflow/SKILL.md
@@ -6,15 +6,15 @@ disable-model-invocation: true
 
 # PR workflow (maintainer)
 
-**Implementer work** (trackers, slices) uses `.local/index-and-planning/current/*`, `.cursor/agents/implementer.md`, and `.cursor/rules/implementation-workflow-governance.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
+**Implementer work:** when `project_ssot.enabled` + `board_only`, slice status lives on the **GitHub Project** (Entry/Exit continuation). Local `.local/index-and-planning/current/*` is offline fallback only — see ADR-008 and `project-ssot-precedence.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
 
 This skill is the **merge path** only: **review → prepare → merge** (slash skills: `review-pr`, `prepare-pr`, `merge-pr`).
 
 ## Order
 
-1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers changed. When scope is architecture-impacting, run **`enterprise-auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
-2. `prepare-pr` — tracker sync + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
-3. `merge-pr` — `merge.py` check, `gh pr merge`, finalize repo state.
+1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers/board status changed. When scope is architecture-impacting, run **`enterprise-auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
+2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
+3. `merge-pr` — `merge.py` check, `gh pr merge`, `merge.py --merge-sha` (sets board card → Done when SSOT on), finalize repo state.
 
 Per-step detail: `.agents/skills/review-pr/`, `prepare-pr/`, `merge-pr/`.
 

--- a/payload/.agents/skills/prepare-pr/SKILL.md
+++ b/payload/.agents/skills/prepare-pr/SKILL.md
@@ -13,7 +13,7 @@ disable-model-invocation: true
 1. `review.md` exists; clear BLOCKER/IMPORTANT items first.
 2. Alignment files present when required (authored via **`enterprise-auditor`** / `enterprise-architecture-audit` skill; see `advisory-audit-alignment-enforcement.mdc`); no open **P0** unless explicitly accepted.
 3. Fixes **only** in PR scope.
-4. Sync trackers when status changed — **`.local/index-and-planning/current/`**: `session-pointer.md`, `change-index.md`, `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md` when applicable.
+4. Status sync: when `project_ssot.enabled` and `sync_policy: board_only`, update **board Status/Notes only** — do **not** dual-write competing `in_progress` into local trackers. Local `.local/index-and-planning/current/` files are offline fallback / session pointer only. When SSOT is disabled or offline fallback is active, sync trackers as usual (`session-pointer.md`, `change-index.md`, `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md` when applicable).
 5. Run (owner from YAML; **Agent/s** auto-merges trackers + pipeline unless `--agents` set):  
    `python .ai_infra/scripts/pr/prepare.py --pr <id|url> --pipeline default`  
    Same **`--agents-from-session`** behavior as review — see **`pr-workflow/SKILL.md`**.  

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -49,14 +49,16 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 
 | Agent | Role |
 |-------|------|
-| `implementer` | Slices, code, trackers (or board when `project_ssot.enabled`) |
-| `test-runner` | Module tests, coverage |
-| `verifier` | Evidence checks |
-| `enterprise-auditor` | Architecture audits |
-| `researcher` | Research corpus (local) |
-| `integrator-mas-agent` | Add agents/skills/MCP to infrastructure |
-| `workflow-drift-guard` | Operational drift (plan ↔ tracker ↔ docs) — [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) |
-| `project-board` | Independent-governed board triage (ADR-006); not in default PR pipelines |
+| `implementer` | Slices, code; board Status when `project_ssot.enabled` |
+| `test-runner` | Module tests, coverage; board Exit Status |
+| `verifier` | Evidence checks; board Done / In review |
+| `enterprise-auditor` | Architecture audits; audit card Status + Notes |
+| `researcher` | Research corpus; research card Done when present |
+| `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
+| `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
+| `project-board` | Board triage helper (ADR-006); not in default PR pipelines |
+
+Continuation: every agent Entry reads the Project; Exit updates Status/Notes — [project-board-collaboration.md](../operations/project-board-collaboration.md).
 
 Integration procedure: [mas-infrastructure-integration.md](../operations/mas-infrastructure-integration.md).  
 Drift validation: `make drift-validate` — see [gate-matrix.md](../operations/gate-matrix.md).

--- a/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -46,6 +46,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-007 | P2 | kit-dev | updates-log fresh when git tree dirty |
 | DRIFT-008 | P2 | consumer | Scaffold trackers present |
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
+| DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
 
 **Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`).
 

--- a/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -11,20 +11,26 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 
 ## Decision
 
-1. **`board_only` wins** when `project_ssot.enabled: true` and `sync_policy: board_only`. Agents must not dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
-2. **Offline fallback:** if enabled is false or `gh`/Projects unavailable, use `fallback: local_trackers` with an explicit warning — then resume board sync; never silent dual-write.
-3. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
-4. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
-5. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
-6. **`project-board` agent:** independent-governed helper; not in PR pipelines. Long-term all agents Anchor on `project_ssot`.
-7. **Production port deferred** until demo + implementer Anchor + dual-write drift check + human sign-off. Marketplace kit stays markdown SSOT until then.
+1. **Only writable SSOT:** when `project_ssot.enabled: true` and `sync_policy: board_only`, the GitHub Project is the **only writable** coordination SSOT for backlog, Status, and multi-agent continuation. Agents must not dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
+2. **`board_only` wins** — dual-mirror (local trackers + board both writable) is rejected; it causes worse agent drift (DRIFT-009).
+3. **Offline fallback:** if enabled is false or `gh`/Projects unavailable, use `fallback: local_trackers` with an explicit warning — then resume board sync; never silent dual-write.
+4. **Read-only exports:** optional snapshots (`project export`) may cache board state for audits/ICC later; they **must not** write Status and must never become a competing SSOT.
+5. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
+6. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
+7. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
+8. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
+9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
+10. **Production port deferred** until demo + implementer Anchor + dual-write drift check + human sign-off. Marketplace kit stays markdown SSOT until then.
+11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization — agents never edit these.
 
 ## Consequences
 
 - New CLI module: `.ai_infra/install/cursor_workflow/project_cli.py`
-- Skill: `.cursor/skills/project-board-ssot/SKILL.md`
+- Skill: `.cursor/skills/project-board-ssot/SKILL.md` (Continuation contract + per-agent rights)
+- Ops: `.ai_infra/docs/operations/project-board-collaboration.md`
 - Agent: `.cursor/agents/project-board.md`
-- Drift: DRIFT-009 advisory when board_only and tracker has competing `in_progress` (experiment)
+- Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); workflow-drift-guard **reads and updates** the board on Exit
+- Post-merge Done: Pattern A `merge.py` (not a dedicated agent)
 
 ## References
 

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -1,0 +1,74 @@
+<!--
+File: project-board-collaboration.md
+Path: .ai_infra/docs/operations/project-board-collaboration.md
+Role: Ops mirror — Project surfaces + per-agent Entry/Exit continuation on the board.
+Used By:
+ - .cursor/skills/project-board-ssot/SKILL.md
+ - .cursor/agents/*.md
+ - AGENTS.md / HANDOFF.md
+Depends On:
+ - github.collaboration.yaml project_ssot
+ - ADR-008
+Notes:
+ - When enabled, every agent reads the Project on Entry and updates Status on Exit.
+-->
+
+# Project board collaboration (agents + humans)
+
+When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project is the only writable SSOT** for backlog, Status, and continuation. Local trackers are offline fallback only; read-only exports never compete with Status. Canonical skill: `.cursor/skills/project-board-ssot/SKILL.md`.
+
+## Continuation (why agents update the board)
+
+| Without board Exit | With board Exit |
+|--------------------|-----------------|
+| Next agent guesses from chat | Next agent lists Ready / In progress / In review |
+| Status drifts from reality | Status column = truth (DRIFT-009 watches dual-write) |
+| Humans cannot see progress | Project UI is the shared dashboard |
+
+**Rule:** Entry = read board. Exit = update Status (and Notes) for the card you touched.
+
+## Surfaces — who may write
+
+| Surface | Human | Agents | GitHub |
+|---------|-------|--------|--------|
+| Card Status | Yes | Yes — every agent Exit | — |
+| Priority / Size | Yes | Triage + own card | — |
+| Create cards | Yes | project-board, implementer, integrator | — |
+| Ready prioritization | **Owner** | Consume; create agreed work | — |
+| Views / workflows / Insights / README / status updates | **Owner only** | Never | Insights auto |
+| Assignee / My items | Yes | Claim = In progress | My items view |
+| PR / audits / secrets | Local | Local | — |
+| Post-merge Status → Done | — | Via `merge.py` (Pattern A) | — |
+| Read-only board export | Consume | `project export` (never writes Status) | — |
+
+## Per-agent Entry / Exit
+
+| Agent | Entry | Exit (board) |
+|-------|-------|--------------|
+| **project-board** | status + list | Full triage; handoff to implementer |
+| **implementer** | status + Ready/claim | →In review / →Done; Notes for next |
+| **test-runner** | status + slice card | →In review or →Done when tests finish |
+| **verifier** | status + related card | →Done or leave In review + Notes |
+| **integrator-mas-agent** | status + claim | →Done on integration card |
+| **enterprise-auditor** | status + audit card | →In review/Done; Notes → artifact paths |
+| **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; cite board in drift-audit; remediation via Notes/Ready handoff — no silent tracker edits |
+| **researcher** | status (+ research card) | Research card →Done + corpus paths in Notes |
+
+## Status path
+
+```text
+Ready → In progress → In review → Done
+```
+
+Handoff: `item_id=PVTI_… · Status=a→b · next=<agent>`
+
+## workflow-drift-guard specifically
+
+1. **Read board first** (`project status`, `list --status in_progress`) so dual-write checks compare board Status vs trackers.
+2. Run `drift validate` (includes DRIFT-009 / DRIFT-010 when board_only; refresh `project export` for DRIFT-010).
+3. Write `.local/workflow-artifacts/drift/*` (evidence stays local).
+4. **Update board:** close the drift-pass card; if dual-write Confirmed, add Notes on the offending card or ask project-board to queue a Ready fix — do not write competing `in_progress` into `work-tracker.md`.
+
+## Human-only
+
+Views, workflows, Insights, Project README, status updates, Ready prioritization, PORT-GATE.

--- a/payload/.ai_infra/docs/operations/token-efficiency.md
+++ b/payload/.ai_infra/docs/operations/token-efficiency.md
@@ -8,12 +8,26 @@ Depends On:
  - .ai_infra/scripts/pr/prepare.py
  - docs/governance/workflow-source-owners.md
 Notes:
- - Pair with session-pointer.md + change-index.md for resume-without-chat.
+ - When project_ssot.enabled: pair with board Status + card Notes for resume-without-chat.
+ - Else: session-pointer.md + change-index.md.
 -->
 
 # Token efficiency (agent contract)
 
 ## Read set (default)
+
+**When `project_ssot.enabled`:**
+
+| Order | Path / command | When |
+|-------|----------------|------|
+| 1 | `python -m cursor_workflow project status` + `project list` | **Every session start** |
+| 2 | Board card body (Acceptance / Rollback / Notes) | Claimed / In progress card |
+| 3 | `.cursor/skills/project-board-ssot/SKILL.md` § Continuation | When mutating Status |
+| 4 | `change-index.md` | Resume mid-slice (thin cache) |
+| 5 | `test-plan.md`, `test-index.md` | When tests change |
+| 6 | `workflow-artifacts/pr/*.md` | Only when phase = review \| prepare \| merge |
+
+**When disabled / offline fallback:**
 
 | Order | Path | When |
 |-------|------|------|
@@ -26,6 +40,15 @@ Notes:
 **Skip:** `.local/generated-data/**`, `history/archive/**`, full `updates-log.md` body, root handoff megadocs unless explicitly tasked.
 
 ## Write set (slice close)
+
+**When board SSOT enabled:**
+
+1. Board Status via `cursor_workflow project set-status` (+ Notes / handoff line)
+2. `change-index.md` — one row per batch  
+3. `history/updates-log.md` — **one line** (no gate dumps)
+4. Do **not** dual-write tracker `in_progress` under `board_only`
+
+**Offline fallback:**
 
 1. `change-index.md` — one row per batch  
 2. `session-pointer.md` — phase, next agent, blockers  

--- a/payload/.ai_infra/docs/operations/workflow-complete.md
+++ b/payload/.ai_infra/docs/operations/workflow-complete.md
@@ -74,15 +74,26 @@ When cutting an RC in a product repo:
 
 This is the **implementation agent** end-of-loop on top of sections **C** and **D** — run it before saying a slice is finished:
 
-1. **`.local/index-and-planning/history/updates-log.md`** — append one top entry (summary, validation, next step; no repeated prepare-gate paste — see **`agent-workflow-procedures.md`**).
-2. **`.local/index-and-planning/current/work-tracker.md`** — resolve task status; keep one primary `in_progress` across the file.
-3. **`test-plan.md` / `test-index.md`** — update when tests or ownership changed.
-4. **`coverage-index.md`** — regenerate after any coverage run that matters for the slice (project-specific tooling; see overlay pack if applicable).
-5. **`implementation-control-center.html`** — under `.local/agents-control-center/dashboards/`; if you add a tracker, update **`../config/pages.json`** and header **Depends On** comments; keep **Coverage** in sync with **`coverage-index.md`**.
-6. **`module-audit.html`** — under `.local/agents-control-center/audits/`; touch only when deliberately refreshing a deep module audit export, not per slice.
-7. **`make drift-validate`** — run before handoff; on P0/P1 findings, hand off to **`workflow-drift-guard`** (`.cursor/agents/workflow-drift-guard.md`).
+**When `project_ssot.enabled` (board-first):**
 
-Canonical detail: **`.local/index-and-planning/current/plan.md`** section **Implementer slice closure (mandatory end-of-loop)**.
+1. **Board Status** — `set-status --to in_review|done`; card Notes name next agent; print handoff line (`item_id=… · Status=… · next=…`).
+2. **`.local/index-and-planning/history/updates-log.md`** — one top entry (no gate dumps).
+3. **`change-index.md`** — one row; do **not** dual-write tracker `in_progress` under `board_only`.
+4. **`test-plan.md` / `test-index.md`** — when tests changed.
+5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); pass `--item-id` or embed `Board-Item: PVTI_…` in the PR body.
+6. **`make drift-validate`** — on P0/P1, hand off to **`workflow-drift-guard`** (reads + updates the board; DRIFT-009/010).
+
+**Offline fallback (project_ssot disabled / no gh):**
+
+1. **`.local/index-and-planning/history/updates-log.md`** — append one top entry.
+2. **`.local/index-and-planning/current/work-tracker.md`** — resolve task status; keep one primary `in_progress`.
+3. **`test-plan.md` / `test-index.md`** — update when tests or ownership changed.
+4. **`coverage-index.md`** — regenerate after any coverage run that matters.
+5. **`implementation-control-center.html`** — under `.local/agents-control-center/dashboards/`; if you add a tracker, update **`../config/pages.json`**.
+6. **`module-audit.html`** — touch only when deliberately refreshing a deep module audit export.
+7. **`make drift-validate`** — hand off to **`workflow-drift-guard`** on P0/P1.
+
+Canonical detail: **`.local/index-and-planning/current/plan.md`** / board card body; skill `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## File retention policy (explicit)
 

--- a/payload/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -348,6 +349,403 @@ def cmd_set_field(args: argparse.Namespace) -> int:
     return 0
 
 
+def _normalize_status(raw: str) -> str:
+    key = str(raw or "").strip().lower().replace(" ", "_").replace("-", "_")
+    if key in ("inprogress",):
+        return "in_progress"
+    if key in ("review",):
+        return "in_review"
+    return key
+
+
+def _item_body(item: dict[str, Any]) -> str:
+    content = item.get("content")
+    if isinstance(content, dict):
+        body = content.get("body")
+        if isinstance(body, str):
+            return body
+    body = item.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def _item_title(item: dict[str, Any]) -> str:
+    title = item.get("title")
+    if isinstance(title, str) and title:
+        return title
+    content = item.get("content")
+    if isinstance(content, dict):
+        t = content.get("title")
+        if isinstance(t, str):
+            return t
+    return ""
+
+
+def fetch_project_items(ssot: dict[str, Any], *, limit: int = 100) -> tuple[list[dict[str, Any]], str | None]:
+    """Return (items, error). Each item keeps gh JSON fields plus normalized helpers."""
+    owner = str(ssot["owner"])
+    number = int(ssot["number"])
+    proc = run_gh(
+        [
+            "project",
+            "item-list",
+            str(number),
+            "--owner",
+            owner,
+            "--format",
+            "json",
+            "--limit",
+            str(limit),
+        ]
+    )
+    if proc.returncode != 0:
+        return [], (proc.stderr or proc.stdout or "gh project item-list failed").strip()
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return [], f"invalid JSON from gh: {exc}"
+    raw = data.get("items") if isinstance(data, dict) else data
+    if not isinstance(raw, list):
+        return [], None
+    items: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict):
+            items.append(item)
+    return items, None
+
+
+def find_item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any] | None:
+    for item in items:
+        if str(item.get("id") or "") == item_id:
+            return item
+    return None
+
+
+def append_notes_to_body(body: str, text: str) -> tuple[str, bool]:
+    """
+    Append text under ## Notes. Returns (new_body, changed).
+    Idempotent when the exact text line is already present.
+    """
+    note_line = text.strip()
+    if not note_line:
+        return body, False
+    if note_line in (body or ""):
+        return body, False
+    body = body or ""
+    marker = "## Notes"
+    if marker in body:
+        # Append after the Notes heading block (before next ## or end).
+        idx = body.find(marker)
+        rest = body[idx + len(marker) :]
+        next_h = rest.find("\n## ")
+        if next_h >= 0:
+            insert_at = idx + len(marker) + next_h
+            new_body = body[:insert_at].rstrip() + f"\n\n- {note_line}\n" + body[insert_at:]
+        else:
+            new_body = body.rstrip() + f"\n\n- {note_line}\n"
+    else:
+        new_body = body.rstrip() + f"\n\n## Notes\n\n- {note_line}\n"
+    return new_body, True
+
+
+def parse_board_item_from_text(text: str) -> str | None:
+    """Extract PVTI_… from a Board-Item: line in PR or card body."""
+    m = re.search(r"(?i)Board-Item:\s*(PVTI_[A-Za-z0-9_-]+)", text or "")
+    return m.group(1) if m else None
+
+
+def find_items_mentioning_pr(
+    items: list[dict[str, Any]],
+    *,
+    pr_number: str,
+    pr_url: str = "",
+) -> list[dict[str, Any]]:
+    """Items whose body/title mention the PR number or URL; prefer in_review/in_progress."""
+    needle_num = str(pr_number).strip().lstrip("#")
+    needles = [n for n in (pr_url, f"#{needle_num}", f"/pull/{needle_num}", needle_num) if n]
+    matches: list[dict[str, Any]] = []
+    for item in items:
+        blob = f"{_item_title(item)}\n{_item_body(item)}"
+        if not any(n and n in blob for n in needles):
+            continue
+        status = _normalize_status(str(item.get("status") or ""))
+        if status in ("in_review", "in_progress", "ready"):
+            matches.append(item)
+        else:
+            matches.append(item)
+    # Prefer in_review then in_progress
+    def rank(it: dict[str, Any]) -> int:
+        s = _normalize_status(str(it.get("status") or ""))
+        return {"in_review": 0, "in_progress": 1, "ready": 2}.get(s, 9)
+
+    matches.sort(key=rank)
+    return matches
+
+
+def resolve_item_id_for_pr(
+    ssot: dict[str, Any],
+    *,
+    pr: str,
+    repo: str | None = None,
+    limit: int = 100,
+) -> tuple[str | None, list[str], str | None]:
+    """
+    Resolve project item id for a PR.
+    Returns (item_id | None, candidate_ids, error | None).
+    Prefers Board-Item in PR body; else body/URL scan of active cards.
+    """
+    pr_ref = str(pr).strip()
+    # Accept URL or number
+    pr_number = pr_ref.rstrip("/").split("/")[-1] if "/" in pr_ref else pr_ref.lstrip("#")
+    repo_flag = repo or str(ssot.get("default_repo") or "")
+    view_args = ["pr", "view", pr_number, "--json", "body,url,number"]
+    if repo_flag:
+        view_args.extend(["--repo", repo_flag])
+    proc = run_gh(view_args)
+    pr_body = ""
+    pr_url = ""
+    if proc.returncode == 0:
+        try:
+            pdata = json.loads(proc.stdout or "{}")
+            pr_body = str(pdata.get("body") or "")
+            pr_url = str(pdata.get("url") or "")
+            if pdata.get("number") is not None:
+                pr_number = str(pdata["number"])
+        except json.JSONDecodeError:
+            pass
+    board_item = parse_board_item_from_text(pr_body)
+    if board_item:
+        return board_item, [board_item], None
+
+    items, err = fetch_project_items(ssot, limit=limit)
+    if err:
+        return None, [], err
+    matches = find_items_mentioning_pr(items, pr_number=pr_number, pr_url=pr_url)
+    ids = [str(m.get("id")) for m in matches if m.get("id")]
+    if len(ids) == 1:
+        return ids[0], ids, None
+    if len(ids) > 1:
+        return None, ids, "ambiguous: multiple project items mention this PR"
+    return None, [], "no project item found for this PR (add Board-Item: PVTI_… to PR body)"
+
+
+def edit_item_body(ssot: dict[str, Any], item_id: str, body: str) -> tuple[bool, str]:
+    project_id = str(ssot["project_id"])
+    proc = run_gh(
+        [
+            "project",
+            "item-edit",
+            "--project-id",
+            project_id,
+            "--id",
+            item_id,
+            "--body",
+            body,
+        ]
+    )
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "gh project item-edit --body failed").strip()
+    return True, "ok"
+
+
+def set_item_status(ssot: dict[str, Any], item_id: str, logical: str) -> tuple[bool, str]:
+    try:
+        option_id = resolve_status_option_id(ssot, logical)
+        field_id = status_field_id(ssot)
+    except KeyError as exc:
+        return False, str(exc)
+    project_id = str(ssot["project_id"])
+    proc = run_gh(
+        [
+            "project",
+            "item-edit",
+            "--project-id",
+            project_id,
+            "--id",
+            item_id,
+            "--field-id",
+            field_id,
+            "--single-select-option-id",
+            option_id,
+        ]
+    )
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "gh project item-edit failed").strip()
+    return True, option_id
+
+
+def build_export_snapshot(ssot: dict[str, Any], items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Read-only snapshot shape for project export / DRIFT-010."""
+    out_items: list[dict[str, Any]] = []
+    for item in items:
+        body = _item_body(item)
+        excerpt = body if len(body) <= 500 else body[:497] + "..."
+        out_items.append(
+            {
+                "id": item.get("id"),
+                "title": _item_title(item),
+                "status": item.get("status"),
+                "status_normalized": _normalize_status(str(item.get("status") or "")),
+                "priority": item.get("priority"),
+                "size": item.get("size"),
+                "body_excerpt": excerpt,
+                "updated_at": item.get("updatedAt") or item.get("updated_at"),
+            }
+        )
+    return {
+        "schema": "project-board-snapshot/v1",
+        "project": {
+            "name": ssot.get("name"),
+            "owner": ssot.get("owner"),
+            "number": ssot.get("number"),
+            "url": ssot.get("url"),
+            "project_id": ssot.get("project_id"),
+            "default_repo": ssot.get("default_repo"),
+        },
+        "items": out_items,
+        "totalCount": len(out_items),
+    }
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project get: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project get: FAIL — {e}", file=sys.stderr)
+        return 2
+    items, err = fetch_project_items(ssot, limit=args.limit)
+    if err:
+        print(f"project get: FAIL — {err}", file=sys.stderr)
+        return 1
+    item = find_item_by_id(items, args.id)
+    if item is None:
+        print(f"project get: FAIL — item not found: {args.id}", file=sys.stderr)
+        return 1
+    payload = {
+        "id": item.get("id"),
+        "title": _item_title(item),
+        "status": item.get("status"),
+        "priority": item.get("priority"),
+        "size": item.get("size"),
+        "body": _item_body(item),
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"id: {payload['id']}")
+        print(f"title: {payload['title']}")
+        print(f"status: {payload['status']}")
+        print(f"priority: {payload['priority']}")
+        print(f"size: {payload['size']}")
+        print("--- body ---")
+        print(payload["body"] or "(empty)")
+    return 0
+
+
+def cmd_append_notes(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project append-notes: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project append-notes: FAIL — {e}", file=sys.stderr)
+        return 2
+    items, err = fetch_project_items(ssot, limit=args.limit)
+    if err:
+        print(f"project append-notes: FAIL — {err}", file=sys.stderr)
+        return 1
+    item = find_item_by_id(items, args.id)
+    if item is None:
+        print(f"project append-notes: FAIL — item not found: {args.id}", file=sys.stderr)
+        return 1
+    body = _item_body(item)
+    new_body, changed = append_notes_to_body(body, args.text)
+    if not changed:
+        print(f"append-notes: {args.id} — already present (idempotent skip)")
+        return 0
+    ok, detail = edit_item_body(ssot, args.id, new_body)
+    if not ok:
+        print(f"project append-notes: FAIL — {detail}", file=sys.stderr)
+        return 1
+    print(f"append-notes: {args.id} — updated")
+    return 0
+
+
+def cmd_find_by_pr(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project find-by-pr: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project find-by-pr: FAIL — {e}", file=sys.stderr)
+        return 2
+    item_id, candidates, err = resolve_item_id_for_pr(
+        ssot, pr=args.pr, repo=args.repo or None, limit=args.limit
+    )
+    payload = {
+        "item_id": item_id,
+        "candidates": candidates,
+        "error": err,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        if item_id:
+            print(item_id)
+        else:
+            print(f"project find-by-pr: FAIL — {err}", file=sys.stderr)
+            if candidates:
+                print("candidates:", ", ".join(candidates), file=sys.stderr)
+            return 1
+    return 0 if item_id else 1
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    """Read-only snapshot — never mutates the board."""
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project export: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project export: FAIL — {e}", file=sys.stderr)
+        return 2
+    items, err = fetch_project_items(ssot, limit=args.limit)
+    if err:
+        print(f"project export: FAIL — {err}", file=sys.stderr)
+        return 1
+    snapshot = build_export_snapshot(ssot, items)
+    text = json.dumps(snapshot, indent=2) + "\n"
+    if args.stdout:
+        print(text, end="")
+        return 0
+    out_path = Path(args.output) if args.output else (
+        root / ".local" / "generated-data" / "project-board-snapshot.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    print(f"Wrote {out_path} ({snapshot['totalCount']} items)")
+    if args.json:
+        print(text, end="")
+    return 0
+
+
 def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     project = sub.add_parser(
         "project",
@@ -393,3 +791,44 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     set_field.add_argument("--field", required=True, choices=("priority", "size"))
     set_field.add_argument("--to", required=True, help="e.g. p1 or s")
     set_field.set_defaults(func=cmd_set_field)
+
+    get_cmd = project_sub.add_parser("get", help="Get one project item by id")
+    get_cmd.add_argument("--directory", type=Path, default=".")
+    get_cmd.add_argument("--id", required=True, help="Project item id (PVTI_…)")
+    get_cmd.add_argument("--limit", type=int, default=100)
+    get_cmd.add_argument("--json", action="store_true")
+    get_cmd.set_defaults(func=cmd_get)
+
+    notes_cmd = project_sub.add_parser(
+        "append-notes", help="Append a line under ## Notes on the card body"
+    )
+    notes_cmd.add_argument("--directory", type=Path, default=".")
+    notes_cmd.add_argument("--id", required=True)
+    notes_cmd.add_argument("--text", required=True)
+    notes_cmd.add_argument("--limit", type=int, default=100)
+    notes_cmd.set_defaults(func=cmd_append_notes)
+
+    find_cmd = project_sub.add_parser(
+        "find-by-pr", help="Resolve project item id from PR (Board-Item or body scan)"
+    )
+    find_cmd.add_argument("--directory", type=Path, default=".")
+    find_cmd.add_argument("--pr", required=True, help="PR number or URL")
+    find_cmd.add_argument("--repo", default="", help="owner/repo (defaults to project_ssot.default_repo)")
+    find_cmd.add_argument("--limit", type=int, default=100)
+    find_cmd.add_argument("--json", action="store_true")
+    find_cmd.set_defaults(func=cmd_find_by_pr)
+
+    export_cmd = project_sub.add_parser(
+        "export", help="Read-only board snapshot (never mutates Status)"
+    )
+    export_cmd.add_argument("--directory", type=Path, default=".")
+    export_cmd.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: .local/generated-data/project-board-snapshot.json)",
+    )
+    export_cmd.add_argument("--limit", type=int, default=100)
+    export_cmd.add_argument("--json", action="store_true", help="Also print JSON to stdout")
+    export_cmd.add_argument("--stdout", action="store_true", help="Print JSON only (no file write)")
+    export_cmd.set_defaults(func=cmd_export)

--- a/payload/.ai_infra/scripts/pr/merge.py
+++ b/payload/.ai_infra/scripts/pr/merge.py
@@ -1,18 +1,20 @@
 """
 File: merge.py
 Path: .ai_infra/scripts/pr/merge.py
-Role: Verifies merge prerequisites and writes merge summary artifact.
+Role: Verifies merge prerequisites and writes merge summary artifact; optional board SSOT close.
 Used By:
  - .agents/skills/merge-pr/SKILL.md
 Depends On:
  - argparse
  - pathlib
  - scripts/pr/local_workflow_paths.py
+ - .ai_infra/install/cursor_workflow/project_cli.py (board sync when project_ssot enabled)
 Notes:
  - This script does not perform git merge; it verifies readiness and logs evidence.
  - Call AFTER gh pr merge with --merge-sha <oid> so the artifact records the correct merge commit.
  - --branch is optional; if omitted the script reads the current git branch.
  - Checks for alignment artifact presence when --arch-impacting flag is set.
+ - When project_ssot is operational, sets card Status → done and appends Notes (non-blocking on failure).
 """
 
 from __future__ import annotations
@@ -23,8 +25,12 @@ import sys
 from pathlib import Path
 
 _PR_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _PR_DIR.parents[2]
+_INSTALL_CW = _REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
 if str(_PR_DIR) not in sys.path:
     sys.path.insert(0, str(_PR_DIR))
+if _INSTALL_CW.is_dir() and str(_INSTALL_CW) not in sys.path:
+    sys.path.insert(0, str(_INSTALL_CW))
 
 from local_workflow_paths import (
     ALIGNMENT_AUDIT_MD,
@@ -67,6 +73,90 @@ def _artifact_matches_pr(file_path: Path, pr_ref: str) -> tuple[bool, str]:
     return True, "ok"
 
 
+def _pr_url(root: Path, pr: str, default_repo: str = "") -> str:
+    """Best-effort PR URL for Notes."""
+    pr_number = pr.rstrip("/").split("/")[-1] if "/" in pr else pr.lstrip("#")
+    if pr.startswith("http"):
+        return pr
+    repo = default_repo
+    if not repo:
+        proc = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            repo = proc.stdout.strip()
+    if repo:
+        return f"https://github.com/{repo}/pull/{pr_number}"
+    return f"PR #{pr_number}"
+
+
+def sync_board_after_merge(
+    *,
+    root: Path,
+    pr: str,
+    merge_sha: str,
+    item_id: str | None = None,
+    skip: bool = False,
+) -> str:
+    """
+    Set project card to done and append merge Notes when project_ssot is operational.
+    Returns a short status line for merge.md. Never raises for board failures.
+    """
+    if skip:
+        return "board sync: skipped (--skip-board-sync)"
+    try:
+        import project_cli
+    except ImportError:
+        return "board sync: skipped (project_cli unavailable)"
+
+    ssot, errs = project_cli.load_project_ssot(root)
+    if errs or ssot is None:
+        return "board sync: skipped (no project_ssot config)"
+    enabled_errs = project_cli.require_enabled(ssot)
+    if enabled_errs:
+        return "board sync: skipped (project_ssot not operational)"
+
+    resolved = item_id
+    candidates: list[str] = []
+    if not resolved:
+        resolved, candidates, find_err = project_cli.resolve_item_id_for_pr(
+            ssot, pr=pr, repo=str(ssot.get("default_repo") or "") or None
+        )
+        if not resolved:
+            detail = find_err or "no item"
+            if candidates:
+                detail += f"; candidates={','.join(candidates)}"
+            print(f"[WARN] board sync: {detail}", file=sys.stderr)
+            return f"board sync: warn — {detail}"
+
+    conventions = ssot.get("conventions") or {}
+    done_logical = str(conventions.get("done_status") or "done")
+    ok, detail = project_cli.set_item_status(ssot, resolved, done_logical)
+    if not ok:
+        print(f"[WARN] board sync set-status failed: {detail}", file=sys.stderr)
+        return f"board sync: warn — set-status failed ({detail})"
+
+    pr_url = _pr_url(root, pr, str(ssot.get("default_repo") or ""))
+    note = f"Merged: {pr_url} @ {merge_sha}"
+    items, list_err = project_cli.fetch_project_items(ssot, limit=100)
+    if list_err:
+        print(f"[WARN] board sync append-notes list failed: {list_err}", file=sys.stderr)
+        return f"board sync: status→{done_logical} on {resolved}; notes warn ({list_err})"
+    item = project_cli.find_item_by_id(items, resolved)
+    body = project_cli._item_body(item) if item else ""
+    new_body, changed = project_cli.append_notes_to_body(body, note)
+    if changed:
+        nok, ndetail = project_cli.edit_item_body(ssot, resolved, new_body)
+        if not nok:
+            print(f"[WARN] board sync append-notes failed: {ndetail}", file=sys.stderr)
+            return f"board sync: status→{done_logical} on {resolved}; notes warn ({ndetail})"
+    print(f"[PASS] board sync: {resolved} → {done_logical}; Notes updated")
+    return f"board sync: {resolved} → {done_logical}; Notes: {note}"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Verify merge readiness and emit merge artifact.")
     parser.add_argument("--pr", required=True, help="PR number or URL")
@@ -98,6 +188,17 @@ def main() -> int:
             "Run prerequisite checks only and do not write workflow merge.md. "
             "Use this for pre-merge validation."
         ),
+    )
+    parser.add_argument(
+        "--item-id",
+        default=None,
+        help="Project item id (PVTI_…) to close after merge; else find-by-pr / Board-Item.",
+    )
+    parser.add_argument(
+        "--skip-board-sync",
+        action="store_true",
+        default=False,
+        help="Do not update GitHub Project Status/Notes after merge.",
     )
     args = parser.parse_args()
 
@@ -155,6 +256,14 @@ def main() -> int:
     merge_sha = args.merge_sha or _head_sha()
     sha_source = "provided" if args.merge_sha else "git HEAD (fallback — prefer passing --merge-sha)"
 
+    board_line = sync_board_after_merge(
+        root=Path.cwd(),
+        pr=args.pr,
+        merge_sha=merge_sha,
+        item_id=args.item_id,
+        skip=args.skip_board_sync,
+    )
+
     merge_file.write_text(
         "\n".join(
             [
@@ -176,9 +285,11 @@ def main() -> int:
                 "## Merge Summary",
                 f"- merge SHA: {merge_sha} ({sha_source})",
                 "- merge execution: completed via gh pr merge",
+                f"- {board_line}",
                 "",
                 "## Agent Notes",
                 "- (agent: add merge method, checks used as evidence, and follow-up work items below)",
+                f"- {board_line}",
             ]
         )
         + "\n",

--- a/payload/.ai_infra/scripts/workflow/drift_checks.py
+++ b/payload/.ai_infra/scripts/workflow/drift_checks.py
@@ -1,7 +1,7 @@
 """
 File: drift_checks.py
 Path: .ai_infra/scripts/workflow/drift_checks.py
-Role: Individual DRIFT-001…008 check functions for workflow drift validation.
+Role: Individual DRIFT-001…010 check functions for workflow drift validation.
 Used By:
  - .ai_infra/scripts/workflow/check_drift.py
 Depends On:
@@ -420,6 +420,215 @@ def check_drift009(paths: DriftPaths) -> CheckResult:
     )
 
 
+def _load_board_snapshot(paths: DriftPaths) -> tuple[dict | None, str]:
+    """Load read-only export if present; else None + reason."""
+    snap = (
+        paths.root
+        / ".local"
+        / "generated-data"
+        / "project-board-snapshot.json"
+    )
+    if not snap.is_file():
+        return None, "no project-board-snapshot.json (run: python -m cursor_workflow project export)"
+    try:
+        import json
+
+        data = json.loads(snap.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return None, f"cannot read snapshot: {exc}"
+    if not isinstance(data, dict):
+        return None, "snapshot is not an object"
+    return data, "ok"
+
+
+def _open_pr_bodies(repo: str) -> tuple[list[dict], str | None]:
+    """Return open PRs as dicts with number, url, body — or error."""
+    import json
+    import subprocess
+
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number,url,body,title",
+        "--limit",
+        "50",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=45, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return [], str(exc)
+    if proc.returncode != 0:
+        return [], (proc.stderr or proc.stdout or "gh pr list failed").strip()
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], f"invalid JSON from gh pr list: {exc}"
+    if not isinstance(data, list):
+        return [], "gh pr list did not return a list"
+    return [p for p in data if isinstance(p, dict)], None
+
+
+def check_drift010(paths: DriftPaths) -> CheckResult:
+    """
+    Advisory: board Status vs open PRs / stale In progress (board_only).
+    Uses read-only snapshot when present; skips offline without failing P0.
+    """
+    collab = paths.root / ".local" / "user_settings" / "github.collaboration.yaml"
+    if not collab.is_file():
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="no github.collaboration.yaml — skipped",
+        )
+    try:
+        import yaml
+    except ImportError:
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="PyYAML missing — skipped",
+        )
+    try:
+        data = yaml.safe_load(collab.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=False,
+            detail=f"cannot parse collab YAML: {exc}",
+        )
+    ssot = data.get("project_ssot") if isinstance(data, dict) else None
+    if not isinstance(ssot, dict) or not ssot.get("enabled"):
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="project_ssot disabled or absent — skipped",
+        )
+    policy = str(ssot.get("sync_policy") or "")
+    if policy != "board_only":
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"sync_policy={policy!r} — board/PR check skipped",
+        )
+
+    snapshot, snap_detail = _load_board_snapshot(paths)
+    if snapshot is None:
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"skipped — {snap_detail}",
+        )
+
+    items = snapshot.get("items") if isinstance(snapshot.get("items"), list) else []
+    repo = str(ssot.get("default_repo") or "")
+    if not repo:
+        proj = snapshot.get("project") if isinstance(snapshot.get("project"), dict) else {}
+        repo = str(proj.get("default_repo") or "")
+
+    open_prs: list[dict] = []
+    pr_err: str | None = None
+    if repo:
+        open_prs, pr_err = _open_pr_bodies(repo)
+        if pr_err:
+            return CheckResult(
+                check_id="DRIFT-010",
+                severity=Severity.P1,
+                passed=True,
+                detail=f"skipped — cannot list open PRs: {pr_err}",
+            )
+
+    # Build set of Board-Item ids referenced by open PRs + PR numbers mentioned
+    open_item_ids: set[str] = set()
+    open_pr_nums: set[str] = set()
+    for pr in open_prs:
+        open_pr_nums.add(str(pr.get("number") or ""))
+        body = str(pr.get("body") or "")
+        m = re.search(r"(?i)Board-Item:\s*(PVTI_[A-Za-z0-9_-]+)", body)
+        if m:
+            open_item_ids.add(m.group(1))
+
+    findings: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id") or "")
+        status = str(
+            item.get("status_normalized")
+            or str(item.get("status") or "").strip().lower().replace(" ", "_")
+        )
+        title = str(item.get("title") or item_id)
+        excerpt = str(item.get("body_excerpt") or "")
+
+        if status == "in_review":
+            # In review should have an open PR referencing this item or mentioning the card
+            linked = item_id in open_item_ids
+            mentioned = any(
+                f"/pull/{n}" in excerpt or f"#{n}" in excerpt for n in open_pr_nums if n
+            )
+            if open_prs and not linked and not mentioned:
+                # Also OK if any open PR body mentions this item id
+                if not any(item_id and item_id in str(p.get("body") or "") for p in open_prs):
+                    findings.append(f"in_review without open PR: {title} ({item_id})")
+
+        if status == "in_progress":
+            # Stale if no open PR references this card and Notes lack a recent handoff marker
+            linked = item_id in open_item_ids
+            has_pr_mention = any(
+                f"/pull/{n}" in excerpt or f"#{n}" in excerpt for n in open_pr_nums if n
+            )
+            if open_prs is not None and repo and not linked and not has_pr_mention:
+                # Soft stale signal: In progress with no PR link when repo has open PRs elsewhere
+                # Only flag when there are open PRs in the repo but none tied to this card —
+                # and excerpt has no "next=" handoff (still actively worked mid-slice is OK).
+                if "next=" not in excerpt.lower() and "Merged:" not in excerpt:
+                    # Don't flag every In progress — only when excerpt looks abandoned (empty Notes)
+                    if not excerpt.strip() or excerpt.strip() in ("...", "(TBD)"):
+                        findings.append(
+                            f"stale in_progress (empty Notes, no open PR link): {title} ({item_id})"
+                        )
+
+    # Merged-but-not-Done is hard without merged PR list; use Notes heuristic:
+    # if Status still in_review/in_progress but body has Merged: line → drift
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = str(
+            item.get("status_normalized")
+            or str(item.get("status") or "").strip().lower().replace(" ", "_")
+        )
+        excerpt = str(item.get("body_excerpt") or "")
+        if status in ("in_review", "in_progress") and "Merged:" in excerpt:
+            findings.append(
+                f"merged-but-not-done: {item.get('title')} ({item.get('id')})"
+            )
+
+    if not findings:
+        return CheckResult(
+            check_id="DRIFT-010",
+            severity=Severity.P1,
+            passed=True,
+            detail="board Status vs open PRs — no mismatches",
+        )
+    return CheckResult(
+        check_id="DRIFT-010",
+        severity=Severity.P1,
+        passed=False,
+        detail="; ".join(findings[:5]) + (f" (+{len(findings) - 5} more)" if len(findings) > 5 else ""),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_drift001,
     check_drift002,
@@ -430,6 +639,7 @@ KIT_DEV_CHECKS = (
     check_drift007,
     check_drift008,
     check_drift009,
+    check_drift010,
 )
 
 CONSUMER_CHECKS = (

--- a/payload/.cursor/agents/enterprise-auditor.md
+++ b/payload/.cursor/agents/enterprise-auditor.md
@@ -8,9 +8,11 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice; else `session-pointer.md` + `change-index.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice (claim/create audit card if missing); else `session-pointer.md` + `change-index.md`.
 
-**Exit:** Update alignment artifacts + `change-index.md`; one line in `updates-log.md`. Optionally set board Status to `in_review`/`done` for the audit card. **Dashboard:** ICC still reads `.local/workflow-artifacts/` — list required sync actions in `enterprise-audit-actions.md` for **implementer** (prefer board Status over dual-writing trackers when `board_only`).
+**Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+
+**Board rights:** Status + Notes on **audit card** required on Exit. No Priority reshuffle; no Project views/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -16,10 +16,12 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Exit (board-first when enabled):**
 
-1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open) or `--to done` (slice closed).
+1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed). Put next agent in card Notes when handing off.
 2. Append `change-index.md`; one line in `history/updates-log.md`.
 3. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-4. Say *prepare gates green* — do not paste full `GATES`.
+4. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+
+**Board rights:** claim Ready→In progress; In review on PR; Done on close; Priority/Size on **own** card; may create slice cards. **Exit Status update is mandatory** for continuation. Do **not** edit Project views/workflows/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 

--- a/payload/.cursor/agents/integrator-mas-agent.md
+++ b/payload/.cursor/agents/integrator-mas-agent.md
@@ -14,9 +14,11 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Else `session-pointer.md` then integration skill.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card. Else `session-pointer.md` then integration skill.
 
-**Exit:** Board Status for the integration card when enabled; append `change-index.md` (Agent: `integrator-mas-agent`); one line in `updates-log.md`. No dual-write under `board_only`. Run verification commands; say outcomes — do not paste full gate lists.
+**Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+
+**Board rights:** Create integration cards; claim→Done; fields on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## Read first (evidence before edits)
 

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -8,9 +8,11 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 ## Anchor (mandatory)
 
-**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/project-board-ssot/SKILL.md`. Run `python -m cursor_workflow project status`.
+**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/project-board-ssot/SKILL.md`. Run `python -m cursor_workflow project status` + `project list`.
 
-**Exit:** Board Status updated via CLI; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+**Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+
+**Board rights:** Full triage — create cards; any Status; Priority/Size. Own Ready queue hygiene so other agents can claim. Never edit Project views/workflows/README/Insights. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 ## Role
 

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -8,9 +8,11 @@ description: Optional local research corpus; hard-stop on product code without e
 
 ## Anchor (mandatory)
 
-**Entry:** When coordinating with implement slices: if `project_ssot.enabled` note board card context via `project status`; else `session-pointer.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
 
-**Exit:** Research-only — update research corpus indexes; do not mutate board Status or `session-pointer` unless user expands scope.
+**Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
+
+**Board rights:** Always **read** board when enabled. **Update** only your research card on Exit. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -8,9 +8,11 @@ description: Module-focused tests, regressions, coverage.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card; else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
 
-**Exit:** Board Status via CLI when enabled (`in_review`/`done` as appropriate); update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write of tracker SSOT under `board_only`.
+**Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+
+**Board rights:** Stay on the slice card; Exit Status update required for continuation. Priority/Size only on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -8,9 +8,11 @@ description: Claims vs evidence; minimal high-signal checks.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card; else `session-pointer.md`. Always read claims to verify against evidence.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card (read Notes for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
 
-**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review`); update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+
+**Board rights:** Confirm Done or leave In review + Notes. Do **not** create cards or reshuffle Priority. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.

--- a/payload/.cursor/agents/workflow-drift-guard.md
+++ b/payload/.cursor/agents/workflow-drift-guard.md
@@ -8,24 +8,27 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (board vs tracker dual-write context); else `session-pointer.md`.
+**Entry:** If `project_ssot.enabled` → **must** `python -m cursor_workflow project status` and `project list --status in_progress` (board vs tracker dual-write context; cite board Status in findings). Else `session-pointer.md`.
 
-**Exit:** Write drift artifacts only; one line in `updates-log.md` when audit completes. Do **not** auto-edit `plan.md` or `work-tracker.md`. Do not invent board Status changes unless the user asks.
+**Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+
+**Board rights:** **Read** board every pass. **Update** Status on the drift-pass card when finished. Remediation = Notes / Ready handoff, not silent tracker writes. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** when project SSOT enabled).
-3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog.
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** when project SSOT enabled; prefer a fresh `project export` snapshot for DRIFT-010).
+3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
 4. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
 5. Do not duplicate governance, integrate, or enterprise-auditor scope (ADR-007 / ADR-008).
 
 ## Read first
 
 - `.cursor/skills/workflow-drift-audit/SKILL.md` — full protocol
+- `.cursor/skills/project-board-ssot/SKILL.md` — when `project_ssot.enabled`
 - `.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md`
 - `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md` (when project_ssot enabled)
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only for context; fallback SSOT)
+- Fallback only: `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only)
 
 ## Write (mandatory)
 
@@ -34,14 +37,14 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Handoff format
 
-Profile • P0/P1/P2 counts • artifact paths • blockers • suggested next agent (implementer / verifier)
+drift profile • P0/P1/P2 counts • board Status cited • item_id (if any) · next=project-board|implementer|…
 
 ## MCP integration
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | `workflow_drift_validate`, trackers — prefer over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `workflow-kit` | Trackers/gates — prefer scripts |
+| External | See `.cursor/mcp.registry.yaml` | Only if listed for this agent |
 
 Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -5,11 +5,14 @@ alwaysApply: true
 
 # Project SSOT precedence (experiment)
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is backlog/status SSOT.
-- Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md`). Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009 guards dual-write).
+- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
+- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+- **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
+- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- PR Pattern A (`prepare.py` GATES), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `HANDOFF.md`.
+- PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
+- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
+- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
-- Keep this file out of marketplace `payload/.cursor/rules/` until production port (install via `overlays/rules/` copy into `.cursor/rules/` only).

--- a/payload/.cursor/skills/enterprise-architecture-audit/SKILL.md
+++ b/payload/.cursor/skills/enterprise-architecture-audit/SKILL.md
@@ -84,7 +84,7 @@ Evidence-Standard: repository + user context only
 
 **Downstream agents:**
 
-- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items into `work-tracker.md` (one primary `in_progress` task). Follow `.cursor/skills/implementation-execution-loop/SKILL.md`.
+- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items onto **board Ready cards** when `project_ssot.enabled` (Acceptance/Rollback in body); else `work-tracker.md` (one primary `in_progress`). Follow `.cursor/skills/implementation-execution-loop/SKILL.md` + `project-board-ssot` Continuation contract.
 - **Alignment / maintainer:** if findings are doc-policy-roadmap drift, also record P0/P1 items per `.ai_infra/docs/roadmap/alignment-audit-schema.md` in `.local/workflow-artifacts/alignment/alignment-audit.md` and `alignment-todos.md` (advisory).
 - **Module map depth:** optionally run `.cursor/skills/audit-module-map/SKILL.md` for `module-map` / HTML export; cite those paths as evidence in the enterprise report.
 

--- a/payload/.cursor/skills/implementation-execution-loop/SKILL.md
+++ b/payload/.cursor/skills/implementation-execution-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-execution-loop
-description: Disciplined implementation slices with tracker updates and handoff.
+description: Disciplined implementation slices with board SSOT continuation and Pattern A gates.
 ---
 
 # Implementation execution loop
@@ -11,7 +11,7 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Inputs
 
-- **When `project_ssot.enabled`:** `.local/user_settings/github.collaboration.yaml` + `.cursor/skills/project-board-ssot/SKILL.md` + board card (Acceptance/Rollback in body)
+- **When `project_ssot.enabled`:** `.local/user_settings/github.collaboration.yaml` + `.cursor/skills/project-board-ssot/SKILL.md` (§ Continuation contract) + board card (Acceptance/Rollback/Notes in body)
 - **Fallback:** `.local/index-and-planning/current/plan.md`, `work-tracker.md`, `session-pointer.md`
 - Project `docs/architecture/` (stub under `.local/.../current/` if present)
 - Test trackers when tests change: `test-plan.md`, `test-index.md`
@@ -21,12 +21,12 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 ## Steps
 
 1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`set-status --to in_progress`). Else read plan + tracker; one task `in_progress` locally.
-2. Document acceptance + rollback on **card body** (or `plan.md` if fallback).
+2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
-6. **Close:** board `set-status --to in_review|done` when SSOT enabled; do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts.
+6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · next=…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
 ## Output
 
-Slice • item_id (if board) • modules/files • gates outcome • blockers • next step
+Slice • item_id • Status before→after • modules/files • gates outcome • blockers • next agent

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -6,63 +6,133 @@ description: Drive GitHub Project SSOT via project_ssot YAML and cursor_workflow
 <!--
 File: SKILL.md
 Path: .cursor/skills/project-board-ssot/SKILL.md
-Role: Procedural skill for board-first backlog/status using project_ssot settings.
+Role: Procedural skill for board-first backlog/status + multi-agent continuation on the Project.
 Used By:
  - .cursor/agents/project-board.md
- - implementer and other agents when project_ssot.enabled
+ - All kit agents when project_ssot.enabled
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:
  - Pattern A: one CLI command per action; no dual-write of work-tracker when board_only.
+ - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
 -->
 
 # Project board SSOT
 
 ## Goal
 
-Use the GitHub Project configured in **`project_ssot`** (`.local/user_settings/github.collaboration.yaml`) as backlog/status SSOT. Prefer CLI over inventing `gh` flags.
+When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Project as the **only writable SSOT** for backlog, Status, and multi-agent continuation. Prefer CLI over inventing `gh` flags. Local trackers are offline fallback only; read-only exports never compete with board Status.
 
 **Agent:** `.cursor/agents/project-board.md`  
+**Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
 **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+
+## Continuation contract (all agents — non-negotiable when enabled)
+
+Work is **indexed on the Project**, not in chat alone.
+
+| Phase | Required |
+|-------|----------|
+| **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
+| **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Print handoff line. |
+| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. |
+
+Handoff line (chat + optional card Notes):
+
+```text
+item_id=PVTI_… · title=… · Status=before→after · next=implementer|verifier|test-runner|…
+```
 
 ## When to use
 
-- Triage Ready / P0–P1 work from the shared board
-- Create DraftIssue cards with Acceptance / Rollback / Notes
-- Move Status (Ready → In progress → In review → Done)
-- Set Priority or Size from YAML option ids
+- Any session where `project_ssot.enabled: true`
+- Triage, create, claim, Priority/Size, Status transitions
+- Multi-agent handoffs (implementer → test-runner → verifier, etc.)
 
 ## Evidence contract
 
 - Cite CLI output or `gh project` JSON for claims.
-- Label **Unknown** when board unreachable.
+- Label **Unknown** when board unreachable → then `fallback: local_trackers` only.
 
-## Procedure
+## Collaboration
+
+### Human vs agent vs GitHub
+
+| Surface | Human | Agents | Derived |
+|---------|-------|--------|---------|
+| Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
+| Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
+| Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
+| My items | Assign in UI | Claim = Status In progress (assignee CLI TBD) | View filter |
+| PR gates, audits, secrets | Local | Local (`local_only`) | — |
+
+### Rules
+
+1. One primary **In progress** per assignee — do not steal others'.
+2. Pull from **Ready** or continue your In progress.
+3. Acceptance / Rollback / Notes on **card body** = continuation index.
+4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
+5. Humans own views, workflows, README, Insights, status updates.
+6. Read-only `project export` (if used) never writes Status.
+7. Post-merge Done is Pattern A (`merge.py`), not a dedicated agent.
+
+### Per-agent rights (what / when / where)
+
+| Agent | Entry (read board) | Exit (must update board) | Local writes |
+|-------|--------------------|--------------------------|--------------|
+| **project-board** | status + list | create/move any Status; Priority/Size; hand off to implementer | change-index, updates-log |
+| **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
+| **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
+| **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
+| **integrator-mas-agent** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
+| **enterprise-auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
+| **workflow-drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to project-board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
+| **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |
+
+### Status path
+
+```text
+Ready → In progress → In review → Done
+```
+
+| Moment | Actor | CLI |
+|--------|-------|-----|
+| Start work | implementer / integrator / test-runner / project-board | `set-status --to in_progress` |
+| PR open / peer handoff | implementer | `set-status --to in_review` |
+| Part verified closed | implementer / verifier / test-runner | `set-status --to done` |
+| Drift / audit pass closed | drift-guard / auditor | `set-status --to done` (their card) |
+| Queue triage | project-board or human | create / set-status / set-field |
+
+## Procedure (CLI)
 
 1. **Status:** `python -m cursor_workflow project status --directory .`
-   - Exit 2 / disabled → use local trackers only (`fallback: local_trackers`); do not invent board ids.
-2. **List queue:** `python -m cursor_workflow project list --status ready --directory .`
-3. **Claim:** `python -m cursor_workflow project set-status --id PVTI_… --to in_progress --directory .`
-   - Respect `conventions.one_in_progress_per_assignee` (do not steal others' In progress).
-4. **Create:** `python -m cursor_workflow project create --title "…" [--body "…"] --directory .`
-5. **Priority/Size:** `python -m cursor_workflow project set-field --id PVTI_… --field priority --to p1 --directory .`
-6. **Close:** `python -m cursor_workflow project set-status --id PVTI_… --to done --directory .` (or `in_review` when PR open)
-7. **Verify:** re-run `project list` or `gh project item-list` — Status matches intent.
+2. **List:** `python -m cursor_workflow project list [--status ready|in_progress|in_review] --directory .`
+3. **Claim:** `set-status --id PVTI_… --to in_progress`
+4. **Create:** `project create --title "…" [--body "…"]`
+5. **Fields:** `set-field --id … --field priority|size --to …`
+6. **Close / handoff:** `set-status --to in_review|done`
+7. **Verify:** `project list` matches intent + handoff line printed
 
 ## Dual-write ban
 
-When `sync_policy: board_only`, do **not** also mark the same slice `in_progress` in `work-tracker.md` as competing SSOT. PR artifacts / audits stay local (`local_only`).
+When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local (`local_only`).
 
 ## Exit criteria
 
-- [ ] `project status` shows `operational: True` (or explicit fallback)
-- [ ] Status change confirmed on the board
-- [ ] No dual-write of tracker SSOT
+- [ ] Entry read board (or explicit offline fallback)
+- [ ] Exit updated Status (or Notes + next agent if still In progress)
+- [ ] Handoff line printed when another agent continues
+- [ ] No dual-write; no edits to Project views/workflows/README/Insights
 
 ## Anti-patterns
 
-- Hardcoding field/option ids instead of reading YAML
-- Bypassing `prepare.py` gates
-- Adding this flow to production `mas-workflow-kit` without port gate
+- Chat-only completion with stale board Status
+- Hardcoding field/option ids
+- Reshuffling Ready/P0 without human or project-board ask
+- Editing Project views, workflows, Insights, or status updates
+- Dual-write board + tracker under `board_only`
+- Port to production kit without PORT-GATE

--- a/payload/.cursor/skills/workflow-drift-audit/SKILL.md
+++ b/payload/.cursor/skills/workflow-drift-audit/SKILL.md
@@ -19,20 +19,23 @@ Notes:
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
+Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
 
 ## When
 
 - Substantive implementer slice closure (recommended)
 - Optional pre-review drift pass before PR workflow
 - After tracker or handoff doc edits
+- When `project_ssot.enabled` — every pass should include board Status evidence
 
 ## Steps
 
-1. **Script first:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer` (no agent required before the script). Include **DRIFT-009** when `project_ssot` board_only is enabled (ADR-008).
-2. Capture profile, check IDs, severities, and details from output.
-3. Write artifacts under `.local/workflow-artifacts/drift/` only.
-4. Do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+3. Capture profile, check IDs, severities, and details from output.
+4. Write artifacts under `.local/workflow-artifacts/drift/` only.
+5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to project-board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+6. Print handoff line with `item_id` when applicable.
 
 ## Evidence contract
 

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -5,11 +5,14 @@ alwaysApply: true
 
 # Project SSOT precedence (experiment)
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is backlog/status SSOT.
-- Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md`). Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009 guards dual-write).
+- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
+- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+- **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
+- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- PR Pattern A (`prepare.py` GATES), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `HANDOFF.md`.
+- PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
+- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
+- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
-- Keep this file out of marketplace `payload/.cursor/rules/` until production port (install via `overlays/rules/` copy into `.cursor/rules/` only).

--- a/skills/enterprise-architecture-audit/SKILL.md
+++ b/skills/enterprise-architecture-audit/SKILL.md
@@ -84,7 +84,7 @@ Evidence-Standard: repository + user context only
 
 **Downstream agents:**
 
-- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items into `work-tracker.md` (one primary `in_progress` task). Follow `.cursor/skills/implementation-execution-loop/SKILL.md`.
+- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items onto **board Ready cards** when `project_ssot.enabled` (Acceptance/Rollback in body); else `work-tracker.md` (one primary `in_progress`). Follow `.cursor/skills/implementation-execution-loop/SKILL.md` + `project-board-ssot` Continuation contract.
 - **Alignment / maintainer:** if findings are doc-policy-roadmap drift, also record P0/P1 items per `.ai_infra/docs/roadmap/alignment-audit-schema.md` in `.local/workflow-artifacts/alignment/alignment-audit.md` and `alignment-todos.md` (advisory).
 - **Module map depth:** optionally run `.cursor/skills/audit-module-map/SKILL.md` for `module-map` / HTML export; cite those paths as evidence in the enterprise report.
 

--- a/skills/implementation-execution-loop/SKILL.md
+++ b/skills/implementation-execution-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-execution-loop
-description: Disciplined implementation slices with tracker updates and handoff.
+description: Disciplined implementation slices with board SSOT continuation and Pattern A gates.
 ---
 
 # Implementation execution loop
@@ -11,7 +11,7 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Inputs
 
-- **When `project_ssot.enabled`:** `.local/user_settings/github.collaboration.yaml` + `.cursor/skills/project-board-ssot/SKILL.md` + board card (Acceptance/Rollback in body)
+- **When `project_ssot.enabled`:** `.local/user_settings/github.collaboration.yaml` + `.cursor/skills/project-board-ssot/SKILL.md` (§ Continuation contract) + board card (Acceptance/Rollback/Notes in body)
 - **Fallback:** `.local/index-and-planning/current/plan.md`, `work-tracker.md`, `session-pointer.md`
 - Project `docs/architecture/` (stub under `.local/.../current/` if present)
 - Test trackers when tests change: `test-plan.md`, `test-index.md`
@@ -21,12 +21,12 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 ## Steps
 
 1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`set-status --to in_progress`). Else read plan + tracker; one task `in_progress` locally.
-2. Document acceptance + rollback on **card body** (or `plan.md` if fallback).
+2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
-6. **Close:** board `set-status --to in_review|done` when SSOT enabled; do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts.
+6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · next=…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
 ## Output
 
-Slice • item_id (if board) • modules/files • gates outcome • blockers • next step
+Slice • item_id • Status before→after • modules/files • gates outcome • blockers • next agent

--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -20,6 +20,9 @@ disable-model-invocation: true
 6. Note merge SHA: `gh api repos/.../pulls/<n> -q .merge_commit_sha` (or `gh pr view` if working).
 7. **Record:**  
    `python .ai_infra/scripts/pr/merge.py --pr <id|url> --pipeline default --merge-sha <sha>`  
+   Optional: `--item-id PVTI_…` when known; `--skip-board-sync` to bypass board close.  
+   When `project_ssot.enabled`, this sets the card → **Done** and appends Notes (`Merged: <PR URL> @ <sha>`). Failure is a **warn** only — merge artifact still writes.  
+   Prefer PR body line `- Board-Item: PVTI_…` under Collaboration so find-by-pr can resolve without `--item-id`.  
    (same `--arch-impacting` if used above). Enrich `merge.md` with method + follow-ups.
 8. **Finalize:** `git checkout main`; `python .ai_infra/scripts/pr/finalize.py --branch <branch>`; prune remotes; confirm feature branch gone on origin.
 

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -6,15 +6,15 @@ disable-model-invocation: true
 
 # PR workflow (maintainer)
 
-**Implementer work** (trackers, slices) uses `.local/index-and-planning/current/*`, `.cursor/agents/implementer.md`, and `.cursor/rules/implementation-workflow-governance.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
+**Implementer work:** when `project_ssot.enabled` + `board_only`, slice status lives on the **GitHub Project** (Entry/Exit continuation). Local `.local/index-and-planning/current/*` is offline fallback only — see ADR-008 and `project-ssot-precedence.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
 
 This skill is the **merge path** only: **review → prepare → merge** (slash skills: `review-pr`, `prepare-pr`, `merge-pr`).
 
 ## Order
 
-1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers changed. When scope is architecture-impacting, run **`enterprise-auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
-2. `prepare-pr` — tracker sync + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
-3. `merge-pr` — `merge.py` check, `gh pr merge`, finalize repo state.
+1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers/board status changed. When scope is architecture-impacting, run **`enterprise-auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
+2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
+3. `merge-pr` — `merge.py` check, `gh pr merge`, `merge.py --merge-sha` (sets board card → Done when SSOT on), finalize repo state.
 
 Per-step detail: `.agents/skills/review-pr/`, `prepare-pr/`, `merge-pr/`.
 

--- a/skills/prepare-pr/SKILL.md
+++ b/skills/prepare-pr/SKILL.md
@@ -13,7 +13,7 @@ disable-model-invocation: true
 1. `review.md` exists; clear BLOCKER/IMPORTANT items first.
 2. Alignment files present when required (authored via **`enterprise-auditor`** / `enterprise-architecture-audit` skill; see `advisory-audit-alignment-enforcement.mdc`); no open **P0** unless explicitly accepted.
 3. Fixes **only** in PR scope.
-4. Sync trackers when status changed — **`.local/index-and-planning/current/`**: `session-pointer.md`, `change-index.md`, `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md` when applicable.
+4. Status sync: when `project_ssot.enabled` and `sync_policy: board_only`, update **board Status/Notes only** — do **not** dual-write competing `in_progress` into local trackers. Local `.local/index-and-planning/current/` files are offline fallback / session pointer only. When SSOT is disabled or offline fallback is active, sync trackers as usual (`session-pointer.md`, `change-index.md`, `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md` when applicable).
 5. Run (owner from YAML; **Agent/s** auto-merges trackers + pipeline unless `--agents` set):  
    `python .ai_infra/scripts/pr/prepare.py --pr <id|url> --pipeline default`  
    Same **`--agents-from-session`** behavior as review — see **`pr-workflow/SKILL.md`**.  

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -6,63 +6,133 @@ description: Drive GitHub Project SSOT via project_ssot YAML and cursor_workflow
 <!--
 File: SKILL.md
 Path: .cursor/skills/project-board-ssot/SKILL.md
-Role: Procedural skill for board-first backlog/status using project_ssot settings.
+Role: Procedural skill for board-first backlog/status + multi-agent continuation on the Project.
 Used By:
  - .cursor/agents/project-board.md
- - implementer and other agents when project_ssot.enabled
+ - All kit agents when project_ssot.enabled
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:
  - Pattern A: one CLI command per action; no dual-write of work-tracker when board_only.
+ - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
 -->
 
 # Project board SSOT
 
 ## Goal
 
-Use the GitHub Project configured in **`project_ssot`** (`.local/user_settings/github.collaboration.yaml`) as backlog/status SSOT. Prefer CLI over inventing `gh` flags.
+When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Project as the **only writable SSOT** for backlog, Status, and multi-agent continuation. Prefer CLI over inventing `gh` flags. Local trackers are offline fallback only; read-only exports never compete with board Status.
 
 **Agent:** `.cursor/agents/project-board.md`  
+**Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
 **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+
+## Continuation contract (all agents — non-negotiable when enabled)
+
+Work is **indexed on the Project**, not in chat alone.
+
+| Phase | Required |
+|-------|----------|
+| **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
+| **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Print handoff line. |
+| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. |
+
+Handoff line (chat + optional card Notes):
+
+```text
+item_id=PVTI_… · title=… · Status=before→after · next=implementer|verifier|test-runner|…
+```
 
 ## When to use
 
-- Triage Ready / P0–P1 work from the shared board
-- Create DraftIssue cards with Acceptance / Rollback / Notes
-- Move Status (Ready → In progress → In review → Done)
-- Set Priority or Size from YAML option ids
+- Any session where `project_ssot.enabled: true`
+- Triage, create, claim, Priority/Size, Status transitions
+- Multi-agent handoffs (implementer → test-runner → verifier, etc.)
 
 ## Evidence contract
 
 - Cite CLI output or `gh project` JSON for claims.
-- Label **Unknown** when board unreachable.
+- Label **Unknown** when board unreachable → then `fallback: local_trackers` only.
 
-## Procedure
+## Collaboration
+
+### Human vs agent vs GitHub
+
+| Surface | Human | Agents | Derived |
+|---------|-------|--------|---------|
+| Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
+| Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
+| Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
+| My items | Assign in UI | Claim = Status In progress (assignee CLI TBD) | View filter |
+| PR gates, audits, secrets | Local | Local (`local_only`) | — |
+
+### Rules
+
+1. One primary **In progress** per assignee — do not steal others'.
+2. Pull from **Ready** or continue your In progress.
+3. Acceptance / Rollback / Notes on **card body** = continuation index.
+4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
+5. Humans own views, workflows, README, Insights, status updates.
+6. Read-only `project export` (if used) never writes Status.
+7. Post-merge Done is Pattern A (`merge.py`), not a dedicated agent.
+
+### Per-agent rights (what / when / where)
+
+| Agent | Entry (read board) | Exit (must update board) | Local writes |
+|-------|--------------------|--------------------------|--------------|
+| **project-board** | status + list | create/move any Status; Priority/Size; hand off to implementer | change-index, updates-log |
+| **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
+| **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
+| **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
+| **integrator-mas-agent** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
+| **enterprise-auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
+| **workflow-drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to project-board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
+| **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |
+
+### Status path
+
+```text
+Ready → In progress → In review → Done
+```
+
+| Moment | Actor | CLI |
+|--------|-------|-----|
+| Start work | implementer / integrator / test-runner / project-board | `set-status --to in_progress` |
+| PR open / peer handoff | implementer | `set-status --to in_review` |
+| Part verified closed | implementer / verifier / test-runner | `set-status --to done` |
+| Drift / audit pass closed | drift-guard / auditor | `set-status --to done` (their card) |
+| Queue triage | project-board or human | create / set-status / set-field |
+
+## Procedure (CLI)
 
 1. **Status:** `python -m cursor_workflow project status --directory .`
-   - Exit 2 / disabled → use local trackers only (`fallback: local_trackers`); do not invent board ids.
-2. **List queue:** `python -m cursor_workflow project list --status ready --directory .`
-3. **Claim:** `python -m cursor_workflow project set-status --id PVTI_… --to in_progress --directory .`
-   - Respect `conventions.one_in_progress_per_assignee` (do not steal others' In progress).
-4. **Create:** `python -m cursor_workflow project create --title "…" [--body "…"] --directory .`
-5. **Priority/Size:** `python -m cursor_workflow project set-field --id PVTI_… --field priority --to p1 --directory .`
-6. **Close:** `python -m cursor_workflow project set-status --id PVTI_… --to done --directory .` (or `in_review` when PR open)
-7. **Verify:** re-run `project list` or `gh project item-list` — Status matches intent.
+2. **List:** `python -m cursor_workflow project list [--status ready|in_progress|in_review] --directory .`
+3. **Claim:** `set-status --id PVTI_… --to in_progress`
+4. **Create:** `project create --title "…" [--body "…"]`
+5. **Fields:** `set-field --id … --field priority|size --to …`
+6. **Close / handoff:** `set-status --to in_review|done`
+7. **Verify:** `project list` matches intent + handoff line printed
 
 ## Dual-write ban
 
-When `sync_policy: board_only`, do **not** also mark the same slice `in_progress` in `work-tracker.md` as competing SSOT. PR artifacts / audits stay local (`local_only`).
+When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local (`local_only`).
 
 ## Exit criteria
 
-- [ ] `project status` shows `operational: True` (or explicit fallback)
-- [ ] Status change confirmed on the board
-- [ ] No dual-write of tracker SSOT
+- [ ] Entry read board (or explicit offline fallback)
+- [ ] Exit updated Status (or Notes + next agent if still In progress)
+- [ ] Handoff line printed when another agent continues
+- [ ] No dual-write; no edits to Project views/workflows/README/Insights
 
 ## Anti-patterns
 
-- Hardcoding field/option ids instead of reading YAML
-- Bypassing `prepare.py` gates
-- Adding this flow to production `mas-workflow-kit` without port gate
+- Chat-only completion with stale board Status
+- Hardcoding field/option ids
+- Reshuffling Ready/P0 without human or project-board ask
+- Editing Project views, workflows, Insights, or status updates
+- Dual-write board + tracker under `board_only`
+- Port to production kit without PORT-GATE

--- a/skills/workflow-drift-audit/SKILL.md
+++ b/skills/workflow-drift-audit/SKILL.md
@@ -19,20 +19,23 @@ Notes:
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
+Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
 
 ## When
 
 - Substantive implementer slice closure (recommended)
 - Optional pre-review drift pass before PR workflow
 - After tracker or handoff doc edits
+- When `project_ssot.enabled` — every pass should include board Status evidence
 
 ## Steps
 
-1. **Script first:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer` (no agent required before the script). Include **DRIFT-009** when `project_ssot` board_only is enabled (ADR-008).
-2. Capture profile, check IDs, severities, and details from output.
-3. Write artifacts under `.local/workflow-artifacts/drift/` only.
-4. Do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+3. Capture profile, check IDs, severities, and details from output.
+4. Write artifacts under `.local/workflow-artifacts/drift/` only.
+5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to project-board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+6. Print handoff line with `item_id` when applicable.
 
 ## Evidence contract
 

--- a/tests/modules/install/test_project_cli.py
+++ b/tests/modules/install/test_project_cli.py
@@ -141,3 +141,127 @@ def test_cmd_list_filters_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
     args = argparse.Namespace(directory=tmp_path, status="ready", limit=50, json=True)
     assert project_cli.cmd_list(args) == 0
+
+
+def test_append_notes_to_body_idempotent() -> None:
+    body, changed = project_cli.append_notes_to_body("", "Merged: https://example/pull/1 @ abc")
+    assert changed
+    assert "## Notes" in body
+    assert "Merged:" in body
+    body2, changed2 = project_cli.append_notes_to_body(body, "Merged: https://example/pull/1 @ abc")
+    assert not changed2
+    assert body2 == body
+
+
+def test_parse_board_item_from_text() -> None:
+    assert (
+        project_cli.parse_board_item_from_text("- Board-Item: PVTI_abc123\n")
+        == "PVTI_abc123"
+    )
+    assert project_cli.parse_board_item_from_text("no item") is None
+
+
+def test_cmd_get(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    payload = {
+        "items": [
+            {
+                "id": "PVTI_x",
+                "title": "Slice",
+                "status": "In progress",
+                "content": {"body": "## Notes\n\nhello"},
+            }
+        ]
+    }
+
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    args = argparse.Namespace(directory=tmp_path, id="PVTI_x", limit=50, json=True)
+    assert project_cli.cmd_get(args) == 0
+
+
+def test_cmd_append_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    payload = {
+        "items": [
+            {
+                "id": "PVTI_x",
+                "title": "Slice",
+                "status": "In review",
+                "content": {"body": "## Acceptance\n\nok"},
+            }
+        ]
+    }
+    calls: list[list[str]] = []
+
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        calls.append(args)
+        if args[:2] == ["project", "item-list"]:
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    args = argparse.Namespace(
+        directory=tmp_path, id="PVTI_x", text="Merged: url @ sha", limit=50
+    )
+    assert project_cli.cmd_append_notes(args) == 0
+    assert any("--body" in c for c in calls)
+
+
+def test_resolve_item_id_from_pr_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        if args[:2] == ["pr", "view"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "number": 7,
+                        "url": "https://github.com/o/r/pull/7",
+                        "body": "- Board-Item: PVTI_from_pr\n",
+                    }
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=1, stdout="", stderr="unexpected")
+
+    monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    item_id, cands, err = project_cli.resolve_item_id_for_pr(SAMPLE_SSOT, pr="7")
+    assert item_id == "PVTI_from_pr"
+    assert err is None
+    assert cands == ["PVTI_from_pr"]
+
+
+def test_find_items_mentioning_pr() -> None:
+    items = [
+        {
+            "id": "a",
+            "status": "In review",
+            "title": "Work",
+            "content": {"body": "See https://github.com/o/r/pull/9"},
+        },
+        {"id": "b", "status": "Done", "title": "Other", "content": {"body": "pull/9"}},
+    ]
+    matches = project_cli.find_items_mentioning_pr(
+        items, pr_number="9", pr_url="https://github.com/o/r/pull/9"
+    )
+    assert matches[0]["id"] == "a"
+
+
+def test_cmd_export_stdout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    payload = {
+        "items": [
+            {"id": "a", "title": "T", "status": "Ready", "content": {"body": "x" * 600}}
+        ]
+    }
+
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    args = argparse.Namespace(
+        directory=tmp_path, output=None, limit=50, json=False, stdout=True
+    )
+    assert project_cli.cmd_export(args) == 0

--- a/tests/modules/pr_workflow/test_merge_board_sync.py
+++ b/tests/modules/pr_workflow/test_merge_board_sync.py
@@ -1,0 +1,99 @@
+"""
+File: test_merge_board_sync.py
+Path: tests/modules/pr_workflow/test_merge_board_sync.py
+Role: Unit tests for post-merge GitHub Project board sync in merge.py.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/pr/merge.py
+ - .ai_infra/install/cursor_workflow/project_cli.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PR_DIR = REPO_ROOT / ".ai_infra" / "scripts" / "pr"
+_CW_DIR = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+for p in (_PR_DIR, _CW_DIR):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import merge as merge_mod  # noqa: E402
+import project_cli  # noqa: E402
+
+
+SAMPLE_SSOT = {
+    "enabled": True,
+    "name": "Playground",
+    "owner": "SavinRazvan",
+    "number": 3,
+    "url": "https://github.com/users/SavinRazvan/projects/3",
+    "project_id": "PVT_kwHOBl46-84A9KZx",
+    "default_repo": "SavinRazvan/mas-workflow-kit-project-ssot",
+    "sync_policy": "board_only",
+    "fields": {
+        "status": {
+            "field_id": "PVTSSF_status",
+            "options": {
+                "done": "98236657",
+                "in_review": "4cc61d42",
+            },
+        },
+    },
+    "conventions": {"done_status": "done"},
+}
+
+
+def test_sync_board_skip_flag(tmp_path: Path) -> None:
+    line = merge_mod.sync_board_after_merge(
+        root=tmp_path, pr="1", merge_sha="abc", skip=True
+    )
+    assert "skipped" in line
+
+
+def test_sync_board_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = {**SAMPLE_SSOT, "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    line = merge_mod.sync_board_after_merge(root=tmp_path, pr="1", merge_sha="abc")
+    assert "not operational" in line
+
+
+def test_sync_board_happy_with_item_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "98236657"))
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: (
+            [{"id": "PVTI_x", "content": {"body": "## Notes\n\n- old"}}],
+            None,
+        ),
+    )
+    monkeypatch.setattr(project_cli, "edit_item_body", lambda *a, **k: (True, "ok"))
+    line = merge_mod.sync_board_after_merge(
+        root=tmp_path, pr="42", merge_sha="deadbeef", item_id="PVTI_x"
+    )
+    assert "PVTI_x" in line
+    assert "done" in line
+    assert "Merged:" in line
+
+
+def test_sync_board_warn_when_no_item(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: (None, [], "no project item found"),
+    )
+    line = merge_mod.sync_board_after_merge(root=tmp_path, pr="99", merge_sha="sha")
+    assert "warn" in line

--- a/tests/modules/workflow_drift/test_drift010_board_pr_stale.py
+++ b/tests/modules/workflow_drift/test_drift010_board_pr_stale.py
@@ -1,0 +1,124 @@
+"""
+File: test_drift010_board_pr_stale.py
+Path: tests/modules/workflow_drift/test_drift010_board_pr_stale.py
+Role: Tests for DRIFT-010 board Status vs open PRs / stale In progress.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/workflow/drift_checks.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".ai_infra" / "scripts" / "workflow"
+if str(WORKFLOW_DIR) not in sys.path:
+    sys.path.insert(0, str(WORKFLOW_DIR))
+
+from drift_checks import check_drift010, drift_paths  # noqa: E402
+
+
+def _scaffold(
+    tmp: Path,
+    *,
+    enabled: bool = True,
+    policy: str = "board_only",
+    snapshot: dict | None = None,
+    write_snapshot: bool = True,
+) -> Path:
+    planning = tmp / ".local" / "index-and-planning" / "current"
+    planning.mkdir(parents=True)
+    (planning / "work-tracker.md").write_text(
+        "# Work Tracker\n\n## Active\n\n(none)\n",
+        encoding="utf-8",
+    )
+    settings = tmp / ".local" / "user_settings"
+    settings.mkdir(parents=True)
+    data = {
+        "version": 1,
+        "owner": {"display_name": "T", "github_user": "@t"},
+        "project_ssot": {
+            "enabled": enabled,
+            "sync_policy": policy,
+            "default_repo": "SavinRazvan/mas-workflow-kit-project-ssot",
+        },
+        "commit_provenance": {"ai_disclosure_mode": "none"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }
+    (settings / "github.collaboration.yaml").write_text(
+        yaml.safe_dump(data), encoding="utf-8"
+    )
+    if write_snapshot and snapshot is not None:
+        gen = tmp / ".local" / "generated-data"
+        gen.mkdir(parents=True)
+        (gen / "project-board-snapshot.json").write_text(
+            json.dumps(snapshot), encoding="utf-8"
+        )
+    return tmp
+
+
+def test_drift010_skips_without_snapshot(tmp_path: Path) -> None:
+    root = _scaffold(tmp_path, snapshot=None, write_snapshot=False)
+    result = check_drift010(drift_paths(root))
+    assert result.passed
+    assert "skipped" in result.detail
+
+
+def test_drift010_skips_when_disabled(tmp_path: Path) -> None:
+    root = _scaffold(tmp_path, enabled=False, snapshot={"items": []})
+    result = check_drift010(drift_paths(root))
+    assert result.passed
+    assert "disabled" in result.detail
+
+
+def test_drift010_detects_merged_but_not_done(
+    monkeypatch, tmp_path: Path
+) -> None:
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": "PVTI_x",
+                "title": "Left open",
+                "status": "In review",
+                "status_normalized": "in_review",
+                "body_excerpt": "Merged: https://github.com/o/r/pull/1 @ abc",
+            }
+        ],
+    }
+    root = _scaffold(tmp_path, snapshot=snap)
+    monkeypatch.setattr(
+        "drift_checks._open_pr_bodies",
+        lambda repo: ([], None),
+    )
+    result = check_drift010(drift_paths(root))
+    assert not result.passed
+    assert "merged-but-not-done" in result.detail
+
+
+def test_drift010_passes_clean_board(monkeypatch, tmp_path: Path) -> None:
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": "PVTI_ok",
+                "title": "Done card",
+                "status": "Done",
+                "status_normalized": "done",
+                "body_excerpt": "Merged: url @ sha",
+            }
+        ],
+    }
+    root = _scaffold(tmp_path, snapshot=snap)
+    monkeypatch.setattr(
+        "drift_checks._open_pr_bodies",
+        lambda repo: ([], None),
+    )
+    result = check_drift010(drift_paths(root))
+    assert result.passed


### PR DESCRIPTION
## Summary

- **A — Writable SSOT docs:** project-board-collaboration ops guide, HANDOFF/AGENTS/README alignment, agent+skill continuation contract (`board_only` precedence).
- **B — Post-merge board sync:** `merge.py` sets linked Project card → **Done** with merge SHA/URL notes; PR body `Board-Item` resolution.
- **C — Export + DRIFT-010:** `project export` CLI snapshot; drift check flags stale In progress/In review cards when PR is merged/closed.

Architecture-impacting: **yes** (workflow/policy, ADR-008, DRIFT-010).

## Test plan

- [x] `pytest tests/modules/install/test_project_cli.py` — export CLI
- [x] `pytest tests/modules/pr_workflow/test_merge_board_sync.py` — post-merge Done sync
- [x] `pytest tests/modules/workflow_drift/test_drift010_board_pr_stale.py` — DRIFT-010
- [x] Full `pytest -q` (prepare gates)
- [x] `python -m cursor_workflow drift validate` (kit-dev gate)

## Collaboration

Action-By: Savin Ionuț Răzvan
GitHub-User: @SavinRazvan
Agent/s: implementer

Made with [Cursor](https://cursor.com)