### PR TITLE
docs: STANDALONE product doctrine (board+local SSOT)

### DIFF
--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -27,7 +27,7 @@ Notes:
 
 Enabling the **plugin** loads agents/skills/rules in the IDE only — it does **not** write files to your project. Run activate to install all three planes on disk:
 
-1. **Plugin from GitHub (recommended):** Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` → open your app → **`/workflow-activate`** (or `python -m cursor_workflow activate --directory .`)
+1. **Plugin from GitHub (recommended):** Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` → open your app → **`/workflow-activate`** (or `python -m cursor_workflow activate --directory .`)
 2. **Marketplace (when listed):** same flow after **Cursor → Marketplace** install
 3. **Kit clone / advanced:** `python -m cursor_workflow install --target . --verify`
 

--- a/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -1,11 +1,11 @@
 # ADR-008: GitHub Project board as agent SSOT
 
-**Status:** accepted (experiment — this sibling repo only)  
-**Date:** 2026-07-17
+**Status:** accepted — **product doctrine for this repository** (`mas-workflow-kit-project-ssot`)  
+**Date:** 2026-07-17 · **STANDALONE:** 2026-07-18
 
 ## Context
 
-MAS Workflow Kit defaults to local markdown trackers under `.local/index-and-planning/current/` as session SSOT. Collaborators cannot share that state. This experiment (`mas-workflow-kit-project-ssot`) configures a GitHub Project in `.local/user_settings/github.collaboration.yaml` → `project_ssot` and drives it via `python -m cursor_workflow project`.
+Classic MAS Workflow Kit used local markdown trackers under `.local/index-and-planning/current/` as session SSOT. Collaborators cannot share that state. **This repository is the product** — already separated from upstream `mas-workflow-kit` — and configures a GitHub Project in `.local/user_settings/github.collaboration.yaml` → `project_ssot`, driven via `python3 -m cursor_workflow project`. Local artifacts remain for PR gates, audits, and evidence.
 
 Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HANDOFF.md).
 
@@ -20,8 +20,8 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 7. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
 8. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
 9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
-10. **Production port deferred** until demo + implementer Anchor + dual-write drift check + human sign-off. Marketplace kit stays markdown SSOT until then.
-11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization — agents never edit these.
+10. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
+11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
 
 ## Consequences
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -13,16 +13,16 @@ Notes:
  - Update this file each material slice; do not rewrite full maintainer megadocs for every change.
 -->
 
-# Implementation status (MAS Workflow Kit)
+# Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-18 (FIX-NOTES-DI edge-case tests)  
-**Product:** MAS Workflow Kit (`mas-workflow-kit`) · CLI: `cursor-workflow` 0.4.0 · **Tests:** 669
+**Last updated:** 2026-07-18 (STANDALONE product doctrine)  
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 669
 
 ## Shipped (confirmed in repo)
 
 | Area | Status | Location |
 |------|--------|----------|
-| Universal rules | 7 `.mdc` | `.cursor/rules/` (6 kit + experiment `project-ssot-precedence`; marketplace `payload/` keeps 6 until port) |
+| Universal rules | 7 `.mdc` | `.cursor/rules/` **and** `payload/.cursor/rules/` (6 kit + `project-ssot-precedence`) |
 | Agents | 8 core; `model: auto`; audit agents write `.local/` artifacts only (no `readonly`) | `.cursor/agents/` |
 | Canonical skills | 11 folders | `.cursor/skills/` |
 | Maintainer skills | 5 folders (additive plugin merge) | `.agents/skills/` |
@@ -49,15 +49,15 @@ Notes:
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
-installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-08: **44 files,
-3588 statements, 100%** when the full suite passes (`generate_coverage_index.py` and
-`migrate_local_workspace_layout.py` are maintainer tooling — omitted from `--cov` per
-`pyproject.toml`). Subprocess-only maintainer scanners
-(`check_governance_consistency.py`, `check_debrand.py`, `check_consumer_purity.py`,
-`check_file_headers.py`) have dedicated module tests but are excluded from this metric by
-design — they are launched via `subprocess` / `make gates`, not imported by the coverage
-run. Running `--cov=.` (tests included) reports ~99% because of order-dependent branches in
-test-helper cleanup code; scope shipped source for marketplace readiness claims.
+installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18: **~4396
+statements, ~94%** on a full suite pass. Primary gap: `project_cli.py` live-`gh` branches
+(~64% — integration paths exercised via targeted unit mocks elsewhere). Subprocess-only
+maintainer scanners (`check_governance_consistency.py`, `check_debrand.py`,
+`check_consumer_purity.py`, `check_file_headers.py`) have dedicated module tests but are
+excluded from this metric by design — they are launched via `subprocess` / `make gates`,
+not imported by the coverage run. Running `--cov=.` (tests included) reports higher
+because of order-dependent branches in test-helper cleanup code; scope shipped source for
+readiness claims.
 
 ## Verification commands
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -13,6 +13,9 @@ Notes:
 
 # Marketplace publish checklist
 
+<!-- Publish target: this product repo (mas-workflow-kit-project-ssot). STANDALONE 2026-07-18 — not upstream mas-workflow-kit. -->
+
+
 **Product:** MAS Workflow Kit · **Plugin id:** `mas-workflow-kit`
 
 ## Pre-publish (kit repo)
