### PR TITLE
docs: product identity mas-workflow-kit-project-ssot

### DIFF
--- a/.ai_infra/docs/governance/drift-prevention.md
+++ b/.ai_infra/docs/governance/drift-prevention.md
@@ -33,7 +33,7 @@ Additionally when changing governance, workflows, `.cursor/`, `.agents/`, or tra
 ## After changing documentation lifecycle
 
 1. Update **`.ai_infra/docs/governance/workflow-source-owners.md`** if ownership moved.
-2. Run **[documentation-maintenance-checklist.md](https://github.com/SavinRazvan/mas-workflow-kit/blob/main/.ai_infra/docs/operations/documentation-maintenance-checklist.md)** for kit doc surfaces.
+2. Run **[documentation-maintenance-checklist.md](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/blob/main/.ai_infra/docs/operations/documentation-maintenance-checklist.md)** for kit doc surfaces.
 
 ## After changing `.local` layout
 
@@ -72,5 +72,5 @@ Script-first checks for plan ↔ tracker ↔ session-pointer coherence and hando
 ## Quarterly (or before kit releases)
 
 - Confirm **`rules-overlap-matrix.md`** still lists all **`.cursor/rules/*.mdc`** files.
-- Skim kit repo [**`IMPLEMENTATION-STATUS.md`**](https://github.com/SavinRazvan/mas-workflow-kit/blob/main/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) vs shipped manifest profiles.
+- Skim kit repo [**`IMPLEMENTATION-STATUS.md`**](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/blob/main/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) vs shipped manifest profiles.
 - Re-run **`make gates`**, **`make drift-validate`**, and **`make install-dry-run`** on the kit repo.

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -14,7 +14,7 @@ Notes:
  - Copied to consumer projects via manifest copy_ai_infra: docs/operations.
 -->
 
-# MAS Workflow Kit — Plugin User Guide
+# MAS Workflow Kit — Project SSOT · Plugin User Guide
 
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.
 
@@ -63,9 +63,9 @@ In **Agent chat** (not the terminal):
 /add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
-Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
+Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit — Project SSOT** card to install:
 
-![Install MAS Workflow Kit from Agent chat](assets/mas-workflow-kit-install.png)
+![Install MAS Workflow Kit — Project SSOT from Agent chat](assets/mas-workflow-kit-install.png)
 
 Optional — explicit branch:
 
@@ -75,13 +75,13 @@ Optional — explicit branch:
 
 This loads agents, skills, and rules into Cursor. Your project may only get `.cursor/settings.json` until you activate (§2).
 
-**When listed:** **Cursor → Marketplace → MAS Workflow Kit → Install** — same two-step flow; you still run **`/workflow-activate`** afterward.
+**When listed:** **Cursor → Marketplace → MAS Workflow Kit — Project SSOT → Install** — same two-step flow; you still run **`/workflow-activate`** afterward.
 
 ---
 
 ## 2. Quick start (4 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project** open (not `mas-workflow-kit`).
+**Need:** Cursor · Python 3.11+ · **your project** open (not the kit product repo `mas-workflow-kit-project-ssot`).
 
 | Step | Action |
 |------|--------|

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -15,7 +15,7 @@ Notes:
 
 # Consumer quickstart
 
-Install the **MAS Workflow Kit** into your project in a few minutes. No special git setup required.
+Install **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) into your project in a few minutes. No special git setup required.
 
 > **Full manual:** [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) — plugin vs activate, complete file tree, use-case matrix, PR and audit chapters.
 
@@ -23,7 +23,7 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 
 ## First run (4 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit repo).
+**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit product repo `mas-workflow-kit-project-ssot`).
 
 | Step | Action |
 |------|--------|
@@ -44,9 +44,9 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 /add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
-Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
+Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit — Project SSOT** card to install:
 
-![Install MAS Workflow Kit from Agent chat — type /add-plugin with the GitHub URL, then click the plugin card](assets/mas-workflow-kit-install.png)
+![Install MAS Workflow Kit — Project SSOT from Agent chat — type /add-plugin with the GitHub URL, then click the plugin card](assets/mas-workflow-kit-install.png)
 
 Optional — pin `main`:
 
