### PR TITLE
feat: @user/agent board Notes attribution

### DIFF
--- a/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -22,6 +22,7 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
 10. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
 11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
+12. **Multi-collaborator attribution:** card Notes use `@owner.github_user/<agent>` (from each person’s `github.collaboration.yaml`). CLI: `append-notes --agent <name>` when `require_attribution_on_exit`. GitHub Assignees are humans only (`set-assignee`); agent role lives in Notes. Handoff: `next=@user/agent`.
 
 ## Consequences
 
@@ -32,6 +33,7 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 - Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); workflow-drift-guard **reads and updates** the board on Exit
 - Post-merge Done: Pattern A `merge.py` (not a dedicated agent)
 - DraftIssue body edits: `append-notes` / `edit_item_body` resolve project item `PVTI_…` → content `DI_…` (+ preserve `--title`); Status/field edits stay on `PVTI_…`
+- Attribution: `append-notes --agent` prefixes `@github_user/agent`; `merge.py` Notes use `@user/merge.py`; `set-assignee` for human My items (Issue-backed)
 
 ## References
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-18 (STANDALONE product doctrine)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 669
+**Last updated:** 2026-07-18 (ATTR-USER-AGENT attribution)  
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 673
 
 ## Shipped (confirmed in repo)
 
@@ -44,7 +44,7 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 669 | `tests/modules/` |
+| Tests | 673 | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -25,7 +25,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Status drifts from reality | Status column = truth (DRIFT-009 watches dual-write) |
 | Humans cannot see progress | Project UI is the shared dashboard |
 
-**Rule:** Entry = read board. Exit = update Status (and Notes) for the card you touched.
+**Rule:** Entry = read board. Exit = update Status and **attributed Notes** (`append-notes --agent <name>` → `@owner.github_user/<agent>`) for the card you touched.
 
 ## Surfaces — who may write
 
@@ -36,10 +36,10 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Create cards | Yes | project-board, implementer, integrator | — |
 | Ready prioritization | **Owner** | Consume; create agreed work | — |
 | Views / workflows / Insights / README / status updates | **Owner only** | Never | Insights auto |
-| Assignee / My items | Yes | Claim = In progress | My items view |
+| Assignee / My items | Yes (`set-assignee` / UI) | Claim = In progress; assignee = **human** only | My items view |
+| Card Notes (`append-notes --agent`) | Yes | Yes — `@user/agent · …`; `next=@user/agent` | — |
 | PR / audits / secrets | Local | Local | — |
-| Post-merge Status → Done | — | Via `merge.py` (Pattern A) | — |
-| Card Notes (`append-notes`) | Yes | Yes — pass `PVTI_…`; CLI resolves `DI_…` for DraftIssue body | — |
+| Post-merge Status → Done | — | Via `merge.py` (Pattern A); Notes `@user/merge.py` | — |
 | Read-only board export | Consume | `project export` (never writes Status) | — |
 
 ## Per-agent Entry / Exit
@@ -47,13 +47,13 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Agent | Entry | Exit (board) |
 |-------|-------|--------------|
 | **project-board** | status + list | Full triage; handoff to implementer |
-| **implementer** | status + Ready/claim | →In review / →Done; Notes for next |
-| **test-runner** | status + slice card | →In review or →Done when tests finish |
-| **verifier** | status + related card | →Done or leave In review + Notes |
-| **integrator-mas-agent** | status + claim | →Done on integration card |
-| **enterprise-auditor** | status + audit card | →In review/Done; Notes → artifact paths |
-| **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; cite board in drift-audit; remediation via Notes/Ready handoff — no silent tracker edits |
-| **researcher** | status (+ research card) | Research card →Done + corpus paths in Notes |
+| **implementer** | status + Ready/claim | →In review / →Done; `append-notes --agent implementer` |
+| **test-runner** | status + slice card | →In review or →Done; `--agent test-runner` |
+| **verifier** | status + related card | →Done or leave In review; `--agent verifier` |
+| **integrator-mas-agent** | status + claim | →Done; `--agent integrator-mas-agent` |
+| **enterprise-auditor** | status + audit card | →In review/Done; `--agent enterprise-auditor` + artifact paths |
+| **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; `--agent workflow-drift-guard`; remediation via Notes/Ready — no silent tracker edits |
+| **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + corpus paths |
 
 ## Status path
 