@@ -86,7 +89,7 @@ export TARGET=~/Projects/my-app
 mkdir -p "$TARGET"
 ```
 
-1. **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` — click the **MAS Workflow Kit** card in the preview ([screenshot](../../../assets/mas-workflow-kit-install.png) · [README](https://github.com/SavinRazvan/mas-workflow-kit#1-install-the-plugin-cursor-chat--not-the-terminal))
+1. **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` — click the **MAS Workflow Kit** card in the preview ([screenshot](../../../assets/mas-workflow-kit-install.png) · [README](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot#1-install-the-plugin-cursor-chat--not-the-terminal))
 2. **File → Open Folder** → `"$TARGET"` (your app — not the kit repo)
 3. **Agent chat:** `/workflow-activate` → wait for **VERIFY PASS**
 4. Edit `.local/user_settings/github.collaboration.yaml` → `python3 -m cursor_workflow contributors validate`
@@ -132,7 +135,7 @@ python3 -m cursor_workflow drift validate --directory . --profile consumer
 ### Quick plugin smoke (from kit repo)
 
 1. Run `make sync-plugin`
-2. In Agent chat: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit`
+2. In Agent chat: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot`
 3. Confirm agents: `implementer`, `enterprise-auditor`, maintainer slash skills
 4. Run **`/workflow-activate`** in Agent chat with a **non-kit** project folder open
 
@@ -189,9 +192,9 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 | Organization name | Savin Ionuț Răzvan |
 | Organization handle | `savin-razvan` (or `mas-workflow-kit`) |
 | Contact email | razvan.i.savin@gmail.com |
-| Logotype URL | `https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit/main/assets/logo.png` |
+| Logotype URL | `https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/logo.png` |
 | Description | MAS Workflow Kit installs multi-agent workflow infrastructure into any Cursor project: agents, skills, rules, PR lifecycle scripts, `.local/` trackers, and optional MCP. Run **`/workflow-activate`** once to scaffold three planes. Pattern A: one script per maintainer action. For teams using agents, audits, and PR-first governance. |
-| GitHub repository | https://github.com/SavinRazvan/mas-workflow-kit |
+| GitHub repository | https://github.com/SavinRazvan/mas-workflow-kit-project-ssot |
 | Owner | Individual · razvan.i.savin@gmail.com |
 | Website URL | https://razvansavin.com/ |
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -16,9 +16,11 @@ Notes:
 
 # Repository map (kit maintainers)
 
-**Audience:** People working in the **`mas-workflow-kit`** git repo — not consumer app projects.
+**Audience:** People working in **this product repo** (`mas-workflow-kit-project-ssot`) — not consumer app projects.
 
 **Not shipped to consumers.** This file lives under `docs/handoff/` (excluded from `manifest.yaml` `copy_ai_infra`). Do not link it from consumer quickstart or PLUGIN-USER-GUIDE body text.
+
+**Lineage:** Originally mirrored from upstream `mas-workflow-kit`; folder layout below still uses that tree shape. This repository is the permanent product (STANDALONE 2026-07-18).
 
 ---
 
@@ -33,10 +35,10 @@ Notes:
 
 ---
 
-## Kit repository (mas-workflow-kit)
+## Product repository (`mas-workflow-kit-project-ssot`)
 
 ```text
-mas-workflow-kit/
+mas-workflow-kit-project-ssot/
 ├── .cursor/                    SSOT — agents, rules, canonical skills
 ├── .agents/skills/             SSOT — maintainer slash skills (+ deprecated stubs)
 ├── agents/                     Generated → Marketplace plugin surface (mirror of .cursor/agents)

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -60,7 +60,7 @@ flowchart LR
 In **Agent chat** (not the terminal):
 
 ```text
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
 Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
@@ -70,7 +70,7 @@ Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card t
 Optional — explicit branch:
 
 ```text
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit/tree/main
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/tree/main
 ```
 
 This loads agents, skills, and rules into Cursor. Your project may only get `.cursor/settings.json` until you activate (§2).
@@ -85,10 +85,10 @@ This loads agents, skills, and rules into Cursor. Your project may only get `.cu
 
 | Step | Action |
 |------|--------|
-| 1. Plugin | Agent chat: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` *(or Marketplace when listed)* |
+| 1. Plugin | Agent chat: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` *(or Marketplace when listed)* |
 | 2. Activate | Open **your app** → Agent chat → **`/workflow-activate`** → wait for **`VERIFY PASS`** and all planes **ready** |
 | 3. Your name | Edit `.local/user_settings/github.collaboration.yaml` → `python3 -m cursor_workflow contributors validate` |
-| 4. Build | **`/implementer`** · read `session-pointer.md` → `plan.md` → `work-tracker.md` |
+| 4. Build | **`/implementer`** · when `project_ssot.enabled`, Entry = `python3 -m cursor_workflow project status` (board first); else `session-pointer.md` → `plan.md` → `work-tracker.md` |
 
 **Step 2 — in Agent chat (not the terminal):**
 
@@ -131,7 +131,7 @@ your-project/
 └── tests/modules/smoke/           # install smoke test only
 ```
 
-**Not installed:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs. Those exist only in the [kit repository](https://github.com/SavinRazvan/mas-workflow-kit).
+**Not installed:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs. Those exist only in the [kit repository](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot).
 
 **Re-activate is safe:** existing trackers, `user_settings/`, and `AGENTS.md` are not overwritten. Kit-managed **dashboard HTML**, JS/CSS, `module-audit.html`, and `pages.json` **are refreshed** on each activate.
 
@@ -148,7 +148,7 @@ your-project/
 
 | Goal | Type in chat |
 |------|--------------|
-| Install plugin | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` |
+| Install plugin | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Activate / refresh | `/workflow-activate` |
 | Implement | `/implementer` |
 | Tests | `/test-runner` |
@@ -246,8 +246,8 @@ Cursor may also auto-delegate subagents when the task matches their `description
 
 Every session:
 
-1. `.local/index-and-planning/current/session-pointer.md`
-2. `plan.md` → `work-tracker.md`
+1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else `.local/index-and-planning/current/session-pointer.md`
+2. Board card Status/Notes (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
 3. **`/implementer`** (or specialist agent from §6)
 4. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
 
@@ -340,4 +340,4 @@ More: [consumer-quickstart.md](consumer-quickstart.md) § Troubleshooting.
 | Upgrade / semver | [upgrade-kit.md](upgrade-kit.md) |
 | Optional project metadata | [project-config.md](project-config.md) |
 
-**Kit maintainers** (not copied to your project): `PLUGIN-ARCHITECTURE.md` and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/mas-workflow-kit/tree/main/.ai_infra/docs/handoff).
+**Kit maintainers** (not copied to your project): `PLUGIN-ARCHITECTURE.md` and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/tree/main/.ai_infra/docs/handoff).

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -27,10 +27,10 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 
 | Step | Action |
 |------|--------|
-| **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` — or **Cursor → Marketplace** when listed |
+| **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` — or **Cursor → Marketplace** when listed |
 | **2. Activate** | Open **your app folder** → Agent chat: **`/workflow-activate`** → wait for **`VERIFY PASS`** |
 | **3. Your name** | Edit `.local/user_settings/github.collaboration.yaml` → set `display_name` + `github_user` → `python3 -m cursor_workflow contributors validate` |
-| **4. Build** | **`/implementer`** · read `session-pointer.md` → `plan.md` → `work-tracker.md` |
+| **4. Build** | **`/implementer`** · when `project_ssot.enabled`, Entry = `python3 -m cursor_workflow project status` (board first); else `session-pointer.md` → `plan.md` → `work-tracker.md` |
 
 **Healthy install?** `python3 -m cursor_workflow health`
 
@@ -41,7 +41,7 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 `/add-plugin` runs in **Cursor Agent chat only** — it is not a shell command.
 
 ```bash
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
 Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
@@ -51,7 +51,7 @@ Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card t
 Optional — pin `main`:
 
 ```bash
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit/tree/main
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/tree/main
 ```
 
 After install you may see only `.cursor/settings.json` in the project. That is expected — run **step 2** to copy the full bundle.
@@ -153,8 +153,8 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 
 ## Step 4 detail — daily workflow
 
-1. Open `.local/index-and-planning/current/session-pointer.md`
-2. Update `plan.md` and `work-tracker.md` for your slice
+1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else open `.local/index-and-planning/current/session-pointer.md`
+2. Claim/update the board card (Status + Notes); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`
 3. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
 4. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
 
@@ -175,7 +175,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 
 | Goal | Command |
 |------|---------|
-| Install plugin (once) | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` |
+| Install plugin (once) | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Activate / refresh kit | `/workflow-activate` |
 | Implement a slice | `/implementer` |
 | Tests / coverage | `/test-runner` |
@@ -309,7 +309,7 @@ Gate details: [gate-matrix.md](gate-matrix.md) (consumer scaffold = 4 checks).
 
 ## Kit clone path (advanced)
 
-When not using the plugin UI — clone [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit), then:
+When not using the plugin UI — clone [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot), then:
 
 ```bash
 python3 -m venv .venv && .venv/bin/pip install -q -r requirements-dev.txt

--- a/.ai_infra/docs/operations/install-dry-run.md
+++ b/.ai_infra/docs/operations/install-dry-run.md
@@ -46,7 +46,7 @@ python .ai_infra/scripts/install/scaffold.py \
 
 See [`scripts/install/README.md`](../../scripts/install/README.md).
 
-**Marketplace / plugin smoke (Track A + B):** kit repo [`marketplace-publish.md`](https://github.com/SavinRazvan/mas-workflow-kit/blob/main/.ai_infra/docs/handoff/marketplace-publish.md) § Automated smoke, or `make smoke-consumer` from kit repo.
+**Marketplace / plugin smoke (Track A + B):** this product repo [`marketplace-publish.md`](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/blob/main/.ai_infra/docs/handoff/marketplace-publish.md) § Automated smoke, or `make smoke-consumer` from this repo.
 
 ## Manual steps
 

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -72,4 +72,4 @@ Handoff: `item_id=PVTI_… · Status=a→b · next=<agent>`
 
 ## Human-only
 
-Views, workflows, Insights, Project README, status updates, Ready prioritization, PORT-GATE.
+Views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap.

--- a/.ai_infra/templates/plugin/skills/workflow-activate/SKILL.md
+++ b/.ai_infra/templates/plugin/skills/workflow-activate/SKILL.md
@@ -54,7 +54,7 @@ Invoke subagent **`/integrator-mas-agent`** with skill **`/mas-infrastructure-in
 
 After plugin enable, parent agent or user should:
 
-0. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit/main/assets/mas-workflow-kit-install.png) — user clicks the **MAS Workflow Kit** card in the preview.
+0. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) — user clicks the **MAS Workflow Kit** card in the preview.
 1. Run **`workflow_activate`** or `cursor_workflow activate`
 2. Hand user to personalize `user_settings/`
 3. Optionally delegate **`/integrator-mas-agent`** for extensions

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -39,7 +39,7 @@ Own **board triage and Status transitions** for the experiment Project SSOT. Han
 |----|--------|
 | Drive board via `cursor_workflow project` | Bypass `prepare.py` gates |
 | Use YAML field/option ids | Dual-write board + tracker SSOT |
-| Hand off code slices to implementer | Mutate production `mas-workflow-kit` |
+| Hand off code slices to implementer | Mutate upstream `mas-workflow-kit` |
 | Fall back to local trackers when disabled | Invent MCP tools |
 
 ## Handoff format

--- a/.cursor/rules/implementation-workflow-governance.mdc
+++ b/.cursor/rules/implementation-workflow-governance.mdc
@@ -9,6 +9,7 @@ alwaysApply: true
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.
 - Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