@@ -116,7 +116,7 @@ python3 -m cursor_workflow activate --directory .
 <summary><strong>Alternative: terminal activate (no plugin UI)</strong></summary>
 
 ```bash
-export KIT=~/Projects/mas-workflow-kit
+export KIT=~/Projects/mas-workflow-kit-project-ssot
 export TARGET=~/Projects/my-app
 mkdir -p "$TARGET"
 "$KIT/.venv/bin/python" "$KIT/payload/cursor_workflow" activate \
@@ -139,7 +139,7 @@ owner:
 ```
 
 ```bash
-cd ~/Projects/my-app   # your activated project — not mas-workflow-kit
+cd ~/Projects/my-app   # your activated project — not `mas-workflow-kit-project-ssot` (the kit product repo)
 python3 -m cursor_workflow contributors validate   # must PASS before first PR
 python3 -m cursor_workflow integrate validate      # optional; P0 must be 0
 python3 -m cursor_workflow health
@@ -191,7 +191,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 
 ## Terminal commands cheat sheet
 
-Run from **your activated project root** (`~/Projects/my-app`), not the kit repo.
+Run from **your activated project root** (`~/Projects/my-app`), not `mas-workflow-kit-project-ssot`.
 
 ```bash
 cd ~/Projects/my-app
@@ -290,7 +290,7 @@ Procedure: [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) §7 · [agent-workflow-p
 
 | Do | Don't |
 |----|-------|
-| Open **your app** in Cursor | Activate while inside `mas-workflow-kit` |
+| Open **your app** in Cursor | Activate while inside `mas-workflow-kit-project-ssot` |
 | **`/workflow-activate`** in chat | Run `make gates` (kit-dev only) |
 | Real paths like `~/Projects/my-app` | Literal `/path/to/your-project` |
 
@@ -309,7 +309,7 @@ Gate details: [gate-matrix.md](gate-matrix.md) (consumer scaffold = 4 checks).
 
 ## Kit clone path (advanced)
 
-When not using the plugin UI — clone [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot), then:
+When not using the plugin UI — clone [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot), then:
 
 ```bash
 python3 -m venv .venv && .venv/bin/pip install -q -r requirements-dev.txt
@@ -352,7 +352,7 @@ If you see:
 |----------|--------|
 | Is it your app's problem? | **No** — your install can be valid while this fails |
 | Is it a kit bug? | **Yes** — the checker assumed a maintainer-only file exists |
-| False positive? | **Yes** — `IMPLEMENTATION-STATUS.md` lives only in the **mas-workflow-kit** repo |
+| False positive? | **Yes** — `IMPLEMENTATION-STATUS.md` lives only in the **mas-workflow-kit-project-ssot** product repo |
 | Who needs to fix it? | **Kit maintainers** (skip the check when the file is absent) |
 | What should you do? | Re-run with `--profile consumer` after upgrading the kit; until then, treat DRIFT-005 as ignorable |
 
@@ -374,10 +374,10 @@ After the kit fix, expect:
 | Only `.cursor/settings.json` after plugin install | Normal — run **`/workflow-activate`** in your app folder for the full bundle |
 | `contributors validate` FAIL | Replace placeholders in `github.collaboration.yaml` |
 | YAML `ParserError` / traceback | Fix `human_coauthors` — keep `[]` or use a proper list; don't uncomment example lines as siblings of `[]` |
-| Validate passes from kit repo but fails in your app | Run commands from **your project** (`cd ~/Projects/my-app`), not `mas-workflow-kit` |
+| Validate passes from kit repo but fails in your app | Run commands from **your project** (`cd ~/Projects/my-app`), not `mas-workflow-kit-project-ssot` |
 | `pytest` not found | Re-run **`/workflow-activate`** (creates `.venv`) |
 | Permission denied on `/path` | You used a placeholder path — create a real folder |
-| Subagents/skills missing in **`/`** menu | Open **your activated project**, not the kit repo; re-run **`/workflow-activate`** if planes are incomplete |
+| Subagents/skills missing in **`/`** menu | Open **your activated project**, not `mas-workflow-kit-project-ssot`; re-run **`/workflow-activate`** if planes are incomplete |
 | Control Center shows **Failed to fetch** | From project root: `python3 -m http.server 8000` then open http://localhost:8000/.local/agents-control-center/dashboards/index.html — not `file://` |
 | Raw markdown (no tables/bold) in Control Center | Re-run **`/workflow-activate`** to refresh `local-markdown.js` |
 | Stale dashboard UI after kit update | `python3 -m cursor_workflow activate --directory .` |

--- a/.ai_infra/templates/plugin/skills/workflow-activate/SKILL.md
+++ b/.ai_infra/templates/plugin/skills/workflow-activate/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workflow-activate
-description: Install MAS Workflow Kit infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
+description: Install MAS Workflow Kit — Project SSOT infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
 ---
 
 # Workflow activate
 
 ## When
 
-First use after enabling the **MAS Workflow Kit** plugin in a project workspace — or when any of the three planes is missing on disk.
+First use after enabling the **MAS Workflow Kit — Project SSOT** plugin (`mas-workflow-kit-project-ssot`) in a project workspace — or when any of the three planes is missing on disk.
 
 ## One command (agent or human)
 

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,21 +1,23 @@
 {
-  "name": "mas-workflow-kit",
-  "displayName": "MAS Workflow Kit",
+  "name": "mas-workflow-kit-project-ssot",
+  "displayName": "MAS Workflow Kit — Project SSOT",
   "version": "0.4.0",
-  "description": "Universal multi-agent workflow infrastructure for Cursor — agents, skills, rules, PR scripts, .local/ anchoring, and optional MCP. Install infrastructure into any project via workflow-activate.",
+  "description": "Multi-agent Cursor workflow with GitHub Project as the only writable SSOT for backlog/status; local artifacts for PR gates and evidence. Install into any project via workflow-activate.",
   "author": {
     "name": "Savin Ionuț Răzvan",
     "email": "razvan.i.savin@gmail.com"
   },
   "homepage": "https://razvansavin.com/",
-  "repository": "https://github.com/SavinRazvan/mas-workflow-kit",
+  "repository": "https://github.com/SavinRazvan/mas-workflow-kit-project-ssot",
   "license": "Apache-2.0",
   "logo": "assets/logo.png",
   "keywords": [
-    "mas-workflow-kit",
+    "mas-workflow-kit-project-ssot",
+    "project-ssot",
     "multi-agent",
     "cursor-workflow",
     "pr-workflow",
+    "github-projects",
     "enterprise-audit",
     "mcp"
   ],
@@ -24,6 +26,7 @@
     "agents",
     "workflow",
     "governance",
+    "project-board",
     "maintainer",
     "automation"
   ]

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflow-activate
-description: Install MAS Workflow Kit infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
+description: Install MAS Workflow Kit — Project SSOT infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
 ---
 <!--
 File: SKILL.md
 Path: .cursor/skills/workflow-activate/SKILL.md
-Role: Install MAS Workflow Kit three planes into the open workspace (ADR-001 Option B).
+Role: Install MAS Workflow Kit — Project SSOT three planes into the open workspace (ADR-001 Option B).
 Used By:
  - PLUGIN-ARCHITECTURE.md
  - sync_plugin_bundle.py (canonical; template fallback at .ai_infra/templates/plugin/skills/)
@@ -19,15 +19,15 @@ Notes:
 
 ## When
 
-User enabled the **MAS Workflow Kit** plugin and opened **their project** (not the kit repo). Run on first use or when planes are missing.
+User enabled the **MAS Workflow Kit — Project SSOT** plugin (`mas-workflow-kit-project-ssot`) and opened **their app** (not this kit product repo). Run on first use or when planes are missing.
 
 ## Guide the user (keep it simple)
 
-1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
-2. Confirm the open folder is **their app**, not `mas-workflow-kit`.
+1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit — Project SSOT** card in the preview.
+2. Confirm the open folder is **their app**, not the kit product repo (`mas-workflow-kit-project-ssot`).
 3. Run activate (below) — or tell them to pick **`/workflow-activate`** from the **`/`** menu.
-4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate`.
-5. Point them to **`/implementer`** (from **`/`** menu). When `project_ssot.enabled` in `github.collaboration.yaml`, Entry is **`python -m cursor_workflow project status`** (board SSOT); else read `session-pointer.md` first.
+4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate` (set `project_ssot` for board SSOT).
+5. Point them to **`/implementer`** (from **`/`** menu). When `project_ssot.enabled`, Entry is **`python -m cursor_workflow project status`** (board SSOT); else read `session-pointer.md` first.
 
 Do **not** dump gate lists or maintainer `make` commands.
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ cd mas-workflow-kit-project-ssot
 
 Open the folder in Cursor → point the agent at **`HANDOFF.md`**.
 
-## Install the plugin (consumers)
+## Install the plugin (consumers — other app repos)
 
-In **Agent chat** (not terminal):
+In **Agent chat** (not terminal), from **your application** workspace:
 
 ```text
 /add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
-Then open **your app** and run `/workflow-activate`.
+Click the **MAS Workflow Kit — Project SSOT** card, then run **`/workflow-activate`** in that same app folder. That copies `.cursor/`, `.ai_infra/`, `.local/` trackers, and agents into the consumer project.
+
+This repository is the **product kit** (develop + ship). Consumer apps **install + activate** it; they do not need upstream `mas-workflow-kit`.
 
 ## Kit quick navigation
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,6 +1,6 @@
 # Plugin assets
 
-Marketplace logotype and docs screenshots for **MAS Workflow Kit**.
+Marketplace logotype and docs screenshots for **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`).
 
 ## Files
 