@@ -61,7 +61,9 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 Ready → In progress → In review → Done
 ```
 
-Handoff: `item_id=PVTI_… · Status=a→b · next=<agent>`
+Handoff: `item_id=PVTI_… · @User/implementer · Status=a→b · next=@User/verifier`
+
+**Attribution:** Notes use `@owner.github_user/<agent>` from each collaborator’s `github.collaboration.yaml` so multi-user boards do not collide.
 
 ## workflow-drift-guard specifically
 

--- a/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/.ai_infra/install/cursor_workflow/project_cli.py
@@ -11,6 +11,7 @@ Depends On:
 Notes:
  - Pattern A: one gh invocation per action; no dual-write of local trackers.
  - DraftIssue body edits resolve PVTI_… → DI_… (+ --title); Status stays on PVTI_….
+ - Notes attribution: @owner.github_user/agent via append-notes --agent.
 """
 
 from __future__ import annotations
@@ -63,6 +64,88 @@ def require_enabled(ssot: dict[str, Any]) -> list[str]:
         if ssot.get(key) in (None, ""):
             return [f"project_ssot.{key} is required when enabled"]
     return []
+
+
+def normalize_github_handle(raw: str) -> str:
+    """Ensure leading @ on a GitHub login."""
+    s = (raw or "").strip()
+    if not s:
+        return ""
+    return s if s.startswith("@") else f"@{s}"
+
+
+def resolve_human_github_user(root: Path) -> str:
+    """Human identity from owner.github_user (not project_ssot.owner)."""
+    us = _import_user_settings(root)
+    handle = us.resolve_github_user(root)
+    return normalize_github_handle(str(handle or ""))
+
+
+def attribution_required(ssot: dict[str, Any]) -> bool:
+    conventions = ssot.get("conventions") or {}
+    return bool(conventions.get("require_attribution_on_exit", True))
+
+
+def format_agent_attribution(root: Path, agent: str) -> str:
+    """Return @github_user/agent for board Notes."""
+    user = resolve_human_github_user(root)
+    agent_key = (agent or "").strip().lstrip("@")
+    if not user:
+        raise ValueError("owner.github_user missing — set github.collaboration.yaml")
+    if not agent_key:
+        raise ValueError("agent name required for attribution")
+    return f"{user}/{agent_key}"
+
+
+def format_note_line(root: Path, agent: str, text: str) -> str:
+    """
+    Prefix note with @user/agent · text.
+    Idempotent if text already starts with that attribution.
+    """
+    attr = format_agent_attribution(root, agent)
+    body = (text or "").strip()
+    if body.startswith(attr):
+        return body
+    # Also accept without requiring exact agent if already @user/something
+    if re.match(r"^@[^\s/]+/[^\s·]+", body):
+        return body
+    if not body:
+        return attr
+    return f"{attr} · {body}"
+
+
+def set_item_assignee(
+    ssot: dict[str, Any], item_id: str, login: str
+) -> tuple[bool, str]:
+    """
+    Assign a GitHub human user to an Issue-backed project item.
+    DraftIssue: not supported — return False with hint to use Notes or promote.
+    """
+    kind, cid, meta, err = resolve_item_content(ssot, item_id)
+    if err or not kind or not cid:
+        return False, err or "could not resolve content for assignee"
+    login_clean = (login or "").strip().lstrip("@")
+    if not login_clean:
+        return False, "assignee login empty"
+
+    if kind == "issue":
+        meta = meta or {}
+        repo = str(meta.get("repo") or ssot.get("default_repo") or "")
+        gh_args = ["issue", "edit", cid, "--add-assignee", login_clean]
+        if repo:
+            gh_args.extend(["--repo", repo])
+        proc = run_gh(gh_args)
+        if proc.returncode != 0:
+            return False, (proc.stderr or proc.stdout or "gh issue edit --add-assignee failed").strip()
+        return True, login_clean
+
+    if kind == "draft":
+        return (
+            False,
+            "DraftIssue has no GitHub Assignees; use Notes @user/agent "
+            "or promote to Issue (promote_to_issue_on_pr)",
+        )
+    return False, f"unsupported content kind {kind!r} for assignee"
 
 
 def resolve_status_option_id(ssot: dict[str, Any], logical: str) -> str:
@@ -781,6 +864,21 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         for e in enabled_errs:
             print(f"project append-notes: FAIL — {e}", file=sys.stderr)
         return 2
+    agent = getattr(args, "agent", None) or ""
+    if attribution_required(ssot) and not str(agent).strip():
+        print(
+            "project append-notes: FAIL — --agent required "
+            "(project_ssot.conventions.require_attribution_on_exit)",
+            file=sys.stderr,
+        )
+        return 2
+    note_text = args.text
+    if str(agent).strip():
+        try:
+            note_text = format_note_line(root, str(agent), args.text)
+        except ValueError as exc:
+            print(f"project append-notes: FAIL — {exc}", file=sys.stderr)
+            return 2
     items, err = fetch_project_items(ssot, limit=args.limit)
     if err:
         print(f"project append-notes: FAIL — {err}", file=sys.stderr)
@@ -790,7 +888,7 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         print(f"project append-notes: FAIL — item not found: {args.id}", file=sys.stderr)
         return 1
     body = _item_body(item)
-    new_body, changed = append_notes_to_body(body, args.text)
+    new_body, changed = append_notes_to_body(body, note_text)
     if not changed:
         print(f"append-notes: {args.id} — already present (idempotent skip)")
         return 0
@@ -799,6 +897,40 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         print(f"project append-notes: FAIL — {detail}", file=sys.stderr)
         return 1
     print(f"append-notes: {args.id} — updated")
+    return 0
+
+
+def cmd_set_assignee(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project set-assignee: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project set-assignee: FAIL — {e}", file=sys.stderr)
+        return 2
+    login = (getattr(args, "login", None) or "").strip()
+    if not login:
+        try:
+            login = resolve_human_github_user(root).lstrip("@")
+        except Exception as exc:  # noqa: BLE001
+            print(f"project set-assignee: FAIL — {exc}", file=sys.stderr)
+            return 2
+    if not login:
+        print(
+            "project set-assignee: FAIL — no login "
+            "(pass --login or set owner.github_user)",
+            file=sys.stderr,
+        )
+        return 2
+    ok, detail = set_item_assignee(ssot, args.id, login)
+    if not ok:
+        print(f"project set-assignee: FAIL — {detail}", file=sys.stderr)
+        return 1
+    print(f"set-assignee: {args.id} → @{detail.lstrip('@')}")
     return 0
 
 
@@ -922,13 +1054,32 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     get_cmd.set_defaults(func=cmd_get)
 
     notes_cmd = project_sub.add_parser(
-        "append-notes", help="Append a line under ## Notes on the card body"
+        "append-notes",
+        help="Append a line under ## Notes (prefix @user/agent when --agent set)",
     )
     notes_cmd.add_argument("--directory", type=Path, default=".")
     notes_cmd.add_argument("--id", required=True)
     notes_cmd.add_argument("--text", required=True)
+    notes_cmd.add_argument(
+        "--agent",
+        default="",
+        help="Agent id for attribution (required when require_attribution_on_exit)",
+    )
     notes_cmd.add_argument("--limit", type=int, default=100)
     notes_cmd.set_defaults(func=cmd_append_notes)
+
+    assignee_cmd = project_sub.add_parser(
+        "set-assignee",
+        help="Assign GitHub human user (Issue-backed); default owner.github_user",
+    )
+    assignee_cmd.add_argument("--directory", type=Path, default=".")
+    assignee_cmd.add_argument("--id", required=True, help="Project item id (PVTI_…)")
+    assignee_cmd.add_argument(
+        "--login",
+        default="",
+        help="GitHub login (default: owner.github_user from collab YAML)",
+    )
+    assignee_cmd.set_defaults(func=cmd_set_assignee)
 
     find_cmd = project_sub.add_parser(
         "find-by-pr", help="Resolve project item id from PR (Board-Item or body scan)"

--- a/.ai_infra/schemas/github-collaboration.schema.json
+++ b/.ai_infra/schemas/github-collaboration.schema.json
@@ -38,7 +38,32 @@
         },
         "fallback": { "type": "string", "enum": ["local_trackers", "none"] },
         "fields": { "type": "object", "additionalProperties": true },
-        "conventions": { "type": "object", "additionalProperties": true },
+        "conventions": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "queue_status": { "type": "string" },
+            "active_status": { "type": "string" },
+            "review_status": { "type": "string" },
+            "done_status": { "type": "string" },
+            "claim": { "type": "string" },
+            "one_in_progress_per_assignee": { "type": "boolean" },
+            "item_kind_default": { "type": "string" },
+            "promote_to_issue_on_pr": { "type": "boolean" },
+            "attribution_format": {
+              "type": "string",
+              "description": "Template for Notes prefix; rendered as @github_user/agent"
+            },
+            "require_attribution_on_exit": {
+              "type": "boolean",
+              "description": "When true, project append-notes requires --agent"
+            },
+            "body_sections": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
         "local_only": {
           "type": "array",
           "items": { "type": "string" }

--- a/.ai_infra/scripts/pr/merge.py
+++ b/.ai_infra/scripts/pr/merge.py
@@ -141,6 +141,10 @@ def sync_board_after_merge(
 
     pr_url = _pr_url(root, pr, str(ssot.get("default_repo") or ""))
     note = f"Merged: {pr_url} @ {merge_sha}"
+    try:
+        note = project_cli.format_note_line(root, "merge.py", note)
+    except Exception:  # noqa: BLE001 — never block merge on attribution
+        pass
     items, list_err = project_cli.fetch_project_items(ssot, limit=100)
     if list_err:
         print(f"[WARN] board sync append-notes list failed: {list_err}", file=sys.stderr)

--- a/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -79,6 +79,9 @@ project_ssot:
     one_in_progress_per_assignee: true
     item_kind_default: draft              # draft | issue
     promote_to_issue_on_pr: true
+    # Board Notes: @github_user/agent (owner.github_user from this file — not project_ssot.owner)
+    attribution_format: "{github_user}/{agent}"
+    require_attribution_on_exit: true
     body_sections:
       - Acceptance
       - Rollback

--- a/.cursor/agents/enterprise-auditor.md
+++ b/.cursor/agents/enterprise-auditor.md
@@ -12,7 +12,7 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
 
-**Board rights:** Status + Notes on **audit card** required on Exit. No Priority reshuffle; no Project views/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent enterprise-auditor` (prefixes `@owner.github_user/enterprise-auditor`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -16,12 +16,13 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Exit (board-first when enabled):**
 
-1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed). Put next agent in card Notes when handing off.
-2. Append `change-index.md`; one line in `history/updates-log.md`.
-3. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-4. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+1. `python3 -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed).
+2. `python3 -m cursor_workflow project append-notes --id PVTI_… --agent implementer --text "… · next=@User/verifier"` (required attribution).
+3. Append `change-index.md`; one line in `history/updates-log.md`.
+4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
+5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
-**Board rights:** claim Ready→In progress; In review on PR; Done on close; Priority/Size on **own** card; may create slice cards. **Exit Status update is mandatory** for continuation. Do **not** edit Project views/workflows/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent implementer` (prefixes `@owner.github_user/implementer`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 

--- a/.cursor/agents/integrator-mas-agent.md
+++ b/.cursor/agents/integrator-mas-agent.md
@@ -18,7 +18,7 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Create integration cards; claim→Done; fields on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent integrator-mas-agent` (prefixes `@owner.github_user/integrator-mas-agent`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 ## Read first (evidence before edits)
 

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -12,7 +12,7 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
 
-**Board rights:** Full triage — create cards; any Status; Priority/Size. Own Ready queue hygiene so other agents can claim. Never edit Project views/workflows/README/Insights. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent project-board` (prefixes `@owner.github_user/project-board`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 ## Role
 

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -12,7 +12,7 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
 
-**Board rights:** Always **read** board when enabled. **Update** only your research card on Exit. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent researcher` (prefixes `@owner.github_user/researcher`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -12,7 +12,7 @@ description: Module-focused tests, regressions, coverage.
 
 **Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
 
-**Board rights:** Stay on the slice card; Exit Status update required for continuation. Priority/Size only on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent test-runner` (prefixes `@owner.github_user/test-runner`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -12,7 +12,7 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
 
-**Board rights:** Confirm Done or leave In review + Notes. Do **not** create cards or reshuffle Priority. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent verifier` (prefixes `@owner.github_user/verifier`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.

--- a/.cursor/agents/workflow-drift-guard.md
+++ b/.cursor/agents/workflow-drift-guard.md
@@ -12,7 +12,7 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
 
-**Board rights:** **Read** board every pass. **Update** Status on the drift-pass card when finished. Remediation = Notes / Ready handoff, not silent tracker writes. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent workflow-drift-guard` (prefixes `@owner.github_user/workflow-drift-guard`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -16,3 +16,4 @@ alwaysApply: true
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
+- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -38,15 +38,16 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Print handoff line. |
-| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent>`. Print handoff line. |
+| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
-Handoff line (chat + optional card Notes):
+Handoff line (chat + card Notes):
 
 ```text
-item_id=PVTI_… · title=… · Status=before→after · next=implementer|verifier|test-runner|…
+item_id=PVTI_… · @User/implementer · Status=before→after · next=@User/verifier
 ```
 
+Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
 ## When to use
 
 - Any session where `project_ssot.enabled: true`
@@ -67,18 +68,18 @@ item_id=PVTI_… · title=… · Status=before→after · next=implementer|verif
 | Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
 | Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
 | Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
-| My items | Assign in UI | Claim = Status In progress (assignee CLI TBD) | View filter |
+| My items | Assign in UI or `project set-assignee` (human login) | Claim = Status In progress + Notes `@user/agent`; assignee = human only | View filter |
 | PR gates, audits, secrets | Local | Local (`local_only`) | — |
 
 ### Rules
 
-1. One primary **In progress** per assignee — do not steal others'.
+1. One primary **In progress** per **human assignee** — do not steal others'.
 2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index.
+3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent>` via `append-notes --agent`.
 4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
 5. Humans own views, workflows, README, Insights, status updates.
 6. Read-only `project export` (if used) never writes Status.
-7. Post-merge Done is Pattern A (`merge.py`), not a dedicated agent.
+7. Post-merge Done is Pattern A (`merge.py`), Notes prefixed `@user/merge.py`.
 
 ### Per-agent rights (what / when / where)
 
@@ -111,11 +112,11 @@ Ready → In progress → In review → Done
 
 1. **Status:** `python -m cursor_workflow project status --directory .`
 2. **List:** `python -m cursor_workflow project list [--status ready|in_progress|in_review] --directory .`
-3. **Claim:** `set-status --id PVTI_… --to in_progress`
+3. **Claim:** `set-status --id PVTI_… --to in_progress` then optional `set-assignee --id PVTI_…` (human) + `append-notes --id … --agent implementer --text "claimed · next=@User/test-runner"`
 4. **Create:** `project create --title "…" [--body "…"]`
 5. **Fields:** `set-field --id … --field priority|size --to …`
 6. **Close / handoff:** `set-status --to in_review|done`
-7. **Notes:** `append-notes --id PVTI_… --text "…"` — agents always pass the project item id (`PVTI_…`); CLI resolves DraftIssue content id (`DI_…`) for body edits and keeps Status on `PVTI_…`
+7. **Notes:** `append-notes --id PVTI_… --agent <agent> --text "…"` — required `--agent` when `require_attribution_on_exit`; CLI prefixes `@owner.github_user/agent ·`. Pass `PVTI_…`; CLI resolves `DI_…` for DraftIssue body.
 8. **Verify:** `project list` matches intent + handoff line printed
 
 ## Dual-write ban

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -126,7 +126,8 @@ GitHub Project #3       →  create / list / claim / status (human + all agents)
 
 | Rule | Detail |
 |------|--------|
-| One claim | Prefer one primary **In progress** card per agent/assignee |
+| One claim | Prefer one primary **In progress** card per **human** assignee |
+| Attribution | Notes: `@owner.github_user/<agent>` via `append-notes --agent`; `next=@user/agent` |
 | Queue | **Ready** (+ Priority P0/P1) = next work |
 | Review | **In review** when PR open; **Done** after merge/close |
 | Create | Agents may create DraftIssue/Issue on the Project when scoping work |

--- a/agents/enterprise-auditor.md
+++ b/agents/enterprise-auditor.md
@@ -12,7 +12,7 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
 
-**Board rights:** Status + Notes on **audit card** required on Exit. No Priority reshuffle; no Project views/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent enterprise-auditor` (prefixes `@owner.github_user/enterprise-auditor`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -16,12 +16,13 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Exit (board-first when enabled):**
 
-1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed). Put next agent in card Notes when handing off.
-2. Append `change-index.md`; one line in `history/updates-log.md`.
-3. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-4. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+1. `python3 -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed).
+2. `python3 -m cursor_workflow project append-notes --id PVTI_… --agent implementer --text "… · next=@User/verifier"` (required attribution).
+3. Append `change-index.md`; one line in `history/updates-log.md`.
+4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
+5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
-**Board rights:** claim Ready→In progress; In review on PR; Done on close; Priority/Size on **own** card; may create slice cards. **Exit Status update is mandatory** for continuation. Do **not** edit Project views/workflows/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent implementer` (prefixes `@owner.github_user/implementer`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 

--- a/agents/integrator-mas-agent.md
+++ b/agents/integrator-mas-agent.md
@@ -18,7 +18,7 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Create integration cards; claim→Done; fields on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent integrator-mas-agent` (prefixes `@owner.github_user/integrator-mas-agent`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 ## Read first (evidence before edits)
 

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -12,7 +12,7 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
 
-**Board rights:** Full triage — create cards; any Status; Priority/Size. Own Ready queue hygiene so other agents can claim. Never edit Project views/workflows/README/Insights. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent project-board` (prefixes `@owner.github_user/project-board`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 ## Role
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -12,7 +12,7 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
 
-**Board rights:** Always **read** board when enabled. **Update** only your research card on Exit. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent researcher` (prefixes `@owner.github_user/researcher`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -12,7 +12,7 @@ description: Module-focused tests, regressions, coverage.
 
 **Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
 
-**Board rights:** Stay on the slice card; Exit Status update required for continuation. Priority/Size only on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent test-runner` (prefixes `@owner.github_user/test-runner`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -12,7 +12,7 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
 
-**Board rights:** Confirm Done or leave In review + Notes. Do **not** create cards or reshuffle Priority. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent verifier` (prefixes `@owner.github_user/verifier`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.

--- a/agents/workflow-drift-guard.md
+++ b/agents/workflow-drift-guard.md
@@ -12,7 +12,7 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
 
-**Board rights:** **Read** board every pass. **Update** Status on the drift-pass card when finished. Remediation = Notes / Ready handoff, not silent tracker writes. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent workflow-drift-guard` (prefixes `@owner.github_user/workflow-drift-guard`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -16,3 +16,4 @@ alwaysApply: true
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
+- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.

--- a/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -22,6 +22,7 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
 10. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
 11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
+12. **Multi-collaborator attribution:** card Notes use `@owner.github_user/<agent>` (from each person’s `github.collaboration.yaml`). CLI: `append-notes --agent <name>` when `require_attribution_on_exit`. GitHub Assignees are humans only (`set-assignee`); agent role lives in Notes. Handoff: `next=@user/agent`.
 
 ## Consequences
 
@@ -32,6 +33,7 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 - Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); workflow-drift-guard **reads and updates** the board on Exit
 - Post-merge Done: Pattern A `merge.py` (not a dedicated agent)
 - DraftIssue body edits: `append-notes` / `edit_item_body` resolve project item `PVTI_…` → content `DI_…` (+ preserve `--title`); Status/field edits stay on `PVTI_…`
+- Attribution: `append-notes --agent` prefixes `@github_user/agent`; `merge.py` Notes use `@user/merge.py`; `set-assignee` for human My items (Issue-backed)
 
 ## References
 

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -25,7 +25,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Status drifts from reality | Status column = truth (DRIFT-009 watches dual-write) |
 | Humans cannot see progress | Project UI is the shared dashboard |
 
-**Rule:** Entry = read board. Exit = update Status (and Notes) for the card you touched.
+**Rule:** Entry = read board. Exit = update Status and **attributed Notes** (`append-notes --agent <name>` → `@owner.github_user/<agent>`) for the card you touched.
 
 ## Surfaces — who may write
 
@@ -36,10 +36,10 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Create cards | Yes | project-board, implementer, integrator | — |
 | Ready prioritization | **Owner** | Consume; create agreed work | — |
 | Views / workflows / Insights / README / status updates | **Owner only** | Never | Insights auto |
-| Assignee / My items | Yes | Claim = In progress | My items view |
+| Assignee / My items | Yes (`set-assignee` / UI) | Claim = In progress; assignee = **human** only | My items view |
+| Card Notes (`append-notes --agent`) | Yes | Yes — `@user/agent · …`; `next=@user/agent` | — |
 | PR / audits / secrets | Local | Local | — |
-| Post-merge Status → Done | — | Via `merge.py` (Pattern A) | — |
-| Card Notes (`append-notes`) | Yes | Yes — pass `PVTI_…`; CLI resolves `DI_…` for DraftIssue body | — |
+| Post-merge Status → Done | — | Via `merge.py` (Pattern A); Notes `@user/merge.py` | — |
 | Read-only board export | Consume | `project export` (never writes Status) | — |
 
 ## Per-agent Entry / Exit
@@ -47,13 +47,13 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Agent | Entry | Exit (board) |
 |-------|-------|--------------|
 | **project-board** | status + list | Full triage; handoff to implementer |
-| **implementer** | status + Ready/claim | →In review / →Done; Notes for next |
-| **test-runner** | status + slice card | →In review or →Done when tests finish |
-| **verifier** | status + related card | →Done or leave In review + Notes |
-| **integrator-mas-agent** | status + claim | →Done on integration card |
-| **enterprise-auditor** | status + audit card | →In review/Done; Notes → artifact paths |
-| **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; cite board in drift-audit; remediation via Notes/Ready handoff — no silent tracker edits |
-| **researcher** | status (+ research card) | Research card →Done + corpus paths in Notes |
+| **implementer** | status + Ready/claim | →In review / →Done; `append-notes --agent implementer` |
+| **test-runner** | status + slice card | →In review or →Done; `--agent test-runner` |
+| **verifier** | status + related card | →Done or leave In review; `--agent verifier` |
+| **integrator-mas-agent** | status + claim | →Done; `--agent integrator-mas-agent` |
+| **enterprise-auditor** | status + audit card | →In review/Done; `--agent enterprise-auditor` + artifact paths |
+| **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; `--agent workflow-drift-guard`; remediation via Notes/Ready — no silent tracker edits |
+| **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + corpus paths |
 
 ## Status path
 
@@ -61,7 +61,9 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 Ready → In progress → In review → Done
 ```
 
-Handoff: `item_id=PVTI_… · Status=a→b · next=<agent>`
+Handoff: `item_id=PVTI_… · @User/implementer · Status=a→b · next=@User/verifier`
+
+**Attribution:** Notes use `@owner.github_user/<agent>` from each collaborator’s `github.collaboration.yaml` so multi-user boards do not collide.
 
 ## workflow-drift-guard specifically
 

--- a/payload/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_cli.py
@@ -11,6 +11,7 @@ Depends On:
 Notes:
  - Pattern A: one gh invocation per action; no dual-write of local trackers.
  - DraftIssue body edits resolve PVTI_… → DI_… (+ --title); Status stays on PVTI_….
+ - Notes attribution: @owner.github_user/agent via append-notes --agent.
 """
 
 from __future__ import annotations
@@ -63,6 +64,88 @@ def require_enabled(ssot: dict[str, Any]) -> list[str]:
         if ssot.get(key) in (None, ""):
             return [f"project_ssot.{key} is required when enabled"]
     return []
+
+
+def normalize_github_handle(raw: str) -> str:
+    """Ensure leading @ on a GitHub login."""
+    s = (raw or "").strip()
+    if not s:
+        return ""
+    return s if s.startswith("@") else f"@{s}"
+
+
+def resolve_human_github_user(root: Path) -> str:
+    """Human identity from owner.github_user (not project_ssot.owner)."""
+    us = _import_user_settings(root)
+    handle = us.resolve_github_user(root)
+    return normalize_github_handle(str(handle or ""))
+
+
+def attribution_required(ssot: dict[str, Any]) -> bool:
+    conventions = ssot.get("conventions") or {}
+    return bool(conventions.get("require_attribution_on_exit", True))
+
+
+def format_agent_attribution(root: Path, agent: str) -> str:
+    """Return @github_user/agent for board Notes."""
+    user = resolve_human_github_user(root)
+    agent_key = (agent or "").strip().lstrip("@")
+    if not user:
+        raise ValueError("owner.github_user missing — set github.collaboration.yaml")
+    if not agent_key:
+        raise ValueError("agent name required for attribution")
+    return f"{user}/{agent_key}"
+
+
+def format_note_line(root: Path, agent: str, text: str) -> str:
+    """
+    Prefix note with @user/agent · text.
+    Idempotent if text already starts with that attribution.
+    """
+    attr = format_agent_attribution(root, agent)
+    body = (text or "").strip()
+    if body.startswith(attr):
+        return body
+    # Also accept without requiring exact agent if already @user/something
+    if re.match(r"^@[^\s/]+/[^\s·]+", body):
+        return body
+    if not body:
+        return attr
+    return f"{attr} · {body}"
+
+
+def set_item_assignee(
+    ssot: dict[str, Any], item_id: str, login: str
+) -> tuple[bool, str]:
+    """
+    Assign a GitHub human user to an Issue-backed project item.
+    DraftIssue: not supported — return False with hint to use Notes or promote.
+    """
+    kind, cid, meta, err = resolve_item_content(ssot, item_id)
+    if err or not kind or not cid:
+        return False, err or "could not resolve content for assignee"
+    login_clean = (login or "").strip().lstrip("@")
+    if not login_clean:
+        return False, "assignee login empty"
+
+    if kind == "issue":
+        meta = meta or {}
+        repo = str(meta.get("repo") or ssot.get("default_repo") or "")
+        gh_args = ["issue", "edit", cid, "--add-assignee", login_clean]
+        if repo:
+            gh_args.extend(["--repo", repo])
+        proc = run_gh(gh_args)
+        if proc.returncode != 0:
+            return False, (proc.stderr or proc.stdout or "gh issue edit --add-assignee failed").strip()
+        return True, login_clean
+
+    if kind == "draft":
+        return (
+            False,
+            "DraftIssue has no GitHub Assignees; use Notes @user/agent "
+            "or promote to Issue (promote_to_issue_on_pr)",
+        )
+    return False, f"unsupported content kind {kind!r} for assignee"
 
 
 def resolve_status_option_id(ssot: dict[str, Any], logical: str) -> str:
@@ -781,6 +864,21 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         for e in enabled_errs:
             print(f"project append-notes: FAIL — {e}", file=sys.stderr)
         return 2
+    agent = getattr(args, "agent", None) or ""
+    if attribution_required(ssot) and not str(agent).strip():
+        print(
+            "project append-notes: FAIL — --agent required "
+            "(project_ssot.conventions.require_attribution_on_exit)",
+            file=sys.stderr,
+        )
+        return 2
+    note_text = args.text
+    if str(agent).strip():
+        try:
+            note_text = format_note_line(root, str(agent), args.text)
+        except ValueError as exc:
+            print(f"project append-notes: FAIL — {exc}", file=sys.stderr)
+            return 2
     items, err = fetch_project_items(ssot, limit=args.limit)
     if err:
         print(f"project append-notes: FAIL — {err}", file=sys.stderr)
@@ -790,7 +888,7 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         print(f"project append-notes: FAIL — item not found: {args.id}", file=sys.stderr)
         return 1
     body = _item_body(item)
-    new_body, changed = append_notes_to_body(body, args.text)
+    new_body, changed = append_notes_to_body(body, note_text)
     if not changed:
         print(f"append-notes: {args.id} — already present (idempotent skip)")
         return 0
@@ -799,6 +897,40 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         print(f"project append-notes: FAIL — {detail}", file=sys.stderr)
         return 1
     print(f"append-notes: {args.id} — updated")
+    return 0
+
+
+def cmd_set_assignee(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    ssot, errs = load_project_ssot(root)
+    if errs or ssot is None:
+        for e in errs:
+            print(f"project set-assignee: FAIL — {e}", file=sys.stderr)
+        return 1
+    enabled_errs = require_enabled(ssot)
+    if enabled_errs:
+        for e in enabled_errs:
+            print(f"project set-assignee: FAIL — {e}", file=sys.stderr)
+        return 2
+    login = (getattr(args, "login", None) or "").strip()
+    if not login:
+        try:
+            login = resolve_human_github_user(root).lstrip("@")
+        except Exception as exc:  # noqa: BLE001
+            print(f"project set-assignee: FAIL — {exc}", file=sys.stderr)
+            return 2
+    if not login:
+        print(
+            "project set-assignee: FAIL — no login "
+            "(pass --login or set owner.github_user)",
+            file=sys.stderr,
+        )
+        return 2
+    ok, detail = set_item_assignee(ssot, args.id, login)
+    if not ok:
+        print(f"project set-assignee: FAIL — {detail}", file=sys.stderr)
+        return 1
+    print(f"set-assignee: {args.id} → @{detail.lstrip('@')}")
     return 0
 
 
@@ -922,13 +1054,32 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     get_cmd.set_defaults(func=cmd_get)
 
     notes_cmd = project_sub.add_parser(
-        "append-notes", help="Append a line under ## Notes on the card body"
+        "append-notes",
+        help="Append a line under ## Notes (prefix @user/agent when --agent set)",
     )
     notes_cmd.add_argument("--directory", type=Path, default=".")
     notes_cmd.add_argument("--id", required=True)
     notes_cmd.add_argument("--text", required=True)
+    notes_cmd.add_argument(
+        "--agent",
+        default="",
+        help="Agent id for attribution (required when require_attribution_on_exit)",
+    )
     notes_cmd.add_argument("--limit", type=int, default=100)
     notes_cmd.set_defaults(func=cmd_append_notes)
+
+    assignee_cmd = project_sub.add_parser(
+        "set-assignee",
+        help="Assign GitHub human user (Issue-backed); default owner.github_user",
+    )
+    assignee_cmd.add_argument("--directory", type=Path, default=".")
+    assignee_cmd.add_argument("--id", required=True, help="Project item id (PVTI_…)")
+    assignee_cmd.add_argument(
+        "--login",
+        default="",
+        help="GitHub login (default: owner.github_user from collab YAML)",
+    )
+    assignee_cmd.set_defaults(func=cmd_set_assignee)
 
     find_cmd = project_sub.add_parser(
         "find-by-pr", help="Resolve project item id from PR (Board-Item or body scan)"

--- a/payload/.ai_infra/schemas/github-collaboration.schema.json
+++ b/payload/.ai_infra/schemas/github-collaboration.schema.json
@@ -38,7 +38,32 @@
         },
         "fallback": { "type": "string", "enum": ["local_trackers", "none"] },
         "fields": { "type": "object", "additionalProperties": true },
-        "conventions": { "type": "object", "additionalProperties": true },
+        "conventions": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "queue_status": { "type": "string" },
+            "active_status": { "type": "string" },
+            "review_status": { "type": "string" },
+            "done_status": { "type": "string" },
+            "claim": { "type": "string" },
+            "one_in_progress_per_assignee": { "type": "boolean" },
+            "item_kind_default": { "type": "string" },
+            "promote_to_issue_on_pr": { "type": "boolean" },
+            "attribution_format": {
+              "type": "string",
+              "description": "Template for Notes prefix; rendered as @github_user/agent"
+            },
+            "require_attribution_on_exit": {
+              "type": "boolean",
+              "description": "When true, project append-notes requires --agent"
+            },
+            "body_sections": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
         "local_only": {
           "type": "array",
           "items": { "type": "string" }

--- a/payload/.ai_infra/scripts/pr/merge.py
+++ b/payload/.ai_infra/scripts/pr/merge.py
@@ -141,6 +141,10 @@ def sync_board_after_merge(
 
     pr_url = _pr_url(root, pr, str(ssot.get("default_repo") or ""))
     note = f"Merged: {pr_url} @ {merge_sha}"
+    try:
+        note = project_cli.format_note_line(root, "merge.py", note)
+    except Exception:  # noqa: BLE001 — never block merge on attribution
+        pass
     items, list_err = project_cli.fetch_project_items(ssot, limit=100)
     if list_err:
         print(f"[WARN] board sync append-notes list failed: {list_err}", file=sys.stderr)

--- a/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -79,6 +79,9 @@ project_ssot:
     one_in_progress_per_assignee: true
     item_kind_default: draft              # draft | issue
     promote_to_issue_on_pr: true
+    # Board Notes: @github_user/agent (owner.github_user from this file — not project_ssot.owner)
+    attribution_format: "{github_user}/{agent}"
+    require_attribution_on_exit: true
     body_sections:
       - Acceptance
       - Rollback

--- a/payload/.cursor/agents/enterprise-auditor.md
+++ b/payload/.cursor/agents/enterprise-auditor.md
@@ -12,7 +12,7 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
 
-**Board rights:** Status + Notes on **audit card** required on Exit. No Priority reshuffle; no Project views/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent enterprise-auditor` (prefixes `@owner.github_user/enterprise-auditor`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -16,12 +16,13 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Exit (board-first when enabled):**
 
-1. `python -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed). Put next agent in card Notes when handing off.
-2. Append `change-index.md`; one line in `history/updates-log.md`.
-3. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-4. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+1. `python3 -m cursor_workflow project set-status --id PVTI_… --to in_review` (PR open / handoff) or `--to done` (slice closed).
+2. `python3 -m cursor_workflow project append-notes --id PVTI_… --agent implementer --text "… · next=@User/verifier"` (required attribution).
+3. Append `change-index.md`; one line in `history/updates-log.md`.
+4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
+5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
-**Board rights:** claim Ready→In progress; In review on PR; Done on close; Priority/Size on **own** card; may create slice cards. **Exit Status update is mandatory** for continuation. Do **not** edit Project views/workflows/README. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent implementer` (prefixes `@owner.github_user/implementer`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 

--- a/payload/.cursor/agents/integrator-mas-agent.md
+++ b/payload/.cursor/agents/integrator-mas-agent.md
@@ -18,7 +18,7 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Create integration cards; claim→Done; fields on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent integrator-mas-agent` (prefixes `@owner.github_user/integrator-mas-agent`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 ## Read first (evidence before edits)
 

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -12,7 +12,7 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
 
-**Board rights:** Full triage — create cards; any Status; Priority/Size. Own Ready queue hygiene so other agents can claim. Never edit Project views/workflows/README/Insights. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent project-board` (prefixes `@owner.github_user/project-board`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 ## Role
 

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -12,7 +12,7 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
 
-**Board rights:** Always **read** board when enabled. **Update** only your research card on Exit. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent researcher` (prefixes `@owner.github_user/researcher`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -12,7 +12,7 @@ description: Module-focused tests, regressions, coverage.
 
 **Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
 
-**Board rights:** Stay on the slice card; Exit Status update required for continuation. Priority/Size only on own card. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent test-runner` (prefixes `@owner.github_user/test-runner`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -12,7 +12,7 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
 
-**Board rights:** Confirm Done or leave In review + Notes. Do **not** create cards or reshuffle Priority. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent verifier` (prefixes `@owner.github_user/verifier`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.

--- a/payload/.cursor/agents/workflow-drift-guard.md
+++ b/payload/.cursor/agents/workflow-drift-guard.md
@@ -12,7 +12,7 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
 
-**Board rights:** **Read** board every pass. **Update** Status on the drift-pass card when finished. Remediation = Notes / Ready handoff, not silent tracker writes. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract.
+**Board rights:** Status + Notes on the card you touch. Exit Notes **must** use `append-notes --agent workflow-drift-guard` (prefixes `@owner.github_user/workflow-drift-guard`). Handoff `next=@user/agent`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -16,3 +16,4 @@ alwaysApply: true
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
+- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -38,15 +38,16 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Print handoff line. |
-| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent>`. Print handoff line. |
+| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
-Handoff line (chat + optional card Notes):
+Handoff line (chat + card Notes):
 
 ```text
-item_id=PVTI_… · title=… · Status=before→after · next=implementer|verifier|test-runner|…
+item_id=PVTI_… · @User/implementer · Status=before→after · next=@User/verifier
 ```
 
+Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
 ## When to use
 
 - Any session where `project_ssot.enabled: true`
@@ -67,18 +68,18 @@ item_id=PVTI_… · title=… · Status=before→after · next=implementer|verif
 | Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
 | Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
 | Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
-| My items | Assign in UI | Claim = Status In progress (assignee CLI TBD) | View filter |
+| My items | Assign in UI or `project set-assignee` (human login) | Claim = Status In progress + Notes `@user/agent`; assignee = human only | View filter |
 | PR gates, audits, secrets | Local | Local (`local_only`) | — |
 
 ### Rules
 
-1. One primary **In progress** per assignee — do not steal others'.
+1. One primary **In progress** per **human assignee** — do not steal others'.
 2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index.
+3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent>` via `append-notes --agent`.
 4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
 5. Humans own views, workflows, README, Insights, status updates.
 6. Read-only `project export` (if used) never writes Status.
-7. Post-merge Done is Pattern A (`merge.py`), not a dedicated agent.
+7. Post-merge Done is Pattern A (`merge.py`), Notes prefixed `@user/merge.py`.
 
 ### Per-agent rights (what / when / where)
 
@@ -111,11 +112,11 @@ Ready → In progress → In review → Done
 
 1. **Status:** `python -m cursor_workflow project status --directory .`
 2. **List:** `python -m cursor_workflow project list [--status ready|in_progress|in_review] --directory .`
-3. **Claim:** `set-status --id PVTI_… --to in_progress`
+3. **Claim:** `set-status --id PVTI_… --to in_progress` then optional `set-assignee --id PVTI_…` (human) + `append-notes --id … --agent implementer --text "claimed · next=@User/test-runner"`
 4. **Create:** `project create --title "…" [--body "…"]`
 5. **Fields:** `set-field --id … --field priority|size --to …`
 6. **Close / handoff:** `set-status --to in_review|done`
-7. **Notes:** `append-notes --id PVTI_… --text "…"` — agents always pass the project item id (`PVTI_…`); CLI resolves DraftIssue content id (`DI_…`) for body edits and keeps Status on `PVTI_…`
+7. **Notes:** `append-notes --id PVTI_… --agent <agent> --text "…"` — required `--agent` when `require_attribution_on_exit`; CLI prefixes `@owner.github_user/agent ·`. Pass `PVTI_…`; CLI resolves `DI_…` for DraftIssue body.
 8. **Verify:** `project list` matches intent + handoff line printed
 
 ## Dual-write ban

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -16,3 +16,4 @@ alwaysApply: true
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
+- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -38,15 +38,16 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Print handoff line. |
-| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent>`. Print handoff line. |
+| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
-Handoff line (chat + optional card Notes):
+Handoff line (chat + card Notes):
 
 ```text
-item_id=PVTI_… · title=… · Status=before→after · next=implementer|verifier|test-runner|…
+item_id=PVTI_… · @User/implementer · Status=before→after · next=@User/verifier
 ```
 
+Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
 ## When to use
 
 - Any session where `project_ssot.enabled: true`
@@ -67,18 +68,18 @@ item_id=PVTI_… · title=… · Status=before→after · next=implementer|verif
 | Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
 | Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
 | Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
-| My items | Assign in UI | Claim = Status In progress (assignee CLI TBD) | View filter |
+| My items | Assign in UI or `project set-assignee` (human login) | Claim = Status In progress + Notes `@user/agent`; assignee = human only | View filter |
 | PR gates, audits, secrets | Local | Local (`local_only`) | — |
 
 ### Rules
 
-1. One primary **In progress** per assignee — do not steal others'.
+1. One primary **In progress** per **human assignee** — do not steal others'.
 2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index.
+3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent>` via `append-notes --agent`.
 4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
 5. Humans own views, workflows, README, Insights, status updates.
 6. Read-only `project export` (if used) never writes Status.
-7. Post-merge Done is Pattern A (`merge.py`), not a dedicated agent.
+7. Post-merge Done is Pattern A (`merge.py`), Notes prefixed `@user/merge.py`.
 
 ### Per-agent rights (what / when / where)
 
@@ -111,11 +112,11 @@ Ready → In progress → In review → Done
 
 1. **Status:** `python -m cursor_workflow project status --directory .`
 2. **List:** `python -m cursor_workflow project list [--status ready|in_progress|in_review] --directory .`
-3. **Claim:** `set-status --id PVTI_… --to in_progress`
+3. **Claim:** `set-status --id PVTI_… --to in_progress` then optional `set-assignee --id PVTI_…` (human) + `append-notes --id … --agent implementer --text "claimed · next=@User/test-runner"`
 4. **Create:** `project create --title "…" [--body "…"]`
 5. **Fields:** `set-field --id … --field priority|size --to …`
 6. **Close / handoff:** `set-status --to in_review|done`
-7. **Notes:** `append-notes --id PVTI_… --text "…"` — agents always pass the project item id (`PVTI_…`); CLI resolves DraftIssue content id (`DI_…`) for body edits and keeps Status on `PVTI_…`
+7. **Notes:** `append-notes --id PVTI_… --agent <agent> --text "…"` — required `--agent` when `require_attribution_on_exit`; CLI prefixes `@owner.github_user/agent ·`. Pass `PVTI_…`; CLI resolves `DI_…` for DraftIssue body.
 8. **Verify:** `project list` matches intent + handoff line printed
 
 ## Dual-write ban

--- a/tests/modules/install/test_project_cli.py
+++ b/tests/modules/install/test_project_cli.py
@@ -71,7 +71,11 @@ SAMPLE_SSOT = {
             "options": {"s": "9592a5a3", "m": "9728cbdc"},
         },
     },
-    "conventions": {"body_sections": ["Acceptance", "Rollback"]},
+    "conventions": {
+        "body_sections": ["Acceptance", "Rollback"],
+        "require_attribution_on_exit": True,
+        "attribution_format": "{github_user}/{agent}",
+    },
 }
 
 
@@ -240,8 +244,13 @@ def test_cmd_append_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
 
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
     args = argparse.Namespace(
-        directory=tmp_path, id="PVTI_x", text="Merged: url @ sha", limit=50
+        directory=tmp_path,
+        id="PVTI_x",
+        text="Merged: url @ sha",
+        agent="implementer",
+        limit=50,
     )
     assert project_cli.cmd_append_notes(args) == 0
     assert any("--body" in c for c in calls)
@@ -250,6 +259,8 @@ def test_cmd_append_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     assert "DI_draft_x" in edit_calls[0]
     assert "--title" in edit_calls[0]
     assert "Slice" in edit_calls[0]
+    body_arg = edit_calls[0][edit_calls[0].index("--body") + 1]
+    assert "@test/implementer" in body_arg
 
 
 def test_edit_item_body_resolves_pvti_to_di(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -468,7 +479,7 @@ def test_cmd_append_notes_idempotent_skip_with_di_resolve(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Idempotent skip must not call item-edit even when DI resolve would run."""
-    note = "Merged: https://example/pull/1 @ abc"
+    note = "@test/implementer · Merged: https://example/pull/1 @ abc"
     payload = {
         "items": [
             {
@@ -507,10 +518,75 @@ def test_cmd_append_notes_idempotent_skip_with_di_resolve(
 
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
-    args = argparse.Namespace(directory=tmp_path, id="PVTI_x", text=note, limit=50)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    args = argparse.Namespace(
+        directory=tmp_path, id="PVTI_x", text=note, agent="implementer", limit=50
+    )
     assert project_cli.cmd_append_notes(args) == 0
     assert not any(c[:2] == ["project", "item-edit"] for c in calls)
     assert not any(c[:2] == ["issue", "edit"] for c in calls)
+
+
+def test_format_agent_attribution_and_note_line(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@SavinRazvan")
+    assert project_cli.format_agent_attribution(tmp_path, "implementer") == (
+        "@SavinRazvan/implementer"
+    )
+    line = project_cli.format_note_line(tmp_path, "implementer", "claimed")
+    assert line == "@SavinRazvan/implementer · claimed"
+    same = project_cli.format_note_line(
+        tmp_path, "implementer", "@SavinRazvan/implementer · claimed"
+    )
+    assert same == "@SavinRazvan/implementer · claimed"
+
+
+def test_cmd_append_notes_requires_agent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    args = argparse.Namespace(
+        directory=tmp_path, id="PVTI_x", text="no agent", agent="", limit=50
+    )
+    assert project_cli.cmd_append_notes(args) == 2
+
+
+def test_set_item_assignee_draft_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("draft", "DI_x", {"title": "T"}, None),
+    )
+    ok, detail = project_cli.set_item_assignee(SAMPLE_SSOT, "PVTI_x", "SavinRazvan")
+    assert not ok
+    assert "DraftIssue" in detail
+
+
+def test_set_item_assignee_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: (
+            "issue",
+            "42",
+            {"title": "T", "repo": "org/repo"},
+            None,
+        ),
+    )
+    monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    ok, detail = project_cli.set_item_assignee(SAMPLE_SSOT, "PVTI_x", "@alice")
+    assert ok
+    assert detail == "alice"
+    assert calls[0][:3] == ["issue", "edit", "42"]
+    assert "--add-assignee" in calls[0]
+    assert "alice" in calls[0]
 
 
 def test_cmd_export_stdout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/modules/pr_workflow/test_merge_board_sync.py
+++ b/tests/modules/pr_workflow/test_merge_board_sync.py
@@ -78,12 +78,18 @@ def test_sync_board_happy_with_item_id(
         ),
     )
     monkeypatch.setattr(project_cli, "edit_item_body", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(
+        project_cli,
+        "format_note_line",
+        lambda root, agent, text: f"@test/{agent} · {text}",
+    )
     line = merge_mod.sync_board_after_merge(
         root=tmp_path, pr="42", merge_sha="deadbeef", item_id="PVTI_x"
     )
     assert "PVTI_x" in line
     assert "done" in line
     assert "Merged:" in line
+    assert "@test/merge.py" in line
 
 
 def test_sync_board_warn_when_no_item(
@@ -143,6 +149,11 @@ def test_sync_board_notes_via_edit_item_body(
         lambda *a, **k: ([{"id": "PVTI_x", "content": {"body": ""}}], None),
     )
     monkeypatch.setattr(project_cli, "edit_item_body", capture_edit)
+    monkeypatch.setattr(
+        project_cli,
+        "format_note_line",
+        lambda root, agent, text: f"@test/{agent} · {text}",
+    )
     line = merge_mod.sync_board_after_merge(
         root=tmp_path, pr="7", merge_sha="abc123", item_id="PVTI_x"
     )
@@ -151,3 +162,4 @@ def test_sync_board_notes_via_edit_item_body(
     assert edited[0][0] == "PVTI_x"
     assert "Merged:" in edited[0][1]
     assert "abc123" in edited[0][1]
+    assert "@test/merge.py" in edited[0][1]


### PR DESCRIPTION
## Summary
- Notes attribution: `@owner.github_user/<agent>` via `append-notes --agent`
- `set-assignee` for human GitHub login (Issue-backed; DraftIssue → Notes-only hint)
- merge.py Notes prefixed `@user/merge.py`; Anchors/skill/ADR/HANDOFF updated

## Test plan
- [x] unit tests project_cli + merge board sync
- [x] drift / integrate / doc-facts green (673)
- [ ] prepare.py on PR


Made with [Cursor](https://cursor.com)