+- When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m cursor_workflow project status` / claim card); local trackers are offline fallback only.
 - Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
 - Exactly one primary task `in_progress` in `work-tracker.md`; do not implement without scope in `plan.md`.
 - Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -1,18 +1,18 @@
 ---
-description: Experiment — GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
+description: GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
 alwaysApply: true
 ---
 
-# Project SSOT precedence (experiment)
+# Project SSOT precedence
 
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 - **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
-- Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
+- This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -136,4 +136,4 @@ When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in 
 - Reshuffling Ready/P0 without human or project-board ask
 - Editing Project views, workflows, Insights, or status updates
 - Dual-write board + tracker under `board_only`
-- Port to production kit without PORT-GATE
+- Do not push to upstream mas-workflow-kit

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -23,7 +23,7 @@ User enabled the **MAS Workflow Kit** plugin and opened **their project** (not t
 
 ## Guide the user (keep it simple)
 
-1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
+1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
 2. Confirm the open folder is **their app**, not `mas-workflow-kit`.
 3. Run activate (below) — or tell them to pick **`/workflow-activate`** from the **`/`** menu.
 4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Project intent
 
-**MAS Workflow Kit** (`mas-workflow-kit`) — universal, installable infrastructure for multi-agent development workflows. Agents call **one script command** per maintainer action; `GATES` are hardcoded in `.ai_infra/scripts/pr/prepare.py` (customize once at install). This is **not** a product application repo unless you add overlays.
+**MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) — this repository **is** the product: installable multi-agent workflow infrastructure with a **GitHub Project** as the **only writable SSOT** for backlog, Status, and multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only`. **Local artifacts** (PR Pattern A, audits, gates, secrets) stay on disk as evidence — never a second Status writer under `board_only`. Agents call **one script command** per maintainer action; `GATES` live in `.ai_infra/scripts/pr/prepare.py`.
 
-**This sibling experiment (`mas-workflow-kit-project-ssot`):** when `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project** is the **only writable SSOT** for backlog, Status, and multi-agent continuation. Agents use `python -m cursor_workflow project …` (see `.cursor/skills/project-board-ssot/SKILL.md` § Collaboration, ADR-008, `overlays/rules/project-ssot-precedence.mdc`). Ops mirror: `.ai_infra/docs/operations/project-board-collaboration.md`. Local trackers are offline fallback only; read-only exports never compete with board Status — no dual-write under `board_only`. Read [`HANDOFF.md`](HANDOFF.md) first.
+**Continuation:** Entry reads the board (`python3 -m cursor_workflow project status`); Exit updates Status and Notes (see `.cursor/skills/project-board-ssot/SKILL.md` § Collaboration, ADR-008, `overlays/rules/project-ssot-precedence.mdc`). Ops: `.ai_infra/docs/operations/project-board-collaboration.md`. Offline fallback trackers only when board unavailable. **STANDALONE:** permanently decoupled from upstream `mas-workflow-kit` (lineage only — do not merge doctrine back). Read [`HANDOFF.md`](HANDOFF.md) first.
 
 ## First reads (onboarding)
 
@@ -32,7 +32,7 @@ Abbreviations: [`.ai_infra/docs/operations/abbreviations-notepad.md`](.ai_infra/
 | `.cursor/rules/file-docstring-header-relations.mdc` | File headers |
 | `.cursor/rules/local-artifact-protection.mdc` | Protected local paths (`.coverage`, `.env`) |
 | `.cursor/rules/advisory-audit-alignment-enforcement.mdc` | Architecture-impacting audits → **`enterprise-auditor`** + alignment artifacts |
-| `.cursor/rules/project-ssot-precedence.mdc` | **Experiment:** board SSOT precedes local trackers when `project_ssot.enabled` (ADR-008) |
+| `.cursor/rules/project-ssot-precedence.mdc` | Board SSOT precedes local trackers when `project_ssot.enabled` (ADR-008) |
 
 **Product rules** belong in **`overlays/rules/`** at install — see [`overlays/README.md`](overlays/README.md). **Do not duplicate gate lists** in chat or `updates-log.md` — say *prepare gates green* or paste failing command output only.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,40 +1,49 @@
 <!--
 File: HANDOFF.md
 Path: HANDOFF.md
-Role: Full experiment handoff for agents continuing Project-SSOT work in this sibling repo.
+Role: Product handoff for board+local SSOT kit in this repository.
 Used By:
  - Cursor agents opening this workspace
- - Maintainer onboarding the experiment
+ - Maintainer onboarding
 Depends On:
- - Production kit: https://github.com/SavinRazvan/mas-workflow-kit (do not mutate for this experiment)
+ - Lineage (read-only): https://github.com/SavinRazvan/mas-workflow-kit
  - GitHub Project: https://github.com/users/SavinRazvan/projects/3
  - Local settings: .local/user_settings/github.collaboration.yaml (identity + project_ssot)
 Notes:
  - Kit mirrored 2026-07-17 (merge commit 1cb6dd7 · tip 8a779fa / v0.4.0).
- - North star: GitHub Project replaces local tracker markdown as SSOT for collaborators + agents.
+ - This repository is the product — permanently decoupled; STANDALONE 2026-07-18.
 -->
 
-# HANDOFF — GitHub Project as agent SSOT (experiment)
+# HANDOFF — GitHub Project as agent SSOT (product)
 
 **Read this file first** when opening `mas-workflow-kit-project-ssot` in Cursor.
 
 | Field | Value |
 |-------|--------|
-| **Experiment repo** | https://github.com/SavinRazvan/mas-workflow-kit-project-ssot |
-| **Production kit (DO NOT break)** | https://github.com/SavinRazvan/mas-workflow-kit |
-| **Production tip at handoff** | `8a779fa` · tag **`v0.4.0`** (mirrored here as merge `1cb6dd7`) |
+| **Product repo** | https://github.com/SavinRazvan/mas-workflow-kit-project-ssot |
+| **Lineage (read-only)** | https://github.com/SavinRazvan/mas-workflow-kit — historical upstream; never merge doctrine back |
+| **Upstream tip at mirror** | `8a779fa` · tag **`v0.4.0`** (mirrored here as merge `1cb6dd7`) |
 | **GitHub Project board** | https://github.com/users/SavinRazvan/projects/3 — **AI Project Playground** |
 | **Project number / owner** | `#3` / `SavinRazvan` (user project) |
 | **Project node id** | `PVT_kwHOBl46-84A9KZx` |
 | **Handoff date** | 2026-07-17 |
-| **Prior session agents** | Composer (explorer) · implementer (kit mirror) · design alignment |
+| **STANDALONE decided** | 2026-07-18 — this repo is the permanent product |
 | **Human owner** | Savin Ionuț Răzvan · `@SavinRazvan` |
 
 ---
 
 ## 1. Goal (north star)
 
-**Hypothesis (clarified):** Collaborators and agents treat the configured **GitHub Project** as the **only writable SSOT** for backlog, Status, and multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only`. Every agent **reads the board on Entry** and **updates Status and Notes on Exit**; card body indexes handoffs — not chat alone. Local trackers are **offline fallback only**; PR gates, audits, secrets stay local. Optional **read-only** exports may cache snapshots but must never compete with board Status.
+**This repository is the product** (`mas-workflow-kit-project-ssot`) — already separated from upstream; permanently decoupled. Separation is done; agents must not create a sibling, fork, or port doctrine back into `mas-workflow-kit`.
+
+### Two surfaces (facts only)
+
+| Surface | Writable? | Role |
+|---------|-----------|------|
+| **GitHub Project board** (`project_ssot` in `.local/user_settings/github.collaboration.yaml`) | **Only writable SSOT** for backlog, Status, Priority/Size, multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only` | Humans + agents track everything here. **Entry** reads the board; **Exit** updates Status and Notes. Card body indexes handoffs — not chat alone. |
+| **Local artifacts** (`.local/…`, PR Pattern A, audits, gates, secrets, coverage) | Evidence / merge readiness / machine-local | Proves how work was verified and merged. **Never** a second Status writer under `board_only`. Offline fallback only when board disabled or `gh` unavailable. |
+
+**Together:** board = structured coordination; local = evidence. No dual-mirror “for safety.”
 
 **Why:**
 
@@ -42,7 +51,7 @@ Notes:
 - Multiple collaborators and **multiple agents** create, claim, and complete the same tasks.
 - Board Status / Priority / Size become the coordination bus (Ready → In progress → In review → Done).
 