@@ -23,6 +23,6 @@ https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main
 
 ## Install screenshot
 
-`mas-workflow-kit-install.png` — Agent chat with `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` and the plugin preview card. Linked from root `README.md` § Get started step 1.
+`mas-workflow-kit-install.png` — Agent chat with `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` and the **MAS Workflow Kit — Project SSOT** preview card. Linked from root `README.md` § Get started step 1.
 
 Publisher: Savin Ionuț Răzvan · [razvansavin.com](https://razvansavin.com/) · [GitHub](https://github.com/SavinRazvan)

--- a/payload/.ai_infra/docs/governance/drift-prevention.md
+++ b/payload/.ai_infra/docs/governance/drift-prevention.md
@@ -33,7 +33,7 @@ Additionally when changing governance, workflows, `.cursor/`, `.agents/`, or tra
 ## After changing documentation lifecycle
 
 1. Update **`.ai_infra/docs/governance/workflow-source-owners.md`** if ownership moved.
-2. Run **[documentation-maintenance-checklist.md](https://github.com/SavinRazvan/mas-workflow-kit/blob/main/.ai_infra/docs/operations/documentation-maintenance-checklist.md)** for kit doc surfaces.
+2. Run **[documentation-maintenance-checklist.md](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/blob/main/.ai_infra/docs/operations/documentation-maintenance-checklist.md)** for kit doc surfaces.
 
 ## After changing `.local` layout
 
@@ -72,5 +72,5 @@ Script-first checks for plan ↔ tracker ↔ session-pointer coherence and hando
 ## Quarterly (or before kit releases)
 
 - Confirm **`rules-overlap-matrix.md`** still lists all **`.cursor/rules/*.mdc`** files.
-- Skim kit repo [**`IMPLEMENTATION-STATUS.md`**](https://github.com/SavinRazvan/mas-workflow-kit/blob/main/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) vs shipped manifest profiles.
+- Skim kit repo [**`IMPLEMENTATION-STATUS.md`**](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/blob/main/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) vs shipped manifest profiles.
 - Re-run **`make gates`**, **`make drift-validate`**, and **`make install-dry-run`** on the kit repo.

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -14,7 +14,7 @@ Notes:
  - Copied to consumer projects via manifest copy_ai_infra: docs/operations.
 -->
 
-# MAS Workflow Kit — Plugin User Guide
+# MAS Workflow Kit — Project SSOT · Plugin User Guide
 
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.
 
@@ -63,9 +63,9 @@ In **Agent chat** (not the terminal):
 /add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
-Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
+Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit — Project SSOT** card to install:
 
-![Install MAS Workflow Kit from Agent chat](assets/mas-workflow-kit-install.png)
+![Install MAS Workflow Kit — Project SSOT from Agent chat](assets/mas-workflow-kit-install.png)
 
 Optional — explicit branch:
 
@@ -75,13 +75,13 @@ Optional — explicit branch:
 
 This loads agents, skills, and rules into Cursor. Your project may only get `.cursor/settings.json` until you activate (§2).
 
-**When listed:** **Cursor → Marketplace → MAS Workflow Kit → Install** — same two-step flow; you still run **`/workflow-activate`** afterward.
+**When listed:** **Cursor → Marketplace → MAS Workflow Kit — Project SSOT → Install** — same two-step flow; you still run **`/workflow-activate`** afterward.
 
 ---
 
 ## 2. Quick start (4 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project** open (not `mas-workflow-kit`).
+**Need:** Cursor · Python 3.11+ · **your project** open (not the kit product repo `mas-workflow-kit-project-ssot`).
 
 | Step | Action |
 |------|--------|

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -15,7 +15,7 @@ Notes:
 
 # Consumer quickstart
 
-Install the **MAS Workflow Kit** into your project in a few minutes. No special git setup required.
+Install **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) into your project in a few minutes. No special git setup required.
 
 > **Full manual:** [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) — plugin vs activate, complete file tree, use-case matrix, PR and audit chapters.
 
@@ -23,7 +23,7 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 
 ## First run (4 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit repo).
+**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit product repo `mas-workflow-kit-project-ssot`).
 
 | Step | Action |
 |------|--------|
@@ -44,9 +44,9 @@ Install the **MAS Workflow Kit** into your project in a few minutes. No special 
 /add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot
 ```
 
-Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit** card to install:
+Cursor shows an **Add Plugin** preview — click the **MAS Workflow Kit — Project SSOT** card to install:
 
-![Install MAS Workflow Kit from Agent chat — type /add-plugin with the GitHub URL, then click the plugin card](assets/mas-workflow-kit-install.png)
+![Install MAS Workflow Kit — Project SSOT from Agent chat — type /add-plugin with the GitHub URL, then click the plugin card](assets/mas-workflow-kit-install.png)
 
 Optional — pin `main`:
 
@@ -116,7 +116,7 @@ python3 -m cursor_workflow activate --directory .
 <summary><strong>Alternative: terminal activate (no plugin UI)</strong></summary>
 
 ```bash
-export KIT=~/Projects/mas-workflow-kit
+export KIT=~/Projects/mas-workflow-kit-project-ssot
 export TARGET=~/Projects/my-app
 mkdir -p "$TARGET"
 "$KIT/.venv/bin/python" "$KIT/payload/cursor_workflow" activate \
@@ -139,7 +139,7 @@ owner:
 ```
 
 ```bash
-cd ~/Projects/my-app   # your activated project — not mas-workflow-kit
+cd ~/Projects/my-app   # your activated project — not `mas-workflow-kit-project-ssot` (the kit product repo)
 python3 -m cursor_workflow contributors validate   # must PASS before first PR
 python3 -m cursor_workflow integrate validate      # optional; P0 must be 0
 python3 -m cursor_workflow health
@@ -191,7 +191,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 
 ## Terminal commands cheat sheet
 
-Run from **your activated project root** (`~/Projects/my-app`), not the kit repo.
+Run from **your activated project root** (`~/Projects/my-app`), not `mas-workflow-kit-project-ssot`.
 
 ```bash
 cd ~/Projects/my-app
@@ -290,7 +290,7 @@ Procedure: [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) §7 · [agent-workflow-p
 
 | Do | Don't |
 |----|-------|
-| Open **your app** in Cursor | Activate while inside `mas-workflow-kit` |
+| Open **your app** in Cursor | Activate while inside `mas-workflow-kit-project-ssot` |
 | **`/workflow-activate`** in chat | Run `make gates` (kit-dev only) |
 | Real paths like `~/Projects/my-app` | Literal `/path/to/your-project` |
 
@@ -309,7 +309,7 @@ Gate details: [gate-matrix.md](gate-matrix.md) (consumer scaffold = 4 checks).
 
 ## Kit clone path (advanced)
 
-When not using the plugin UI — clone [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot), then:
+When not using the plugin UI — clone [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot), then:
 
 ```bash
 python3 -m venv .venv && .venv/bin/pip install -q -r requirements-dev.txt
@@ -352,7 +352,7 @@ If you see:
 |----------|--------|
 | Is it your app's problem? | **No** — your install can be valid while this fails |
 | Is it a kit bug? | **Yes** — the checker assumed a maintainer-only file exists |
-| False positive? | **Yes** — `IMPLEMENTATION-STATUS.md` lives only in the **mas-workflow-kit** repo |
+| False positive? | **Yes** — `IMPLEMENTATION-STATUS.md` lives only in the **mas-workflow-kit-project-ssot** product repo |
 | Who needs to fix it? | **Kit maintainers** (skip the check when the file is absent) |
 | What should you do? | Re-run with `--profile consumer` after upgrading the kit; until then, treat DRIFT-005 as ignorable |
 
@@ -374,10 +374,10 @@ After the kit fix, expect:
 | Only `.cursor/settings.json` after plugin install | Normal — run **`/workflow-activate`** in your app folder for the full bundle |
 | `contributors validate` FAIL | Replace placeholders in `github.collaboration.yaml` |
 | YAML `ParserError` / traceback | Fix `human_coauthors` — keep `[]` or use a proper list; don't uncomment example lines as siblings of `[]` |
-| Validate passes from kit repo but fails in your app | Run commands from **your project** (`cd ~/Projects/my-app`), not `mas-workflow-kit` |
+| Validate passes from kit repo but fails in your app | Run commands from **your project** (`cd ~/Projects/my-app`), not `mas-workflow-kit-project-ssot` |
 | `pytest` not found | Re-run **`/workflow-activate`** (creates `.venv`) |
 | Permission denied on `/path` | You used a placeholder path — create a real folder |
-| Subagents/skills missing in **`/`** menu | Open **your activated project**, not the kit repo; re-run **`/workflow-activate`** if planes are incomplete |
+| Subagents/skills missing in **`/`** menu | Open **your activated project**, not `mas-workflow-kit-project-ssot`; re-run **`/workflow-activate`** if planes are incomplete |
 | Control Center shows **Failed to fetch** | From project root: `python3 -m http.server 8000` then open http://localhost:8000/.local/agents-control-center/dashboards/index.html — not `file://` |
 | Raw markdown (no tables/bold) in Control Center | Re-run **`/workflow-activate`** to refresh `local-markdown.js` |
 | Stale dashboard UI after kit update | `python3 -m cursor_workflow activate --directory .` |

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflow-activate
-description: Install MAS Workflow Kit infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
+description: Install MAS Workflow Kit — Project SSOT infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
 ---
 <!--
 File: SKILL.md
 Path: .cursor/skills/workflow-activate/SKILL.md
-Role: Install MAS Workflow Kit three planes into the open workspace (ADR-001 Option B).
+Role: Install MAS Workflow Kit — Project SSOT three planes into the open workspace (ADR-001 Option B).
 Used By:
  - PLUGIN-ARCHITECTURE.md
  - sync_plugin_bundle.py (canonical; template fallback at .ai_infra/templates/plugin/skills/)
@@ -19,15 +19,15 @@ Notes:
 
 ## When
 
-User enabled the **MAS Workflow Kit** plugin and opened **their project** (not the kit repo). Run on first use or when planes are missing.
+User enabled the **MAS Workflow Kit — Project SSOT** plugin (`mas-workflow-kit-project-ssot`) and opened **their app** (not this kit product repo). Run on first use or when planes are missing.
 
 ## Guide the user (keep it simple)
 
-1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
-2. Confirm the open folder is **their app**, not `mas-workflow-kit`.
+1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit — Project SSOT** card in the preview.
+2. Confirm the open folder is **their app**, not the kit product repo (`mas-workflow-kit-project-ssot`).
 3. Run activate (below) — or tell them to pick **`/workflow-activate`** from the **`/`** menu.
-4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate`.
-5. Point them to **`/implementer`** (from **`/`** menu). When `project_ssot.enabled` in `github.collaboration.yaml`, Entry is **`python -m cursor_workflow project status`** (board SSOT); else read `session-pointer.md` first.
+4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate` (set `project_ssot` for board SSOT).
+5. Point them to **`/implementer`** (from **`/`** menu). When `project_ssot.enabled`, Entry is **`python -m cursor_workflow project status`** (board SSOT); else read `session-pointer.md` first.
 
 Do **not** dump gate lists or maintainer `make` commands.
 

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflow-activate
-description: Install MAS Workflow Kit infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
+description: Install MAS Workflow Kit — Project SSOT infrastructure into the current workspace from the plugin payload (ADR-001 Option B).
 ---
 <!--
 File: SKILL.md
 Path: .cursor/skills/workflow-activate/SKILL.md
-Role: Install MAS Workflow Kit three planes into the open workspace (ADR-001 Option B).
+Role: Install MAS Workflow Kit — Project SSOT three planes into the open workspace (ADR-001 Option B).
 Used By:
  - PLUGIN-ARCHITECTURE.md
  - sync_plugin_bundle.py (canonical; template fallback at .ai_infra/templates/plugin/skills/)
@@ -19,15 +19,15 @@ Notes:
 
 ## When
 
-User enabled the **MAS Workflow Kit** plugin and opened **their project** (not the kit repo). Run on first use or when planes are missing.
+User enabled the **MAS Workflow Kit — Project SSOT** plugin (`mas-workflow-kit-project-ssot`) and opened **their app** (not this kit product repo). Run on first use or when planes are missing.
 
 ## Guide the user (keep it simple)
 
-1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit** card in the preview.
-2. Confirm the open folder is **their app**, not `mas-workflow-kit`.
+1. If plugin not installed: Agent chat → `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` (chat only — not terminal). Show [install screenshot](https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/mas-workflow-kit-install.png) or [consumer-quickstart § step 1](../../.ai_infra/docs/operations/consumer-quickstart.md#step-1-detail--install-plugin-from-github) — user clicks the **MAS Workflow Kit — Project SSOT** card in the preview.
+2. Confirm the open folder is **their app**, not the kit product repo (`mas-workflow-kit-project-ssot`).
 3. Run activate (below) — or tell them to pick **`/workflow-activate`** from the **`/`** menu.
-4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate`.
-5. Point them to **`/implementer`** (from **`/`** menu). When `project_ssot.enabled` in `github.collaboration.yaml`, Entry is **`python -m cursor_workflow project status`** (board SSOT); else read `session-pointer.md` first.
+4. Tell them to edit `.local/user_settings/github.collaboration.yaml` → `contributors validate` (set `project_ssot` for board SSOT).
+5. Point them to **`/implementer`** (from **`/`** menu). When `project_ssot.enabled`, Entry is **`python -m cursor_workflow project status`** (board SSOT); else read `session-pointer.md` first.
 
 Do **not** dump gate lists or maintainer `make` commands.
 


### PR DESCRIPTION
## Summary
- `.cursor-plugin/plugin.json` → name/repo/displayName for **MAS Workflow Kit — Project SSOT**
- Consumer install docs + `/workflow-activate` say: install from this repo; activate in **your app** (not the kit product repo)
- Lineage to upstream `mas-workflow-kit` remains read-only where historical

## Test plan
- [x] `sync_plugin_bundle.py --check`
- [x] doc facts / integrate validate


Made with [Cursor](https://cursor.com)