### PR TITLE
docs: align STANDALONE product framing and board Pattern A recipes

### DIFF
--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -20,9 +20,9 @@ disable-model-invocation: true
 6. Note merge SHA: `gh api repos/.../pulls/<n> -q .merge_commit_sha` (or `gh pr view` if working).
 7. **Record:**  
    `python .ai_infra/scripts/pr/merge.py --pr <id|url> --pipeline default --merge-sha <sha>`  
-   Optional: `--item-id PVTI_…` when known; `--skip-board-sync` to bypass board close.  
+   Optional: `--item-id <from PR Board-Item line or find-by-pr>` when known; `--skip-board-sync` to bypass board close.  
    When `project_ssot.enabled`, this sets the card → **Done** and appends Notes (`Merged: <PR URL> @ <sha>`). Failure is a **warn** only — merge artifact still writes.  
-   Prefer PR body line `- Board-Item: PVTI_…` under Collaboration so find-by-pr can resolve without `--item-id`.  
+   Prefer PR body line `- Board-Item: <item_id>` under Collaboration (from `project last` or create output) so `find-by-pr` resolves without `--item-id`.  
    (same `--arch-impacting` if used above). Enrich `merge.md` with method + follow-ups.
 8. **Finalize:** `git checkout main`; `python .ai_infra/scripts/pr/finalize.py --branch <branch>`; prune remotes; confirm feature branch gone on origin.
 