-**Settings story (same habit as identity):** Project config lives in **`.local/user_settings/github.collaboration.yaml`** next to `owner.display_name` / `owner.github_user` — one worksheet agents always read. Do **not** invent a second settings file as the primary habit (a separate `github.projects.yaml` was an earlier idea; **superseded**).
+**Settings story (same habit as identity):** Project config lives in **`.local/user_settings/github.collaboration.yaml`** next to `owner.display_name` / `owner.github_user` — one worksheet agents always read.
 
 **What still stays local / in-repo (not “moved to the board”):**
 
@@ -54,50 +63,50 @@ Notes:
 | Offline fallback trackers | If no `project` scope / no `gh` — **resume-only** local trackers; never a second writer under `board_only` |
 | Read-only board export (optional) | Snapshot cache for audits/ICC later — never writes Status |
 
-**Non-goal (this experiment):** Do **not** rewrite production `mas-workflow-kit` `main` until this sibling proves the model. Marketplace `v0.4.0` consumers stay on markdown SSOT until an explicit port. Do **not** dual-mirror local trackers + board “for safety.”
+**Non-goals:** Do **not** dual-mirror local trackers + board “for safety.” Do **not** push this product’s doctrine into upstream `mas-workflow-kit`. Do **not** treat this repo as a temporary sandbox awaiting a port.
 
 **Success looks like:**
 
 1. Agents **create** and **load** tasks from the configured Project (not from `work-tracker.md`).
 2. Agent Anchors read `project_ssot` from collab YAML → board; Exit updates card Status and Notes (continuation contract).
-3. Humans follow progress **only** on the Project UI; local tracker markdown is **offline fallback only** (not a writable SSOT under `board_only`).
+3. Humans follow progress **only** on the Project UI; local tracker markdown is **offline fallback only**.
 4. Clear auth (`project` scopes) + settings onboarding for every collaborator who opts in.
-5. Rollback = abandon this sibling repo; production kit unchanged.
+5. Rollback = disable `project_ssot` / use `fallback: local_trackers` **in this repo** (not abandon the product).
 
 **Failure / abort if:**
 
 - Board API too fragile for agent loops, or auth story too heavy for consumers.
-- Dual SSOT (board + markdown) causes worse drift than today — **board must win**; do not leave two writers.
+- Dual SSOT (board + markdown) causes worse drift — **board must win**; do not leave two writers.
 - Gates / Pattern A cannot coexist with board-first workflow.
 
 ---
 
-## 2. Safety model (why this repo exists)
+## 2. Safety model (already separated)
 
-GitHub does **not** allow forking your own repo to yourself. Isolation = **sibling public repo**:
+GitHub does **not** allow forking your own repo to yourself. Isolation was done via a **sibling public repo** — **this workspace is already that repo.**
 
 | Repo | Role |
 |------|------|
-| `mas-workflow-kit` | Production / marketplace source of truth |
-| `mas-workflow-kit-project-ssot` | **This** experiment sandbox |
+| `mas-workflow-kit` | Historical lineage / optional reference only |
+| `mas-workflow-kit-project-ssot` | **This product** — board+local SSOT kit |
 
-Also related (unrelated experiment): `mas-workflow-kit-trae` — ignore unless asked.
+Also related (unrelated): `mas-workflow-kit-trae` — ignore unless asked.
 
-**Rule for agents:** Never push experiment-only SSOT changes to `mas-workflow-kit` unless the human explicitly asks to port a proven design.
+**Rule for agents:** Never push board-SSOT or product doctrine to `mas-workflow-kit`. Do not instruct anyone to “create sibling / mirror kit” again — that work is done.
 
 ---
 
 ## 3. Design
 
-### 3.1 Current kit agent model (production baseline)
+### 3.1 Historical kit baseline (pre-board)
 
-Agents live under `.cursor/agents/` (7): `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `workflow-drift-guard`, `integrator-mas-agent`, `researcher`.
+Agents live under `.cursor/agents/` (now 8 including `project-board`): `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `workflow-drift-guard`, `integrator-mas-agent`, `researcher`, `project-board`.
 
-They are **session Task agents**, not always-on GitHub bots. Today they read **local** `.local/index-and-planning/current/*` first (`session-pointer.md` → `plan.md` → `work-tracker.md`).
+They are **session Task agents**, not always-on GitHub bots. **Before board SSOT**, they read **local** `.local/index-and-planning/current/*` first (`session-pointer.md` → `plan.md` → `work-tracker.md`). That Entry path is **historical** — see §3.2 for current product behavior.
 
 PR lifecycle stays Pattern A: scripts in `.ai_infra/scripts/pr/` (`review` / `prepare` / `merge`); `prepare.py` GATES are SSOT for merge prep.
 
-### 3.2 Target experiment model (board replaces trackers)
+### 3.2 Shipped product model (board replaces trackers as Status SSOT)
 
 ```text
 .local/user_settings/github.collaboration.yaml
@@ -110,7 +119,7 @@ GitHub Project #3       →  create / list / claim / status (human + all agents)
                         →  card → In review → Done
 
 .local/index-and-planning/*.md
-                        →  DEPRECATED as SSOT (offline fallback only, then remove writes)
+                        →  offline fallback only (not writable SSOT under board_only)
 ```
 
 **Multi-agent / multi-collaborator conventions:**
@@ -138,15 +147,13 @@ GitHub Project #3       →  create / list / claim / status (human + all agents)
 | Do | Do not |
 |----|--------|
 | List/filter board; create drafts/issues; set Status/Priority/Size | Bypass `prepare.py` gates |
-| Anchor every agent procedure on `project_ssot` | Force-push / rewrite production kit history |
-| Hand off via card Status + Assignees | Require marketplace consumers to use Projects before port |
+| Anchor every agent procedure on `project_ssot` | Force-push / rewrite upstream kit history |
+| Hand off via card Status + Notes | Push doctrine into `mas-workflow-kit` |
 | Fall back to local trackers only when board unavailable | Leave dual SSOT without a winner |
 
 ### 3.3 Settings — `project_ssot` in collaboration YAML (canonical)
 
-Extend **`.local/user_settings/github.collaboration.yaml`** (exemplar under `.ai_infra/templates/user-settings/`). Schema already allows `additionalProperties: true`; tighten later in this experiment.
-
-Target shape (not fully live until BOARD-SPIKE / wiring slices):
+Extend **`.local/user_settings/github.collaboration.yaml`** (exemplar under `.ai_infra/templates/user-settings/`).
 
 ```yaml
 # .local/user_settings/github.collaboration.yaml
@@ -155,7 +162,6 @@ owner:
   display_name: "Savin Ionuț Răzvan"
   github_user: "@SavinRazvan"
 
-# NEW — agents always read this (same file as identity)
 project_ssot:
   enabled: true
   owner: SavinRazvan
@@ -172,7 +178,7 @@ project_ssot:
 # existing: commit_provenance, pr_collaboration.pipelines, …
 ```
 
-**Tools:** Pattern A via `gh project …` first; optional GitHub MCP later (`/connect-external-mcp`). Optional committed pointer in `project.config.yaml` for “canonical board” — deferred.
+**Tools:** Pattern A via `gh project …` first; optional GitHub MCP later (`/connect-external-mcp`).
 
 ### 3.4 Auth (every collaborator who manages the board)
 
@@ -188,7 +194,7 @@ Existing `repo` / `workflow` suffice for PR workflow without Projects.
 
 ---
 
-## 4. Experiments already run (live evidence)
+## 4. Evidence already run
 
 ### 4.1 Consumer kit verification (Smart-Notes, earlier session)
 
@@ -197,22 +203,15 @@ On `~/Projects/Smart-Notes` with kit **0.4.0**:
 - `python3 -m cursor_workflow` → usage error without subcommand (**expected**)
 - `health` → `kit_version: 0.4.0`, **PASS**
 - `gates` → pytest green; **governance FAIL** on 8 app unit tests missing file headers under `tests/modules/core|notes/` — **legitimate project gap**, not outdated kit
-- Distinction: consumer **`prepare.py`** = 2 gates; **`cursor_workflow gates`** = 4 substantive (+ doc-facts skip)
 
-### 4.2 Tag / release (production kit)
+### 4.2 Upstream kit tag at fork time (lineage)
 
-Human deleted old tags/releases; agent recreated **only** `v0.4.0` on `8a779fa` + GitHub Release (Latest).  
+Human deleted old tags/releases; agent recreated **only** `v0.4.0` on `8a779fa` + GitHub Release (Latest) on the **upstream** kit.  
 Release: https://github.com/SavinRazvan/mas-workflow-kit/releases/tag/v0.4.0
 
 ### 4.3 Project board smoke (2026-07-17) — confirmed in UI
 
-Auth refreshed with `project` scope. Board had **3 DraftIssue** items (explorer):
-
-| Title | Item id | Status | Priority | Size |
-|-------|---------|--------|----------|------|
-| `[Explorer] Hello from Cursor agent` | `PVTI_lAHOBl46-84A9KZxzgzNYB4` | **Ready** | — | — |
-| `[Explorer] Triage: document board fields` | `PVTI_lAHOBl46-84A9KZxzgzNYCY` | **In progress** | — | — |
-| `[Explorer] Priority P1 sample` | `PVTI_lAHOBl46-84A9KZxzgzNYCw` | **Backlog** | **P1** | **S** |
+Auth refreshed with `project` scope. Field/option ids for Status / Priority / Size are in collab YAML and CLI.
 
 **Status option ids (for `gh project item-edit`):**
 
@@ -228,28 +227,24 @@ Auth refreshed with `project` scope. Board had **3 DraftIssue** items (explorer)
 **Size option ids:** XS=`eff732af` · S=`9592a5a3` · M=`9728cbdc` · L=`c53df028` · XL=`7b141a16`
 
 ```bash
-gh project item-create 3 --owner SavinRazvan --title "…" --body "…" --format json
-gh project item-edit --project-id PVT_kwHOBl46-84A9KZx --id PVTI_… \
-  --field-id PVTSSF_lAHOBl46-84A9KZxzgw8mco --single-select-option-id 47fc9ee4
-gh project item-list 3 --owner SavinRazvan --format json
+python3 -m cursor_workflow project status
+python3 -m cursor_workflow project list
+python3 -m cursor_workflow project set-status --id PVTI_… --to in_progress
 ```
-
-Explorer drafts are **safe to delete** when cleaning the board.
 
 ### 4.4 Kit mirror into this repo (2026-07-17)
 
-- Merge `kit/main` → experiment `main`: commit **`1cb6dd7`** (pushed).
-- `health` / `contributors validate` PASS; `integrate validate` P0 PASS (P1 INT-013 = experiment README intentionally omits full kit agent roster — accepted divergence).
+- Merge `kit/main` → this `main`: commit **`1cb6dd7`** (pushed). Isolation complete.
 
 ---
 
 ## 5. Conversation intent summary
 
-1. Verify consumer CLI / gates vs kit 0.4.0; recreate clean `v0.4.0` release.
+1. Verify consumer CLI / gates vs kit 0.4.0; recreate clean `v0.4.0` release (upstream).
 2. Prove Cursor agent can drive GitHub Projects with `project` scope → **yes**.
-3. Isolate experiment in **sibling repo**; mirror full kit (done).
-4. **North star (human, 2026-07-17):** replace local tracker artifacts with Project SSOT; configure board in **`github.collaboration.yaml`** like display name / GitHub user; **all agent procedures** create/load/update tasks on that Project for multi-collaborator / multi-agent work.
-5. Port to production kit only after this experiment proves the model.
+3. Isolate in **sibling repo**; mirror full kit (**done** — this workspace).
+4. **North star:** replace local tracker Status SSOT with Project board; configure board in **`github.collaboration.yaml`**; **all agent procedures** create/load/update tasks on that Project.
+5. **STANDALONE 2026-07-18:** this repo is the permanent product — **no** port back to `mas-workflow-kit`.
 
 ---
 
@@ -257,47 +252,31 @@ Explorer drafts are **safe to delete** when cleaning the board.
 
 | Agent / skill | Use for |
 |---------------|---------|
-| **integrator-mas-agent** + `mas-infrastructure-integration` | Wire `project_ssot` settings + shared board skill/CLI + first agent surfaces (independent-governed → then MAS Anchors) |
-| **implementer** | First agent Anchor rewrite to board-first; product/code slices |
-| **enterprise-auditor** | Alignment before claiming trackers deleted / before production port |
-| **verifier** | Prove board-SSOT claims with `gh project` evidence |
-| **workflow-drift-guard** | New rules: board vs leftover markdown drift |
+| **integrator-mas-agent** + `mas-infrastructure-integration` | Wire `project_ssot` settings + shared board skill/CLI |
+| **implementer** | Product/code slices; board-first Anchors |
+| **enterprise-auditor** | Alignment / scorecard |
+| **verifier** | Prove board-SSOT claims with evidence |
+| **workflow-drift-guard** | Board vs leftover markdown drift (DRIFT-009/010) |
+| **project-board** | Triage / Status transitions (independent-governed) |
 
-Do **not** run production marketplace publish from this repo.
+Do **not** run upstream marketplace publish from this repo against `mas-workflow-kit`.
 
 ---
 
 ## 7. Phased plan (ordered)
 
-### A. Done — workspace
+### A–D. Done — workspace + board SSOT
 
-- [x] Mirror / merge production kit (`1cb6dd7`)
-- [x] `gh` has `project` scope; board reachable
-- [x] Collab identity filled (`contributors validate` PASS)
+- [x] Mirror / merge upstream kit (`1cb6dd7`); `gh` has `project` scope
+- [x] `project_ssot` + CLI + `project-board` + ADR-008
+- [x] All agent Anchors board-first; DRIFT-009/010; A→B→C; FIX-NOTES-DI
 
-### B. BOARD-SPIKE-001 (P0) — done
+### E. Explicitly defer (product backlog — not a port gate)
 
-- [x] Add **`project_ssot`** block to local + **exemplar** `github.collaboration.yaml` (field ids from §4.3).
-- [x] Shared skill/CLI: list Ready, create item, set Status/Priority/Size (`cursor_workflow project` / `gh project` Pattern A).
-- [x] Thin `.cursor/agents/project-board.md` (**independent-governed**, ADR-006).
-- [x] Vertical demo: `[Explorer] Hello…` → In progress → Done on the board.
-- [x] ADR-008 **only in this repo**: board-only SSOT vs offline fallback.
-
-### C. BOARD-ANCHOR-002 (P1) — done
-
-- [x] Rewrite agent **Entry/Exit Anchors** starting with `implementer`: read `project_ssot` → board; stop writing trackers as SSOT (fallback only).
-
-### D. BOARD-ROLL-003 (P2) — done
-
-- [x] Remaining agents board-first; DRIFT-009 dual-write guard; AGENTS/experiment overlay.
-
-### E. Explicitly defer (until human PORT-GATE)
-
-- Porting to `mas-workflow-kit` main / marketplace bump
-- Deleting production `.local` tracker contract for consumers
+- ICC Control Center board tab (EA-010 Ready)
 - Always-on GitHub Actions bot
 - Requiring GitHub MCP before `gh` path works
-- ICC Control Center board tab (see §8)
+- Optional `promote_to_issue_on_pr`
 
 ---
 
@@ -307,45 +286,45 @@ Do **not** run production marketplace publish from this repo.
 |----------|-------|
 | Board-only vs dual mirror? | **Board wins — only writable SSOT.** Offline fallback only; no dual writers “for safety.” |
 | DraftIssue vs real Issues? | Drafts OK for smoke; Issues better for PR linking. |
-| Consumer installs? | Projects opt-in until production port. |
+| Consumer installs? | Install plugin from **this** repo: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Offline / no `gh`? | `fallback: local_trackers` then resume board sync. |
-| Card → which repo? | Convention: Repository field or body path; default = this experiment repo. |
-| Control Center dashboards? | **Deferred (EA-010).** Read-only `project export` may land first; ICC panel that *reads* the export is future — never a second writer. Humans follow Project #3 UI for backlog/status. |
-| Who updates the Project? | **Every agent** Entry=read board; Exit=update Status/Notes. Post-merge Done = Pattern A (`merge.py`). Rights: `project-board-ssot` skill § Continuation; ops `project-board-collaboration.md`. **You:** views, workflows, Insights, README, status updates, Ready prioritization. |
+| Card → which repo? | Convention: Repository field or body path; default = this product repo. |
+| Control Center dashboards? | **Deferred (EA-010).** Read-only `project export` may land first; ICC panel that *reads* the export is future — never a second writer. |
+| Who updates the Project? | **Every agent** Entry=read board; Exit=update Status/Notes. Post-merge Done = Pattern A (`merge.py`). Rights: `project-board-ssot` skill § Continuation; ops `project-board-collaboration.md`. **You:** views, workflows, Insights, README, status updates, Ready prioritization / product roadmap. |
 
 ---
 
 ## 9. Key links
 
 - Board: https://github.com/users/SavinRazvan/projects/3  