--- a/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -28,7 +28,7 @@ Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](
 
 | Profile | When | Checks |
 |---------|------|--------|
-| `kit-dev` | Default for mas-workflow-kit repo | DRIFT-001…008 (full set) |
+| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…008 (full set) |
 | `consumer` | `work-tracker.md` contains exemplar `STARTER-001` | DRIFT-005, DRIFT-008 (relaxed tracker rules) |
 
 Auto-detect profile from `work-tracker.md` unless `--profile` overrides.

--- a/.ai_infra/docs/governance/folder-charter.md
+++ b/.ai_infra/docs/governance/folder-charter.md
@@ -78,4 +78,4 @@ Per [local-artifact-protection.mdc](../../../.cursor/rules/local-artifact-protec
 - **Tier 2 runtime content** — filled under `.local/workflow-artifacts/*` during slices (PR, alignment, drift, enterprise audit, release, audit preflight).
 - Live slice trackers — **`.local/index-and-planning/current/`** (summarize in `updates-log.md`).
 - Generated coverage/CI JSON — **`.local/generated-data/`**.
-- Product application code — out of scope for **mas-workflow-kit**; use consumer `overlays/rules/` when needed.
+- Product application code — out of scope for the kit product repo; use consumer `overlays/rules/` when needed.

--- a/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
+++ b/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
@@ -67,7 +67,7 @@ flowchart LR
 ## Kit dev repo (where we build the plugin)
 
 ```text
-mas-workflow-kit/
+mas-workflow-kit-project-ssot/
 ├── AGENTS.md
 ├── .cursor-plugin/plugin.json  # marketplace manifest — no path fields (spec-exact discovery)
 ├── agents/                     # generated (make sync-plugin) — COMMITTED, sibling of .cursor-plugin/

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -16,7 +16,7 @@ Notes:
 <!-- Publish target: this product repo (mas-workflow-kit-project-ssot). STANDALONE 2026-07-18 — not upstream mas-workflow-kit. -->
 
 
-**Product:** MAS Workflow Kit · **Plugin id:** `mas-workflow-kit`
+**Product:** MAS Workflow Kit — Project SSOT · **Plugin id:** `mas-workflow-kit-project-ssot` (lineage plugin id `mas-workflow-kit` is upstream-only)
 
 ## Pre-publish (kit repo)
 
@@ -190,7 +190,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 | Field | Value |
 |-------|--------|
 | Organization name | Savin Ionuț Răzvan |
-| Organization handle | `savin-razvan` (or `mas-workflow-kit`) |
+| Organization handle | `savin-razvan` (or `mas-workflow-kit-project-ssot`) |
 | Contact email | razvan.i.savin@gmail.com |
 | Logotype URL | `https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/logo.png` |
 | Description | MAS Workflow Kit installs multi-agent workflow infrastructure into any Cursor project: agents, skills, rules, PR lifecycle scripts, `.local/` trackers, and optional MCP. Run **`/workflow-activate`** once to scaffold three planes. Pattern A: one script per maintainer action. For teams using agents, audits, and PR-first governance. |
@@ -200,7 +200,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Manifest:** `.cursor-plugin/plugin.json` — `author`, `homepage`, `repository`, `logo` aligned with the table above.
 
-**Listing copy review (2026-07-07):** Verified `plugin.json` `description`, the Description row above, and README consumer sections (`What you get`, agent/skill/rule counts) against `IMPLEMENTATION-STATUS.md` on `main` — 633 tests (post DRIFT-005 slice), DOC-006 PASS, coverage scope 3588 stmts / 100% on `--cov=.ai_infra --cov=cursor_workflow`. No stale test or coverage numbers in marketplace-facing copy; feature counts (7 agents, 10 skills, 5 PR skills, 6 rules) match shipped inventory.
+**Listing copy review (2026-07-07):** Verified `plugin.json` `description`, the Description row above, and README consumer sections (`What you get`, agent/skill/rule counts) against `IMPLEMENTATION-STATUS.md` on `main` — 633 tests (post DRIFT-005 slice), DOC-006 PASS, coverage scope 3588 stmts / 100% on `--cov=.ai_infra --cov=cursor_workflow`. No stale test or coverage numbers in marketplace-facing copy; feature counts (8 agents, 11 skills, 5 PR skills, 7 rules) match shipped inventory.
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Record: `.local/workflow-artifacts/release/smoke-consumer-smart-notes-2026-07-08.md`.
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -87,7 +87,7 @@ What **`/workflow-activate`** copies into **your app** (e.g. Smart-Notes):
 my-app/
 ├── AGENTS.md                       Stub router (from template)
 ├── .cursor/
-│   ├── agents/                     7 agents (from payload)
+│   ├── agents/                     8 agents (from payload; incl. project-board)
 │   ├── rules/                      6 rules
 │   └── skills/                     10 canonical skills only (no repo-root skills/ merge)
 ├── .agents/skills/                 5 maintainer slash folders (+ audit-alignment stub)

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -108,7 +108,7 @@ From `manifest.yaml` (default profile **`with_mcp`**):
 your-project/
 ├── AGENTS.md                      # thin router (not overwritten on re-activate)
 ├── .cursor/
-│   ├── agents/                    # 7 subagents
+│   ├── agents/                    # 8 subagents (incl. project-board)
 │   ├── skills/                    # protocols (activate, audit, integration, …)
 │   ├── rules/                     # always-applied governance
 │   └── mcp.json                   # with_mcp profile
@@ -220,7 +220,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **Check install health** | — | `python3 -m cursor_workflow health` | [gate-matrix.md](gate-matrix.md) |
 | **Dry-run install preview** | — | `scaffold.py --dry-run` | [install-dry-run.md](install-dry-run.md) |
 
-### Full `/` menu (7 agents + skills)
+### Full `/` menu (8 agents + skills)
 
 | Chat name | Disk path |
 |-----------|-----------|

--- a/.ai_infra/docs/operations/install-dry-run.md
+++ b/.ai_infra/docs/operations/install-dry-run.md
@@ -66,7 +66,7 @@ If you must debug scaffold behavior, install from **`payload/`** (not repo root)
 
 ```bash
 TARGET=/tmp/workflow-kit-dry-run
-SOURCE=/path/to/mas-workflow-kit/payload
+SOURCE=/path/to/mas-workflow-kit-project-ssot/payload
 python3 -m cursor_workflow install --target "$TARGET" --source "$SOURCE" --dry-run
 ```
 

--- a/.ai_infra/docs/operations/workflow-complete.md
+++ b/.ai_infra/docs/operations/workflow-complete.md
@@ -80,7 +80,7 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 2. **`.local/index-and-planning/history/updates-log.md`** — one top entry (no gate dumps).
 3. **`change-index.md`** — one row; do **not** dual-write tracker `in_progress` under `board_only`.
 4. **`test-plan.md` / `test-index.md`** — when tests changed.
-5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); pass `--item-id` or embed `Board-Item: PVTI_…` in the PR body.
+5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); `find-by-pr` resolves from the PR body, or pass `--item-id` when known. Prefer `- Board-Item: <id>` in the PR Collaboration section (never paste docs placeholders).
 6. **`make drift-validate`** — on P0/P1, hand off to **`workflow-drift-guard`** (reads + updates the board; DRIFT-009/010).
 
 **Offline fallback (project_ssot disabled / no gh):**

--- a/.ai_infra/scripts/install/README.md
+++ b/.ai_infra/scripts/install/README.md
@@ -4,7 +4,7 @@ Scaffold the universal **MAS Workflow Kit** into a consumer project.
 
 ## Usage
 
-From the **mas-workflow-kit** repo root:
+From the **mas-workflow-kit-project-ssot** product repo root:
 
 ```bash
 # Preview

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -44,7 +44,7 @@ Work is **indexed on the Project**, not in chat alone.
 Handoff line (chat + card Notes):
 
 ```text
-item_id=<real PVTI_ from create or project last> · @User/implementer · Status=before→after · next=@User/verifier
+item_id=<from project last or create> · @User/implementer · Status=before→after · next=@User/verifier
 ```
 
 Prefer `--last` after create so agents never invent ids.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -230,7 +230,8 @@ Auth refreshed with `project` scope. Field/option ids for Status / Priority / Si
 ```bash
 python3 -m cursor_workflow project status
 python3 -m cursor_workflow project list
-python3 -m cursor_workflow project set-status --id PVTI_… --to in_progress
+python3 -m cursor_workflow project claim --last --agent implementer
+# atomics (power use): project set-status --last --to in_progress
 ```
 
 ### 4.4 Kit mirror into this repo (2026-07-17)

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -28,7 +28,7 @@ Also customize `.ai_infra/scripts/pr/prepare.py` `GATES` once — document extra
 
 ## Anti-patterns
 
-- Do not put product rules in universal `.cursor/rules/` in the **mas-workflow-kit** repo
+- Do not put product rules in universal `.cursor/rules/` in the **mas-workflow-kit-project-ssot** product repo
 - Do not duplicate `GATES` in overlay markdown — point to `prepare.py`
 - Do not treat overlays as agent runtime config (Pattern A: hardcoded scripts)
 

--- a/payload/.agents/skills/merge-pr/SKILL.md
+++ b/payload/.agents/skills/merge-pr/SKILL.md
@@ -20,9 +20,9 @@ disable-model-invocation: true
 6. Note merge SHA: `gh api repos/.../pulls/<n> -q .merge_commit_sha` (or `gh pr view` if working).
 7. **Record:**  
    `python .ai_infra/scripts/pr/merge.py --pr <id|url> --pipeline default --merge-sha <sha>`  
-   Optional: `--item-id PVTI_…` when known; `--skip-board-sync` to bypass board close.  
+   Optional: `--item-id <from PR Board-Item line or find-by-pr>` when known; `--skip-board-sync` to bypass board close.  
    When `project_ssot.enabled`, this sets the card → **Done** and appends Notes (`Merged: <PR URL> @ <sha>`). Failure is a **warn** only — merge artifact still writes.  
-   Prefer PR body line `- Board-Item: PVTI_…` under Collaboration so find-by-pr can resolve without `--item-id`.  
+   Prefer PR body line `- Board-Item: <item_id>` under Collaboration (from `project last` or create output) so `find-by-pr` resolves without `--item-id`.  
    (same `--arch-impacting` if used above). Enrich `merge.md` with method + follow-ups.
 8. **Finalize:** `git checkout main`; `python .ai_infra/scripts/pr/finalize.py --branch <branch>`; prune remotes; confirm feature branch gone on origin.
 

--- a/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -28,7 +28,7 @@ Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](
 
 | Profile | When | Checks |
 |---------|------|--------|
-| `kit-dev` | Default for mas-workflow-kit repo | DRIFT-001…008 (full set) |
+| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…008 (full set) |
 | `consumer` | `work-tracker.md` contains exemplar `STARTER-001` | DRIFT-005, DRIFT-008 (relaxed tracker rules) |
 
 Auto-detect profile from `work-tracker.md` unless `--profile` overrides.

--- a/payload/.ai_infra/docs/governance/folder-charter.md
+++ b/payload/.ai_infra/docs/governance/folder-charter.md
@@ -78,4 +78,4 @@ Per [local-artifact-protection.mdc](../../../.cursor/rules/local-artifact-protec
 - **Tier 2 runtime content** — filled under `.local/workflow-artifacts/*` during slices (PR, alignment, drift, enterprise audit, release, audit preflight).
 - Live slice trackers — **`.local/index-and-planning/current/`** (summarize in `updates-log.md`).
 - Generated coverage/CI JSON — **`.local/generated-data/`**.
-- Product application code — out of scope for **mas-workflow-kit**; use consumer `overlays/rules/` when needed.
+- Product application code — out of scope for the kit product repo; use consumer `overlays/rules/` when needed.

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -108,7 +108,7 @@ From `manifest.yaml` (default profile **`with_mcp`**):
 your-project/
 ├── AGENTS.md                      # thin router (not overwritten on re-activate)
 ├── .cursor/
-│   ├── agents/                    # 7 subagents
+│   ├── agents/                    # 8 subagents (incl. project-board)
 │   ├── skills/                    # protocols (activate, audit, integration, …)
 │   ├── rules/                     # always-applied governance
 │   └── mcp.json                   # with_mcp profile
@@ -220,7 +220,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **Check install health** | — | `python3 -m cursor_workflow health` | [gate-matrix.md](gate-matrix.md) |
 | **Dry-run install preview** | — | `scaffold.py --dry-run` | [install-dry-run.md](install-dry-run.md) |
 
-### Full `/` menu (7 agents + skills)
+### Full `/` menu (8 agents + skills)
 
 | Chat name | Disk path |
 |-----------|-----------|

--- a/payload/.ai_infra/docs/operations/install-dry-run.md
+++ b/payload/.ai_infra/docs/operations/install-dry-run.md
@@ -66,7 +66,7 @@ If you must debug scaffold behavior, install from **`payload/`** (not repo root)
 
 ```bash
 TARGET=/tmp/workflow-kit-dry-run
-SOURCE=/path/to/mas-workflow-kit/payload
+SOURCE=/path/to/mas-workflow-kit-project-ssot/payload
 python3 -m cursor_workflow install --target "$TARGET" --source "$SOURCE" --dry-run
 ```
 

--- a/payload/.ai_infra/docs/operations/workflow-complete.md
+++ b/payload/.ai_infra/docs/operations/workflow-complete.md
@@ -80,7 +80,7 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 2. **`.local/index-and-planning/history/updates-log.md`** — one top entry (no gate dumps).
 3. **`change-index.md`** — one row; do **not** dual-write tracker `in_progress` under `board_only`.
 4. **`test-plan.md` / `test-index.md`** — when tests changed.
-5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); pass `--item-id` or embed `Board-Item: PVTI_…` in the PR body.
+5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); `find-by-pr` resolves from the PR body, or pass `--item-id` when known. Prefer `- Board-Item: <id>` in the PR Collaboration section (never paste docs placeholders).
 6. **`make drift-validate`** — on P0/P1, hand off to **`workflow-drift-guard`** (reads + updates the board; DRIFT-009/010).
 
 **Offline fallback (project_ssot disabled / no gh):**

--- a/payload/.ai_infra/scripts/install/README.md
+++ b/payload/.ai_infra/scripts/install/README.md
@@ -4,7 +4,7 @@ Scaffold the universal **MAS Workflow Kit** into a consumer project.
 
 ## Usage
 
-From the **mas-workflow-kit** repo root:
+From the **mas-workflow-kit-project-ssot** product repo root:
 
 ```bash
 # Preview

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -44,7 +44,7 @@ Work is **indexed on the Project**, not in chat alone.
 Handoff line (chat + card Notes):
 
 ```text
-item_id=<real PVTI_ from create or project last> · @User/implementer · Status=before→after · next=@User/verifier
+item_id=<from project last or create> · @User/implementer · Status=before→after · next=@User/verifier
 ```
 
 Prefer `--last` after create so agents never invent ids.

--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -20,9 +20,9 @@ disable-model-invocation: true
 6. Note merge SHA: `gh api repos/.../pulls/<n> -q .merge_commit_sha` (or `gh pr view` if working).
 7. **Record:**  
    `python .ai_infra/scripts/pr/merge.py --pr <id|url> --pipeline default --merge-sha <sha>`  
-   Optional: `--item-id PVTI_…` when known; `--skip-board-sync` to bypass board close.  
+   Optional: `--item-id <from PR Board-Item line or find-by-pr>` when known; `--skip-board-sync` to bypass board close.  
    When `project_ssot.enabled`, this sets the card → **Done** and appends Notes (`Merged: <PR URL> @ <sha>`). Failure is a **warn** only — merge artifact still writes.  
-   Prefer PR body line `- Board-Item: PVTI_…` under Collaboration so find-by-pr can resolve without `--item-id`.  
+   Prefer PR body line `- Board-Item: <item_id>` under Collaboration (from `project last` or create output) so `find-by-pr` resolves without `--item-id`.  
    (same `--arch-impacting` if used above). Enrich `merge.md` with method + follow-ups.
 8. **Finalize:** `git checkout main`; `python .ai_infra/scripts/pr/finalize.py --branch <branch>`; prune remotes; confirm feature branch gone on origin.
 

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -44,7 +44,7 @@ Work is **indexed on the Project**, not in chat alone.
 Handoff line (chat + card Notes):
 
 ```text
-item_id=<real PVTI_ from create or project last> · @User/implementer · Status=before→after · next=@User/verifier
+item_id=<from project last or create> · @User/implementer · Status=before→after · next=@User/verifier
 ```
 
 Prefer `--last` after create so agents never invent ids.


### PR DESCRIPTION
## Summary
- Remove stale upstream `mas-workflow-kit` repo paths from install/ops/maintainer docs; this repo is the permanent product (STANDALONE).
- Fix agent/skill counts (8 agents, 11 skills, 7 rules) in PLUGIN-USER-GUIDE, repository-map, and marketplace-publish.
- Prefer `--last` / `find-by-pr` over copy-paste placeholder item ids in HANDOFF, workflow-complete, merge-pr, and project-board-ssot skill.
- Ran `sync_plugin_bundle.py` + `--check` (payload parity green).

## Test plan
- [x] `python3 .ai_infra/scripts/release/sync_plugin_bundle.py --check`
- [ ] `pytest -q` (doc-only slice; gates on merge prep)

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: implementer
- Board-Item: PVTI_lAHOBl46-84A9KZxzgzRH-g

Made with [Cursor](https://cursor.com)