-- Experiment repo: https://github.com/SavinRazvan/mas-workflow-kit-project-ssot  
-- Production kit: https://github.com/SavinRazvan/mas-workflow-kit  
-- Release: https://github.com/SavinRazvan/mas-workflow-kit/releases/tag/v0.4.0  
+- **Product repo:** https://github.com/SavinRazvan/mas-workflow-kit-project-ssot  
+- Lineage (read-only): https://github.com/SavinRazvan/mas-workflow-kit  
+- Upstream release at mirror: https://github.com/SavinRazvan/mas-workflow-kit/releases/tag/v0.4.0  
 - Settings (local): `.local/user_settings/github.collaboration.yaml`  
-- Kit docs: `.ai_infra/docs/operations/connect-external-mcp.md`, `consumer-quickstart.md`, ADR-004 (MCP), ADR-006 (agent integration)
+- Docs: `.ai_infra/docs/operations/connect-external-mcp.md`, `consumer-quickstart.md`, ADR-004 (MCP), ADR-006 (agent integration), ADR-008 (board SSOT)
 
 ---
 
 ## 10. Handoff checklist for receiving agent
 
-- [x] Read this `HANDOFF.md` entirely (north star = board replaces tracker SSOT)  
+- [x] Read this `HANDOFF.md` entirely (north star = board + local artifacts)  
 - [x] Confirm `gh` has `project` scope  
-- [x] Open board URL; explorer items present (or recreate)  
-- [x] Mirror / merge production kit into this repo  
-- [x] Agree with human: Project in **collab YAML**; all agents use Project; phased P0→P2  
-- [x] Run **BOARD-SPIKE-001** / ANCHOR / ROLL — no production port without human sign-off  
-- [x] Update this file’s “Last agent / Last updated” when you finish a slice  
+- [x] Open board URL  
+- [x] Mirror / merge upstream kit into this repo (done historically)  
+- [x] BOARD-SPIKE / ANCHOR / ROLL / A→B→C / FIX-NOTES-DI shipped  
+- [x] **STANDALONE 2026-07-18** — no upstream port  
+- [ ] Update this file’s “Last agent / Last updated” when you finish a slice  
 
-**Last agent (writer):** implementer (Cursor) · **Last updated:** 2026-07-17  
-**Next agent:** maintainer (@SavinRazvan) — **PORT-GATE** approve or defer production port (board card `PVTI_lAHOBl46-84A9KZxzgzOZuE`).
+**Last agent (writer):** implementer (Cursor) · **Last updated:** 2026-07-18  
+**Next agent:** any agent — Entry=`project status`; Ready backlog includes EA-010.
 
-**Implemented (2026-07-17):** `cursor_workflow project` CLI, `project-board` agent/skill, ADR-008, Ready→Done demo, all agent Anchors board-first, DRIFT-009, payload sync, experiment overlay installed, board seeded, doc-facts hygiene.
+**Implemented:** `cursor_workflow project` CLI, `project-board` agent/skill, ADR-008, all agent Anchors board-first, DRIFT-009/010, merge.py board sync, FIX-NOTES-DI, payload sync, `project-ssot-precedence` overlay.
 
-### PORT-GATE decision (human)
+### STANDALONE decision (human)
 
 | Field | Value |
 |-------|--------|
-| **Status** | **Deferred** until explicit approve (safe default per ADR-008 §7) |
-| **Board card** | `[PORT-GATE] …` · `PVTI_lAHOBl46-84A9KZxzgzOZuE` · In progress / P0 |
-| **Approve** | Record date + “PORT approved” here; then open port PR to `mas-workflow-kit` |
-| **Defer** | Leave marketplace on markdown SSOT; keep iterating in this sibling |
+| **Status** | **STANDALONE decided** 2026-07-18 |
+| **Board card** | Was `[PORT-GATE] …` · `PVTI_lAHOBl46-84A9KZxzgzOZuE` → **Done** |
+| **Decision** | This repo is the permanent product. **No** port to `mas-workflow-kit`. Board = only writable SSOT; local = evidence. |
+| **Next** | Ready backlog (e.g. EA-010) / normal slices |

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # mas-workflow-kit-project-ssot
 
-**Experiment:** Make a **GitHub Project** the SSOT for backlog/status — replace local tracker markdown so collaborators and agents share one board (configured in `github.collaboration.yaml` like identity).
+**Product:** MAS Workflow Kit — Project SSOT. Collaborators and agents share one **GitHub Project** as the **only writable SSOT** for backlog/status; **local artifacts** hold PR gates, audits, and evidence. Configured in `github.collaboration.yaml` like identity.
 
 | | |
 |--|--|
 | **Board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
-| **Production kit (do not break)** | [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) |
+| **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
+| **Lineage (read-only)** | [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) — historical upstream; never merge doctrine back |
 | **Agent handoff (READ FIRST)** | [HANDOFF.md](./HANDOFF.md) |
 
-**Experiment agents (8):** `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `researcher`, `integrator-mas-agent`, `workflow-drift-guard`, `project-board` — see [AGENTS.md](./AGENTS.md). Board CLI: `python -m cursor_workflow project …`. **Continuation:** every agent reads the Project on Entry and updates Status/Notes on Exit ([project-board-collaboration.md](.ai_infra/docs/operations/project-board-collaboration.md)).
+**Agents (8):** `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `researcher`, `integrator-mas-agent`, `workflow-drift-guard`, `project-board` — see [AGENTS.md](./AGENTS.md). Board CLI: `python3 -m cursor_workflow project …`. **Continuation:** every agent reads the Project on Entry and updates Status/Notes on Exit ([project-board-collaboration.md](.ai_infra/docs/operations/project-board-collaboration.md)).
 
-This repository is an isolated sibling sandbox. If the experiment fails, abandon this repo; leave marketplace `mas-workflow-kit` on markdown SSOT.
+**STANDALONE 2026-07-18:** this repository **is** the product (already separated). Do not treat it as a temporary sandbox or a port queue into upstream `mas-workflow-kit`.
 
-**Kit mirror:** This tree includes a full merge of production [`mas-workflow-kit`](https://github.com/SavinRazvan/mas-workflow-kit) `main` (tip `8a779fa` / tag `v0.4.0`). Use kit docs below for agents, skills, PR workflow, and CLI — but follow [HANDOFF.md](./HANDOFF.md) for experiment scope and board-first work. This experiment workspace applies **7 universal** Cursor rules (6 kit + `project-ssot-precedence`).
+**Lineage:** Tree originally mirrored from [`mas-workflow-kit`](https://github.com/SavinRazvan/mas-workflow-kit) `main` (tip `8a779fa` / tag `v0.4.0`). Follow [HANDOFF.md](./HANDOFF.md) for board+local SSOT. This workspace applies **7 universal** Cursor rules (6 kit + `project-ssot-precedence`).
 
 ## Clone (new Cursor window)
 
@@ -23,7 +24,17 @@ cd mas-workflow-kit-project-ssot
 
 Open the folder in Cursor → point the agent at **`HANDOFF.md`**.
 
-## Kit quick navigation (mirrored from production)
+## Install the plugin (consumers)
+
+In **Agent chat** (not terminal):
+
+```text
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
+```
+
+Then open **your app** and run `/workflow-activate`.
+
+## Kit quick navigation
 
 - **Plugin manual** — [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md)
 - **Consumer quickstart** — [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md)

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -39,7 +39,7 @@ Own **board triage and Status transitions** for the experiment Project SSOT. Han
 |----|--------|
 | Drive board via `cursor_workflow project` | Bypass `prepare.py` gates |
 | Use YAML field/option ids | Dual-write board + tracker SSOT |
-| Hand off code slices to implementer | Mutate production `mas-workflow-kit` |
+| Hand off code slices to implementer | Mutate upstream `mas-workflow-kit` |
 | Fall back to local trackers when disabled | Invent MCP tools |
 
 ## Handoff format

--- a/assets/README.md
+++ b/assets/README.md
@@ -18,11 +18,11 @@ Place **`logo.png`** or **`logo.svg`** here (1:1 aspect ratio, recommended 512×
 After commit to `main`, the marketplace **Logotype URL** is:
 
 ```bash
-https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit/main/assets/logo.png
+https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/logo.png
 ```
 
 ## Install screenshot
 
-`mas-workflow-kit-install.png` — Agent chat with `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` and the plugin preview card. Linked from root `README.md` § Get started step 1.
+`mas-workflow-kit-install.png` — Agent chat with `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` and the plugin preview card. Linked from root `README.md` § Get started step 1.
 
 Publisher: Savin Ionuț Răzvan · [razvansavin.com](https://razvansavin.com/) · [GitHub](https://github.com/SavinRazvan)

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -336,7 +336,7 @@ export default function BoardSsotVsKitCanvas() {
         <Stat value="Markdown" label="Classic SSOT" />
         <Stat value="GitHub Project" label="Shipped SSOT" tone="success" />
         <Stat value="0 / 0 / 0" label="DRIFT P0 P1 P2" tone="success" />
-        <Stat value="In progress" label="PORT-GATE" tone="warning" />
+        <Stat value="STANDALONE" label="Decided 2026-07-18" tone="success" />
       </Grid>
 
       <Callout tone="success" title="North star (shipped)">
@@ -552,7 +552,7 @@ export default function BoardSsotVsKitCanvas() {
         <Callout tone="success" title="append-notes on draft issues (FIX-NOTES-DI)">
           Previously a known gap. append-notes now resolves PVTI_ → DI_ + title for
           DraftIssue content; Status stays on PVTI_; Issue-backed cards use gh issue
-          edit. Smoke OK; board card Done. Shipped locally — pending PR to main.
+          edit. Shipped on main (PR #3).
         </Callout>
       </CollapsibleSection>
 
@@ -590,10 +590,10 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">cursor_workflow project CLI (9 commands)</Text>
               <Text size="small">8 agent Anchors + continuation contract</Text>
               <Text size="small">ADR-008 + project-ssot-precedence overlay</Text>
-              <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI local</Text>
+              <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI on main (PR #3)</Text>
               <Text size="small">Edge-case tests: focused 36+; collect ~669</Text>
               <Text size="small">DRIFT validate P0=0 P1=0 P2=0</Text>
-              <Text size="small">Doc-drift skill residuals fixed (local)</Text>
+              <Text size="small">STANDALONE decided — this repo is the product</Text>
             </Stack>
           </CardBody>
         </Card>
@@ -603,28 +603,26 @@ export default function BoardSsotVsKitCanvas() {
           </CardHeader>
           <CardBody>
             <Stack gap={4}>
-              <Text size="small">PORT-GATE — In progress (human)</Text>
-              <Text size="small">Production mas-workflow-kit port approval</Text>
-              <Text size="small">Marketplace bump for consumers</Text>
+              <Text size="small">STANDALONE decided — no upstream port</Text>
               <Text size="small">EA-010 Ready — ICC read-only board panel</Text>
               <Text size="small">promote_to_issue_on_pr — optional future</Text>
-              <Text size="small">FIX-NOTES-DI + residuals — pending PR</Text>
+              <Text size="small">Install screenshot asset TBD if UI text differs</Text>
             </Stack>
           </CardBody>
         </Card>
       </Grid>
 
       <Spacer />
-      <Callout tone="neutral" title="How to read this before PORT-GATE">
+      <Callout tone="neutral" title="How to read this (STANDALONE product)">
         Classic kit solved disciplined agents + PR gates on local markdown.
-        This experiment relocated coordination to one GitHub Project — A→B→C merged,
-        follow-ups done locally. Production kit stays markdown SSOT until explicit
-        human port approval.
+        This repository is the permanent product: coordination on one GitHub Project,
+        evidence in local artifacts. Upstream mas-workflow-kit is lineage only —
+        no port back. Board Entry/Exit continues every agent slice.
       </Callout>
 
       <Text size="small" tone="tertiary">
-        Source: HANDOFF §1 · ADR-008 · PR #2 merged · FIX-NOTES-DI local · drift
-        validate green · 2026-07-18
+        Source: HANDOFF §1 · ADR-008 · STANDALONE 2026-07-18 · PR #2/#3 merged ·
+        drift validate green · 2026-07-18
       </Text>
     </Stack>
   );

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -1,18 +1,18 @@
 ---
-description: Experiment — GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
+description: GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
 alwaysApply: true
 ---
 
-# Project SSOT precedence (experiment)
+# Project SSOT precedence
 
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 - **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
-- Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
+- This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -27,7 +27,7 @@ Notes:
 
 Enabling the **plugin** loads agents/skills/rules in the IDE only — it does **not** write files to your project. Run activate to install all three planes on disk:
 
-1. **Plugin from GitHub (recommended):** Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` → open your app → **`/workflow-activate`** (or `python -m cursor_workflow activate --directory .`)
+1. **Plugin from GitHub (recommended):** Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` → open your app → **`/workflow-activate`** (or `python -m cursor_workflow activate --directory .`)
 2. **Marketplace (when listed):** same flow after **Cursor → Marketplace** install
 3. **Kit clone / advanced:** `python -m cursor_workflow install --target . --verify`
 

--- a/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -1,11 +1,11 @@
 # ADR-008: GitHub Project board as agent SSOT
 
-**Status:** accepted (experiment — this sibling repo only)  
-**Date:** 2026-07-17
+**Status:** accepted — **product doctrine for this repository** (`mas-workflow-kit-project-ssot`)  
+**Date:** 2026-07-17 · **STANDALONE:** 2026-07-18
 
 ## Context
 
-MAS Workflow Kit defaults to local markdown trackers under `.local/index-and-planning/current/` as session SSOT. Collaborators cannot share that state. This experiment (`mas-workflow-kit-project-ssot`) configures a GitHub Project in `.local/user_settings/github.collaboration.yaml` → `project_ssot` and drives it via `python -m cursor_workflow project`.
+Classic MAS Workflow Kit used local markdown trackers under `.local/index-and-planning/current/` as session SSOT. Collaborators cannot share that state. **This repository is the product** — already separated from upstream `mas-workflow-kit` — and configures a GitHub Project in `.local/user_settings/github.collaboration.yaml` → `project_ssot`, driven via `python3 -m cursor_workflow project`. Local artifacts remain for PR gates, audits, and evidence.
 
 Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HANDOFF.md).
 
@@ -20,8 +20,8 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 7. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
 8. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
 9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
-10. **Production port deferred** until demo + implementer Anchor + dual-write drift check + human sign-off. Marketplace kit stays markdown SSOT until then.
-11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization — agents never edit these.
+10. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
+11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
 
 ## Consequences
 

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -60,7 +60,7 @@ flowchart LR
 In **Agent chat** (not the terminal):
 
 ```text
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
 Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
@@ -70,7 +70,7 @@ Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card t
 Optional — explicit branch:
 
 ```text
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit/tree/main
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/tree/main
 ```
 
 This loads agents, skills, and rules into Cursor. Your project may only get `.cursor/settings.json` until you activate (§2).
@@ -85,10 +85,10 @@ This loads agents, skills, and rules into Cursor. Your project may only get `.cu
 
 | Step | Action |
 |------|--------|
-| 1. Plugin | Agent chat: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` *(or Marketplace when listed)* |
+| 1. Plugin | Agent chat: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` *(or Marketplace when listed)* |
 | 2. Activate | Open **your app** → Agent chat → **`/workflow-activate`** → wait for **`VERIFY PASS`** and all planes **ready** |
 | 3. Your name | Edit `.local/user_settings/github.collaboration.yaml` → `python3 -m cursor_workflow contributors validate` |
-| 4. Build | **`/implementer`** · read `session-pointer.md` → `plan.md` → `work-tracker.md` |
+| 4. Build | **`/implementer`** · when `project_ssot.enabled`, Entry = `python3 -m cursor_workflow project status` (board first); else `session-pointer.md` → `plan.md` → `work-tracker.md` |
 
 **Step 2 — in Agent chat (not the terminal):**
 
@@ -131,7 +131,7 @@ your-project/
 └── tests/modules/smoke/           # install smoke test only
 ```
 
-**Not installed:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs. Those exist only in the [kit repository](https://github.com/SavinRazvan/mas-workflow-kit).
+**Not installed:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs. Those exist only in the [kit repository](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot).
 
 **Re-activate is safe:** existing trackers, `user_settings/`, and `AGENTS.md` are not overwritten. Kit-managed **dashboard HTML**, JS/CSS, `module-audit.html`, and `pages.json` **are refreshed** on each activate.
 
@@ -148,7 +148,7 @@ your-project/
 
 | Goal | Type in chat |
 |------|--------------|
-| Install plugin | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` |
+| Install plugin | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Activate / refresh | `/workflow-activate` |
 | Implement | `/implementer` |
 | Tests | `/test-runner` |
@@ -246,8 +246,8 @@ Cursor may also auto-delegate subagents when the task matches their `description
 
 Every session:
 
-1. `.local/index-and-planning/current/session-pointer.md`
-2. `plan.md` → `work-tracker.md`
+1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else `.local/index-and-planning/current/session-pointer.md`
+2. Board card Status/Notes (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
 3. **`/implementer`** (or specialist agent from §6)
 4. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
 
@@ -340,4 +340,4 @@ More: [consumer-quickstart.md](consumer-quickstart.md) § Troubleshooting.
 | Upgrade / semver | [upgrade-kit.md](upgrade-kit.md) |
 | Optional project metadata | [project-config.md](project-config.md) |
 
-**Kit maintainers** (not copied to your project): `PLUGIN-ARCHITECTURE.md` and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/mas-workflow-kit/tree/main/.ai_infra/docs/handoff).
+**Kit maintainers** (not copied to your project): `PLUGIN-ARCHITECTURE.md` and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/tree/main/.ai_infra/docs/handoff).

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -27,10 +27,10 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 
 | Step | Action |
 |------|--------|
-| **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` — or **Cursor → Marketplace** when listed |
+| **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` — or **Cursor → Marketplace** when listed |
 | **2. Activate** | Open **your app folder** → Agent chat: **`/workflow-activate`** → wait for **`VERIFY PASS`** |
 | **3. Your name** | Edit `.local/user_settings/github.collaboration.yaml` → set `display_name` + `github_user` → `python3 -m cursor_workflow contributors validate` |
-| **4. Build** | **`/implementer`** · read `session-pointer.md` → `plan.md` → `work-tracker.md` |
+| **4. Build** | **`/implementer`** · when `project_ssot.enabled`, Entry = `python3 -m cursor_workflow project status` (board first); else `session-pointer.md` → `plan.md` → `work-tracker.md` |
 
 **Healthy install?** `python3 -m cursor_workflow health`
 
@@ -41,7 +41,7 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 `/add-plugin` runs in **Cursor Agent chat only** — it is not a shell command.
 
 ```bash
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
 Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
@@ -51,7 +51,7 @@ Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card t
 Optional — pin `main`:
 
 ```bash
-/add-plugin https://github.com/SavinRazvan/mas-workflow-kit/tree/main
+/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/tree/main
 ```
 
 After install you may see only `.cursor/settings.json` in the project. That is expected — run **step 2** to copy the full bundle.
@@ -153,8 +153,8 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 
 ## Step 4 detail — daily workflow
 
-1. Open `.local/index-and-planning/current/session-pointer.md`
-2. Update `plan.md` and `work-tracker.md` for your slice
+1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else open `.local/index-and-planning/current/session-pointer.md`
+2. Claim/update the board card (Status + Notes); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`
 3. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
 4. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
 
@@ -175,7 +175,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 
 | Goal | Command |
 |------|---------|
-| Install plugin (once) | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` |
+| Install plugin (once) | `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Activate / refresh kit | `/workflow-activate` |
 | Implement a slice | `/implementer` |
 | Tests / coverage | `/test-runner` |
@@ -309,7 +309,7 @@ Gate details: [gate-matrix.md](gate-matrix.md) (consumer scaffold = 4 checks).
 
 ## Kit clone path (advanced)
 
-When not using the plugin UI — clone [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit), then:
+When not using the plugin UI — clone [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot), then:
 
 ```bash
 python3 -m venv .venv && .venv/bin/pip install -q -r requirements-dev.txt

--- a/payload/.ai_infra/docs/operations/install-dry-run.md
+++ b/payload/.ai_infra/docs/operations/install-dry-run.md
@@ -46,7 +46,7 @@ python .ai_infra/scripts/install/scaffold.py \
 
 See [`scripts/install/README.md`](../../scripts/install/README.md).
 
-**Marketplace / plugin smoke (Track A + B):** kit repo [`marketplace-publish.md`](https://github.com/SavinRazvan/mas-workflow-kit/blob/main/.ai_infra/docs/handoff/marketplace-publish.md) § Automated smoke, or `make smoke-consumer` from kit repo.
+**Marketplace / plugin smoke (Track A + B):** this product repo [`marketplace-publish.md`](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/blob/main/.ai_infra/docs/handoff/marketplace-publish.md) § Automated smoke, or `make smoke-consumer` from this repo.
 
 ## Manual steps
 

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -72,4 +72,4 @@ Handoff: `item_id=PVTI_… · Status=a→b · next=<agent>`
 
 ## Human-only
 
-Views, workflows, Insights, Project README, status updates, Ready prioritization, PORT-GATE.
+Views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap.

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -39,7 +39,7 @@ Own **board triage and Status transitions** for the experiment Project SSOT. Han
 |----|--------|
 | Drive board via `cursor_workflow project` | Bypass `prepare.py` gates |
 | Use YAML field/option ids | Dual-write board + tracker SSOT |
-| Hand off code slices to implementer | Mutate production `mas-workflow-kit` |
+| Hand off code slices to implementer | Mutate upstream `mas-workflow-kit` |
 | Fall back to local trackers when disabled | Invent MCP tools |
 
 ## Handoff format

--- a/payload/.cursor/rules/implementation-workflow-governance.mdc
+++ b/payload/.cursor/rules/implementation-workflow-governance.mdc
@@ -9,6 +9,7 @@ alwaysApply: true
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.
 - Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
+- When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m cursor_workflow project status` / claim card); local trackers are offline fallback only.
 - Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
 - Exactly one primary task `in_progress` in `work-tracker.md`; do not implement without scope in `plan.md`.
 - Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -1,18 +1,18 @@
 ---
-description: Experiment — GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
+description: GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
 alwaysApply: true
 ---
 
-# Project SSOT precedence (experiment)
+# Project SSOT precedence
 
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 - **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
-- Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
+- This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -136,4 +136,4 @@ When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in 
 - Reshuffling Ready/P0 without human or project-board ask
 - Editing Project views, workflows, Insights, or status updates
 - Dual-write board + tracker under `board_only`
-- Port to production kit without PORT-GATE
+- Do not push to upstream mas-workflow-kit

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -23,7 +23,7 @@ User enabled the **MAS Workflow Kit** plugin and opened **their project** (not t
 
 ## Guide the user (keep it simple)
 
-1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
+1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
 2. Confirm the open folder is **their app**, not `mas-workflow-kit`.
 3. Run activate (below) — or tell them to pick **`/workflow-activate`** from the **`/`** menu.
 4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate`.

--- a/rules/implementation-workflow-governance.mdc
+++ b/rules/implementation-workflow-governance.mdc
@@ -9,6 +9,7 @@ alwaysApply: true
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.
 - Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
+- When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m cursor_workflow project status` / claim card); local trackers are offline fallback only.
 - Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
 - Exactly one primary task `in_progress` in `work-tracker.md`; do not implement without scope in `plan.md`.
 - Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -1,18 +1,18 @@
 ---
-description: Experiment — GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
+description: GitHub Project SSOT precedes local tracker markdown when project_ssot.enabled
 alwaysApply: true
 ---
 
-# Project SSOT precedence (experiment)
+# Project SSOT precedence
 
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
 - **workflow-drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` for this experiment only — see ADR-008 (`board_only` wins; DRIFT-009).
+- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
-- Do not port this rule to production `mas-workflow-kit` until the experiment port gate passes.
+- This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -136,4 +136,4 @@ When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in 
 - Reshuffling Ready/P0 without human or project-board ask
 - Editing Project views, workflows, Insights, or status updates
 - Dual-write board + tracker under `board_only`
-- Port to production kit without PORT-GATE
+- Do not push to upstream mas-workflow-kit

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -23,7 +23,7 @@ User enabled the **MAS Workflow Kit** plugin and opened **their project** (not t
 
 ## Guide the user (keep it simple)
 
-1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
+1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
 2. Confirm the open folder is **their app**, not `mas-workflow-kit`.
 3. Run activate (below) — or tell them to pick **`/workflow-activate`** from the **`/`** menu.
 4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate`.


### PR DESCRIPTION
## Summary
- Retarget north star: this repo is the permanent product (already separated); no port to `mas-workflow-kit`
- Board = only writable SSOT; local artifacts = evidence; install URLs → this GitHub repo
- Close PORT-GATE as STANDALONE; refresh canvas / IMPLEMENTATION-STATUS / consumer Entry

## Test plan
- [x] anti-drift greps clean
- [x] drift validate P0=0
- [x] integrate validate P0=0
- [x] check_doc_facts + governance green
- [ ] prepare.py gates on PR


Made with [Cursor](https://cursor.com)