### PR TITLE
Ship CONT-TS: timestamped Notes, continuity index, outbox, doc/agent alignment

### DIFF
--- a/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -28,7 +28,7 @@ Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](
 
 | Profile | When | Checks |
 |---------|------|--------|
-| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…008 (full set) |
+| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…010 + 004b (full set; 004b/009–010 when `board_only`) |
 | `consumer` | `work-tracker.md` contains exemplar `STARTER-001` | DRIFT-005, DRIFT-008 (relaxed tracker rules) |
 
 Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
@@ -41,6 +41,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-002 | P0 | kit-dev | At most one `in_progress` in work-tracker |
 | DRIFT-003 | P1 | kit-dev | Active task token appears in plan Current focus |
 | DRIFT-004 | P1 | kit-dev | session-pointer Phase/Next sanity vs plan |
+| DRIFT-004b | P1 | kit-dev | When `board_only`, session-pointer Board id/Status vs `project export` snapshot (stale In progress vs Done) |
 | DRIFT-005 | P1 (kit-dev) / P2 skip (consumer) | both | IMPLEMENTATION-STATUS test count vs pytest collect; **PASS (skip)** when file absent (consumer install — not a consumer failure) |
 | DRIFT-006 | P2 | kit-dev | test-index Owned tests paths resolve |
 | DRIFT-007 | P2 | kit-dev | updates-log fresh when git tree dirty |
@@ -48,7 +49,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
 | DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
 
-**Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`).
+**Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`). Pending `project_ssot.outbox` ops are **not** a drift failure — cite `project outbox status` in artifacts when relevant.
 
 ### Gate placement
 

--- a/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -14,28 +14,29 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 1. **Only writable SSOT:** when `project_ssot.enabled: true` and `sync_policy: board_only`, the GitHub Project is the **only writable** coordination SSOT for backlog, Status, and multi-agent continuation. Agents must not dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
 2. **`board_only` wins** — dual-mirror (local trackers + board both writable) is rejected; it causes worse agent drift (DRIFT-009).
 3. **Offline fallback:** if enabled is false or `gh`/Projects unavailable, use `fallback: local_trackers` with an explicit warning — then resume board sync; never silent dual-write.
-4. **Read-only exports:** optional snapshots (`project export`) may cache board state for audits/ICC later; they **must not** write Status and must never become a competing SSOT.
-5. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
-6. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
-7. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
-8. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
-9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
-10. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
-11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
-12. **Multi-collaborator attribution:** card Notes use `@owner.github_user/<agent>` (from each person’s `github.collaboration.yaml`). CLI: `append-notes --agent <name>` when `require_attribution_on_exit`. GitHub Assignees are humans only (`set-assignee`); agent role lives in Notes. Handoff: `next=@user/agent`.
-13. **Board Pattern A recipes:** lifecycle actions are one CLI command each — `create-from-template`, `claim`, `handoff`, `validate-item`, `doctor` — wrapping atomics. Prefer recipes over multi-step shell. Exit codes: `0` ok; `2` usage/config; `3` gh/network; `4` not found; `5` validation. Card body templates live under `.ai_infra/templates/project-board/`. Project README/settings remain human-only (paste `project-readme.md` in the UI — never into a shell).
+4. **Rate-limit outbox:** when GraphQL quota blocks writes, `project_ssot.outbox` stores structured ops in a local JSONL (`.local/generated-data/board-outbox.jsonl`). EXIT_QUEUED (6) is soft-success; `outbox flush` restores the board after reset. Outbox is **never** authoritative Status.
+5. **Read-only exports:** optional snapshots (`project export`) may cache board state for audits/ICC later; they **must not** write Status and must never become a competing SSOT.
+6. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
+7. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
+8. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
+9. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
+10. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
+11. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
+12. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
+13. **Multi-collaborator attribution:** card Notes use `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (from each person’s `github.collaboration.yaml`; CLI stamps UTC). CLI: `append-notes --agent <name>` when `require_attribution_on_exit`. GitHub Assignees are humans only (`set-assignee`); agent role lives in Notes. Handoff: `next=@user/agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
+14. **Board Pattern A recipes:** lifecycle actions are one CLI command each — `create-from-template`, `claim`, `handoff`, `validate-item`, `doctor`, `queue`, `outbox status|flush` — wrapping atomics. Prefer recipes over multi-step shell. Exit codes: `0` ok; `2` usage/config; `3` gh/network; `4` not found; `5` validation; `6` queued. Card body templates live under `.ai_infra/templates/project-board/`. Project README/settings remain human-only (paste `project-readme.md` in the UI — never into a shell).
 
 ## Consequences
 
-- New CLI module: `.ai_infra/install/cursor_workflow/project_cli.py`
+- New CLI module: `.ai_infra/install/cursor_workflow/project_cli.py` + `project_outbox.py`
 - Skill: `.cursor/skills/project-board-ssot/SKILL.md` (Continuation contract + per-agent rights)
 - Ops: `.ai_infra/docs/operations/project-board-collaboration.md`
 - Agent: `.cursor/agents/project-board.md`
-- Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); workflow-drift-guard **reads and updates** the board on Exit
+- Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); DRIFT-004b (session Board vs snapshot); workflow-drift-guard **reads and updates** the board on Exit; pending outbox is not a DRIFT failure
 - Post-merge Done: Pattern A `merge.py` (not a dedicated agent)
 - DraftIssue body edits: `append-notes` / `edit_item_body` resolve project item `PVTI_…` → content `DI_…` (+ preserve `--title`); Status/field edits stay on `PVTI_…`
-- Attribution: `append-notes --agent` prefixes `@github_user/agent`; `merge.py` Notes use `@user/merge.py`; `set-assignee` for human My items (Issue-backed)
-- Board Pattern A recipes + templates + structured `CODE=` exit lines; atomics remain for power use
+- Attribution: `append-notes --agent` prefixes `@github_user/agent · <ISO-8601-UTC> ·`; `merge.py` Notes use `@user/merge.py`; `set-assignee` for human My items (Issue-backed)
+- Board Pattern A recipes + templates + structured `CODE=` exit lines; rate-limit outbox (`project_ssot.outbox`); atomics remain for power use
 
 ## References
 

--- a/.ai_infra/docs/decisions/README.md
+++ b/.ai_infra/docs/decisions/README.md
@@ -9,6 +9,6 @@
 | [ADR-005](ADR-005-docs-split.md) | Consumer vs maintainer docs split | accepted |
 | [ADR-006](ADR-006-agent-integration-model.md) | Agent integration model (MAS vs independent) | accepted |
 | [ADR-007](ADR-007-workflow-drift-guard.md) | Workflow drift guard (operational drift detection) | accepted |
-| [ADR-008](ADR-008-project-board-ssot.md) | GitHub Project board as agent SSOT (experiment) | accepted |
+| [ADR-008](ADR-008-project-board-ssot.md) | GitHub Project board as agent SSOT (product doctrine) | accepted |
 
 New decisions: add `ADR-NNN-short-title.md` and update this index.

--- a/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/.ai_infra/docs/governance/workflow-source-owners.md
@@ -11,7 +11,7 @@ Depends On:
  - .ai_infra/scripts/pr/local_workflow_paths.py
 Notes:
  - Executable behavior wins over prose; prose must link to scripts instead of copying steps.
- - Last reviewed: 2026-06-29
+ - Last reviewed: 2026-07-18
 -->
 
 # Workflow source owners
@@ -24,7 +24,7 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `merge-pr` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (10 folders) | Plugin sync, agents |
+| Canonical Cursor skills | `.cursor/skills/` (11 folders) | Plugin sync, agents |
 | Maintainer slash skills | `.agents/skills/` (5 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-18 (ATTR-USER-AGENT attribution)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 692
+**Last updated:** 2026-07-18 (COV-100 — scoped coverage)  
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 901
 
 ## Shipped (confirmed in repo)
 
@@ -30,7 +30,10 @@ Notes:
 | workflow-activate skill | Kit dev + plugin | `.cursor/skills/workflow-activate/` |
 | PR scripts + prepare gates | Pattern A — **2** universal; **4** on kit-dev (drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` |
 | Governance + debrand scanners | CI-ready | `.ai_infra/scripts/architecture/` |
-| Workflow drift validate | ADR-007 | `.ai_infra/scripts/workflow/check_drift.py` |
+| Workflow drift validate | ADR-007 (+ DRIFT-004b) | `.ai_infra/scripts/workflow/check_drift.py` |
+| Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_cli.py` + skill § Notes |
+| Local continuity-index | Rolling ≥3-day UTC rows; board Notes = full card lifetime | `history/continuity-index.md` (+ exemplar) |
+| Board outbox (rate-limit) | `project queue` / `outbox status|flush`; EXIT_QUEUED=6; **58 mocked unit tests** | `project_outbox.py` + `project_cli.py` + `tests/modules/install/test_project_outbox.py` |
 | Doc facts validate | DOC-001…006 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |
 | Anchoring | session-pointer, change-index | `.local/.../current/` |
@@ -44,20 +47,20 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 692 | `tests/modules/` |
+| Tests | 901 | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
-installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18: **~4396
-statements, ~94%** on a full suite pass. Primary gap: `project_cli.py` live-`gh` branches
-(~64% — integration paths exercised via targeted unit mocks elsewhere). Subprocess-only
-maintainer scanners (`check_governance_consistency.py`, `check_debrand.py`,
-`check_consumer_purity.py`, `check_file_headers.py`) have dedicated module tests but are
-excluded from this metric by design — they are launched via `subprocess` / `make gates`,
-not imported by the coverage run. Running `--cov=.` (tests included) reports higher
-because of order-dependent branches in test-helper cleanup code; scope shipped source for
-readiness claims.
+installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18
+(COV-100): **5352 statements, 100%** on a full suite pass (900 passed, 1 skipped).
+One import-order `sys.path` bootstrap in `merge.py` is `# pragma: no cover`.
+Subprocess-only maintainer scanners (`check_governance_consistency.py`,
+`check_debrand.py`, `check_consumer_purity.py`, `check_file_headers.py`) have
+dedicated module tests but are excluded from this metric by design — they are
+launched via `subprocess` / `make gates`, not imported by the coverage run.
+Running `--cov=.` (tests included) reports higher because of order-dependent
+branches in test-helper cleanup code; scope shipped source for readiness claims.
 
 ## Verification commands
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -202,6 +202,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07):** Verified `plugin.json` `description`, the Description row above, and README consumer sections (`What you get`, agent/skill/rule counts) against `IMPLEMENTATION-STATUS.md` on `main` — 633 tests (post DRIFT-005 slice), DOC-006 PASS, coverage scope 3588 stmts / 100% on `--cov=.ai_infra --cov=cursor_workflow`. No stale test or coverage numbers in marketplace-facing copy; feature counts (8 agents, 11 skills, 5 PR skills, 7 rules) match shipped inventory.
 
+**Listing copy refresh (2026-07-18 DOC-ALIGN):** Re-verified README/AGENTS.md/repository-map against shipped tree — **692** tests, ~4396 stmts / ~94% coverage per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633-test line above is archival only.
+
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Record: `.local/workflow-artifacts/release/smoke-consumer-smart-notes-2026-07-08.md`.
 
 ## Publish

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -124,7 +124,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 
 ---
 
-## Agents (7) — all active
+## Agents (8) — all active
 
 | Agent | `.cursor/agents/` | Consumer | Invoke |
 |-------|:-----------------:|:--------:|--------|
@@ -134,6 +134,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `enterprise-auditor` | Yes | Yes | `/enterprise-auditor` |
 | `integrator-mas-agent` | Yes | Yes | `/integrator-mas-agent` |
 | `workflow-drift-guard` | Yes | Yes | `/workflow-drift-guard` |
+| `project-board` | Yes | Yes | `/project-board` |
 | `researcher` | Yes | Yes (optional) | `/researcher` |
 
 **Deprecated agents:** none.
@@ -142,7 +143,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 
 ## Skills
 
-### Canonical — `.cursor/skills/` (10) → consumer `.cursor/skills/`
+### Canonical — `.cursor/skills/` (11) → consumer `.cursor/skills/`
 
 | Skill | Paired agent |
 |-------|----------------|
@@ -153,6 +154,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `implementation-execution-loop` | `implementer` |
 | `test-module-coverage` | `test-runner` |
 | `mas-infrastructure-integration` | `integrator-mas-agent` |
+| `project-board-ssot` | `project-board` (board Entry/Exit; ADR-008) |
 | `workflow-activate` | Install / re-activate |
 | `connect-external-mcp` | MCP setup |
 | `research-corpus-execution` | `researcher` |
@@ -175,18 +177,19 @@ Merged view for Cursor plugin loading from GitHub. **Not** copied as a single tr
 
 ---
 
-## Rules (6) — consumer `.cursor/rules/`
+## Rules — consumer `.cursor/rules/` (6 kit) · kit-dev repo (7)
 
-| Rule | alwaysApply |
-|------|:-----------:|
-| `implementation-workflow-governance.mdc` | Yes |
-| `pr-workflow-enforcement.mdc` | Yes |
-| `commit-trailer-format.mdc` | Yes |
-| `file-docstring-header-relations.mdc` | Yes |
-| `local-artifact-protection.mdc` | Yes |
-| `advisory-audit-alignment-enforcement.mdc` | Yes |
+| Rule | alwaysApply | Kit-dev `.cursor/rules/` |
+|------|:-----------:|:------------------------:|
+| `implementation-workflow-governance.mdc` | Yes | Yes |
+| `pr-workflow-enforcement.mdc` | Yes | Yes |
+| `commit-trailer-format.mdc` | Yes | Yes |
+| `file-docstring-header-relations.mdc` | Yes | Yes |
+| `local-artifact-protection.mdc` | Yes | Yes |
+| `advisory-audit-alignment-enforcement.mdc` | Yes | Yes |
+| `project-ssot-precedence.mdc` | — | Yes (product repo + overlay at install) |
 
-Product overlays: `overlays/rules/*.mdc` → consumer `.cursor/rules/` at install (empty in core kit).
+Product overlays: `overlays/rules/*.mdc` → consumer `.cursor/rules/` at install (`project-ssot-precedence` ships in this product repo).
 
 ---
 
@@ -208,6 +211,7 @@ Product overlays: `overlays/rules/*.mdc` → consumer `.cursor/rules/` at instal
 | Subtree | Tier | Writer |
 |---------|------|--------|
 | `index-and-planning/current/` | 1 base + 2 runtime | scaffold + agents |
+| `index-and-planning/history/` | 2 | agents — `updates-log.md`; `continuity-index.md` (rolling ≥3-day UTC rows; board Notes = full lifetime) |
 | `workflow-artifacts/pr/` | 2 | review/prepare/merge scripts |
 | `workflow-artifacts/alignment/` | 2 | `enterprise-auditor` |
 | `workflow-artifacts/drift/` | 2 | `workflow-drift-guard` |

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -247,9 +247,10 @@ Cursor may also auto-delegate subagents when the task matches their `description
 Every session:
 
 1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else `.local/index-and-planning/current/session-pointer.md`
-2. Board card Status/Notes (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
-3. **`/implementer`** (or specialist agent from §6)
-4. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
+2. Board card Status/Notes — attribution `@user/agent · <ISO-8601-UTC> · …` (CLI stamps); local `history/continuity-index.md` rolls ≥3 days (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
+3. Rate-limit: EXIT_QUEUED → `python3 -m cursor_workflow project outbox flush` after quota recovers (`project_ssot.outbox` in collaboration YAML)
+4. **`/implementer`** (or specialist agent from §6)
+5. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
 
 Token contract: [token-efficiency.md](token-efficiency.md) · Layout: [local-workspace-layout.md](local-workspace-layout.md).
 

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -154,9 +154,10 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 ## Step 4 detail — daily workflow
 
 1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else open `.local/index-and-planning/current/session-pointer.md`
-2. Claim/update the board card (Status + Notes); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`
-3. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
-4. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
+2. Claim/update the board card (Status + Notes `@user/agent · <ISO-8601-UTC> · …`); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`; optional `history/continuity-index.md` (≥3-day local rollup)
+3. If board writes hit GraphQL rate-limit (EXIT_QUEUED): `project outbox status` / later `outbox flush` — enable `project_ssot.outbox` defaults after activate
+4. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
+5. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
 
 **Add your own agent/skill/MCP:** **`/integrator-mas-agent`** + **`/mas-infrastructure-integration`**
 

--- a/.ai_infra/docs/operations/gate-matrix.md
+++ b/.ai_infra/docs/operations/gate-matrix.md
@@ -23,7 +23,7 @@ Three gate surfaces exist by design (Pattern A).
 | **`make doc-validate`** | After doc/agent/rule changes | DOC-001…006 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | **`make verify-all`** | Pre-audit / release readiness | 7 (+ optional ci-seed): sync-plugin → gates → drift → integrate → check-plugin → health → contributors | `.ai_infra/scripts/architecture/verify_all.py` |
 | **`scaffold --verify`** | Post-install smoke on consumer | 4: testing artifacts + pytest + governance + debrand (no doc facts) | `.ai_infra/scripts/install/scaffold.py` `_run_verify` |
-| **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…008) | `.ai_infra/scripts/workflow/check_drift.py` |
+| **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…010 + 004b on kit-dev; consumer profile subset) | `.ai_infra/scripts/workflow/check_drift.py` |
 | **Consumer drift** | Post-install verify on app projects | `drift validate --profile consumer` — DRIFT-005 (skip when `IMPLEMENTATION-STATUS.md` absent) + DRIFT-008 | [consumer-quickstart.md](consumer-quickstart.md#drift-on-consumer-apps) |
 | **`kit-quality.yml` (CI)** | Push/PR on kit repo | seed → sync-plugin → gates → drift → integrate → check-plugin → health → contributors → governance (redundant with gates) → install-dry-run | `.github/workflows/kit-quality.yml` |
 

--- a/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/.ai_infra/docs/operations/local-workspace-layout.md
@@ -44,7 +44,7 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | Path | Purpose |
 |------|---------|
 | `index-and-planning/current/` | Live trackers: `plan.md`, `work-tracker.md`, `session-pointer.md`, `change-index.md`, tests, `architecture.md` |
-| `index-and-planning/history/` | `updates-log.md` |
+| `index-and-planning/history/` | `updates-log.md` (UTC-prefixed lines), `continuity-index.md` (rolling ≥3-day board↔artifact index) |
 | `index-and-planning/audits/` | Local governance audit snapshots |
 | `agents-control-center/` | Dashboard config (`config/pages.json`) and optional HTML |
 | `workflow-artifacts/pr/` | `review.md`, `prep.md`, `merge.md` |

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -37,7 +37,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Ready prioritization | **Owner** | Consume; create agreed work | — |
 | Views / workflows / Insights / README / status updates | **Owner only** | Never | Insights auto |
 | Assignee / My items | Yes (`set-assignee` / UI) | Claim = In progress; assignee = **human** only | My items view |
-| Card Notes (`append-notes --agent`) | Yes | Yes — `@user/agent · …`; `next=@user/agent` | — |
+| Card Notes (`append-notes --agent`) | Yes | Yes — `@user/agent · YYYY-MM-DDTHH:MM:SSZ · …`; `next=@user/agent` | — |
 | PR / audits / secrets | Local | Local | — |
 | Post-merge Status → Done | — | Via `merge.py` (Pattern A); Notes `@user/merge.py` | — |
 | Read-only board export | Consume | `project export` (never writes Status) | — |
@@ -65,7 +65,7 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 
 **Safe flow:** `project guide` then `create-from-template` → `claim --last` → `handoff --last`. Never paste docs placeholder ids as `--id`.
 
-**Attribution:** Notes use `@owner.github_user/<agent>` from each collaborator’s `github.collaboration.yaml` so multi-user boards do not collide.
+**Attribution:** Notes use `@owner.github_user/<agent> · <ISO-8601-UTC> · …` from each collaborator’s `github.collaboration.yaml` (CLI stamps UTC; do not hand-forge timestamps). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 
 ## workflow-drift-guard specifically
 
@@ -73,6 +73,18 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 2. Run `drift validate` (includes DRIFT-009 / DRIFT-010 when board_only; refresh `project export` for DRIFT-010).
 3. Write `.local/workflow-artifacts/drift/*` (evidence stays local).
 4. **Update board:** close the drift-pass card; if dual-write Confirmed, add Notes on the offending card or ask project-board to queue a Ready fix — do not write competing `in_progress` into `work-tracker.md`.
+
+## Rate limits & outbox
+
+GitHub GraphQL quota (~5000/hour) can block board writes. When `project_ssot.outbox.enabled`:
+
+1. Live write fails with rate-limit → CLI **enqueues** to `.local/generated-data/board-outbox.jsonl` and returns **EXIT_QUEUED (6)**.
+2. Agent continues local evidence (`change-index`, handoff line) — **do not** hammer `gh` / retry loops.
+3. After quota recovers: `python3 -m cursor_workflow project outbox status` then `outbox flush` (capped by `max_flush_per_run`; refuses if `remaining < min_graphql_remaining`).
+4. Explicit enqueue: `project queue --op append-notes|set-status|handoff|claim|set-assignee …`
+5. Outbox is a **local buffer**, never a second Status SSOT.
+
+Who flushes: any agent/human after reset; prefer implementer or project-board at slice close. Pending outbox is **not** a DRIFT failure.
 
 ## Exit codes (board Pattern A)
 
@@ -83,8 +95,9 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 | 3 | `gh` / network |
 | 4 | Item not found |
 | 5 | Validation (sections, claim policy, attribution) |
+| 6 | Queued to outbox (soft-success; flush later) |
 
-Stderr: `project <cmd>: FAIL — CODE=n · reason`.
+Stderr: `project <cmd>: FAIL — CODE=n · reason` or `QUEUED — …`.
 
 ## Human-only
 

--- a/.ai_infra/docs/operations/token-efficiency.md
+++ b/.ai_infra/docs/operations/token-efficiency.md
@@ -45,15 +45,16 @@ Notes:
 
 1. Board Status via `cursor_workflow project set-status` (+ Notes / handoff line)
 2. `change-index.md` — one row per batch  
-3. `history/updates-log.md` — **one line** (no gate dumps)
-4. Do **not** dual-write tracker `in_progress` under `board_only`
+3. `history/updates-log.md` — **one line** prefixed `YYYY-MM-DDTHH:MM:SSZ` (no gate dumps)
+4. `history/continuity-index.md` — optional row when board item + local artifacts touched (keep ≥3 days)
+5. Do **not** dual-write tracker `in_progress` under `board_only`
 
 **Offline fallback:**
 
 1. `change-index.md` — one row per batch  
 2. `session-pointer.md` — phase, next agent, blockers  
 3. `work-tracker.md` / `plan.md` — if status changed  
-4. `history/updates-log.md` — **one line** (no gate dumps)
+4. `history/updates-log.md` — **one line** prefixed `YYYY-MM-DDTHH:MM:SSZ` (no gate dumps)
 
 ## Never paste in chat
 
@@ -84,9 +85,12 @@ Do **not** run individual gates in chat when `prepare.py` exists unless `verifie
 | Create card | `python -m cursor_workflow project create-from-template --title "…" --template slice` |
 | Claim | `python -m cursor_workflow project claim --last --agent <name>` |
 | Handoff | `python -m cursor_workflow project handoff --last --agent <name> --next <agent> [--to in_review]` |
+| Outbox status | `python -m cursor_workflow project outbox status` |
+| Queue (no live write) | `python -m cursor_workflow project queue --op … --last --agent <name>` |
+| Flush outbox | `python -m cursor_workflow project outbox flush` |
 | Safe recipes | `python -m cursor_workflow project guide` |
 
-Prefer `--last` after `create-from-template`. Never paste docs placeholder ids. Never paste Project settings UI into the shell.
+Prefer `--last` after `create-from-template`. Never paste docs placeholder ids. Never paste Project settings UI into the shell. On EXIT_QUEUED (6), do not retry — flush after GraphQL quota recovers.
 
 ## Maintainer lane
 

--- a/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/.ai_infra/install/cursor_workflow/project_cli.py
@@ -12,8 +12,9 @@ Notes:
  - Pattern A: one gh invocation per action; recipes (claim/handoff/create-from-template)
    are one lifecycle command each; no dual-write of local trackers.
  - DraftIssue body edits resolve PVTI_… → DI_… (+ --title); Status stays on PVTI_….
- - Notes attribution: @owner.github_user/agent via append-notes --agent.
- - Exit codes: 0 ok; 2 usage/config; 3 gh/network; 4 not found; 5 validation.
+ - Notes attribution: @owner.github_user/agent · ISO-8601-UTC · text via append-notes --agent.
+ - Exit codes: 0 ok; 2 usage/config; 3 gh/network; 4 not found; 5 validation; 6 queued (outbox).
+ - Rate-limit outbox: project_outbox.py + project_ssot.outbox (local buffer, not SSOT).
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ import json
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +34,7 @@ EXIT_USAGE = 2
 EXIT_GH = 3
 EXIT_NOT_FOUND = 4
 EXIT_VALIDATION = 5
+EXIT_QUEUED = 6
 
 _TEMPLATE_NAMES = ("slice", "bug")
 _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
@@ -134,6 +137,11 @@ def is_placeholder_item_id(raw: str) -> bool:
         return True
     # Docs form with only punctuation after prefix
     if re.match(r"^(PVTI_|DI_)[\.…_-]*$", s):
+        return True
+    # Real GitHub Project item ids are long (e.g. PVTI_lAHO…); reject stubs
+    if re.match(r"^PVTI_", s) and len(s) < 20:
+        return True
+    if re.match(r"^DI_", s) and len(s) < 12:
         return True
     return False
 
@@ -252,21 +260,40 @@ def format_agent_attribution(root: Path, agent: str) -> str:
     return f"{user}/{agent_key}"
 
 
+NOTE_LINE_WITH_TIMESTAMP_RE = re.compile(
+    r"^@[^\s/]+/[^\s·]+\s*·\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z(?:\s*·\s*|$)"
+)
+NOTE_ATTRIBUTION_PREFIX_RE = re.compile(r"^(@[^\s/]+/[^\s·]+)")
+
+
+def utc_note_timestamp() -> str:
+    """Return current UTC timestamp for board Notes (test hook)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def format_note_line(root: Path, agent: str, text: str) -> str:
     """
-    Prefix note with @user/agent · text.
-    Idempotent if text already starts with that attribution.
+    Prefix note with @user/agent · ISO-8601-UTC · text.
+    Idempotent if text already has a UTC timestamp after attribution.
     """
     attr = format_agent_attribution(root, agent)
     body = (text or "").strip()
-    if body.startswith(attr):
+    if NOTE_LINE_WITH_TIMESTAMP_RE.match(body):
         return body
-    # Also accept without requiring exact agent if already @user/something
-    if re.match(r"^@[^\s/]+/[^\s·]+", body):
-        return body
+    attr_match = NOTE_ATTRIBUTION_PREFIX_RE.match(body)
+    if attr_match:
+        prefix = attr_match.group(1)
+        rest = body[len(prefix) :].lstrip()
+        if rest.startswith("·"):
+            rest = rest[1:].strip()
+        ts = utc_note_timestamp()
+        if rest:
+            return f"{prefix} · {ts} · {rest}"
+        return f"{prefix} · {ts}"
+    ts = utc_note_timestamp()
     if not body:
-        return attr
-    return f"{attr} · {body}"
+        return f"{attr} · {ts}"
+    return f"{attr} · {ts} · {body}"
 
 
 def set_item_assignee(
@@ -693,13 +720,48 @@ def cmd_set_status(args: argparse.Namespace) -> int:
         ]
     )
     if proc.returncode != 0:
-        return fail(
-            "set-status",
-            EXIT_GH,
-            (proc.stderr or proc.stdout or "gh project item-edit failed").strip(),
+        detail = (proc.stderr or proc.stdout or "gh project item-edit failed").strip()
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="set-status",
+            err_detail=detail,
+            op="set-status",
+            item_id=item_id,
+            agent=(getattr(args, "agent", None) or "project-cli"),
+            payload={"to": args.to},
         )
+        if queued is not None:
+            return queued
+        return fail("set-status", EXIT_GH, detail)
     print(f"set-status: {item_id} → {args.to} ({option_id})")
     return EXIT_OK
+
+
+def _try_queue_rate_limit(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    err_detail: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """Delegate to project_outbox.maybe_enqueue_on_gh_fail."""
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    return _outbox.maybe_enqueue_on_gh_fail(
+        root,
+        ssot,
+        cmd=cmd,
+        err_detail=err_detail,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
 
 
 def cmd_set_field(args: argparse.Namespace) -> int:
@@ -1172,6 +1234,19 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         limit=args.limit,
     )
     if not ok:
+        if err_code == EXIT_GH:
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="append-notes",
+                err_detail=detail,
+                op="append-notes",
+                item_id=item_id,
+                agent=getattr(args, "agent", None) or "project-cli",
+                payload={"text": args.text},
+            )
+            if queued is not None:
+                return queued
         return fail("append-notes", err_code, detail)
     if detail == "idempotent":
         print(f"append-notes: {item_id} — already present (idempotent skip)")
@@ -1203,8 +1278,21 @@ def cmd_set_assignee(args: argparse.Namespace) -> int:
     ok, detail = set_item_assignee(ssot, item_id, login)
     if not ok:
         # DraftIssue / unsupported → validation; gh failures look like network
-        code_out = EXIT_VALIDATION if "DraftIssue" in detail or "unsupported" in detail else EXIT_GH
-        return fail("set-assignee", code_out, detail)
+        if "DraftIssue" in detail or "unsupported" in detail:
+            return fail("set-assignee", EXIT_VALIDATION, detail)
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="set-assignee",
+            err_detail=detail,
+            op="set-assignee",
+            item_id=item_id,
+            agent=(getattr(args, "agent", None) or "project-cli"),
+            payload={"login": login},
+        )
+        if queued is not None:
+            return queued
+        return fail("set-assignee", EXIT_GH, detail)
     print(f"set-assignee: {item_id} → @{detail.lstrip('@')}")
     return EXIT_OK
 
@@ -1228,8 +1316,24 @@ def cmd_claim(args: argparse.Namespace) -> int:
     if not user:
         return fail("claim", EXIT_USAGE, "owner.github_user missing")
     conventions = ssot.get("conventions") or {}
+    claim_payload = {
+        "to": "in_progress",
+        "text": getattr(args, "text", None) or "claimed",
+    }
     items, err = fetch_project_items(ssot, limit=args.limit)
     if err:
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="claim",
+            err_detail=err,
+            op="claim",
+            item_id=item_id,
+            agent=agent,
+            payload=claim_payload,
+        )
+        if queued is not None:
+            return queued
         return fail("claim", EXIT_GH, err)
     item = find_item_by_id(items, item_id)
     if item is None:
@@ -1248,7 +1352,21 @@ def cmd_claim(args: argparse.Namespace) -> int:
             )
     ok, detail = set_item_status(ssot, item_id, "in_progress")
     if not ok:
-        return fail("claim", EXIT_GH if "unknown status" not in detail else EXIT_USAGE, detail)
+        if "unknown status" in detail:
+            return fail("claim", EXIT_USAGE, detail)
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="claim",
+            err_detail=detail,
+            op="claim",
+            item_id=item_id,
+            agent=agent,
+            payload=claim_payload,
+        )
+        if queued is not None:
+            return queued
+        return fail("claim", EXIT_GH, detail)
     claim_mode = str(conventions.get("claim") or "set_assignee")
     if claim_mode == "set_assignee":
         a_ok, a_detail = set_item_assignee(ssot, item_id, user.lstrip("@"))
@@ -1261,6 +1379,23 @@ def cmd_claim(args: argparse.Namespace) -> int:
         root, ssot, item_id, agent=agent, text=note, limit=args.limit
     )
     if not n_ok:
+        if n_code == EXIT_GH:
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="claim",
+                err_detail=n_detail,
+                op="append-notes",
+                item_id=item_id,
+                agent=agent,
+                payload={"text": note},
+            )
+            if queued is not None:
+                print(
+                    "claim: status set; Notes QUEUED due to rate-limit",
+                    file=sys.stderr,
+                )
+                return queued
         return fail("claim", n_code, f"status set but Notes failed: {n_detail}")
     save_last_item_id(root, item_id, title=_item_title(item), action="claim")
     attr = format_agent_attribution(root, agent)
@@ -1295,6 +1430,22 @@ def cmd_handoff(args: argparse.Namespace) -> int:
         return fail("handoff", EXIT_USAGE, str(exc))
     items, err = fetch_project_items(ssot, limit=args.limit)
     if err:
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="handoff",
+            err_detail=err,
+            op="handoff",
+            item_id=item_id,
+            agent=agent,
+            payload={
+                "next": next_agent,
+                "to": (getattr(args, "to", None) or "").strip(),
+                "note": (getattr(args, "text", None) or "").strip(),
+            },
+        )
+        if queued is not None:
+            return queued
         return fail("handoff", EXIT_GH, err)
     item = find_item_by_id(items, item_id)
     if item is None:
@@ -1308,15 +1459,38 @@ def cmd_handoff(args: argparse.Namespace) -> int:
     if status_to:
         ok, detail = set_item_status(ssot, item_id, status_to)
         if not ok:
-            return fail(
-                "handoff",
-                EXIT_USAGE if "unknown" in detail.lower() else EXIT_GH,
-                detail,
+            if "unknown" in detail.lower():
+                return fail("handoff", EXIT_USAGE, detail)
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="handoff",
+                err_detail=detail,
+                op="handoff",
+                item_id=item_id,
+                agent=agent,
+                payload={"next": next_agent, "to": status_to, "note": extra},
             )
+            if queued is not None:
+                return queued
+            return fail("handoff", EXIT_GH, detail)
     n_ok, n_detail, n_code = append_notes_helper(
         root, ssot, item_id, agent=agent, text=note_core, limit=args.limit
     )
     if not n_ok:
+        if n_code == EXIT_GH:
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="handoff",
+                err_detail=n_detail,
+                op="handoff",
+                item_id=item_id,
+                agent=agent,
+                payload={"next": next_agent, "to": status_to, "note": extra},
+            )
+            if queued is not None:
+                return queued
         return fail("handoff", n_code, n_detail)
     save_last_item_id(root, item_id, title=_item_title(item), action="handoff")
     after = status_to or before or "?"
@@ -1382,6 +1556,7 @@ def cmd_guide(args: argparse.Namespace) -> int:
     print("# Safe board recipes — use --last; never paste docs placeholders as --id")
     print(f"# last item_id: {lid}")
     print("python3 -m cursor_workflow project doctor")
+    print("python3 -m cursor_workflow project outbox status")
     print(
         'python3 -m cursor_workflow project create-from-template '
         '--title "[SLICE] short-name" --template slice --status ready'
@@ -1392,6 +1567,115 @@ def cmd_guide(args: argparse.Namespace) -> int:
         f"--next {nxt} --to in_review"
     )
     print("python3 -m cursor_workflow project validate-item --last")
+    print("# If EXIT_QUEUED (6): python3 -m cursor_workflow project outbox flush")
+    return EXIT_OK
+
+
+def cmd_queue(args: argparse.Namespace) -> int:
+    """Explicit enqueue (no live board write)."""
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    root = Path(args.directory).resolve()
+    ssot, code = _load_enabled_ssot(root, "queue")
+    if ssot is None:
+        return code
+    item_id, id_code = resolve_item_id_arg(root, args, "queue")
+    if item_id is None:
+        return id_code
+    agent = (getattr(args, "agent", None) or "").strip()
+    if not agent:
+        return fail("queue", EXIT_USAGE, "--agent required")
+    op = (getattr(args, "op", None) or "").strip()
+    payload: dict[str, Any] = {}
+    if op == "append-notes":
+        text = (getattr(args, "text", None) or "").strip()
+        if not text:
+            return fail("queue", EXIT_USAGE, "--text required for append-notes")
+        payload = {"text": text}
+    elif op == "set-status":
+        to = (getattr(args, "to", None) or "").strip()
+        if not to:
+            return fail("queue", EXIT_USAGE, "--to required for set-status")
+        payload = {"to": to}
+    elif op == "handoff":
+        nxt = (getattr(args, "next", None) or "").strip()
+        if not nxt:
+            return fail("queue", EXIT_USAGE, "--next required for handoff")
+        payload = {
+            "next": nxt,
+            "to": (getattr(args, "to", None) or "").strip(),
+            "note": (getattr(args, "text", None) or "").strip(),
+        }
+    elif op == "claim":
+        payload = {
+            "to": (getattr(args, "to", None) or "in_progress").strip() or "in_progress",
+            "text": (getattr(args, "text", None) or "claimed").strip(),
+        }
+    elif op == "set-assignee":
+        login = (getattr(args, "login", None) or "").strip()
+        if not login:
+            try:
+                login = resolve_human_github_user(root)
+            except Exception as exc:  # noqa: BLE001
+                return fail("queue", EXIT_USAGE, str(exc))
+        payload = {"login": login.lstrip("@")}
+    else:
+        return fail(
+            "queue",
+            EXIT_USAGE,
+            "op must be append-notes|set-status|handoff|claim|set-assignee",
+        )
+    entry, err = _outbox.enqueue_op(
+        root, ssot, op=op, item_id=item_id, agent=agent, payload=payload
+    )
+    if entry is None:
+        return fail("queue", EXIT_VALIDATION, err)
+    print(_outbox.queued_message("queue", entry))
+    return EXIT_QUEUED
+
+
+def cmd_outbox_status(args: argparse.Namespace) -> int:
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    root = Path(args.directory).resolve()
+    ssot, code = _load_enabled_ssot(root, "outbox")
+    if ssot is None:
+        return code
+    cfg = _outbox.load_outbox_config(ssot)
+    path = _outbox.outbox_path(root, cfg)
+    counts = _outbox.count_outbox(path)
+    rl = _outbox.graphql_rate_limit()
+    print(f"outbox.enabled: {cfg['enabled']}")
+    print(f"outbox.path: {path}")
+    print(
+        f"counts: pending={counts['pending']} failed={counts['failed']} "
+        f"done={counts['done']} total={counts['total']}"
+    )
+    if rl.get("error"):
+        print(f"graphql: error — {rl['error']}")
+    else:
+        reset = _outbox.format_reset_iso(rl.get("reset_epoch"))
+        print(
+            f"graphql: remaining={rl.get('remaining')}/{rl.get('limit')} "
+            f"reset={reset} min_flush={cfg['min_graphql_remaining']}"
+        )
+    return EXIT_OK
+
+
+def cmd_outbox_flush(args: argparse.Namespace) -> int:
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    root = Path(args.directory).resolve()
+    ssot, code = _load_enabled_ssot(root, "outbox")
+    if ssot is None:
+        return code
+    max_ops = getattr(args, "max", None)
+    code_out, summary = _outbox.flush_outbox(
+        root, ssot, max_ops=max_ops, limit=getattr(args, "limit", 100) or 100
+    )
+    if code_out != EXIT_OK:
+        return fail("outbox flush", code_out, summary)
+    print(f"outbox flush: {summary}")
     return EXIT_OK
 
 
@@ -1416,29 +1700,77 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         path = tpl_dir / f"card-body-{name}.md"
         if not path.is_file():
             return fail("doctor", EXIT_USAGE, f"missing template {path}")
-    proc = run_gh(
-        [
-            "project",
-            "item-list",
-            str(ssot["number"]),
-            "--owner",
-            str(ssot["owner"]),
-            "--format",
-            "json",
-            "--limit",
-            "1",
-        ]
-    )
-    if proc.returncode != 0:
-        return fail(
-            "doctor",
-            EXIT_GH,
-            (proc.stderr or proc.stdout or "gh project not readable").strip(),
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    cfg_pre = _outbox.load_outbox_config(ssot)
+    rl_pre = _outbox.graphql_rate_limit()
+    skip_live = False
+    if not rl_pre.get("error"):
+        try:
+            rem_pre = int(rl_pre.get("remaining")) if rl_pre.get("remaining") is not None else 9999
+        except (TypeError, ValueError):
+            rem_pre = 9999
+        if rem_pre < int(cfg_pre["min_graphql_remaining"]):
+            skip_live = True
+            print(
+                "doctor: WARN — skipping live gh project item-list (low GraphQL quota)",
+                file=sys.stderr,
+            )
+    if not skip_live:
+        proc = run_gh(
+            [
+                "project",
+                "item-list",
+                str(ssot["number"]),
+                "--owner",
+                str(ssot["owner"]),
+                "--format",
+                "json",
+                "--limit",
+                "1",
+            ]
         )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "gh project not readable").strip()
+            if _outbox.is_rate_limit_error(detail):
+                print(
+                    "doctor: WARN — gh project item-list rate-limited; config still ok",
+                    file=sys.stderr,
+                )
+            else:
+                return fail("doctor", EXIT_GH, detail)
     print("doctor: ok")
     print(f"project: {ssot.get('name')} ({ssot.get('url')})")
     print(f"human: {user}")
     print(f"templates: {tpl_dir}")
+    cfg = cfg_pre
+    path = _outbox.outbox_path(root, cfg)
+    counts = _outbox.count_outbox(path)
+    rl = rl_pre
+    print(f"outbox: enabled={cfg['enabled']} pending={counts['pending']} path={path}")
+    if rl.get("error"):
+        print(f"doctor: WARN — graphql rate_limit: {rl['error']}", file=sys.stderr)
+    else:
+        rem = rl.get("remaining")
+        try:
+            rem_i = int(rem) if rem is not None else -1
+        except (TypeError, ValueError):
+            rem_i = -1
+        reset = _outbox.format_reset_iso(rl.get("reset_epoch"))
+        print(f"graphql: remaining={rem}/{rl.get('limit')} reset={reset}")
+        if rem_i >= 0 and rem_i < int(cfg["min_graphql_remaining"]):
+            print(
+                f"doctor: WARN — GraphQL remaining {rem_i} < "
+                f"min_graphql_remaining {cfg['min_graphql_remaining']}; "
+                f"prefer outbox queue; flush after {reset}",
+                file=sys.stderr,
+            )
+    if counts["pending"] > 0:
+        print(
+            f"doctor: WARN — {counts['pending']} pending outbox ops; "
+            f"run: python3 -m cursor_workflow project outbox flush",
+            file=sys.stderr,
+        )
     return EXIT_OK
 
 
@@ -1557,6 +1889,11 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         "--to",
         required=True,
         help="Logical status: backlog|ready|in_progress|in_review|done",
+    )
+    set_status.add_argument(
+        "--agent",
+        default="project-cli",
+        help="Agent id for outbox attribution if rate-limited",
     )
     set_status.set_defaults(func=cmd_set_status)
 
@@ -1679,3 +2016,43 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     export_cmd.add_argument("--json", action="store_true", help="Also print JSON to stdout")
     export_cmd.add_argument("--stdout", action="store_true", help="Print JSON only (no file write)")
     export_cmd.set_defaults(func=cmd_export)
+
+    queue_cmd = project_sub.add_parser(
+        "queue",
+        help="Enqueue a board op to local outbox (no live write; EXIT_QUEUED=6)",
+    )
+    queue_cmd.add_argument("--directory", type=Path, default=".")
+    _add_id_or_last(queue_cmd)
+    queue_cmd.add_argument(
+        "--op",
+        required=True,
+        choices=("append-notes", "set-status", "handoff", "claim", "set-assignee"),
+    )
+    queue_cmd.add_argument("--agent", required=True)
+    queue_cmd.add_argument("--text", default="", help="Notes text / handoff note / claim text")
+    queue_cmd.add_argument("--to", default="", help="Status for set-status/handoff/claim")
+    queue_cmd.add_argument("--next", default="", help="Next agent for handoff")
+    queue_cmd.add_argument("--login", default="", help="Assignee login for set-assignee")
+    queue_cmd.set_defaults(func=cmd_queue)
+
+    outbox_cmd = project_sub.add_parser(
+        "outbox",
+        help="Inspect or flush rate-limit board outbox",
+    )
+    outbox_sub = outbox_cmd.add_subparsers(dest="outbox_command", required=True)
+    ob_status = outbox_sub.add_parser("status", help="Counts + GraphQL remaining")
+    ob_status.add_argument("--directory", type=Path, default=".")
+    ob_status.set_defaults(func=cmd_outbox_status)
+    ob_flush = outbox_sub.add_parser(
+        "flush",
+        help="Apply pending outbox ops (refuses if GraphQL remaining too low)",
+    )
+    ob_flush.add_argument("--directory", type=Path, default=".")
+    ob_flush.add_argument(
+        "--max",
+        type=int,
+        default=None,
+        help="Override max_flush_per_run from settings",
+    )
+    ob_flush.add_argument("--limit", type=int, default=100)
+    ob_flush.set_defaults(func=cmd_outbox_flush)

--- a/.ai_infra/install/cursor_workflow/project_outbox.py
+++ b/.ai_infra/install/cursor_workflow/project_outbox.py
@@ -1,0 +1,463 @@
+"""
+File: project_outbox.py
+Path: .ai_infra/install/cursor_workflow/project_outbox.py
+Role: Rate-limit-safe board outbox — enqueue/flush JSONL ops from project_ssot.outbox.
+Used By:
+ - .ai_infra/install/cursor_workflow/project_cli.py
+Depends On:
+ - project_cli helpers (attribution, set_item_*, append_notes_helper) via late imports
+Notes:
+ - Outbox is a local buffer, never a second Status SSOT (ADR-008).
+ - Flush is pull-based; refuses when GraphQL remaining < min_graphql_remaining.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_GH = 3
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+EXIT_QUEUED = 6
+
+_OUTBOX_OPS = frozenset(
+    {"append-notes", "set-status", "handoff", "claim", "set-assignee"}
+)
+_DEFAULT_PATH = ".local/generated-data/board-outbox.jsonl"
+_RATE_LIMIT_RE = re.compile(
+    r"rate\s*limit|API rate limit exceeded|secondary rate limit",
+    re.IGNORECASE,
+)
+
+
+def load_outbox_config(ssot: dict[str, Any]) -> dict[str, Any]:
+    """Return outbox settings with defaults."""
+    raw = ssot.get("outbox") if isinstance(ssot.get("outbox"), dict) else {}
+    return {
+        "enabled": bool(raw.get("enabled", True)),
+        "path": str(raw.get("path") or _DEFAULT_PATH).strip() or _DEFAULT_PATH,
+        "min_graphql_remaining": int(raw.get("min_graphql_remaining") or 200),
+        "max_flush_per_run": int(raw.get("max_flush_per_run") or 10),
+        "retry_backoff_seconds": int(raw.get("retry_backoff_seconds") or 30),
+    }
+
+
+def outbox_path(root: Path, cfg: dict[str, Any]) -> Path:
+    rel = Path(str(cfg.get("path") or _DEFAULT_PATH))
+    return (root / rel).resolve() if not rel.is_absolute() else rel
+
+
+def is_rate_limit_error(text: str) -> bool:
+    return bool(_RATE_LIMIT_RE.search(text or ""))
+
+
+def graphql_rate_limit() -> dict[str, Any]:
+    """
+    Read GraphQL quota via gh api rate_limit (REST — cheap).
+    Returns keys: remaining, limit, reset_epoch, error (optional).
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "api", "rate_limit", "--jq", ".resources.graphql"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": str(exc),
+        }
+    if proc.returncode != 0:
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": (proc.stderr or proc.stdout or "gh api rate_limit failed").strip(),
+        }
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": f"invalid JSON: {exc}",
+        }
+    if not isinstance(data, dict):
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": "graphql resource not an object",
+        }
+    return {
+        "remaining": data.get("remaining"),
+        "limit": data.get("limit"),
+        "reset_epoch": data.get("reset"),
+        "error": None,
+    }
+
+
+def format_reset_iso(reset_epoch: Any) -> str:
+    try:
+        ts = int(reset_epoch)
+    except (TypeError, ValueError):
+        return "(unknown)"
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def validate_outbox_entry(entry: dict[str, Any]) -> list[str]:
+    """Lightweight validation (schema fields)."""
+    errs: list[str] = []
+    for key in ("id", "ts", "agent", "github_user", "op", "item_id", "payload", "status"):
+        if key not in entry:
+            errs.append(f"missing {key}")
+    op = str(entry.get("op") or "")
+    if op and op not in _OUTBOX_OPS:
+        errs.append(f"unknown op {op!r}")
+    status = str(entry.get("status") or "")
+    if status and status not in ("pending", "done", "failed"):
+        errs.append(f"bad status {status!r}")
+    item_id = str(entry.get("item_id") or "")
+    if item_id and (
+        not re.match(r"^PVTI_[A-Za-z0-9_-]+$", item_id) or len(item_id) < 20
+    ):
+        errs.append(f"bad item_id {item_id!r}")
+    if not isinstance(entry.get("payload"), dict):
+        errs.append("payload must be object")
+    attempts = entry.get("attempts", 0)
+    if not isinstance(attempts, int) or attempts < 0:
+        errs.append("attempts must be non-negative int")
+    # payload shape checks
+    payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+    if op == "append-notes" and not str(payload.get("text") or "").strip():
+        errs.append("append-notes payload.text required")
+    if op == "set-status" and not str(payload.get("to") or "").strip():
+        errs.append("set-status payload.to required")
+    if op == "handoff":
+        if not str(payload.get("next") or "").strip():
+            errs.append("handoff payload.next required")
+    if op == "set-assignee" and not str(payload.get("login") or "").strip():
+        errs.append("set-assignee payload.login required")
+    return errs
+
+
+def read_outbox_entries(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            entries.append(data)
+    return entries
+
+
+def write_outbox_entries(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(e, ensure_ascii=False) + "\n" for e in entries]
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def enqueue_op(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+    github_user: str = "",
+) -> tuple[dict[str, Any] | None, str]:
+    """
+    Append a pending outbox entry. Returns (entry, error_message).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return None, "outbox.enabled is false"
+    # Late import to avoid circular import at module load
+    from project_cli import (  # noqa: PLC0415
+        is_placeholder_item_id,
+        normalize_github_handle,
+        resolve_human_github_user,
+    )
+
+    if is_placeholder_item_id(item_id):
+        return None, f"placeholder item_id {item_id!r}"
+    op_key = (op or "").strip()
+    if op_key not in _OUTBOX_OPS:
+        return None, f"unknown op {op!r}"
+    agent_s = (agent or "").strip()
+    if not agent_s:
+        return None, "agent required"
+    user = (github_user or "").strip()
+    if not user:
+        try:
+            user = resolve_human_github_user(root)
+        except Exception as exc:  # noqa: BLE001
+            return None, str(exc)
+    user = normalize_github_handle(user)
+    if not user:
+        return None, "github_user missing"
+    entry: dict[str, Any] = {
+        "id": str(uuid.uuid4()),
+        "ts": _utc_now(),
+        "agent": agent_s,
+        "github_user": user if user.startswith("@") else f"@{user}",
+        "op": op_key,
+        "item_id": item_id.strip(),
+        "payload": dict(payload or {}),
+        "status": "pending",
+        "attempts": 0,
+        "last_error": None,
+    }
+    errs = validate_outbox_entry(entry)
+    if errs:
+        return None, "; ".join(errs)
+    path = outbox_path(root, cfg)
+    entries = read_outbox_entries(path)
+    entries.append(entry)
+    write_outbox_entries(path, entries)
+    return entry, ""
+
+
+def queued_message(cmd: str, entry: dict[str, Any]) -> str:
+    return (
+        f"project {cmd}: QUEUED — id={entry.get('id')} op={entry.get('op')} "
+        f"item={entry.get('item_id')} · run: python3 -m cursor_workflow project outbox flush"
+    )
+
+
+def maybe_enqueue_on_gh_fail(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    err_detail: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """
+    If outbox enabled and error looks like rate-limit, enqueue and return EXIT_QUEUED.
+    Otherwise return None (caller should fail as before).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return None
+    if not is_rate_limit_error(err_detail):
+        return None
+    entry, err = enqueue_op(
+        root,
+        ssot,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+    if entry is None:
+        print(
+            f"project {cmd}: FAIL — CODE={EXIT_GH} · rate-limit and enqueue failed: {err}",
+            file=sys.stderr,
+        )
+        return EXIT_GH
+    print(queued_message(cmd, entry), file=sys.stderr)
+    return EXIT_QUEUED
+
+
+def count_outbox(path: Path) -> dict[str, int]:
+    entries = read_outbox_entries(path)
+    counts = {"pending": 0, "done": 0, "failed": 0, "total": len(entries)}
+    for e in entries:
+        st = str(e.get("status") or "")
+        if st in counts:
+            counts[st] += 1
+    return counts
+
+
+def apply_outbox_entry(
+    root: Path,
+    ssot: dict[str, Any],
+    entry: dict[str, Any],
+    *,
+    limit: int = 100,
+) -> tuple[bool, str]:
+    """Apply one pending entry to the live board. Returns (ok, detail)."""
+    from project_cli import (  # noqa: PLC0415
+        append_notes_helper,
+        format_agent_attribution,
+        set_item_assignee,
+        set_item_status,
+    )
+
+    op = str(entry.get("op") or "")
+    item_id = str(entry.get("item_id") or "")
+    agent = str(entry.get("agent") or "")
+    payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+
+    if op == "append-notes":
+        ok, detail, _code = append_notes_helper(
+            root,
+            ssot,
+            item_id,
+            agent=agent,
+            text=str(payload.get("text") or ""),
+            limit=limit,
+        )
+        return ok, detail
+
+    if op == "set-status":
+        ok, detail = set_item_status(ssot, item_id, str(payload.get("to") or ""))
+        return ok, detail
+
+    if op == "set-assignee":
+        login = str(payload.get("login") or "").lstrip("@")
+        ok, detail = set_item_assignee(ssot, item_id, login)
+        return ok, detail
+
+    if op == "claim":
+        to = str(payload.get("to") or "in_progress")
+        ok, detail = set_item_status(ssot, item_id, to)
+        if not ok:
+            return False, detail
+        note = str(payload.get("text") or "claimed (outbox flush)")
+        n_ok, n_detail, _ = append_notes_helper(
+            root, ssot, item_id, agent=agent, text=note, limit=limit
+        )
+        if not n_ok:
+            return False, f"status set but Notes failed: {n_detail}"
+        return True, "claimed"
+
+    if op == "handoff":
+        next_agent = str(payload.get("next") or "").strip().lstrip("@")
+        status_to = str(payload.get("to") or "").strip()
+        extra = str(payload.get("note") or payload.get("text") or "").strip()
+        if status_to:
+            ok, detail = set_item_status(ssot, item_id, status_to)
+            if not ok:
+                return False, detail
+        try:
+            next_attr = format_agent_attribution(root, next_agent)
+        except ValueError as exc:
+            return False, str(exc)
+        note_core = f"next={next_attr}"
+        if extra:
+            note_core = f"{extra} · {note_core}"
+        n_ok, n_detail, _ = append_notes_helper(
+            root, ssot, item_id, agent=agent, text=note_core, limit=limit
+        )
+        return n_ok, n_detail
+
+    return False, f"unsupported op {op!r}"
+
+
+def flush_outbox(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    max_ops: int | None = None,
+    limit: int = 100,
+) -> tuple[int, str]:
+    """
+    Flush pending entries. Returns (exit_code, summary).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return EXIT_USAGE, "outbox.enabled is false"
+    path = outbox_path(root, cfg)
+    rl = graphql_rate_limit()
+    remaining = rl.get("remaining")
+    min_rem = int(cfg["min_graphql_remaining"])
+    if rl.get("error"):
+        return EXIT_GH, f"cannot read rate_limit: {rl['error']}"
+    try:
+        rem_i = int(remaining) if remaining is not None else -1
+    except (TypeError, ValueError):
+        rem_i = -1
+    if rem_i < min_rem:
+        reset = format_reset_iso(rl.get("reset_epoch"))
+        return (
+            EXIT_GH,
+            f"GraphQL remaining={rem_i} < min={min_rem}; refuse flush until {reset}",
+        )
+
+    cap = int(max_ops if max_ops is not None else cfg["max_flush_per_run"])
+    if cap < 1:
+        cap = 1
+    entries = read_outbox_entries(path)
+    pending_idxs = [i for i, e in enumerate(entries) if str(e.get("status")) == "pending"]
+    done_n = fail_n = 0
+    stopped_early = False
+    backoff = int(cfg["retry_backoff_seconds"])
+
+    applied = 0
+    for idx in pending_idxs:
+        if applied >= cap:
+            break
+        # Re-check remaining mid-batch
+        rl2 = graphql_rate_limit()
+        try:
+            rem2 = int(rl2.get("remaining")) if rl2.get("remaining") is not None else rem_i
+        except (TypeError, ValueError):
+            rem2 = rem_i
+        if rem2 < min_rem:
+            stopped_early = True
+            break
+
+        entry = entries[idx]
+        entry["attempts"] = int(entry.get("attempts") or 0) + 1
+        ok, detail = apply_outbox_entry(root, ssot, entry, limit=limit)
+        if ok:
+            entry["status"] = "done"
+            entry["last_error"] = None
+            done_n += 1
+        else:
+            entry["last_error"] = detail
+            if is_rate_limit_error(detail):
+                entry["status"] = "pending"
+                stopped_early = True
+                write_outbox_entries(path, entries)
+                return (
+                    EXIT_GH,
+                    f"flush stopped on rate-limit after done={done_n}; detail={detail}",
+                )
+            entry["status"] = "failed"
+            fail_n += 1
+            if backoff > 0:
+                time.sleep(backoff)
+        entries[idx] = entry
+        applied += 1
+        write_outbox_entries(path, entries)
+
+    write_outbox_entries(path, entries)
+    left = sum(1 for e in entries if str(e.get("status")) == "pending")
+    summary = (
+        f"flushed done={done_n} failed={fail_n} pending_left={left}"
+        + (" (stopped early: low quota)" if stopped_early else "")
+    )
+    return EXIT_OK, summary

--- a/.ai_infra/mcp_servers/workflow_mcp/README.md
+++ b/.ai_infra/mcp_servers/workflow_mcp/README.md
@@ -37,7 +37,7 @@ External servers: [connect-external-mcp.md](../../docs/operations/connect-extern
 | `workflow_contributors_validate` | validate user settings YAML |
 | `workflow_list_session_agents` | change-index + session-pointer → merged Agent/s |
 | `workflow_integrate_validate` | `.ai_infra/scripts/integration/validate.py` (INT-001…014) |
-| `workflow_drift_validate` | `.ai_infra/scripts/workflow/check_drift.py` (DRIFT-001…008) |
+| `workflow_drift_validate` | `.ai_infra/scripts/workflow/check_drift.py` (DRIFT-001…010 kit-dev; consumer subset) |
 | `workflow_activate` | `.ai_infra/install/cursor_workflow/activate_cli.py` (three-plane install) |
 | `workflow_doc_facts_validate` | `.ai_infra/scripts/architecture/check_doc_facts.py` (DOC-001…006) |
 | `workflow_verify_all` | `.ai_infra/scripts/architecture/verify_all.py` (maintainer matrix) |

--- a/.ai_infra/schemas/github-collaboration.schema.json
+++ b/.ai_infra/schemas/github-collaboration.schema.json
@@ -37,6 +37,33 @@
           "enum": ["board_only", "board_first", "offline_fallback"]
         },
         "fallback": { "type": "string", "enum": ["local_trackers", "none"] },
+        "outbox": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Local JSONL buffer for board writes when GraphQL is rate-limited (not a second SSOT)",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": {
+              "type": "string",
+              "description": "Repo-relative path to board-outbox.jsonl"
+            },
+            "min_graphql_remaining": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Refuse flush (and warn in doctor) below this GraphQL remaining"
+            },
+            "max_flush_per_run": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Max pending ops applied per outbox flush"
+            },
+            "retry_backoff_seconds": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Sleep between flush ops after soft failures"
+            }
+          }
+        },
         "fields": { "type": "object", "additionalProperties": true },
         "conventions": {
           "type": "object",

--- a/.ai_infra/scripts/install/scaffold.py
+++ b/.ai_infra/scripts/install/scaffold.py
@@ -359,6 +359,11 @@ def _scaffold_local(source: Path, target: Path, dry_run: bool, log: list[str]) -
     if updates_src.is_file():
         _copy_file_if_missing(updates_src, updates_dst, dry_run, log)
 
+    continuity_src = exemplars / "continuity-index.md"
+    continuity_dst = history / "continuity-index.md"
+    if continuity_src.is_file():
+        _copy_file_if_missing(continuity_src, continuity_dst, dry_run, log)
+
     arch_stub = target / ".local" / "index-and-planning" / "current" / "architecture.md"
     if not arch_stub.exists() and not dry_run:
         arch_stub.write_text(

--- a/.ai_infra/scripts/pr/merge.py
+++ b/.ai_infra/scripts/pr/merge.py
@@ -29,7 +29,8 @@ _REPO_ROOT = _PR_DIR.parents[2]
 _INSTALL_CW = _REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
 if str(_PR_DIR) not in sys.path:
     sys.path.insert(0, str(_PR_DIR))
-if _INSTALL_CW.is_dir() and str(_INSTALL_CW) not in sys.path:
+if _INSTALL_CW.is_dir() and str(_INSTALL_CW) not in sys.path:  # pragma: no cover
+    # Import-order dependent: often already on path from project_cli tests.
     sys.path.insert(0, str(_INSTALL_CW))
 
 from local_workflow_paths import (

--- a/.ai_infra/scripts/workflow/README.md
+++ b/.ai_infra/scripts/workflow/README.md
@@ -12,7 +12,7 @@ make drift-validate
 
 ## Checks
 
-See `drift_checks.py` — DRIFT-001…008. Profile `kit-dev` (default) or `consumer` (when `STARTER-001` in work-tracker, or `--profile consumer`).
+See `drift_checks.py` — DRIFT-001…010 + 004b on kit-dev (004b/009–010 when `project_ssot.sync_policy: board_only`); consumer profile runs DRIFT-005 + DRIFT-008 only.
 
 **DRIFT-005 on consumer:** When `IMPLEMENTATION-STATUS.md` is absent (normal on plugin installs), the check **PASSes (skip)** — not a consumer failure. A FAIL on missing file indicates an older kit payload (false positive; see `consumer-quickstart.md`).
 

--- a/.ai_infra/scripts/workflow/drift_checks.py
+++ b/.ai_infra/scripts/workflow/drift_checks.py
@@ -1,7 +1,7 @@
 """
 File: drift_checks.py
 Path: .ai_infra/scripts/workflow/drift_checks.py
-Role: Individual DRIFT-001…010 check functions for workflow drift validation.
+Role: Individual DRIFT-001…010 (+004b) check functions for workflow drift validation.
 Used By:
  - .ai_infra/scripts/workflow/check_drift.py
 Depends On:
@@ -235,6 +235,158 @@ def check_drift004(paths: DriftPaths) -> CheckResult:
         severity=Severity.P1,
         passed=passed,
         detail="; ".join(detail_parts),
+    )
+
+
+_ACTIVE_POINTER_STATUSES = frozenset(
+    {"in_progress", "in_review", "ready", "todo", "backlog"}
+)
+_DONE_POINTER_STATUSES = frozenset({"done", "complete", "completed", "closed"})
+
+
+def _normalize_status_token(raw: str) -> str:
+    return re.sub(r"\s+", "_", (raw or "").strip().lower())
+
+
+def _parse_session_board_field(board_cell: str) -> tuple[str | None, str]:
+    """Return (item_id, status_claim) from session-pointer Board cell."""
+    cell = (board_cell or "").strip()
+    if not cell:
+        return None, ""
+    m = re.search(r"(PVTI_[A-Za-z0-9_-]+)", cell)
+    if not m:
+        return None, ""
+    item_id = m.group(1)
+    rest = (cell[: m.start()] + cell[m.end() :]).strip(" -–—|,;")
+    return item_id, rest
+
+
+def _load_ssot_policy(paths: DriftPaths) -> tuple[dict | None, str]:
+    """Load project_ssot dict or None + skip/fail reason."""
+    collab = paths.root / ".local" / "user_settings" / "github.collaboration.yaml"
+    if not collab.is_file():
+        return None, "no github.collaboration.yaml — skipped"
+    try:
+        import yaml
+    except ImportError:
+        return None, "PyYAML missing — skipped"
+    try:
+        data = yaml.safe_load(collab.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        return None, f"cannot parse collab YAML: {exc}"
+    if not isinstance(data, dict):
+        return None, "collab YAML not a mapping — skipped"
+    ssot = data.get("project_ssot")
+    if not isinstance(ssot, dict) or not ssot.get("enabled"):
+        return None, "project_ssot disabled or absent — skipped"
+    return ssot, "ok"
+
+
+def check_drift004b(paths: DriftPaths) -> CheckResult:
+    """
+    Advisory: session-pointer Board id/Status vs export snapshot (board_only).
+    Catches stale 'In progress' pointers when the card is already Done.
+    """
+    ssot, ssot_detail = _load_ssot_policy(paths)
+    if ssot is None:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=ssot_detail,
+        )
+    policy = str(ssot.get("sync_policy") or "")
+    if policy != "board_only":
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"sync_policy={policy!r} — board/session check skipped",
+        )
+
+    session = _read(paths.session_pointer)
+    board_cell = _extract_table_field(session, "Board")
+    item_id, status_claim = _parse_session_board_field(board_cell)
+    if not item_id:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail="no Board item id in session-pointer — skipped",
+        )
+
+    snapshot, snap_detail = _load_board_snapshot(paths)
+    if snapshot is None:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"skipped — {snap_detail}",
+        )
+
+    items = snapshot.get("items") if isinstance(snapshot.get("items"), list) else []
+    match: dict | None = None
+    for item in items:
+        if isinstance(item, dict) and str(item.get("id") or "") == item_id:
+            match = item
+            break
+    if match is None:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=False,
+            detail=f"session Board {item_id} missing from export snapshot",
+        )
+
+    snap_status = _normalize_status_token(
+        str(
+            match.get("status_normalized")
+            or match.get("status")
+            or ""
+        )
+    )
+    pointer_status = _normalize_status_token(status_claim)
+    if not pointer_status:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"Board {item_id} present in snapshot (status={snap_status or 'unknown'})",
+        )
+
+    if (
+        pointer_status in _ACTIVE_POINTER_STATUSES
+        and snap_status in _DONE_POINTER_STATUSES
+    ):
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=False,
+            detail=(
+                f"session Board {item_id} claims {pointer_status} "
+                f"but snapshot is {snap_status}"
+            ),
+        )
+
+    if pointer_status == snap_status or (
+        pointer_status in _DONE_POINTER_STATUSES
+        and snap_status in _DONE_POINTER_STATUSES
+    ):
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"session Board {item_id} status aligns with snapshot ({snap_status})",
+        )
+
+    return CheckResult(
+        check_id="DRIFT-004b",
+        severity=Severity.P1,
+        passed=False,
+        detail=(
+            f"session Board {item_id} status={pointer_status} "
+            f"vs snapshot={snap_status}"
+        ),
     )
 
 
@@ -634,6 +786,7 @@ KIT_DEV_CHECKS = (
     check_drift002,
     check_drift003,
     check_drift004,
+    check_drift004b,
     check_drift005,
     check_drift006,
     check_drift007,

--- a/.ai_infra/templates/local-workspace/exemplars/continuity-index.md
+++ b/.ai_infra/templates/local-workspace/exemplars/continuity-index.md
@@ -1,0 +1,24 @@
+<!--
+File: continuity-index.md
+Path: .ai_infra/templates/local-workspace/exemplars/continuity-index.md
+Role: Exemplar for install → .local/index-and-planning/history/continuity-index.md
+Used By:
+ - Agent slice close (board SSOT + local artifact cross-index)
+Depends On:
+ - token-efficiency.md, project-board-collaboration.md
+Notes:
+ - Rolling local index (≥3 calendar days). Board Notes keep full card lifetime.
+-->
+
+# Continuity index (rolling ≥3 days)
+
+Local cross-index between **board item_ids** and **local artifact paths** touched during recent slices.
+Board card **Notes** (timestamped by CLI) retain the full card lifetime from day 1; this file is a
+thin local resume cache only.
+
+**Retention:** keep entries for **≥3 calendar days** (UTC date on each row). On update, drop rows
+older than three days unless still referenced in `change-index.md`.
+
+**Row format:** `YYYY-MM-DDTHH:MM:SSZ · item_id=<PVTI_…> · paths=<comma-separated> · agent=<name> · note=<short>`
+
+(none yet)

--- a/.ai_infra/templates/local-workspace/exemplars/updates-log.md
+++ b/.ai_infra/templates/local-workspace/exemplars/updates-log.md
@@ -8,6 +8,7 @@ Depends On:
  - slice handoffs
 Notes:
  - One line per substantive change; see token-efficiency.md.
+ - New lines start with `YYYY-MM-DDTHH:MM:SSZ` (UTC preferred).
 -->
 
 # Updates log

--- a/.ai_infra/templates/project-board/README.md
+++ b/.ai_infra/templates/project-board/README.md
@@ -18,9 +18,19 @@ Notes:
 |------|-----|-----|
 | `card-body-slice.md` | Agents | `python3 -m cursor_workflow project create-from-template --template slice --title "…"` |
 | `card-body-bug.md` | Agents | `create-from-template --template bug` |
+| `outbox-entry.schema.json` | Agents / CLI | Validate lines in `.local/generated-data/board-outbox.jsonl` |
+| `outbox-entry.example.json` | Docs | Exemplar outbox line (never paste fake `item_id` as `--id`) |
 | `project-readme.md` | **Humans** | Copy into Project settings → README (GitHub UI). Do **not** paste into a terminal. |
 
 Card bodies always include `## Acceptance`, `## Rollback`, and `## Notes` so `validate-item` and Entry/Exit stay consistent.
+
+**Notes format (CLI):** `@github_user/agent · YYYY-MM-DDTHH:MM:SSZ · text` — stamped by `claim`, `handoff`, and `append-notes --agent`. Do not hand-forge timestamps.
+
+| Need | Template / action |
+|------|-------------------|
+| slice / feature work | `create-from-template --template slice` |
+| bug fix | `create-from-template --template bug` |
+| Project README | **Humans only** — paste `project-readme.md` in Project settings UI |
 
 **Do not** paste Project settings labels (`Project name`, `Short description`, `README`, …) into bash — use `cursor_workflow project` recipes instead.
 
@@ -34,3 +44,13 @@ python3 -m cursor_workflow project handoff --last --agent implementer --next ver
 ```
 
 `--last` reads `.local/generated-data/project-last-item.json` (machine-local pointer, not a second Status SSOT).
+
+**Rate-limit outbox (do not hammer GraphQL):**
+
+```bash
+python3 -m cursor_workflow project outbox status
+python3 -m cursor_workflow project queue --op append-notes --last --agent implementer --text "deferred note"
+python3 -m cursor_workflow project outbox flush
+```
+
+When a write returns `EXIT_QUEUED` (6), continue local evidence (`change-index` / handoff line); flush after `gh api rate_limit` recovers. Outbox is **not** a second Status SSOT.

--- a/.ai_infra/templates/project-board/card-body-bug.md
+++ b/.ai_infra/templates/project-board/card-body-bug.md
@@ -9,4 +9,6 @@
 
 ## Notes
 
+<!-- agents: Notes lines are auto-timestamped by CLI -->
+
 {{notes}}

--- a/.ai_infra/templates/project-board/card-body-slice.md
+++ b/.ai_infra/templates/project-board/card-body-slice.md
@@ -8,4 +8,6 @@
 
 ## Notes
 
+<!-- agents: Notes lines are auto-timestamped by CLI -->
+
 {{notes}}

--- a/.ai_infra/templates/project-board/outbox-entry.example.json
+++ b/.ai_infra/templates/project-board/outbox-entry.example.json
@@ -1,0 +1,12 @@
+{
+  "id": "00000000-0000-4000-8000-000000000001",
+  "ts": "2026-07-18T12:00:00Z",
+  "agent": "implementer",
+  "github_user": "@SavinRazvan",
+  "op": "append-notes",
+  "item_id": "PVTI_exampleRealIdFromCreate",
+  "payload": { "text": "queued while GraphQL rate-limited" },
+  "status": "pending",
+  "attempts": 0,
+  "last_error": null
+}

--- a/.ai_infra/templates/project-board/outbox-entry.schema.json
+++ b/.ai_infra/templates/project-board/outbox-entry.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://workflow-kit.local/schemas/board-outbox-entry.schema.json",
+  "title": "BoardOutboxEntry",
+  "type": "object",
+  "required": [
+    "id",
+    "ts",
+    "agent",
+    "github_user",
+    "op",
+    "item_id",
+    "payload",
+    "status",
+    "attempts"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "ts": { "type": "string", "minLength": 1 },
+    "agent": { "type": "string", "minLength": 1 },
+    "github_user": { "type": "string", "minLength": 1 },
+    "op": {
+      "type": "string",
+      "enum": [
+        "append-notes",
+        "set-status",
+        "handoff",
+        "claim",
+        "set-assignee"
+      ]
+    },
+    "item_id": {
+      "type": "string",
+      "pattern": "^PVTI_[A-Za-z0-9_-]+$"
+    },
+    "payload": { "type": "object", "additionalProperties": true },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "done", "failed"]
+    },
+    "attempts": { "type": "integer", "minimum": 0 },
+    "last_error": { "type": ["string", "null"] }
+  }
+}

--- a/.ai_infra/templates/project-board/project-readme.md
+++ b/.ai_infra/templates/project-board/project-readme.md
@@ -7,6 +7,7 @@ This GitHub Project is the **only writable SSOT** for backlog, Status, and multi
 ```bash
 python3 -m cursor_workflow project doctor
 python3 -m cursor_workflow project guide --agent implementer
+python3 -m cursor_workflow project outbox status
 python3 -m cursor_workflow project create-from-template --title "[SLICE] short-name" --template slice --status ready
 python3 -m cursor_workflow project claim --last --agent implementer
 python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review
@@ -14,7 +15,8 @@ python3 -m cursor_workflow project handoff --last --agent implementer --next ver
 
 Use `--last` after create (saved under `.local/generated-data/project-last-item.json`). Do **not** invent or paste placeholder ids from docs.
 
-Notes are attributed as `@github_user/agent` (from `owner.github_user`).
+If writes return EXIT_QUEUED (6) / rate-limit: `project outbox flush` after GraphQL quota recovers — do not retry in a loop.
+Notes are attributed and timestamped by CLI as `@github_user/agent · YYYY-MM-DDTHH:MM:SSZ · text` (from `owner.github_user`). Use `claim` / `handoff` / `append-notes --agent` — do not hand-forge times.
 
 ## Humans only (this UI)
 

--- a/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -44,6 +44,14 @@ project_ssot:
   sync_policy: board_only
   fallback: local_trackers                # local_trackers | none
 
+  # Rate-limit outbox (local buffer — never a second Status SSOT)
+  outbox:
+    enabled: true
+    path: .local/generated-data/board-outbox.jsonl
+    min_graphql_remaining: 200
+    max_flush_per_run: 10
+    retry_backoff_seconds: 30
+
   # Project V2 single-select fields (replace ids from field-list)
   fields:
     status:

--- a/.cursor/agents/enterprise-auditor.md
+++ b/.cursor/agents/enterprise-auditor.md
@@ -8,11 +8,13 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice (claim/create audit card if missing); else `session-pointer.md` + `change-index.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context. If no audit card: `create-from-template --template slice --title "[AUDIT] …" --status ready` then `claim --last --agent enterprise-auditor`. Else `session-pointer.md` + `change-index.md`.
 
-**Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 
@@ -23,6 +25,7 @@ Act as a **Principal Enterprise Architect** using **strict evidence-only discipl
 ## Read first (scope + workflow)
 
 - `.cursor/skills/enterprise-architecture-audit/SKILL.md` — **full operating protocol, phases, scorecard, and output contract**
+- `.ai_infra/templates/project-board/README.md` — when creating audit cards
 - `AGENTS.md`, `README.md`
 - `.local/index-and-planning/current/plan.md`, `work-tracker.md` (if present — do not assume content)
 - Project `docs/architecture/` (local stub: `.local/.../current/architecture.md`)
@@ -49,7 +52,9 @@ When project overlays exist (`overlays/rules/*.mdc`), cross-check claims against
 
 ## Handoff format
 
-Audit date • artifact paths • scoring summary + confidence • top 5 ROI • P0/P1 count • unknowns • suggested next agent (implementer / test-runner / maintainer)
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -22,7 +22,11 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
 5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+
+**STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 
@@ -32,8 +36,9 @@ Deliver **small, reversible** slices with production quality: clear module bound
 
 - `.cursor/skills/implementation-execution-loop/SKILL.md` — slice lifecycle protocol
 - `.cursor/skills/project-board-ssot/SKILL.md` — when `project_ssot.enabled`
+- `.ai_infra/templates/project-board/README.md` — when creating cards
 - `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `.local/index-and-planning/current/architecture.md` (experiment stub)
+- `.local/index-and-planning/current/architecture.md` (architecture stub)
 - Fallback only: `session-pointer.md`, `plan.md`, `work-tracker.md`
 
 When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. After meaningful coverage runs: run **`make coverage-index`** when coverage mattered.  
@@ -49,11 +54,13 @@ When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. Afte
 
 ## Architecture
 
-Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Experiment precedence: `overlays/rules/project-ssot-precedence.mdc`.
+Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Board SSOT precedence: `overlays/rules/project-ssot-precedence.mdc`.
 
 ## Handoff format
 
-Slice name • item_id • Status • what changed • commands pass/fail • blockers • next step
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/integrator-mas-agent.md
+++ b/.cursor/agents/integrator-mas-agent.md
@@ -14,24 +14,29 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card. Else `session-pointer.md` then integration skill.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card (`claim --last` after create). Else `session-pointer.md` then integration skill.
 
-**Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+
+**STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.
 
 ## Read first (evidence before edits)
 
 | Order | Path | Why |
 |-------|------|-----|
 | 1 | `.cursor/skills/mas-infrastructure-integration/SKILL.md` | Integration procedure (canonical) |
-| 2 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
-| 3 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
-| 4 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
-| 5 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
-| 6 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
-| 7 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
-| 8 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
+| 2 | `.ai_infra/templates/project-board/README.md` | When creating board cards |
+| 3 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
+| 4 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
+| 5 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
+| 6 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
+| 7 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
+| 8 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
+| 9 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
 
 **Skip** `.local/generated-data/**` unless validating coverage exports.
 
@@ -47,7 +52,7 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 ## Loop (one integration slice)
 
 1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
+2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` / `claim --last --agent integrator-mas-agent`); put Acceptance/Rollback on the card body; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
 3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
 4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
 5. **Verify** — `python -m cursor_workflow contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
@@ -72,7 +77,9 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 
 ## Handoff format
 
-Integration type • files touched • MAS-integrated vs independent • commands PASS/FAIL • registry/pipeline updates • next agent
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -12,24 +12,27 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 ## Role
 
-Own **board triage and Status transitions** for the experiment Project SSOT. Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines.
+Own **board triage and Status transitions** for the product Project SSOT (`mas-workflow-kit-project-ssot`). Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines.
 
 ## Read first
 
 - `.cursor/skills/project-board-ssot/SKILL.md`
+- `.ai_infra/templates/project-board/README.md` — when creating cards
 - `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `HANDOFF.md` §1 / §3.2 (experiment north star)
+- `HANDOFF.md` §1 (STANDALONE product + board SSOT)
 - `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
 ## Loop
 
 1. `python -m cursor_workflow project status --directory .`
 2. `python -m cursor_workflow project list --status ready --directory .` (or backlog)
-3. Claim with `set-status --to in_progress` or create with `project create`
+3. Prefer Pattern A: `create-from-template --template slice|bug` then `claim --last --agent project-board` (or `claim --id <real PVTI_>`). Use `--template bug` for defect/`fix/` work. Avoid raw multi-step claim unless atomics are required.
 4. Print handoff line for implementer: item id, title, next Status target
 5. **Verify:** CLI exit 0 + board list reflects change
 
@@ -44,7 +47,9 @@ Own **board triage and Status transitions** for the experiment Project SSOT. Han
 
 ## Handoff format
 
-slice • item_id • Status before/after • CLI PASS/FAIL • next agent (usually implementer)
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -10,9 +10,11 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
 
-**Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** skill § Template routing when a research card is needed; Notes timestamps via CLI; do not hand-forge times.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 
@@ -45,7 +47,9 @@ Research manifest/enrichment scripts live in **project overlays** (pack-specific
 
 ## Handoff format
 
-Slice ID • files touched • evidence added • backlog status • next slice
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -10,9 +10,11 @@ description: Module-focused tests, regressions, coverage.
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
 
-**Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.
@@ -21,6 +23,12 @@ description: Module-focused tests, regressions, coverage.
 - Strategy detail: `.cursor/skills/test-module-coverage/SKILL.md`.
 
 Report: tests added/updated • scope run • gaps • `test-index.md` / `test-plan.md` updates if any.
+
+## Handoff format
+
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -10,9 +10,11 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card (read Notes for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
 
-**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.
@@ -25,6 +27,12 @@ description: Claims vs evidence; minimal high-signal checks.
 5. Output: passed • failed • missing • **one** next action.
 
 Do not approve merge readiness without artifacts under `.local/workflow-artifacts/pr/` when the maintainer workflow is in play (`.ai_infra/scripts/pr/local_workflow_paths.py`). Flag drift vs `AGENTS.md` and `.cursor/rules/*`.
+
+## Handoff format
+
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/agents/workflow-drift-guard.md
+++ b/.cursor/agents/workflow-drift-guard.md
@@ -10,9 +10,11 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Entry:** If `project_ssot.enabled` → **must** `python -m cursor_workflow project status` and `project list --status in_progress` (board vs tracker dual-write context; cite board Status in findings). Else `session-pointer.md`.
 
-**Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
@@ -37,7 +39,9 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Handoff format
 
-drift profile • P0/P1/P2 counts • board Status cited • item_id (if any) · next=project-board|implementer|…
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -12,8 +12,11 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.
+- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
+- Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.

--- a/.cursor/skills/implementation-execution-loop/SKILL.md
+++ b/.cursor/skills/implementation-execution-loop/SKILL.md
@@ -20,7 +20,7 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Steps
 
-1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`set-status --to in_progress`). Else read plan + tracker; one task `in_progress` locally.
+1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`. Else read plan + tracker; one task `in_progress` locally.
 2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -38,7 +38,7 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent>`. Print handoff line. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
 | **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
 Handoff line (chat + card Notes):
@@ -77,7 +77,7 @@ Multi-collaborator: each human’s `owner.github_user` namespaces their agents (
 
 1. One primary **In progress** per **human assignee** — do not steal others'.
 2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent>` via `append-notes --agent`.
+3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (or `claim`/`handoff` recipes).
 4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
 5. Humans own views, workflows, README, Insights, status updates.
 6. Read-only `project export` (if used) never writes Status.
@@ -116,6 +116,22 @@ Ready → In progress → In review → Done
 
 Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (not into a shell).
 
+### Template routing
+
+| Need | Who | Template / action |
+|------|-----|-------------------|
+| slice / feature / `chore/` | implementer, project-board, integrator | `create-from-template --template slice` |
+| bug / defect / `fix/` | implementer, project-board | `create-from-template --template bug` |
+| audit pass | enterprise-auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
+| consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
+| Project README | **Humans only** | paste `project-readme.md` in Project settings UI |
+
+Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
+
+**Notes format:** `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · text` — auto-stamped by CLI on `claim`, `handoff`, and `append-notes --agent`. Idempotent when timestamp already present. Do not hand-forge times.
+
+**Local continuity:** append UTC-prefixed lines to `history/updates-log.md`; optional row in `history/continuity-index.md` (rolling ≥3 days). Board Notes retain full card lifetime.
+
 1. **Doctor / guide:** `project doctor` · `project guide --agent implementer`
 2. **Status / list:** `project status` · `project list [--status ready|in_progress|in_review]`
 3. **Create:** `project create-from-template --title "[SLICE] short-name" --template slice --status ready`
@@ -125,7 +141,9 @@ Human Project README: paste `.ai_infra/templates/project-board/project-readme.md
 7. **Atomics (power use):** `set-status` · `set-field` · `append-notes --agent` · `get --last` · `export`
 8. **Verify:** `project list` + handoff line; `project last` prints saved id
 
-Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation.
+Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation · `6` queued (outbox; soft-success — flush later).
+
+Rate-limit: `project outbox status` / `project queue` / `project outbox flush` — see `project_ssot.outbox` in collaboration YAML.
 
 ## Dual-write ban
 
@@ -135,6 +153,8 @@ When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in 
 
 - [ ] Entry read board (or explicit offline fallback)
 - [ ] Exit updated Status (or Notes + next agent if still In progress)
+- [ ] If EXIT_QUEUED: confirmed via `outbox status`; no API hammering
+- [ ] Handoff line printed with real item_id
 - [ ] Handoff line printed when another agent continues
 - [ ] No dual-write; no edits to Project views/workflows/README/Insights
 

--- a/.cursor/skills/workflow-drift-audit/SKILL.md
+++ b/.cursor/skills/workflow-drift-audit/SKILL.md
@@ -19,7 +19,7 @@ Notes:
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
+Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **session Board vs export (DRIFT-004b)**, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
 
 ## When
 
@@ -31,7 +31,7 @@ Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer i
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
 3. Capture profile, check IDs, severities, and details from output.
 4. Write artifacts under `.local/workflow-artifacts/drift/` only.
 5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to project-board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) — this repository **is** the product: installable multi-agent workflow infrastructure with a **GitHub Project** as the **only writable SSOT** for backlog, Status, and multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only`. **Local artifacts** (PR Pattern A, audits, gates, secrets) stay on disk as evidence — never a second Status writer under `board_only`. Agents call **one script command** per maintainer action; `GATES` live in `.ai_infra/scripts/pr/prepare.py`.
 
-**Continuation:** Entry reads the board (`python3 -m cursor_workflow project status`); Exit updates Status and Notes (see `.cursor/skills/project-board-ssot/SKILL.md` § Collaboration, ADR-008, `overlays/rules/project-ssot-precedence.mdc`). Ops: `.ai_infra/docs/operations/project-board-collaboration.md`. Offline fallback trackers only when board unavailable. **STANDALONE:** permanently decoupled from upstream `mas-workflow-kit` (lineage only — do not merge doctrine back). Read [`HANDOFF.md`](HANDOFF.md) first.
+**Continuation:** Entry reads the board (`python3 -m cursor_workflow project status`); Exit updates Status and Notes (see `.cursor/skills/project-board-ssot/SKILL.md` § Collaboration, ADR-008, `overlays/rules/project-ssot-precedence.mdc`). Ops: `.ai_infra/docs/operations/project-board-collaboration.md`. Offline fallback trackers only when board unavailable. Rate-limit: EXIT_QUEUED (6) → `project outbox` (local buffer, not a second SSOT). **STANDALONE:** permanently decoupled from upstream `mas-workflow-kit` (lineage only — do not merge doctrine back). Read [`HANDOFF.md`](HANDOFF.md) first.
 
 ## First reads (onboarding)
 
@@ -43,7 +43,7 @@ Abbreviations: [`.ai_infra/docs/operations/abbreviations-notepad.md`](.ai_infra/
 1. If `project_ssot.enabled` → `python -m cursor_workflow project status` → board list/claim (`.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract). Read card Notes for prior handoffs.
 2. Else → `.local/index-and-planning/current/session-pointer.md` → `plan.md` → `work-tracker.md`.
 
-**After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`.
+**After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. Notes attribution: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`.
 
 Token contract: [`.ai_infra/docs/operations/token-efficiency.md`](.ai_infra/docs/operations/token-efficiency.md).
 
@@ -81,10 +81,10 @@ Required in every commit message (see **`.cursor/rules/commit-trailer-format.mdc
 
 | Root | Role |
 |------|------|
-| `.cursor/agents/` | Subagent cards (7) — Task delegation; **`model: auto`**; audit agents write `.local/` artifacts only |
-| `.cursor/skills/` | **Canonical protocols** (10 folders: audit, drift, implement loop, activate, …) |
+| `.cursor/agents/` | Subagent cards (8) — Task delegation; **`model: auto`**; audit agents write `.local/` artifacts only |
+| `.cursor/skills/` | **Canonical protocols** (11 folders: audit, drift, implement loop, activate, project-board, …) |
 | `.agents/skills/` | **Maintainer slash skills** (5 folders: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `audit-alignment` stub → `enterprise-auditor`) — additive in plugin sync |
-| `.cursor/rules/` | Six universal `alwaysApply` rules — high context cost by design |
+| `.cursor/rules/` | **7** `alwaysApply` rules in this product repo (6 kit + `project-ssot-precedence`) — high context cost by design |
 
 **Plugin sync:** `.cursor/skills/` wins; `.agents/skills/` never overwrites same folder name (`sync_plugin_bundle.py`).
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -61,6 +61,7 @@ Notes:
 | Commit/PR attribution (`owner`, trailers, pipelines) | Already in collab YAML |
 | `.venv`, secrets, coverage dumps | Machine-local |
 | Offline fallback trackers | If no `project` scope / no `gh` — **resume-only** local trackers; never a second writer under `board_only` |
+| Rate-limit outbox | `.local/generated-data/board-outbox.jsonl` via `project queue` / auto-enqueue; flush with `outbox flush` — buffer only, not SSOT |
 | Read-only board export (optional) | Snapshot cache for audits/ICC later — never writes Status |
 
 **Non-goals:** Do **not** dual-mirror local trackers + board “for safety.” Do **not** push this product’s doctrine into upstream `mas-workflow-kit`. Do **not** treat this repo as a temporary sandbox awaiting a port.
@@ -127,7 +128,7 @@ GitHub Project #3       →  create / list / claim / status (human + all agents)
 | Rule | Detail |
 |------|--------|
 | One claim | Prefer one primary **In progress** card per **human** assignee |
-| Attribution | Notes: `@owner.github_user/<agent>` via `append-notes --agent`; `next=@user/agent` |
+| Attribution | Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (CLI stamps UTC); `next=@user/agent`; local `history/continuity-index.md` rolls ≥3 days |
 | Queue | **Ready** (+ Priority P0/P1) = next work |
 | Review | **In review** when PR open; **Done** after merge/close |
 | Create | Agents may create DraftIssue/Issue on the Project when scoping work |
@@ -290,6 +291,7 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 | DraftIssue vs real Issues? | Drafts OK for smoke; Issues better for PR linking. |
 | Consumer installs? | Install plugin from **this** repo: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Offline / no `gh`? | `fallback: local_trackers` then resume board sync. |
+| GraphQL rate-limit? | `project_ssot.outbox` — EXIT_QUEUED (6); `outbox flush` after reset. Never hammer API; outbox ≠ Status SSOT. |
 | Card → which repo? | Convention: Repository field or body path; default = this product repo. |
 | Control Center dashboards? | **Deferred (EA-010).** Read-only `project export` may land first; ICC panel that *reads* the export is future — never a second writer. |
 | Who updates the Project? | **Every agent** Entry=read board; Exit=update Status/Notes. Post-merge Done = Pattern A (`merge.py`). Rights: `project-board-ssot` skill § Continuation; ops `project-board-collaboration.md`. **You:** views, workflows, Insights, README, status updates, Ready prioritization / product roadmap. |

--- a/agents/enterprise-auditor.md
+++ b/agents/enterprise-auditor.md
@@ -8,11 +8,13 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice (claim/create audit card if missing); else `session-pointer.md` + `change-index.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context. If no audit card: `create-from-template --template slice --title "[AUDIT] …" --status ready` then `claim --last --agent enterprise-auditor`. Else `session-pointer.md` + `change-index.md`.
 
-**Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 
@@ -23,6 +25,7 @@ Act as a **Principal Enterprise Architect** using **strict evidence-only discipl
 ## Read first (scope + workflow)
 
 - `.cursor/skills/enterprise-architecture-audit/SKILL.md` — **full operating protocol, phases, scorecard, and output contract**
+- `.ai_infra/templates/project-board/README.md` — when creating audit cards
 - `AGENTS.md`, `README.md`
 - `.local/index-and-planning/current/plan.md`, `work-tracker.md` (if present — do not assume content)
 - Project `docs/architecture/` (local stub: `.local/.../current/architecture.md`)
@@ -49,7 +52,9 @@ When project overlays exist (`overlays/rules/*.mdc`), cross-check claims against
 
 ## Handoff format
 
-Audit date • artifact paths • scoring summary + confidence • top 5 ROI • P0/P1 count • unknowns • suggested next agent (implementer / test-runner / maintainer)
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -22,7 +22,11 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
 5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+
+**STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 
@@ -32,8 +36,9 @@ Deliver **small, reversible** slices with production quality: clear module bound
 
 - `.cursor/skills/implementation-execution-loop/SKILL.md` — slice lifecycle protocol
 - `.cursor/skills/project-board-ssot/SKILL.md` — when `project_ssot.enabled`
+- `.ai_infra/templates/project-board/README.md` — when creating cards
 - `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `.local/index-and-planning/current/architecture.md` (experiment stub)
+- `.local/index-and-planning/current/architecture.md` (architecture stub)
 - Fallback only: `session-pointer.md`, `plan.md`, `work-tracker.md`
 
 When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. After meaningful coverage runs: run **`make coverage-index`** when coverage mattered.  
@@ -49,11 +54,13 @@ When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. Afte
 
 ## Architecture
 
-Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Experiment precedence: `overlays/rules/project-ssot-precedence.mdc`.
+Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Board SSOT precedence: `overlays/rules/project-ssot-precedence.mdc`.
 
 ## Handoff format
 
-Slice name • item_id • Status • what changed • commands pass/fail • blockers • next step
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/integrator-mas-agent.md
+++ b/agents/integrator-mas-agent.md
@@ -14,24 +14,29 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card. Else `session-pointer.md` then integration skill.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card (`claim --last` after create). Else `session-pointer.md` then integration skill.
 
-**Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+
+**STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.
 
 ## Read first (evidence before edits)
 
 | Order | Path | Why |
 |-------|------|-----|
 | 1 | `.cursor/skills/mas-infrastructure-integration/SKILL.md` | Integration procedure (canonical) |
-| 2 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
-| 3 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
-| 4 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
-| 5 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
-| 6 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
-| 7 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
-| 8 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
+| 2 | `.ai_infra/templates/project-board/README.md` | When creating board cards |
+| 3 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
+| 4 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
+| 5 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
+| 6 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
+| 7 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
+| 8 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
+| 9 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
 
 **Skip** `.local/generated-data/**` unless validating coverage exports.
 
@@ -47,7 +52,7 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 ## Loop (one integration slice)
 
 1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
+2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` / `claim --last --agent integrator-mas-agent`); put Acceptance/Rollback on the card body; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
 3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
 4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
 5. **Verify** — `python -m cursor_workflow contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
@@ -72,7 +77,9 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 
 ## Handoff format
 
-Integration type • files touched • MAS-integrated vs independent • commands PASS/FAIL • registry/pipeline updates • next agent
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -12,24 +12,27 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 ## Role
 
-Own **board triage and Status transitions** for the experiment Project SSOT. Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines.
+Own **board triage and Status transitions** for the product Project SSOT (`mas-workflow-kit-project-ssot`). Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines.
 
 ## Read first
 
 - `.cursor/skills/project-board-ssot/SKILL.md`
+- `.ai_infra/templates/project-board/README.md` — when creating cards
 - `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `HANDOFF.md` §1 / §3.2 (experiment north star)
+- `HANDOFF.md` §1 (STANDALONE product + board SSOT)
 - `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
 ## Loop
 
 1. `python -m cursor_workflow project status --directory .`
 2. `python -m cursor_workflow project list --status ready --directory .` (or backlog)
-3. Claim with `set-status --to in_progress` or create with `project create`
+3. Prefer Pattern A: `create-from-template --template slice|bug` then `claim --last --agent project-board` (or `claim --id <real PVTI_>`). Use `--template bug` for defect/`fix/` work. Avoid raw multi-step claim unless atomics are required.
 4. Print handoff line for implementer: item id, title, next Status target
 5. **Verify:** CLI exit 0 + board list reflects change
 
@@ -44,7 +47,9 @@ Own **board triage and Status transitions** for the experiment Project SSOT. Han
 
 ## Handoff format
 
-slice • item_id • Status before/after • CLI PASS/FAIL • next agent (usually implementer)
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -10,9 +10,11 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
 
-**Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** skill § Template routing when a research card is needed; Notes timestamps via CLI; do not hand-forge times.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 
@@ -45,7 +47,9 @@ Research manifest/enrichment scripts live in **project overlays** (pack-specific
 
 ## Handoff format
 
-Slice ID • files touched • evidence added • backlog status • next slice
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -10,9 +10,11 @@ description: Module-focused tests, regressions, coverage.
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
 
-**Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.
@@ -21,6 +23,12 @@ description: Module-focused tests, regressions, coverage.
 - Strategy detail: `.cursor/skills/test-module-coverage/SKILL.md`.
 
 Report: tests added/updated • scope run • gaps • `test-index.md` / `test-plan.md` updates if any.
+
+## Handoff format
+
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -10,9 +10,11 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card (read Notes for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
 
-**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.
@@ -25,6 +27,12 @@ description: Claims vs evidence; minimal high-signal checks.
 5. Output: passed • failed • missing • **one** next action.
 
 Do not approve merge readiness without artifacts under `.local/workflow-artifacts/pr/` when the maintainer workflow is in play (`.ai_infra/scripts/pr/local_workflow_paths.py`). Flag drift vs `AGENTS.md` and `.cursor/rules/*`.
+
+## Handoff format
+
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/agents/workflow-drift-guard.md
+++ b/agents/workflow-drift-guard.md
@@ -10,9 +10,11 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Entry:** If `project_ssot.enabled` → **must** `python -m cursor_workflow project status` and `project list --status in_progress` (board vs tracker dual-write context; cite board Status in findings). Else `session-pointer.md`.
 
-**Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
@@ -37,7 +39,9 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Handoff format
 
-drift profile • P0/P1/P2 counts • board Status cited • item_id (if any) · next=project-board|implementer|…
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -12,9 +12,11 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.
+- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 - Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.

--- a/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -28,7 +28,7 @@ Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](
 
 | Profile | When | Checks |
 |---------|------|--------|
-| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…008 (full set) |
+| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…010 + 004b (full set; 004b/009–010 when `board_only`) |
 | `consumer` | `work-tracker.md` contains exemplar `STARTER-001` | DRIFT-005, DRIFT-008 (relaxed tracker rules) |
 
 Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
@@ -41,6 +41,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-002 | P0 | kit-dev | At most one `in_progress` in work-tracker |
 | DRIFT-003 | P1 | kit-dev | Active task token appears in plan Current focus |
 | DRIFT-004 | P1 | kit-dev | session-pointer Phase/Next sanity vs plan |
+| DRIFT-004b | P1 | kit-dev | When `board_only`, session-pointer Board id/Status vs `project export` snapshot (stale In progress vs Done) |
 | DRIFT-005 | P1 (kit-dev) / P2 skip (consumer) | both | IMPLEMENTATION-STATUS test count vs pytest collect; **PASS (skip)** when file absent (consumer install — not a consumer failure) |
 | DRIFT-006 | P2 | kit-dev | test-index Owned tests paths resolve |
 | DRIFT-007 | P2 | kit-dev | updates-log fresh when git tree dirty |
@@ -48,7 +49,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
 | DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
 
-**Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`).
+**Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`). Pending `project_ssot.outbox` ops are **not** a drift failure — cite `project outbox status` in artifacts when relevant.
 
 ### Gate placement
 

--- a/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
+++ b/payload/.ai_infra/docs/decisions/ADR-008-project-board-ssot.md
@@ -14,28 +14,29 @@ Related: [ADR-006](ADR-006-agent-integration-model.md), [HANDOFF.md](../../../HA
 1. **Only writable SSOT:** when `project_ssot.enabled: true` and `sync_policy: board_only`, the GitHub Project is the **only writable** coordination SSOT for backlog, Status, and multi-agent continuation. Agents must not dual-write competing slice status to `work-tracker.md` / `session-pointer.md`.
 2. **`board_only` wins** — dual-mirror (local trackers + board both writable) is rejected; it causes worse agent drift (DRIFT-009).
 3. **Offline fallback:** if enabled is false or `gh`/Projects unavailable, use `fallback: local_trackers` with an explicit warning — then resume board sync; never silent dual-write.
-4. **Read-only exports:** optional snapshots (`project export`) may cache board state for audits/ICC later; they **must not** write Status and must never become a competing SSOT.
-5. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
-6. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
-7. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
-8. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
-9. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
-10. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
-11. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
-12. **Multi-collaborator attribution:** card Notes use `@owner.github_user/<agent>` (from each person’s `github.collaboration.yaml`). CLI: `append-notes --agent <name>` when `require_attribution_on_exit`. GitHub Assignees are humans only (`set-assignee`); agent role lives in Notes. Handoff: `next=@user/agent`.
-13. **Board Pattern A recipes:** lifecycle actions are one CLI command each — `create-from-template`, `claim`, `handoff`, `validate-item`, `doctor` — wrapping atomics. Prefer recipes over multi-step shell. Exit codes: `0` ok; `2` usage/config; `3` gh/network; `4` not found; `5` validation. Card body templates live under `.ai_infra/templates/project-board/`. Project README/settings remain human-only (paste `project-readme.md` in the UI — never into a shell).
+4. **Rate-limit outbox:** when GraphQL quota blocks writes, `project_ssot.outbox` stores structured ops in a local JSONL (`.local/generated-data/board-outbox.jsonl`). EXIT_QUEUED (6) is soft-success; `outbox flush` restores the board after reset. Outbox is **never** authoritative Status.
+5. **Read-only exports:** optional snapshots (`project export`) may cache board state for audits/ICC later; they **must not** write Status and must never become a competing SSOT.
+6. **Config habit:** board identity and field ids live next to `owner` in `github.collaboration.yaml` (not a separate primary settings file).
+7. **Tooling:** Pattern A CLI (`cursor_workflow project`) wrapping `gh project`; MCP optional later.
+8. **Item kind:** default DraftIssue; promote to Issue when linking PRs (`promote_to_issue_on_pr`).
+9. **`project-board` agent:** independent-governed helper; not in PR pipelines. **All agents** Anchor on `project_ssot` when enabled: **Entry reads** the Project; **Exit updates** Status (and Notes) so work stays indexed for the next agent (continuation contract in `project-board-ssot` skill).
+10. **Post-merge card close:** Pattern A (`merge.py` + project CLI) sets Status → Done and appends Notes (PR URL + SHA) — **not** a dedicated post-merge agent.
+11. **Permanent decoupling (STANDALONE):** this repo is the board-SSOT product. Do **not** merge doctrine into upstream `mas-workflow-kit`. Upstream is historical lineage only.
+12. **Human-only Project surfaces:** views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap — agents never edit these.
+13. **Multi-collaborator attribution:** card Notes use `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (from each person’s `github.collaboration.yaml`; CLI stamps UTC). CLI: `append-notes --agent <name>` when `require_attribution_on_exit`. GitHub Assignees are humans only (`set-assignee`); agent role lives in Notes. Handoff: `next=@user/agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
+14. **Board Pattern A recipes:** lifecycle actions are one CLI command each — `create-from-template`, `claim`, `handoff`, `validate-item`, `doctor`, `queue`, `outbox status|flush` — wrapping atomics. Prefer recipes over multi-step shell. Exit codes: `0` ok; `2` usage/config; `3` gh/network; `4` not found; `5` validation; `6` queued. Card body templates live under `.ai_infra/templates/project-board/`. Project README/settings remain human-only (paste `project-readme.md` in the UI — never into a shell).
 
 ## Consequences
 
-- New CLI module: `.ai_infra/install/cursor_workflow/project_cli.py`
+- New CLI module: `.ai_infra/install/cursor_workflow/project_cli.py` + `project_outbox.py`
 - Skill: `.cursor/skills/project-board-ssot/SKILL.md` (Continuation contract + per-agent rights)
 - Ops: `.ai_infra/docs/operations/project-board-collaboration.md`
 - Agent: `.cursor/agents/project-board.md`
-- Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); workflow-drift-guard **reads and updates** the board on Exit
+- Drift: DRIFT-009 (dual-write) and DRIFT-010 (board vs PRs / stale In progress; read-only export); DRIFT-004b (session Board vs snapshot); workflow-drift-guard **reads and updates** the board on Exit; pending outbox is not a DRIFT failure
 - Post-merge Done: Pattern A `merge.py` (not a dedicated agent)
 - DraftIssue body edits: `append-notes` / `edit_item_body` resolve project item `PVTI_…` → content `DI_…` (+ preserve `--title`); Status/field edits stay on `PVTI_…`
-- Attribution: `append-notes --agent` prefixes `@github_user/agent`; `merge.py` Notes use `@user/merge.py`; `set-assignee` for human My items (Issue-backed)
-- Board Pattern A recipes + templates + structured `CODE=` exit lines; atomics remain for power use
+- Attribution: `append-notes --agent` prefixes `@github_user/agent · <ISO-8601-UTC> ·`; `merge.py` Notes use `@user/merge.py`; `set-assignee` for human My items (Issue-backed)
+- Board Pattern A recipes + templates + structured `CODE=` exit lines; rate-limit outbox (`project_ssot.outbox`); atomics remain for power use
 
 ## References
 

--- a/payload/.ai_infra/docs/decisions/README.md
+++ b/payload/.ai_infra/docs/decisions/README.md
@@ -9,6 +9,6 @@
 | [ADR-005](ADR-005-docs-split.md) | Consumer vs maintainer docs split | accepted |
 | [ADR-006](ADR-006-agent-integration-model.md) | Agent integration model (MAS vs independent) | accepted |
 | [ADR-007](ADR-007-workflow-drift-guard.md) | Workflow drift guard (operational drift detection) | accepted |
-| [ADR-008](ADR-008-project-board-ssot.md) | GitHub Project board as agent SSOT (experiment) | accepted |
+| [ADR-008](ADR-008-project-board-ssot.md) | GitHub Project board as agent SSOT (product doctrine) | accepted |
 
 New decisions: add `ADR-NNN-short-title.md` and update this index.

--- a/payload/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/payload/.ai_infra/docs/governance/workflow-source-owners.md
@@ -11,7 +11,7 @@ Depends On:
  - .ai_infra/scripts/pr/local_workflow_paths.py
 Notes:
  - Executable behavior wins over prose; prose must link to scripts instead of copying steps.
- - Last reviewed: 2026-06-29
+ - Last reviewed: 2026-07-18
 -->
 
 # Workflow source owners
@@ -24,7 +24,7 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `merge-pr` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (10 folders) | Plugin sync, agents |
+| Canonical Cursor skills | `.cursor/skills/` (11 folders) | Plugin sync, agents |
 | Maintainer slash skills | `.agents/skills/` (5 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -247,9 +247,10 @@ Cursor may also auto-delegate subagents when the task matches their `description
 Every session:
 
 1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else `.local/index-and-planning/current/session-pointer.md`
-2. Board card Status/Notes (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
-3. **`/implementer`** (or specialist agent from §6)
-4. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
+2. Board card Status/Notes — attribution `@user/agent · <ISO-8601-UTC> · …` (CLI stamps); local `history/continuity-index.md` rolls ≥3 days (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
+3. Rate-limit: EXIT_QUEUED → `python3 -m cursor_workflow project outbox flush` after quota recovers (`project_ssot.outbox` in collaboration YAML)
+4. **`/implementer`** (or specialist agent from §6)
+5. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
 
 Token contract: [token-efficiency.md](token-efficiency.md) · Layout: [local-workspace-layout.md](local-workspace-layout.md).
 

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -154,9 +154,10 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 ## Step 4 detail — daily workflow
 
 1. When `project_ssot.enabled`: `python3 -m cursor_workflow project status` (board first); else open `.local/index-and-planning/current/session-pointer.md`
-2. Claim/update the board card (Status + Notes); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`
-3. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
-4. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
+2. Claim/update the board card (Status + Notes `@user/agent · <ISO-8601-UTC> · …`); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`; optional `history/continuity-index.md` (≥3-day local rollup)
+3. If board writes hit GraphQL rate-limit (EXIT_QUEUED): `project outbox status` / later `outbox flush` — enable `project_ssot.outbox` defaults after activate
+4. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
+5. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
 
 **Add your own agent/skill/MCP:** **`/integrator-mas-agent`** + **`/mas-infrastructure-integration`**
 

--- a/payload/.ai_infra/docs/operations/gate-matrix.md
+++ b/payload/.ai_infra/docs/operations/gate-matrix.md
@@ -23,7 +23,7 @@ Three gate surfaces exist by design (Pattern A).
 | **`make doc-validate`** | After doc/agent/rule changes | DOC-001…006 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | **`make verify-all`** | Pre-audit / release readiness | 7 (+ optional ci-seed): sync-plugin → gates → drift → integrate → check-plugin → health → contributors | `.ai_infra/scripts/architecture/verify_all.py` |
 | **`scaffold --verify`** | Post-install smoke on consumer | 4: testing artifacts + pytest + governance + debrand (no doc facts) | `.ai_infra/scripts/install/scaffold.py` `_run_verify` |
-| **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…008) | `.ai_infra/scripts/workflow/check_drift.py` |
+| **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…010 + 004b on kit-dev; consumer profile subset) | `.ai_infra/scripts/workflow/check_drift.py` |
 | **Consumer drift** | Post-install verify on app projects | `drift validate --profile consumer` — DRIFT-005 (skip when `IMPLEMENTATION-STATUS.md` absent) + DRIFT-008 | [consumer-quickstart.md](consumer-quickstart.md#drift-on-consumer-apps) |
 | **`kit-quality.yml` (CI)** | Push/PR on kit repo | seed → sync-plugin → gates → drift → integrate → check-plugin → health → contributors → governance (redundant with gates) → install-dry-run | `.github/workflows/kit-quality.yml` |
 

--- a/payload/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/payload/.ai_infra/docs/operations/local-workspace-layout.md
@@ -44,7 +44,7 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | Path | Purpose |
 |------|---------|
 | `index-and-planning/current/` | Live trackers: `plan.md`, `work-tracker.md`, `session-pointer.md`, `change-index.md`, tests, `architecture.md` |
-| `index-and-planning/history/` | `updates-log.md` |
+| `index-and-planning/history/` | `updates-log.md` (UTC-prefixed lines), `continuity-index.md` (rolling ≥3-day board↔artifact index) |
 | `index-and-planning/audits/` | Local governance audit snapshots |
 | `agents-control-center/` | Dashboard config (`config/pages.json`) and optional HTML |
 | `workflow-artifacts/pr/` | `review.md`, `prep.md`, `merge.md` |

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -37,7 +37,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Ready prioritization | **Owner** | Consume; create agreed work | — |
 | Views / workflows / Insights / README / status updates | **Owner only** | Never | Insights auto |
 | Assignee / My items | Yes (`set-assignee` / UI) | Claim = In progress; assignee = **human** only | My items view |
-| Card Notes (`append-notes --agent`) | Yes | Yes — `@user/agent · …`; `next=@user/agent` | — |
+| Card Notes (`append-notes --agent`) | Yes | Yes — `@user/agent · YYYY-MM-DDTHH:MM:SSZ · …`; `next=@user/agent` | — |
 | PR / audits / secrets | Local | Local | — |
 | Post-merge Status → Done | — | Via `merge.py` (Pattern A); Notes `@user/merge.py` | — |
 | Read-only board export | Consume | `project export` (never writes Status) | — |
@@ -65,7 +65,7 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 
 **Safe flow:** `project guide` then `create-from-template` → `claim --last` → `handoff --last`. Never paste docs placeholder ids as `--id`.
 
-**Attribution:** Notes use `@owner.github_user/<agent>` from each collaborator’s `github.collaboration.yaml` so multi-user boards do not collide.
+**Attribution:** Notes use `@owner.github_user/<agent> · <ISO-8601-UTC> · …` from each collaborator’s `github.collaboration.yaml` (CLI stamps UTC; do not hand-forge timestamps). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 
 ## workflow-drift-guard specifically
 
@@ -73,6 +73,18 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 2. Run `drift validate` (includes DRIFT-009 / DRIFT-010 when board_only; refresh `project export` for DRIFT-010).
 3. Write `.local/workflow-artifacts/drift/*` (evidence stays local).
 4. **Update board:** close the drift-pass card; if dual-write Confirmed, add Notes on the offending card or ask project-board to queue a Ready fix — do not write competing `in_progress` into `work-tracker.md`.
+
+## Rate limits & outbox
+
+GitHub GraphQL quota (~5000/hour) can block board writes. When `project_ssot.outbox.enabled`:
+
+1. Live write fails with rate-limit → CLI **enqueues** to `.local/generated-data/board-outbox.jsonl` and returns **EXIT_QUEUED (6)**.
+2. Agent continues local evidence (`change-index`, handoff line) — **do not** hammer `gh` / retry loops.
+3. After quota recovers: `python3 -m cursor_workflow project outbox status` then `outbox flush` (capped by `max_flush_per_run`; refuses if `remaining < min_graphql_remaining`).
+4. Explicit enqueue: `project queue --op append-notes|set-status|handoff|claim|set-assignee …`
+5. Outbox is a **local buffer**, never a second Status SSOT.
+
+Who flushes: any agent/human after reset; prefer implementer or project-board at slice close. Pending outbox is **not** a DRIFT failure.
 
 ## Exit codes (board Pattern A)
 
@@ -83,8 +95,9 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 | 3 | `gh` / network |
 | 4 | Item not found |
 | 5 | Validation (sections, claim policy, attribution) |
+| 6 | Queued to outbox (soft-success; flush later) |
 
-Stderr: `project <cmd>: FAIL — CODE=n · reason`.
+Stderr: `project <cmd>: FAIL — CODE=n · reason` or `QUEUED — …`.
 
 ## Human-only
 

--- a/payload/.ai_infra/docs/operations/token-efficiency.md
+++ b/payload/.ai_infra/docs/operations/token-efficiency.md
@@ -45,15 +45,16 @@ Notes:
 
 1. Board Status via `cursor_workflow project set-status` (+ Notes / handoff line)
 2. `change-index.md` — one row per batch  
-3. `history/updates-log.md` — **one line** (no gate dumps)
-4. Do **not** dual-write tracker `in_progress` under `board_only`
+3. `history/updates-log.md` — **one line** prefixed `YYYY-MM-DDTHH:MM:SSZ` (no gate dumps)
+4. `history/continuity-index.md` — optional row when board item + local artifacts touched (keep ≥3 days)
+5. Do **not** dual-write tracker `in_progress` under `board_only`
 
 **Offline fallback:**
 
 1. `change-index.md` — one row per batch  
 2. `session-pointer.md` — phase, next agent, blockers  
 3. `work-tracker.md` / `plan.md` — if status changed  
-4. `history/updates-log.md` — **one line** (no gate dumps)
+4. `history/updates-log.md` — **one line** prefixed `YYYY-MM-DDTHH:MM:SSZ` (no gate dumps)
 
 ## Never paste in chat
 
@@ -84,9 +85,12 @@ Do **not** run individual gates in chat when `prepare.py` exists unless `verifie
 | Create card | `python -m cursor_workflow project create-from-template --title "…" --template slice` |
 | Claim | `python -m cursor_workflow project claim --last --agent <name>` |
 | Handoff | `python -m cursor_workflow project handoff --last --agent <name> --next <agent> [--to in_review]` |
+| Outbox status | `python -m cursor_workflow project outbox status` |
+| Queue (no live write) | `python -m cursor_workflow project queue --op … --last --agent <name>` |
+| Flush outbox | `python -m cursor_workflow project outbox flush` |
 | Safe recipes | `python -m cursor_workflow project guide` |
 
-Prefer `--last` after `create-from-template`. Never paste docs placeholder ids. Never paste Project settings UI into the shell.
+Prefer `--last` after `create-from-template`. Never paste docs placeholder ids. Never paste Project settings UI into the shell. On EXIT_QUEUED (6), do not retry — flush after GraphQL quota recovers.
 
 ## Maintainer lane
 

--- a/payload/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_cli.py
@@ -12,8 +12,9 @@ Notes:
  - Pattern A: one gh invocation per action; recipes (claim/handoff/create-from-template)
    are one lifecycle command each; no dual-write of local trackers.
  - DraftIssue body edits resolve PVTI_… → DI_… (+ --title); Status stays on PVTI_….
- - Notes attribution: @owner.github_user/agent via append-notes --agent.
- - Exit codes: 0 ok; 2 usage/config; 3 gh/network; 4 not found; 5 validation.
+ - Notes attribution: @owner.github_user/agent · ISO-8601-UTC · text via append-notes --agent.
+ - Exit codes: 0 ok; 2 usage/config; 3 gh/network; 4 not found; 5 validation; 6 queued (outbox).
+ - Rate-limit outbox: project_outbox.py + project_ssot.outbox (local buffer, not SSOT).
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ import json
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +34,7 @@ EXIT_USAGE = 2
 EXIT_GH = 3
 EXIT_NOT_FOUND = 4
 EXIT_VALIDATION = 5
+EXIT_QUEUED = 6
 
 _TEMPLATE_NAMES = ("slice", "bug")
 _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
@@ -134,6 +137,11 @@ def is_placeholder_item_id(raw: str) -> bool:
         return True
     # Docs form with only punctuation after prefix
     if re.match(r"^(PVTI_|DI_)[\.…_-]*$", s):
+        return True
+    # Real GitHub Project item ids are long (e.g. PVTI_lAHO…); reject stubs
+    if re.match(r"^PVTI_", s) and len(s) < 20:
+        return True
+    if re.match(r"^DI_", s) and len(s) < 12:
         return True
     return False
 
@@ -252,21 +260,40 @@ def format_agent_attribution(root: Path, agent: str) -> str:
     return f"{user}/{agent_key}"
 
 
+NOTE_LINE_WITH_TIMESTAMP_RE = re.compile(
+    r"^@[^\s/]+/[^\s·]+\s*·\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z(?:\s*·\s*|$)"
+)
+NOTE_ATTRIBUTION_PREFIX_RE = re.compile(r"^(@[^\s/]+/[^\s·]+)")
+
+
+def utc_note_timestamp() -> str:
+    """Return current UTC timestamp for board Notes (test hook)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def format_note_line(root: Path, agent: str, text: str) -> str:
     """
-    Prefix note with @user/agent · text.
-    Idempotent if text already starts with that attribution.
+    Prefix note with @user/agent · ISO-8601-UTC · text.
+    Idempotent if text already has a UTC timestamp after attribution.
     """
     attr = format_agent_attribution(root, agent)
     body = (text or "").strip()
-    if body.startswith(attr):
+    if NOTE_LINE_WITH_TIMESTAMP_RE.match(body):
         return body
-    # Also accept without requiring exact agent if already @user/something
-    if re.match(r"^@[^\s/]+/[^\s·]+", body):
-        return body
+    attr_match = NOTE_ATTRIBUTION_PREFIX_RE.match(body)
+    if attr_match:
+        prefix = attr_match.group(1)
+        rest = body[len(prefix) :].lstrip()
+        if rest.startswith("·"):
+            rest = rest[1:].strip()
+        ts = utc_note_timestamp()
+        if rest:
+            return f"{prefix} · {ts} · {rest}"
+        return f"{prefix} · {ts}"
+    ts = utc_note_timestamp()
     if not body:
-        return attr
-    return f"{attr} · {body}"
+        return f"{attr} · {ts}"
+    return f"{attr} · {ts} · {body}"
 
 
 def set_item_assignee(
@@ -693,13 +720,48 @@ def cmd_set_status(args: argparse.Namespace) -> int:
         ]
     )
     if proc.returncode != 0:
-        return fail(
-            "set-status",
-            EXIT_GH,
-            (proc.stderr or proc.stdout or "gh project item-edit failed").strip(),
+        detail = (proc.stderr or proc.stdout or "gh project item-edit failed").strip()
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="set-status",
+            err_detail=detail,
+            op="set-status",
+            item_id=item_id,
+            agent=(getattr(args, "agent", None) or "project-cli"),
+            payload={"to": args.to},
         )
+        if queued is not None:
+            return queued
+        return fail("set-status", EXIT_GH, detail)
     print(f"set-status: {item_id} → {args.to} ({option_id})")
     return EXIT_OK
+
+
+def _try_queue_rate_limit(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    err_detail: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """Delegate to project_outbox.maybe_enqueue_on_gh_fail."""
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    return _outbox.maybe_enqueue_on_gh_fail(
+        root,
+        ssot,
+        cmd=cmd,
+        err_detail=err_detail,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
 
 
 def cmd_set_field(args: argparse.Namespace) -> int:
@@ -1172,6 +1234,19 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         limit=args.limit,
     )
     if not ok:
+        if err_code == EXIT_GH:
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="append-notes",
+                err_detail=detail,
+                op="append-notes",
+                item_id=item_id,
+                agent=getattr(args, "agent", None) or "project-cli",
+                payload={"text": args.text},
+            )
+            if queued is not None:
+                return queued
         return fail("append-notes", err_code, detail)
     if detail == "idempotent":
         print(f"append-notes: {item_id} — already present (idempotent skip)")
@@ -1203,8 +1278,21 @@ def cmd_set_assignee(args: argparse.Namespace) -> int:
     ok, detail = set_item_assignee(ssot, item_id, login)
     if not ok:
         # DraftIssue / unsupported → validation; gh failures look like network
-        code_out = EXIT_VALIDATION if "DraftIssue" in detail or "unsupported" in detail else EXIT_GH
-        return fail("set-assignee", code_out, detail)
+        if "DraftIssue" in detail or "unsupported" in detail:
+            return fail("set-assignee", EXIT_VALIDATION, detail)
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="set-assignee",
+            err_detail=detail,
+            op="set-assignee",
+            item_id=item_id,
+            agent=(getattr(args, "agent", None) or "project-cli"),
+            payload={"login": login},
+        )
+        if queued is not None:
+            return queued
+        return fail("set-assignee", EXIT_GH, detail)
     print(f"set-assignee: {item_id} → @{detail.lstrip('@')}")
     return EXIT_OK
 
@@ -1228,8 +1316,24 @@ def cmd_claim(args: argparse.Namespace) -> int:
     if not user:
         return fail("claim", EXIT_USAGE, "owner.github_user missing")
     conventions = ssot.get("conventions") or {}
+    claim_payload = {
+        "to": "in_progress",
+        "text": getattr(args, "text", None) or "claimed",
+    }
     items, err = fetch_project_items(ssot, limit=args.limit)
     if err:
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="claim",
+            err_detail=err,
+            op="claim",
+            item_id=item_id,
+            agent=agent,
+            payload=claim_payload,
+        )
+        if queued is not None:
+            return queued
         return fail("claim", EXIT_GH, err)
     item = find_item_by_id(items, item_id)
     if item is None:
@@ -1248,7 +1352,21 @@ def cmd_claim(args: argparse.Namespace) -> int:
             )
     ok, detail = set_item_status(ssot, item_id, "in_progress")
     if not ok:
-        return fail("claim", EXIT_GH if "unknown status" not in detail else EXIT_USAGE, detail)
+        if "unknown status" in detail:
+            return fail("claim", EXIT_USAGE, detail)
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="claim",
+            err_detail=detail,
+            op="claim",
+            item_id=item_id,
+            agent=agent,
+            payload=claim_payload,
+        )
+        if queued is not None:
+            return queued
+        return fail("claim", EXIT_GH, detail)
     claim_mode = str(conventions.get("claim") or "set_assignee")
     if claim_mode == "set_assignee":
         a_ok, a_detail = set_item_assignee(ssot, item_id, user.lstrip("@"))
@@ -1261,6 +1379,23 @@ def cmd_claim(args: argparse.Namespace) -> int:
         root, ssot, item_id, agent=agent, text=note, limit=args.limit
     )
     if not n_ok:
+        if n_code == EXIT_GH:
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="claim",
+                err_detail=n_detail,
+                op="append-notes",
+                item_id=item_id,
+                agent=agent,
+                payload={"text": note},
+            )
+            if queued is not None:
+                print(
+                    "claim: status set; Notes QUEUED due to rate-limit",
+                    file=sys.stderr,
+                )
+                return queued
         return fail("claim", n_code, f"status set but Notes failed: {n_detail}")
     save_last_item_id(root, item_id, title=_item_title(item), action="claim")
     attr = format_agent_attribution(root, agent)
@@ -1295,6 +1430,22 @@ def cmd_handoff(args: argparse.Namespace) -> int:
         return fail("handoff", EXIT_USAGE, str(exc))
     items, err = fetch_project_items(ssot, limit=args.limit)
     if err:
+        queued = _try_queue_rate_limit(
+            root,
+            ssot,
+            cmd="handoff",
+            err_detail=err,
+            op="handoff",
+            item_id=item_id,
+            agent=agent,
+            payload={
+                "next": next_agent,
+                "to": (getattr(args, "to", None) or "").strip(),
+                "note": (getattr(args, "text", None) or "").strip(),
+            },
+        )
+        if queued is not None:
+            return queued
         return fail("handoff", EXIT_GH, err)
     item = find_item_by_id(items, item_id)
     if item is None:
@@ -1308,15 +1459,38 @@ def cmd_handoff(args: argparse.Namespace) -> int:
     if status_to:
         ok, detail = set_item_status(ssot, item_id, status_to)
         if not ok:
-            return fail(
-                "handoff",
-                EXIT_USAGE if "unknown" in detail.lower() else EXIT_GH,
-                detail,
+            if "unknown" in detail.lower():
+                return fail("handoff", EXIT_USAGE, detail)
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="handoff",
+                err_detail=detail,
+                op="handoff",
+                item_id=item_id,
+                agent=agent,
+                payload={"next": next_agent, "to": status_to, "note": extra},
             )
+            if queued is not None:
+                return queued
+            return fail("handoff", EXIT_GH, detail)
     n_ok, n_detail, n_code = append_notes_helper(
         root, ssot, item_id, agent=agent, text=note_core, limit=args.limit
     )
     if not n_ok:
+        if n_code == EXIT_GH:
+            queued = _try_queue_rate_limit(
+                root,
+                ssot,
+                cmd="handoff",
+                err_detail=n_detail,
+                op="handoff",
+                item_id=item_id,
+                agent=agent,
+                payload={"next": next_agent, "to": status_to, "note": extra},
+            )
+            if queued is not None:
+                return queued
         return fail("handoff", n_code, n_detail)
     save_last_item_id(root, item_id, title=_item_title(item), action="handoff")
     after = status_to or before or "?"
@@ -1382,6 +1556,7 @@ def cmd_guide(args: argparse.Namespace) -> int:
     print("# Safe board recipes — use --last; never paste docs placeholders as --id")
     print(f"# last item_id: {lid}")
     print("python3 -m cursor_workflow project doctor")
+    print("python3 -m cursor_workflow project outbox status")
     print(
         'python3 -m cursor_workflow project create-from-template '
         '--title "[SLICE] short-name" --template slice --status ready'
@@ -1392,6 +1567,115 @@ def cmd_guide(args: argparse.Namespace) -> int:
         f"--next {nxt} --to in_review"
     )
     print("python3 -m cursor_workflow project validate-item --last")
+    print("# If EXIT_QUEUED (6): python3 -m cursor_workflow project outbox flush")
+    return EXIT_OK
+
+
+def cmd_queue(args: argparse.Namespace) -> int:
+    """Explicit enqueue (no live board write)."""
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    root = Path(args.directory).resolve()
+    ssot, code = _load_enabled_ssot(root, "queue")
+    if ssot is None:
+        return code
+    item_id, id_code = resolve_item_id_arg(root, args, "queue")
+    if item_id is None:
+        return id_code
+    agent = (getattr(args, "agent", None) or "").strip()
+    if not agent:
+        return fail("queue", EXIT_USAGE, "--agent required")
+    op = (getattr(args, "op", None) or "").strip()
+    payload: dict[str, Any] = {}
+    if op == "append-notes":
+        text = (getattr(args, "text", None) or "").strip()
+        if not text:
+            return fail("queue", EXIT_USAGE, "--text required for append-notes")
+        payload = {"text": text}
+    elif op == "set-status":
+        to = (getattr(args, "to", None) or "").strip()
+        if not to:
+            return fail("queue", EXIT_USAGE, "--to required for set-status")
+        payload = {"to": to}
+    elif op == "handoff":
+        nxt = (getattr(args, "next", None) or "").strip()
+        if not nxt:
+            return fail("queue", EXIT_USAGE, "--next required for handoff")
+        payload = {
+            "next": nxt,
+            "to": (getattr(args, "to", None) or "").strip(),
+            "note": (getattr(args, "text", None) or "").strip(),
+        }
+    elif op == "claim":
+        payload = {
+            "to": (getattr(args, "to", None) or "in_progress").strip() or "in_progress",
+            "text": (getattr(args, "text", None) or "claimed").strip(),
+        }
+    elif op == "set-assignee":
+        login = (getattr(args, "login", None) or "").strip()
+        if not login:
+            try:
+                login = resolve_human_github_user(root)
+            except Exception as exc:  # noqa: BLE001
+                return fail("queue", EXIT_USAGE, str(exc))
+        payload = {"login": login.lstrip("@")}
+    else:
+        return fail(
+            "queue",
+            EXIT_USAGE,
+            "op must be append-notes|set-status|handoff|claim|set-assignee",
+        )
+    entry, err = _outbox.enqueue_op(
+        root, ssot, op=op, item_id=item_id, agent=agent, payload=payload
+    )
+    if entry is None:
+        return fail("queue", EXIT_VALIDATION, err)
+    print(_outbox.queued_message("queue", entry))
+    return EXIT_QUEUED
+
+
+def cmd_outbox_status(args: argparse.Namespace) -> int:
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    root = Path(args.directory).resolve()
+    ssot, code = _load_enabled_ssot(root, "outbox")
+    if ssot is None:
+        return code
+    cfg = _outbox.load_outbox_config(ssot)
+    path = _outbox.outbox_path(root, cfg)
+    counts = _outbox.count_outbox(path)
+    rl = _outbox.graphql_rate_limit()
+    print(f"outbox.enabled: {cfg['enabled']}")
+    print(f"outbox.path: {path}")
+    print(
+        f"counts: pending={counts['pending']} failed={counts['failed']} "
+        f"done={counts['done']} total={counts['total']}"
+    )
+    if rl.get("error"):
+        print(f"graphql: error — {rl['error']}")
+    else:
+        reset = _outbox.format_reset_iso(rl.get("reset_epoch"))
+        print(
+            f"graphql: remaining={rl.get('remaining')}/{rl.get('limit')} "
+            f"reset={reset} min_flush={cfg['min_graphql_remaining']}"
+        )
+    return EXIT_OK
+
+
+def cmd_outbox_flush(args: argparse.Namespace) -> int:
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    root = Path(args.directory).resolve()
+    ssot, code = _load_enabled_ssot(root, "outbox")
+    if ssot is None:
+        return code
+    max_ops = getattr(args, "max", None)
+    code_out, summary = _outbox.flush_outbox(
+        root, ssot, max_ops=max_ops, limit=getattr(args, "limit", 100) or 100
+    )
+    if code_out != EXIT_OK:
+        return fail("outbox flush", code_out, summary)
+    print(f"outbox flush: {summary}")
     return EXIT_OK
 
 
@@ -1416,29 +1700,77 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         path = tpl_dir / f"card-body-{name}.md"
         if not path.is_file():
             return fail("doctor", EXIT_USAGE, f"missing template {path}")
-    proc = run_gh(
-        [
-            "project",
-            "item-list",
-            str(ssot["number"]),
-            "--owner",
-            str(ssot["owner"]),
-            "--format",
-            "json",
-            "--limit",
-            "1",
-        ]
-    )
-    if proc.returncode != 0:
-        return fail(
-            "doctor",
-            EXIT_GH,
-            (proc.stderr or proc.stdout or "gh project not readable").strip(),
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    cfg_pre = _outbox.load_outbox_config(ssot)
+    rl_pre = _outbox.graphql_rate_limit()
+    skip_live = False
+    if not rl_pre.get("error"):
+        try:
+            rem_pre = int(rl_pre.get("remaining")) if rl_pre.get("remaining") is not None else 9999
+        except (TypeError, ValueError):
+            rem_pre = 9999
+        if rem_pre < int(cfg_pre["min_graphql_remaining"]):
+            skip_live = True
+            print(
+                "doctor: WARN — skipping live gh project item-list (low GraphQL quota)",
+                file=sys.stderr,
+            )
+    if not skip_live:
+        proc = run_gh(
+            [
+                "project",
+                "item-list",
+                str(ssot["number"]),
+                "--owner",
+                str(ssot["owner"]),
+                "--format",
+                "json",
+                "--limit",
+                "1",
+            ]
         )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "gh project not readable").strip()
+            if _outbox.is_rate_limit_error(detail):
+                print(
+                    "doctor: WARN — gh project item-list rate-limited; config still ok",
+                    file=sys.stderr,
+                )
+            else:
+                return fail("doctor", EXIT_GH, detail)
     print("doctor: ok")
     print(f"project: {ssot.get('name')} ({ssot.get('url')})")
     print(f"human: {user}")
     print(f"templates: {tpl_dir}")
+    cfg = cfg_pre
+    path = _outbox.outbox_path(root, cfg)
+    counts = _outbox.count_outbox(path)
+    rl = rl_pre
+    print(f"outbox: enabled={cfg['enabled']} pending={counts['pending']} path={path}")
+    if rl.get("error"):
+        print(f"doctor: WARN — graphql rate_limit: {rl['error']}", file=sys.stderr)
+    else:
+        rem = rl.get("remaining")
+        try:
+            rem_i = int(rem) if rem is not None else -1
+        except (TypeError, ValueError):
+            rem_i = -1
+        reset = _outbox.format_reset_iso(rl.get("reset_epoch"))
+        print(f"graphql: remaining={rem}/{rl.get('limit')} reset={reset}")
+        if rem_i >= 0 and rem_i < int(cfg["min_graphql_remaining"]):
+            print(
+                f"doctor: WARN — GraphQL remaining {rem_i} < "
+                f"min_graphql_remaining {cfg['min_graphql_remaining']}; "
+                f"prefer outbox queue; flush after {reset}",
+                file=sys.stderr,
+            )
+    if counts["pending"] > 0:
+        print(
+            f"doctor: WARN — {counts['pending']} pending outbox ops; "
+            f"run: python3 -m cursor_workflow project outbox flush",
+            file=sys.stderr,
+        )
     return EXIT_OK
 
 
@@ -1557,6 +1889,11 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         "--to",
         required=True,
         help="Logical status: backlog|ready|in_progress|in_review|done",
+    )
+    set_status.add_argument(
+        "--agent",
+        default="project-cli",
+        help="Agent id for outbox attribution if rate-limited",
     )
     set_status.set_defaults(func=cmd_set_status)
 
@@ -1679,3 +2016,43 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     export_cmd.add_argument("--json", action="store_true", help="Also print JSON to stdout")
     export_cmd.add_argument("--stdout", action="store_true", help="Print JSON only (no file write)")
     export_cmd.set_defaults(func=cmd_export)
+
+    queue_cmd = project_sub.add_parser(
+        "queue",
+        help="Enqueue a board op to local outbox (no live write; EXIT_QUEUED=6)",
+    )
+    queue_cmd.add_argument("--directory", type=Path, default=".")
+    _add_id_or_last(queue_cmd)
+    queue_cmd.add_argument(
+        "--op",
+        required=True,
+        choices=("append-notes", "set-status", "handoff", "claim", "set-assignee"),
+    )
+    queue_cmd.add_argument("--agent", required=True)
+    queue_cmd.add_argument("--text", default="", help="Notes text / handoff note / claim text")
+    queue_cmd.add_argument("--to", default="", help="Status for set-status/handoff/claim")
+    queue_cmd.add_argument("--next", default="", help="Next agent for handoff")
+    queue_cmd.add_argument("--login", default="", help="Assignee login for set-assignee")
+    queue_cmd.set_defaults(func=cmd_queue)
+
+    outbox_cmd = project_sub.add_parser(
+        "outbox",
+        help="Inspect or flush rate-limit board outbox",
+    )
+    outbox_sub = outbox_cmd.add_subparsers(dest="outbox_command", required=True)
+    ob_status = outbox_sub.add_parser("status", help="Counts + GraphQL remaining")
+    ob_status.add_argument("--directory", type=Path, default=".")
+    ob_status.set_defaults(func=cmd_outbox_status)
+    ob_flush = outbox_sub.add_parser(
+        "flush",
+        help="Apply pending outbox ops (refuses if GraphQL remaining too low)",
+    )
+    ob_flush.add_argument("--directory", type=Path, default=".")
+    ob_flush.add_argument(
+        "--max",
+        type=int,
+        default=None,
+        help="Override max_flush_per_run from settings",
+    )
+    ob_flush.add_argument("--limit", type=int, default=100)
+    ob_flush.set_defaults(func=cmd_outbox_flush)

--- a/payload/.ai_infra/install/cursor_workflow/project_outbox.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_outbox.py
@@ -1,0 +1,463 @@
+"""
+File: project_outbox.py
+Path: .ai_infra/install/cursor_workflow/project_outbox.py
+Role: Rate-limit-safe board outbox — enqueue/flush JSONL ops from project_ssot.outbox.
+Used By:
+ - .ai_infra/install/cursor_workflow/project_cli.py
+Depends On:
+ - project_cli helpers (attribution, set_item_*, append_notes_helper) via late imports
+Notes:
+ - Outbox is a local buffer, never a second Status SSOT (ADR-008).
+ - Flush is pull-based; refuses when GraphQL remaining < min_graphql_remaining.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_GH = 3
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+EXIT_QUEUED = 6
+
+_OUTBOX_OPS = frozenset(
+    {"append-notes", "set-status", "handoff", "claim", "set-assignee"}
+)
+_DEFAULT_PATH = ".local/generated-data/board-outbox.jsonl"
+_RATE_LIMIT_RE = re.compile(
+    r"rate\s*limit|API rate limit exceeded|secondary rate limit",
+    re.IGNORECASE,
+)
+
+
+def load_outbox_config(ssot: dict[str, Any]) -> dict[str, Any]:
+    """Return outbox settings with defaults."""
+    raw = ssot.get("outbox") if isinstance(ssot.get("outbox"), dict) else {}
+    return {
+        "enabled": bool(raw.get("enabled", True)),
+        "path": str(raw.get("path") or _DEFAULT_PATH).strip() or _DEFAULT_PATH,
+        "min_graphql_remaining": int(raw.get("min_graphql_remaining") or 200),
+        "max_flush_per_run": int(raw.get("max_flush_per_run") or 10),
+        "retry_backoff_seconds": int(raw.get("retry_backoff_seconds") or 30),
+    }
+
+
+def outbox_path(root: Path, cfg: dict[str, Any]) -> Path:
+    rel = Path(str(cfg.get("path") or _DEFAULT_PATH))
+    return (root / rel).resolve() if not rel.is_absolute() else rel
+
+
+def is_rate_limit_error(text: str) -> bool:
+    return bool(_RATE_LIMIT_RE.search(text or ""))
+
+
+def graphql_rate_limit() -> dict[str, Any]:
+    """
+    Read GraphQL quota via gh api rate_limit (REST — cheap).
+    Returns keys: remaining, limit, reset_epoch, error (optional).
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "api", "rate_limit", "--jq", ".resources.graphql"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": str(exc),
+        }
+    if proc.returncode != 0:
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": (proc.stderr or proc.stdout or "gh api rate_limit failed").strip(),
+        }
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": f"invalid JSON: {exc}",
+        }
+    if not isinstance(data, dict):
+        return {
+            "remaining": None,
+            "limit": None,
+            "reset_epoch": None,
+            "error": "graphql resource not an object",
+        }
+    return {
+        "remaining": data.get("remaining"),
+        "limit": data.get("limit"),
+        "reset_epoch": data.get("reset"),
+        "error": None,
+    }
+
+
+def format_reset_iso(reset_epoch: Any) -> str:
+    try:
+        ts = int(reset_epoch)
+    except (TypeError, ValueError):
+        return "(unknown)"
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def validate_outbox_entry(entry: dict[str, Any]) -> list[str]:
+    """Lightweight validation (schema fields)."""
+    errs: list[str] = []
+    for key in ("id", "ts", "agent", "github_user", "op", "item_id", "payload", "status"):
+        if key not in entry:
+            errs.append(f"missing {key}")
+    op = str(entry.get("op") or "")
+    if op and op not in _OUTBOX_OPS:
+        errs.append(f"unknown op {op!r}")
+    status = str(entry.get("status") or "")
+    if status and status not in ("pending", "done", "failed"):
+        errs.append(f"bad status {status!r}")
+    item_id = str(entry.get("item_id") or "")
+    if item_id and (
+        not re.match(r"^PVTI_[A-Za-z0-9_-]+$", item_id) or len(item_id) < 20
+    ):
+        errs.append(f"bad item_id {item_id!r}")
+    if not isinstance(entry.get("payload"), dict):
+        errs.append("payload must be object")
+    attempts = entry.get("attempts", 0)
+    if not isinstance(attempts, int) or attempts < 0:
+        errs.append("attempts must be non-negative int")
+    # payload shape checks
+    payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+    if op == "append-notes" and not str(payload.get("text") or "").strip():
+        errs.append("append-notes payload.text required")
+    if op == "set-status" and not str(payload.get("to") or "").strip():
+        errs.append("set-status payload.to required")
+    if op == "handoff":
+        if not str(payload.get("next") or "").strip():
+            errs.append("handoff payload.next required")
+    if op == "set-assignee" and not str(payload.get("login") or "").strip():
+        errs.append("set-assignee payload.login required")
+    return errs
+
+
+def read_outbox_entries(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            entries.append(data)
+    return entries
+
+
+def write_outbox_entries(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(e, ensure_ascii=False) + "\n" for e in entries]
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def enqueue_op(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+    github_user: str = "",
+) -> tuple[dict[str, Any] | None, str]:
+    """
+    Append a pending outbox entry. Returns (entry, error_message).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return None, "outbox.enabled is false"
+    # Late import to avoid circular import at module load
+    from project_cli import (  # noqa: PLC0415
+        is_placeholder_item_id,
+        normalize_github_handle,
+        resolve_human_github_user,
+    )
+
+    if is_placeholder_item_id(item_id):
+        return None, f"placeholder item_id {item_id!r}"
+    op_key = (op or "").strip()
+    if op_key not in _OUTBOX_OPS:
+        return None, f"unknown op {op!r}"
+    agent_s = (agent or "").strip()
+    if not agent_s:
+        return None, "agent required"
+    user = (github_user or "").strip()
+    if not user:
+        try:
+            user = resolve_human_github_user(root)
+        except Exception as exc:  # noqa: BLE001
+            return None, str(exc)
+    user = normalize_github_handle(user)
+    if not user:
+        return None, "github_user missing"
+    entry: dict[str, Any] = {
+        "id": str(uuid.uuid4()),
+        "ts": _utc_now(),
+        "agent": agent_s,
+        "github_user": user if user.startswith("@") else f"@{user}",
+        "op": op_key,
+        "item_id": item_id.strip(),
+        "payload": dict(payload or {}),
+        "status": "pending",
+        "attempts": 0,
+        "last_error": None,
+    }
+    errs = validate_outbox_entry(entry)
+    if errs:
+        return None, "; ".join(errs)
+    path = outbox_path(root, cfg)
+    entries = read_outbox_entries(path)
+    entries.append(entry)
+    write_outbox_entries(path, entries)
+    return entry, ""
+
+
+def queued_message(cmd: str, entry: dict[str, Any]) -> str:
+    return (
+        f"project {cmd}: QUEUED — id={entry.get('id')} op={entry.get('op')} "
+        f"item={entry.get('item_id')} · run: python3 -m cursor_workflow project outbox flush"
+    )
+
+
+def maybe_enqueue_on_gh_fail(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    err_detail: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """
+    If outbox enabled and error looks like rate-limit, enqueue and return EXIT_QUEUED.
+    Otherwise return None (caller should fail as before).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return None
+    if not is_rate_limit_error(err_detail):
+        return None
+    entry, err = enqueue_op(
+        root,
+        ssot,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+    if entry is None:
+        print(
+            f"project {cmd}: FAIL — CODE={EXIT_GH} · rate-limit and enqueue failed: {err}",
+            file=sys.stderr,
+        )
+        return EXIT_GH
+    print(queued_message(cmd, entry), file=sys.stderr)
+    return EXIT_QUEUED
+
+
+def count_outbox(path: Path) -> dict[str, int]:
+    entries = read_outbox_entries(path)
+    counts = {"pending": 0, "done": 0, "failed": 0, "total": len(entries)}
+    for e in entries:
+        st = str(e.get("status") or "")
+        if st in counts:
+            counts[st] += 1
+    return counts
+
+
+def apply_outbox_entry(
+    root: Path,
+    ssot: dict[str, Any],
+    entry: dict[str, Any],
+    *,
+    limit: int = 100,
+) -> tuple[bool, str]:
+    """Apply one pending entry to the live board. Returns (ok, detail)."""
+    from project_cli import (  # noqa: PLC0415
+        append_notes_helper,
+        format_agent_attribution,
+        set_item_assignee,
+        set_item_status,
+    )
+
+    op = str(entry.get("op") or "")
+    item_id = str(entry.get("item_id") or "")
+    agent = str(entry.get("agent") or "")
+    payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+
+    if op == "append-notes":
+        ok, detail, _code = append_notes_helper(
+            root,
+            ssot,
+            item_id,
+            agent=agent,
+            text=str(payload.get("text") or ""),
+            limit=limit,
+        )
+        return ok, detail
+
+    if op == "set-status":
+        ok, detail = set_item_status(ssot, item_id, str(payload.get("to") or ""))
+        return ok, detail
+
+    if op == "set-assignee":
+        login = str(payload.get("login") or "").lstrip("@")
+        ok, detail = set_item_assignee(ssot, item_id, login)
+        return ok, detail
+
+    if op == "claim":
+        to = str(payload.get("to") or "in_progress")
+        ok, detail = set_item_status(ssot, item_id, to)
+        if not ok:
+            return False, detail
+        note = str(payload.get("text") or "claimed (outbox flush)")
+        n_ok, n_detail, _ = append_notes_helper(
+            root, ssot, item_id, agent=agent, text=note, limit=limit
+        )
+        if not n_ok:
+            return False, f"status set but Notes failed: {n_detail}"
+        return True, "claimed"
+
+    if op == "handoff":
+        next_agent = str(payload.get("next") or "").strip().lstrip("@")
+        status_to = str(payload.get("to") or "").strip()
+        extra = str(payload.get("note") or payload.get("text") or "").strip()
+        if status_to:
+            ok, detail = set_item_status(ssot, item_id, status_to)
+            if not ok:
+                return False, detail
+        try:
+            next_attr = format_agent_attribution(root, next_agent)
+        except ValueError as exc:
+            return False, str(exc)
+        note_core = f"next={next_attr}"
+        if extra:
+            note_core = f"{extra} · {note_core}"
+        n_ok, n_detail, _ = append_notes_helper(
+            root, ssot, item_id, agent=agent, text=note_core, limit=limit
+        )
+        return n_ok, n_detail
+
+    return False, f"unsupported op {op!r}"
+
+
+def flush_outbox(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    max_ops: int | None = None,
+    limit: int = 100,
+) -> tuple[int, str]:
+    """
+    Flush pending entries. Returns (exit_code, summary).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return EXIT_USAGE, "outbox.enabled is false"
+    path = outbox_path(root, cfg)
+    rl = graphql_rate_limit()
+    remaining = rl.get("remaining")
+    min_rem = int(cfg["min_graphql_remaining"])
+    if rl.get("error"):
+        return EXIT_GH, f"cannot read rate_limit: {rl['error']}"
+    try:
+        rem_i = int(remaining) if remaining is not None else -1
+    except (TypeError, ValueError):
+        rem_i = -1
+    if rem_i < min_rem:
+        reset = format_reset_iso(rl.get("reset_epoch"))
+        return (
+            EXIT_GH,
+            f"GraphQL remaining={rem_i} < min={min_rem}; refuse flush until {reset}",
+        )
+
+    cap = int(max_ops if max_ops is not None else cfg["max_flush_per_run"])
+    if cap < 1:
+        cap = 1
+    entries = read_outbox_entries(path)
+    pending_idxs = [i for i, e in enumerate(entries) if str(e.get("status")) == "pending"]
+    done_n = fail_n = 0
+    stopped_early = False
+    backoff = int(cfg["retry_backoff_seconds"])
+
+    applied = 0
+    for idx in pending_idxs:
+        if applied >= cap:
+            break
+        # Re-check remaining mid-batch
+        rl2 = graphql_rate_limit()
+        try:
+            rem2 = int(rl2.get("remaining")) if rl2.get("remaining") is not None else rem_i
+        except (TypeError, ValueError):
+            rem2 = rem_i
+        if rem2 < min_rem:
+            stopped_early = True
+            break
+
+        entry = entries[idx]
+        entry["attempts"] = int(entry.get("attempts") or 0) + 1
+        ok, detail = apply_outbox_entry(root, ssot, entry, limit=limit)
+        if ok:
+            entry["status"] = "done"
+            entry["last_error"] = None
+            done_n += 1
+        else:
+            entry["last_error"] = detail
+            if is_rate_limit_error(detail):
+                entry["status"] = "pending"
+                stopped_early = True
+                write_outbox_entries(path, entries)
+                return (
+                    EXIT_GH,
+                    f"flush stopped on rate-limit after done={done_n}; detail={detail}",
+                )
+            entry["status"] = "failed"
+            fail_n += 1
+            if backoff > 0:
+                time.sleep(backoff)
+        entries[idx] = entry
+        applied += 1
+        write_outbox_entries(path, entries)
+
+    write_outbox_entries(path, entries)
+    left = sum(1 for e in entries if str(e.get("status")) == "pending")
+    summary = (
+        f"flushed done={done_n} failed={fail_n} pending_left={left}"
+        + (" (stopped early: low quota)" if stopped_early else "")
+    )
+    return EXIT_OK, summary

--- a/payload/.ai_infra/mcp_servers/workflow_mcp/README.md
+++ b/payload/.ai_infra/mcp_servers/workflow_mcp/README.md
@@ -37,7 +37,7 @@ External servers: [connect-external-mcp.md](../../docs/operations/connect-extern
 | `workflow_contributors_validate` | validate user settings YAML |
 | `workflow_list_session_agents` | change-index + session-pointer → merged Agent/s |
 | `workflow_integrate_validate` | `.ai_infra/scripts/integration/validate.py` (INT-001…014) |
-| `workflow_drift_validate` | `.ai_infra/scripts/workflow/check_drift.py` (DRIFT-001…008) |
+| `workflow_drift_validate` | `.ai_infra/scripts/workflow/check_drift.py` (DRIFT-001…010 kit-dev; consumer subset) |
 | `workflow_activate` | `.ai_infra/install/cursor_workflow/activate_cli.py` (three-plane install) |
 | `workflow_doc_facts_validate` | `.ai_infra/scripts/architecture/check_doc_facts.py` (DOC-001…006) |
 | `workflow_verify_all` | `.ai_infra/scripts/architecture/verify_all.py` (maintainer matrix) |

--- a/payload/.ai_infra/schemas/github-collaboration.schema.json
+++ b/payload/.ai_infra/schemas/github-collaboration.schema.json
@@ -37,6 +37,33 @@
           "enum": ["board_only", "board_first", "offline_fallback"]
         },
         "fallback": { "type": "string", "enum": ["local_trackers", "none"] },
+        "outbox": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Local JSONL buffer for board writes when GraphQL is rate-limited (not a second SSOT)",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": {
+              "type": "string",
+              "description": "Repo-relative path to board-outbox.jsonl"
+            },
+            "min_graphql_remaining": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Refuse flush (and warn in doctor) below this GraphQL remaining"
+            },
+            "max_flush_per_run": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Max pending ops applied per outbox flush"
+            },
+            "retry_backoff_seconds": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Sleep between flush ops after soft failures"
+            }
+          }
+        },
         "fields": { "type": "object", "additionalProperties": true },
         "conventions": {
           "type": "object",

--- a/payload/.ai_infra/scripts/install/scaffold.py
+++ b/payload/.ai_infra/scripts/install/scaffold.py
@@ -359,6 +359,11 @@ def _scaffold_local(source: Path, target: Path, dry_run: bool, log: list[str]) -
     if updates_src.is_file():
         _copy_file_if_missing(updates_src, updates_dst, dry_run, log)
 
+    continuity_src = exemplars / "continuity-index.md"
+    continuity_dst = history / "continuity-index.md"
+    if continuity_src.is_file():
+        _copy_file_if_missing(continuity_src, continuity_dst, dry_run, log)
+
     arch_stub = target / ".local" / "index-and-planning" / "current" / "architecture.md"
     if not arch_stub.exists() and not dry_run:
         arch_stub.write_text(

--- a/payload/.ai_infra/scripts/pr/merge.py
+++ b/payload/.ai_infra/scripts/pr/merge.py
@@ -29,7 +29,8 @@ _REPO_ROOT = _PR_DIR.parents[2]
 _INSTALL_CW = _REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
 if str(_PR_DIR) not in sys.path:
     sys.path.insert(0, str(_PR_DIR))
-if _INSTALL_CW.is_dir() and str(_INSTALL_CW) not in sys.path:
+if _INSTALL_CW.is_dir() and str(_INSTALL_CW) not in sys.path:  # pragma: no cover
+    # Import-order dependent: often already on path from project_cli tests.
     sys.path.insert(0, str(_INSTALL_CW))
 
 from local_workflow_paths import (

--- a/payload/.ai_infra/scripts/workflow/README.md
+++ b/payload/.ai_infra/scripts/workflow/README.md
@@ -12,7 +12,7 @@ make drift-validate
 
 ## Checks
 
-See `drift_checks.py` — DRIFT-001…008. Profile `kit-dev` (default) or `consumer` (when `STARTER-001` in work-tracker, or `--profile consumer`).
+See `drift_checks.py` — DRIFT-001…010 + 004b on kit-dev (004b/009–010 when `project_ssot.sync_policy: board_only`); consumer profile runs DRIFT-005 + DRIFT-008 only.
 
 **DRIFT-005 on consumer:** When `IMPLEMENTATION-STATUS.md` is absent (normal on plugin installs), the check **PASSes (skip)** — not a consumer failure. A FAIL on missing file indicates an older kit payload (false positive; see `consumer-quickstart.md`).
 

--- a/payload/.ai_infra/scripts/workflow/drift_checks.py
+++ b/payload/.ai_infra/scripts/workflow/drift_checks.py
@@ -1,7 +1,7 @@
 """
 File: drift_checks.py
 Path: .ai_infra/scripts/workflow/drift_checks.py
-Role: Individual DRIFT-001…010 check functions for workflow drift validation.
+Role: Individual DRIFT-001…010 (+004b) check functions for workflow drift validation.
 Used By:
  - .ai_infra/scripts/workflow/check_drift.py
 Depends On:
@@ -235,6 +235,158 @@ def check_drift004(paths: DriftPaths) -> CheckResult:
         severity=Severity.P1,
         passed=passed,
         detail="; ".join(detail_parts),
+    )
+
+
+_ACTIVE_POINTER_STATUSES = frozenset(
+    {"in_progress", "in_review", "ready", "todo", "backlog"}
+)
+_DONE_POINTER_STATUSES = frozenset({"done", "complete", "completed", "closed"})
+
+
+def _normalize_status_token(raw: str) -> str:
+    return re.sub(r"\s+", "_", (raw or "").strip().lower())
+
+
+def _parse_session_board_field(board_cell: str) -> tuple[str | None, str]:
+    """Return (item_id, status_claim) from session-pointer Board cell."""
+    cell = (board_cell or "").strip()
+    if not cell:
+        return None, ""
+    m = re.search(r"(PVTI_[A-Za-z0-9_-]+)", cell)
+    if not m:
+        return None, ""
+    item_id = m.group(1)
+    rest = (cell[: m.start()] + cell[m.end() :]).strip(" -–—|,;")
+    return item_id, rest
+
+
+def _load_ssot_policy(paths: DriftPaths) -> tuple[dict | None, str]:
+    """Load project_ssot dict or None + skip/fail reason."""
+    collab = paths.root / ".local" / "user_settings" / "github.collaboration.yaml"
+    if not collab.is_file():
+        return None, "no github.collaboration.yaml — skipped"
+    try:
+        import yaml
+    except ImportError:
+        return None, "PyYAML missing — skipped"
+    try:
+        data = yaml.safe_load(collab.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        return None, f"cannot parse collab YAML: {exc}"
+    if not isinstance(data, dict):
+        return None, "collab YAML not a mapping — skipped"
+    ssot = data.get("project_ssot")
+    if not isinstance(ssot, dict) or not ssot.get("enabled"):
+        return None, "project_ssot disabled or absent — skipped"
+    return ssot, "ok"
+
+
+def check_drift004b(paths: DriftPaths) -> CheckResult:
+    """
+    Advisory: session-pointer Board id/Status vs export snapshot (board_only).
+    Catches stale 'In progress' pointers when the card is already Done.
+    """
+    ssot, ssot_detail = _load_ssot_policy(paths)
+    if ssot is None:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=ssot_detail,
+        )
+    policy = str(ssot.get("sync_policy") or "")
+    if policy != "board_only":
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"sync_policy={policy!r} — board/session check skipped",
+        )
+
+    session = _read(paths.session_pointer)
+    board_cell = _extract_table_field(session, "Board")
+    item_id, status_claim = _parse_session_board_field(board_cell)
+    if not item_id:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail="no Board item id in session-pointer — skipped",
+        )
+
+    snapshot, snap_detail = _load_board_snapshot(paths)
+    if snapshot is None:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"skipped — {snap_detail}",
+        )
+
+    items = snapshot.get("items") if isinstance(snapshot.get("items"), list) else []
+    match: dict | None = None
+    for item in items:
+        if isinstance(item, dict) and str(item.get("id") or "") == item_id:
+            match = item
+            break
+    if match is None:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=False,
+            detail=f"session Board {item_id} missing from export snapshot",
+        )
+
+    snap_status = _normalize_status_token(
+        str(
+            match.get("status_normalized")
+            or match.get("status")
+            or ""
+        )
+    )
+    pointer_status = _normalize_status_token(status_claim)
+    if not pointer_status:
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"Board {item_id} present in snapshot (status={snap_status or 'unknown'})",
+        )
+
+    if (
+        pointer_status in _ACTIVE_POINTER_STATUSES
+        and snap_status in _DONE_POINTER_STATUSES
+    ):
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=False,
+            detail=(
+                f"session Board {item_id} claims {pointer_status} "
+                f"but snapshot is {snap_status}"
+            ),
+        )
+
+    if pointer_status == snap_status or (
+        pointer_status in _DONE_POINTER_STATUSES
+        and snap_status in _DONE_POINTER_STATUSES
+    ):
+        return CheckResult(
+            check_id="DRIFT-004b",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"session Board {item_id} status aligns with snapshot ({snap_status})",
+        )
+
+    return CheckResult(
+        check_id="DRIFT-004b",
+        severity=Severity.P1,
+        passed=False,
+        detail=(
+            f"session Board {item_id} status={pointer_status} "
+            f"vs snapshot={snap_status}"
+        ),
     )
 
 
@@ -634,6 +786,7 @@ KIT_DEV_CHECKS = (
     check_drift002,
     check_drift003,
     check_drift004,
+    check_drift004b,
     check_drift005,
     check_drift006,
     check_drift007,

--- a/payload/.ai_infra/templates/local-workspace/exemplars/continuity-index.md
+++ b/payload/.ai_infra/templates/local-workspace/exemplars/continuity-index.md
@@ -1,0 +1,24 @@
+<!--
+File: continuity-index.md
+Path: .ai_infra/templates/local-workspace/exemplars/continuity-index.md
+Role: Exemplar for install → .local/index-and-planning/history/continuity-index.md
+Used By:
+ - Agent slice close (board SSOT + local artifact cross-index)
+Depends On:
+ - token-efficiency.md, project-board-collaboration.md
+Notes:
+ - Rolling local index (≥3 calendar days). Board Notes keep full card lifetime.
+-->
+
+# Continuity index (rolling ≥3 days)
+
+Local cross-index between **board item_ids** and **local artifact paths** touched during recent slices.
+Board card **Notes** (timestamped by CLI) retain the full card lifetime from day 1; this file is a
+thin local resume cache only.
+
+**Retention:** keep entries for **≥3 calendar days** (UTC date on each row). On update, drop rows
+older than three days unless still referenced in `change-index.md`.
+
+**Row format:** `YYYY-MM-DDTHH:MM:SSZ · item_id=<PVTI_…> · paths=<comma-separated> · agent=<name> · note=<short>`
+
+(none yet)

--- a/payload/.ai_infra/templates/local-workspace/exemplars/updates-log.md
+++ b/payload/.ai_infra/templates/local-workspace/exemplars/updates-log.md
@@ -8,6 +8,7 @@ Depends On:
  - slice handoffs
 Notes:
  - One line per substantive change; see token-efficiency.md.
+ - New lines start with `YYYY-MM-DDTHH:MM:SSZ` (UTC preferred).
 -->
 
 # Updates log

--- a/payload/.ai_infra/templates/project-board/README.md
+++ b/payload/.ai_infra/templates/project-board/README.md
@@ -18,9 +18,19 @@ Notes:
 |------|-----|-----|
 | `card-body-slice.md` | Agents | `python3 -m cursor_workflow project create-from-template --template slice --title "…"` |
 | `card-body-bug.md` | Agents | `create-from-template --template bug` |
+| `outbox-entry.schema.json` | Agents / CLI | Validate lines in `.local/generated-data/board-outbox.jsonl` |
+| `outbox-entry.example.json` | Docs | Exemplar outbox line (never paste fake `item_id` as `--id`) |
 | `project-readme.md` | **Humans** | Copy into Project settings → README (GitHub UI). Do **not** paste into a terminal. |
 
 Card bodies always include `## Acceptance`, `## Rollback`, and `## Notes` so `validate-item` and Entry/Exit stay consistent.
+
+**Notes format (CLI):** `@github_user/agent · YYYY-MM-DDTHH:MM:SSZ · text` — stamped by `claim`, `handoff`, and `append-notes --agent`. Do not hand-forge timestamps.
+
+| Need | Template / action |
+|------|-------------------|
+| slice / feature work | `create-from-template --template slice` |
+| bug fix | `create-from-template --template bug` |
+| Project README | **Humans only** — paste `project-readme.md` in Project settings UI |
 
 **Do not** paste Project settings labels (`Project name`, `Short description`, `README`, …) into bash — use `cursor_workflow project` recipes instead.
 
@@ -34,3 +44,13 @@ python3 -m cursor_workflow project handoff --last --agent implementer --next ver
 ```
 
 `--last` reads `.local/generated-data/project-last-item.json` (machine-local pointer, not a second Status SSOT).
+
+**Rate-limit outbox (do not hammer GraphQL):**
+
+```bash
+python3 -m cursor_workflow project outbox status
+python3 -m cursor_workflow project queue --op append-notes --last --agent implementer --text "deferred note"
+python3 -m cursor_workflow project outbox flush
+```
+
+When a write returns `EXIT_QUEUED` (6), continue local evidence (`change-index` / handoff line); flush after `gh api rate_limit` recovers. Outbox is **not** a second Status SSOT.

--- a/payload/.ai_infra/templates/project-board/card-body-bug.md
+++ b/payload/.ai_infra/templates/project-board/card-body-bug.md
@@ -9,4 +9,6 @@
 
 ## Notes
 
+<!-- agents: Notes lines are auto-timestamped by CLI -->
+
 {{notes}}

--- a/payload/.ai_infra/templates/project-board/card-body-slice.md
+++ b/payload/.ai_infra/templates/project-board/card-body-slice.md
@@ -8,4 +8,6 @@
 
 ## Notes
 
+<!-- agents: Notes lines are auto-timestamped by CLI -->
+
 {{notes}}

--- a/payload/.ai_infra/templates/project-board/outbox-entry.example.json
+++ b/payload/.ai_infra/templates/project-board/outbox-entry.example.json
@@ -1,0 +1,12 @@
+{
+  "id": "00000000-0000-4000-8000-000000000001",
+  "ts": "2026-07-18T12:00:00Z",
+  "agent": "implementer",
+  "github_user": "@SavinRazvan",
+  "op": "append-notes",
+  "item_id": "PVTI_exampleRealIdFromCreate",
+  "payload": { "text": "queued while GraphQL rate-limited" },
+  "status": "pending",
+  "attempts": 0,
+  "last_error": null
+}

--- a/payload/.ai_infra/templates/project-board/outbox-entry.schema.json
+++ b/payload/.ai_infra/templates/project-board/outbox-entry.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://workflow-kit.local/schemas/board-outbox-entry.schema.json",
+  "title": "BoardOutboxEntry",
+  "type": "object",
+  "required": [
+    "id",
+    "ts",
+    "agent",
+    "github_user",
+    "op",
+    "item_id",
+    "payload",
+    "status",
+    "attempts"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "ts": { "type": "string", "minLength": 1 },
+    "agent": { "type": "string", "minLength": 1 },
+    "github_user": { "type": "string", "minLength": 1 },
+    "op": {
+      "type": "string",
+      "enum": [
+        "append-notes",
+        "set-status",
+        "handoff",
+        "claim",
+        "set-assignee"
+      ]
+    },
+    "item_id": {
+      "type": "string",
+      "pattern": "^PVTI_[A-Za-z0-9_-]+$"
+    },
+    "payload": { "type": "object", "additionalProperties": true },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "done", "failed"]
+    },
+    "attempts": { "type": "integer", "minimum": 0 },
+    "last_error": { "type": ["string", "null"] }
+  }
+}

--- a/payload/.ai_infra/templates/project-board/project-readme.md
+++ b/payload/.ai_infra/templates/project-board/project-readme.md
@@ -7,6 +7,7 @@ This GitHub Project is the **only writable SSOT** for backlog, Status, and multi
 ```bash
 python3 -m cursor_workflow project doctor
 python3 -m cursor_workflow project guide --agent implementer
+python3 -m cursor_workflow project outbox status
 python3 -m cursor_workflow project create-from-template --title "[SLICE] short-name" --template slice --status ready
 python3 -m cursor_workflow project claim --last --agent implementer
 python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review
@@ -14,7 +15,8 @@ python3 -m cursor_workflow project handoff --last --agent implementer --next ver
 
 Use `--last` after create (saved under `.local/generated-data/project-last-item.json`). Do **not** invent or paste placeholder ids from docs.
 
-Notes are attributed as `@github_user/agent` (from `owner.github_user`).
+If writes return EXIT_QUEUED (6) / rate-limit: `project outbox flush` after GraphQL quota recovers — do not retry in a loop.
+Notes are attributed and timestamped by CLI as `@github_user/agent · YYYY-MM-DDTHH:MM:SSZ · text` (from `owner.github_user`). Use `claim` / `handoff` / `append-notes --agent` — do not hand-forge times.
 
 ## Humans only (this UI)
 

--- a/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -44,6 +44,14 @@ project_ssot:
   sync_policy: board_only
   fallback: local_trackers                # local_trackers | none
 
+  # Rate-limit outbox (local buffer — never a second Status SSOT)
+  outbox:
+    enabled: true
+    path: .local/generated-data/board-outbox.jsonl
+    min_graphql_remaining: 200
+    max_flush_per_run: 10
+    retry_backoff_seconds: 30
+
   # Project V2 single-select fields (replace ids from field-list)
   fields:
     status:

--- a/payload/.cursor/agents/enterprise-auditor.md
+++ b/payload/.cursor/agents/enterprise-auditor.md
@@ -8,11 +8,13 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context for the audit slice (claim/create audit card if missing); else `session-pointer.md` + `change-index.md`.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + board context. If no audit card: `create-from-template --template slice --title "[AUDIT] …" --status ready` then `claim --last --agent enterprise-auditor`. Else `session-pointer.md` + `change-index.md`.
 
-**Exit:** Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
 
@@ -23,6 +25,7 @@ Act as a **Principal Enterprise Architect** using **strict evidence-only discipl
 ## Read first (scope + workflow)
 
 - `.cursor/skills/enterprise-architecture-audit/SKILL.md` — **full operating protocol, phases, scorecard, and output contract**
+- `.ai_infra/templates/project-board/README.md` — when creating audit cards
 - `AGENTS.md`, `README.md`
 - `.local/index-and-planning/current/plan.md`, `work-tracker.md` (if present — do not assume content)
 - Project `docs/architecture/` (local stub: `.local/.../current/architecture.md`)
@@ -49,7 +52,9 @@ When project overlays exist (`overlays/rules/*.mdc`), cross-check claims against
 
 ## Handoff format
 
-Audit date • artifact paths • scoring summary + confidence • top 5 ROI • P0/P1 count • unknowns • suggested next agent (implementer / test-runner / maintainer)
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -22,7 +22,11 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
 5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+
+**STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.
 
 **Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
 
@@ -32,8 +36,9 @@ Deliver **small, reversible** slices with production quality: clear module bound
 
 - `.cursor/skills/implementation-execution-loop/SKILL.md` — slice lifecycle protocol
 - `.cursor/skills/project-board-ssot/SKILL.md` — when `project_ssot.enabled`
+- `.ai_infra/templates/project-board/README.md` — when creating cards
 - `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `.local/index-and-planning/current/architecture.md` (experiment stub)
+- `.local/index-and-planning/current/architecture.md` (architecture stub)
 - Fallback only: `session-pointer.md`, `plan.md`, `work-tracker.md`
 
 When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. After meaningful coverage runs: run **`make coverage-index`** when coverage mattered.  
@@ -49,11 +54,13 @@ When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. Afte
 
 ## Architecture
 
-Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Experiment precedence: `overlays/rules/project-ssot-precedence.mdc`.
+Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Board SSOT precedence: `overlays/rules/project-ssot-precedence.mdc`.
 
 ## Handoff format
 
-Slice name • item_id • Status • what changed • commands pass/fail • blockers • next step
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/integrator-mas-agent.md
+++ b/payload/.cursor/agents/integrator-mas-agent.md
@@ -14,24 +14,29 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card. Else `session-pointer.md` then integration skill.
+**Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + skill `.cursor/skills/mas-infrastructure-integration/SKILL.md` (and `project-board-ssot` when touching board wiring). Claim/create integration card (`claim --last` after create). Else `session-pointer.md` then integration skill.
 
-**Exit:** **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+
+**STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.
 
 ## Read first (evidence before edits)
 
 | Order | Path | Why |
 |-------|------|-----|
 | 1 | `.cursor/skills/mas-infrastructure-integration/SKILL.md` | Integration procedure (canonical) |
-| 2 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
-| 3 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
-| 4 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
-| 5 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
-| 6 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
-| 7 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
-| 8 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
+| 2 | `.ai_infra/templates/project-board/README.md` | When creating board cards |
+| 3 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
+| 4 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
+| 5 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
+| 6 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
+| 7 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
+| 8 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
+| 9 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
 
 **Skip** `.local/generated-data/**` unless validating coverage exports.
 
@@ -47,7 +52,7 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 ## Loop (one integration slice)
 
 1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
+2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` / `claim --last --agent integrator-mas-agent`); put Acceptance/Rollback on the card body; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
 3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
 4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
 5. **Verify** — `python -m cursor_workflow contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
@@ -72,7 +77,9 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 
 ## Handoff format
 
-Integration type • files touched • MAS-integrated vs independent • commands PASS/FAIL • registry/pipeline updates • next agent
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -12,24 +12,27 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `project-board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 ## Role
 
-Own **board triage and Status transitions** for the experiment Project SSOT. Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines.
+Own **board triage and Status transitions** for the product Project SSOT (`mas-workflow-kit-project-ssot`). Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines.
 
 ## Read first
 
 - `.cursor/skills/project-board-ssot/SKILL.md`
+- `.ai_infra/templates/project-board/README.md` — when creating cards
 - `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `HANDOFF.md` §1 / §3.2 (experiment north star)
+- `HANDOFF.md` §1 (STANDALONE product + board SSOT)
 - `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
 ## Loop
 
 1. `python -m cursor_workflow project status --directory .`
 2. `python -m cursor_workflow project list --status ready --directory .` (or backlog)
-3. Claim with `set-status --to in_progress` or create with `project create`
+3. Prefer Pattern A: `create-from-template --template slice|bug` then `claim --last --agent project-board` (or `claim --id <real PVTI_>`). Use `--template bug` for defect/`fix/` work. Avoid raw multi-step claim unless atomics are required.
 4. Print handoff line for implementer: item id, title, next Status target
 5. **Verify:** CLI exit 0 + board list reflects change
 
@@ -44,7 +47,9 @@ Own **board triage and Status transitions** for the experiment Project SSOT. Han
 
 ## Handoff format
 
-slice • item_id • Status before/after • CLI PASS/FAIL • next agent (usually implementer)
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -10,9 +10,11 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
 
-**Exit:** Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Research corpus indexes under `_research_results/`. When a **research board card** exists: **must** `set-status --to done` and put corpus paths in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** skill § Template routing when a research card is needed; Notes timestamps via CLI; do not hand-forge times.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.
 
@@ -45,7 +47,9 @@ Research manifest/enrichment scripts live in **project overlays** (pack-specific
 
 ## Handoff format
 
-Slice ID • files touched • evidence added • backlog status • next slice
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -10,9 +10,11 @@ description: Module-focused tests, regressions, coverage.
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/project-board-ssot/SKILL.md` when board SSOT is on.
 
-**Exit:** **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.
@@ -21,6 +23,12 @@ description: Module-focused tests, regressions, coverage.
 - Strategy detail: `.cursor/skills/test-module-coverage/SKILL.md`.
 
 Report: tests added/updated • scope run • gaps • `test-index.md` / `test-plan.md` updates if any.
+
+## Handoff format
+
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -10,9 +10,11 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Entry:** If `project_ssot.enabled` → `python -m cursor_workflow project status` + related board card (read Notes for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
 
-**Exit:** Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.
@@ -25,6 +27,12 @@ description: Claims vs evidence; minimal high-signal checks.
 5. Output: passed • failed • missing • **one** next action.
 
 Do not approve merge readiness without artifacts under `.local/workflow-artifacts/pr/` when the maintainer workflow is in play (`.ai_infra/scripts/pr/local_workflow_paths.py`). Flag drift vs `AGENTS.md` and `.cursor/rules/*`.
+
+## Handoff format
+
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/agents/workflow-drift-guard.md
+++ b/payload/.cursor/agents/workflow-drift-guard.md
@@ -10,9 +10,11 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Entry:** If `project_ssot.enabled` → **must** `python -m cursor_workflow project status` and `project list --status in_progress` (board vs tracker dual-write context; cite board Status in findings). Else `session-pointer.md`.
 
-**Exit:** Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+**Exit:** Prefer `handoff --last` / `claim --last` after create. Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **project-board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
 
-**Board rights:** Status + Notes on the card you touch. Prefer `project claim` / `project handoff --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
@@ -37,7 +39,9 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 ## Handoff format
 
-drift profile • P0/P1/P2 counts • board Status cited • item_id (if any) · next=project-board|implementer|…
+```text
+item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
+```
 
 ## MCP integration
 

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -12,8 +12,11 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.
+- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
+- Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.

--- a/payload/.cursor/skills/implementation-execution-loop/SKILL.md
+++ b/payload/.cursor/skills/implementation-execution-loop/SKILL.md
@@ -20,7 +20,7 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Steps
 
-1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`set-status --to in_progress`). Else read plan + tracker; one task `in_progress` locally.
+1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`. Else read plan + tracker; one task `in_progress` locally.
 2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -38,7 +38,7 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent>`. Print handoff line. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
 | **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
 Handoff line (chat + card Notes):
@@ -77,7 +77,7 @@ Multi-collaborator: each human’s `owner.github_user` namespaces their agents (
 
 1. One primary **In progress** per **human assignee** — do not steal others'.
 2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent>` via `append-notes --agent`.
+3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (or `claim`/`handoff` recipes).
 4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
 5. Humans own views, workflows, README, Insights, status updates.
 6. Read-only `project export` (if used) never writes Status.
@@ -116,6 +116,22 @@ Ready → In progress → In review → Done
 
 Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (not into a shell).
 
+### Template routing
+
+| Need | Who | Template / action |
+|------|-----|-------------------|
+| slice / feature / `chore/` | implementer, project-board, integrator | `create-from-template --template slice` |
+| bug / defect / `fix/` | implementer, project-board | `create-from-template --template bug` |
+| audit pass | enterprise-auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
+| consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
+| Project README | **Humans only** | paste `project-readme.md` in Project settings UI |
+
+Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
+
+**Notes format:** `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · text` — auto-stamped by CLI on `claim`, `handoff`, and `append-notes --agent`. Idempotent when timestamp already present. Do not hand-forge times.
+
+**Local continuity:** append UTC-prefixed lines to `history/updates-log.md`; optional row in `history/continuity-index.md` (rolling ≥3 days). Board Notes retain full card lifetime.
+
 1. **Doctor / guide:** `project doctor` · `project guide --agent implementer`
 2. **Status / list:** `project status` · `project list [--status ready|in_progress|in_review]`
 3. **Create:** `project create-from-template --title "[SLICE] short-name" --template slice --status ready`
@@ -125,7 +141,9 @@ Human Project README: paste `.ai_infra/templates/project-board/project-readme.md
 7. **Atomics (power use):** `set-status` · `set-field` · `append-notes --agent` · `get --last` · `export`
 8. **Verify:** `project list` + handoff line; `project last` prints saved id
 
-Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation.
+Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation · `6` queued (outbox; soft-success — flush later).
+
+Rate-limit: `project outbox status` / `project queue` / `project outbox flush` — see `project_ssot.outbox` in collaboration YAML.
 
 ## Dual-write ban
 
@@ -135,6 +153,8 @@ When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in 
 
 - [ ] Entry read board (or explicit offline fallback)
 - [ ] Exit updated Status (or Notes + next agent if still In progress)
+- [ ] If EXIT_QUEUED: confirmed via `outbox status`; no API hammering
+- [ ] Handoff line printed with real item_id
 - [ ] Handoff line printed when another agent continues
 - [ ] No dual-write; no edits to Project views/workflows/README/Insights
 

--- a/payload/.cursor/skills/workflow-drift-audit/SKILL.md
+++ b/payload/.cursor/skills/workflow-drift-audit/SKILL.md
@@ -19,7 +19,7 @@ Notes:
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
+Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **session Board vs export (DRIFT-004b)**, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
 
 ## When
 
@@ -31,7 +31,7 @@ Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer i
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
 3. Capture profile, check IDs, severities, and details from output.
 4. Write artifacts under `.local/workflow-artifacts/drift/` only.
 5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to project-board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -12,8 +12,11 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` GATES), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
 - Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `HANDOFF.md`.
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent>` (user → their agents) via `append-notes --agent`.
+- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
+- Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.

--- a/skills/implementation-execution-loop/SKILL.md
+++ b/skills/implementation-execution-loop/SKILL.md
@@ -20,7 +20,7 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Steps
 
-1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`set-status --to in_progress`). Else read plan + tracker; one task `in_progress` locally.
+1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`. Else read plan + tracker; one task `in_progress` locally.
 2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -38,7 +38,7 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent>`. Print handoff line. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
 | **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
 Handoff line (chat + card Notes):
@@ -77,7 +77,7 @@ Multi-collaborator: each human’s `owner.github_user` namespaces their agents (
 
 1. One primary **In progress** per **human assignee** — do not steal others'.
 2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent>` via `append-notes --agent`.
+3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (or `claim`/`handoff` recipes).
 4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
 5. Humans own views, workflows, README, Insights, status updates.
 6. Read-only `project export` (if used) never writes Status.
@@ -116,6 +116,22 @@ Ready → In progress → In review → Done
 
 Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (not into a shell).
 
+### Template routing
+
+| Need | Who | Template / action |
+|------|-----|-------------------|
+| slice / feature / `chore/` | implementer, project-board, integrator | `create-from-template --template slice` |
+| bug / defect / `fix/` | implementer, project-board | `create-from-template --template bug` |
+| audit pass | enterprise-auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
+| consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
+| Project README | **Humans only** | paste `project-readme.md` in Project settings UI |
+
+Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
+
+**Notes format:** `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · text` — auto-stamped by CLI on `claim`, `handoff`, and `append-notes --agent`. Idempotent when timestamp already present. Do not hand-forge times.
+
+**Local continuity:** append UTC-prefixed lines to `history/updates-log.md`; optional row in `history/continuity-index.md` (rolling ≥3 days). Board Notes retain full card lifetime.
+
 1. **Doctor / guide:** `project doctor` · `project guide --agent implementer`
 2. **Status / list:** `project status` · `project list [--status ready|in_progress|in_review]`
 3. **Create:** `project create-from-template --title "[SLICE] short-name" --template slice --status ready`
@@ -125,7 +141,9 @@ Human Project README: paste `.ai_infra/templates/project-board/project-readme.md
 7. **Atomics (power use):** `set-status` · `set-field` · `append-notes --agent` · `get --last` · `export`
 8. **Verify:** `project list` + handoff line; `project last` prints saved id
 
-Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation.
+Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation · `6` queued (outbox; soft-success — flush later).
+
+Rate-limit: `project outbox status` / `project queue` / `project outbox flush` — see `project_ssot.outbox` in collaboration YAML.
 
 ## Dual-write ban
 
@@ -135,6 +153,8 @@ When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in 
 
 - [ ] Entry read board (or explicit offline fallback)
 - [ ] Exit updated Status (or Notes + next agent if still In progress)
+- [ ] If EXIT_QUEUED: confirmed via `outbox status`; no API hammering
+- [ ] Handoff line printed with real item_id
 - [ ] Handoff line printed when another agent continues
 - [ ] No dual-write; no edits to Project views/workflows/README/Insights
 

--- a/skills/workflow-drift-audit/SKILL.md
+++ b/skills/workflow-drift-audit/SKILL.md
@@ -19,7 +19,7 @@ Notes:
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
+Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **session Board vs export (DRIFT-004b)**, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `enterprise-auditor` or `verifier`.
 
 ## When
 
@@ -31,7 +31,7 @@ Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer i
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
 3. Capture profile, check IDs, severities, and details from output.
 4. Write artifacts under `.local/workflow-artifacts/drift/` only.
 5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to project-board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.

--- a/tests/modules/install/test_project_cli.py
+++ b/tests/modules/install/test_project_cli.py
@@ -26,6 +26,8 @@ if str(_PKG_DIR) not in sys.path:
 
 import project_cli  # noqa: E402
 
+VALID_PVTI = "PVTI_lAHOBl46-84A9KZxcli01"
+
 
 def _write_collab(tmp: Path, ssot: dict) -> None:
     path = tmp / ".local" / "user_settings" / "github.collaboration.yaml"
@@ -40,7 +42,6 @@ def _write_collab(tmp: Path, ssot: dict) -> None:
     path.write_text(yaml.safe_dump(data), encoding="utf-8")
     # Minimal pr scripts so _import_user_settings can find the package when using real load —
     # tests monkeypatch load instead when needed.
-
 
 SAMPLE_SSOT = {
     "enabled": True,
@@ -121,14 +122,14 @@ def test_cmd_set_status_maps_and_calls_gh(monkeypatch: pytest.MonkeyPatch, tmp_p
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
     args = argparse.Namespace(
         directory=tmp_path,
-        id="PVTI_test",
+        id=VALID_PVTI,
         to="in_progress",
     )
     assert project_cli.cmd_set_status(args) == 0
     assert calls
     assert "--single-select-option-id" in calls[0]
     assert "47fc9ee4" in calls[0]
-    assert "PVTI_test" in calls[0]
+    assert VALID_PVTI in calls[0]
     # Status must not GraphQL-resolve to DI_
     assert not any(c[:2] == ["api", "graphql"] for c in calls)
     assert not any(any(str(a).startswith("DI_") for a in c) for c in calls)
@@ -191,7 +192,7 @@ def test_cmd_get(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     payload = {
         "items": [
             {
-                "id": "PVTI_x",
+                "id": VALID_PVTI,
                 "title": "Slice",
                 "status": "In progress",
                 "content": {"body": "## Notes\n\nhello"},
@@ -204,7 +205,7 @@ def test_cmd_get(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
-    args = argparse.Namespace(directory=tmp_path, id="PVTI_x", limit=50, json=True)
+    args = argparse.Namespace(directory=tmp_path, id=VALID_PVTI, limit=50, json=True)
     assert project_cli.cmd_get(args) == 0
 
 
@@ -212,7 +213,7 @@ def test_cmd_append_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     payload = {
         "items": [
             {
-                "id": "PVTI_x",
+                "id": VALID_PVTI,
                 "title": "Slice",
                 "status": "In review",
                 "content": {"body": "## Acceptance\n\nok"},
@@ -223,7 +224,7 @@ def test_cmd_append_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     gql = {
         "data": {
             "node": {
-                "id": "PVTI_x",
+                "id": VALID_PVTI,
                 "content": {
                     "__typename": "DraftIssue",
                     "id": "DI_draft_x",
@@ -247,7 +248,7 @@ def test_cmd_append_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
     args = argparse.Namespace(
         directory=tmp_path,
-        id="PVTI_x",
+        id=VALID_PVTI,
         text="Merged: url @ sha",
         agent="implementer",
         limit=50,
@@ -479,11 +480,13 @@ def test_cmd_append_notes_idempotent_skip_with_di_resolve(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Idempotent skip must not call item-edit even when DI resolve would run."""
-    note = "@test/implementer · Merged: https://example/pull/1 @ abc"
+    fixed_ts = "2026-07-18T10:14:40Z"
+    monkeypatch.setattr(project_cli, "utc_note_timestamp", lambda: fixed_ts)
+    note = f"@test/implementer · {fixed_ts} · Merged: https://example/pull/1 @ abc"
     payload = {
         "items": [
             {
-                "id": "PVTI_x",
+                "id": VALID_PVTI,
                 "title": "Slice",
                 "status": "In review",
                 "content": {"body": f"## Notes\n\n- {note}"},
@@ -520,7 +523,7 @@ def test_cmd_append_notes_idempotent_skip_with_di_resolve(
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
     monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
     args = argparse.Namespace(
-        directory=tmp_path, id="PVTI_x", text=note, agent="implementer", limit=50
+        directory=tmp_path, id=VALID_PVTI, text=note, agent="implementer", limit=50
     )
     assert project_cli.cmd_append_notes(args) == 0
     assert not any(c[:2] == ["project", "item-edit"] for c in calls)
@@ -530,16 +533,48 @@ def test_cmd_append_notes_idempotent_skip_with_di_resolve(
 def test_format_agent_attribution_and_note_line(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    fixed_ts = "2026-07-18T10:14:40Z"
     monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@SavinRazvan")
+    monkeypatch.setattr(project_cli, "utc_note_timestamp", lambda: fixed_ts)
     assert project_cli.format_agent_attribution(tmp_path, "implementer") == (
         "@SavinRazvan/implementer"
     )
     line = project_cli.format_note_line(tmp_path, "implementer", "claimed")
-    assert line == "@SavinRazvan/implementer · claimed"
-    same = project_cli.format_note_line(
+    assert line == f"@SavinRazvan/implementer · {fixed_ts} · claimed"
+    stamped = project_cli.format_note_line(
+        tmp_path,
+        "implementer",
+        f"@SavinRazvan/implementer · {fixed_ts} · claimed",
+    )
+    assert stamped == f"@SavinRazvan/implementer · {fixed_ts} · claimed"
+    restamped = project_cli.format_note_line(
+        tmp_path,
+        "implementer",
+        f"@SavinRazvan/implementer · {fixed_ts} · claimed",
+    )
+    assert restamped == stamped
+
+
+def test_format_note_line_adds_timestamp_to_existing_attribution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fixed_ts = "2026-07-18T10:14:40Z"
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@SavinRazvan")
+    monkeypatch.setattr(project_cli, "utc_note_timestamp", lambda: fixed_ts)
+    line = project_cli.format_note_line(
         tmp_path, "implementer", "@SavinRazvan/implementer · claimed"
     )
-    assert same == "@SavinRazvan/implementer · claimed"
+    assert line == f"@SavinRazvan/implementer · {fixed_ts} · claimed"
+
+
+def test_format_note_line_empty_text_stamps_attribution_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fixed_ts = "2026-07-18T10:14:40Z"
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@SavinRazvan")
+    monkeypatch.setattr(project_cli, "utc_note_timestamp", lambda: fixed_ts)
+    line = project_cli.format_note_line(tmp_path, "implementer", "")
+    assert line == f"@SavinRazvan/implementer · {fixed_ts}"
 
 
 def test_cmd_append_notes_requires_agent(
@@ -547,7 +582,7 @@ def test_cmd_append_notes_requires_agent(
 ) -> None:
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
     args = argparse.Namespace(
-        directory=tmp_path, id="PVTI_x", text="no agent", agent="", limit=50
+        directory=tmp_path, id=VALID_PVTI, text="no agent", agent="", limit=50
     )
     assert project_cli.cmd_append_notes(args) == 2
 
@@ -558,7 +593,7 @@ def test_set_item_assignee_draft_fails(monkeypatch: pytest.MonkeyPatch) -> None:
         "resolve_item_content",
         lambda *a, **k: ("draft", "DI_x", {"title": "T"}, None),
     )
-    ok, detail = project_cli.set_item_assignee(SAMPLE_SSOT, "PVTI_x", "SavinRazvan")
+    ok, detail = project_cli.set_item_assignee(SAMPLE_SSOT, VALID_PVTI, "SavinRazvan")
     assert not ok
     assert "DraftIssue" in detail
 
@@ -581,7 +616,7 @@ def test_set_item_assignee_issue(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     monkeypatch.setattr(project_cli, "run_gh", fake_gh)
-    ok, detail = project_cli.set_item_assignee(SAMPLE_SSOT, "PVTI_x", "@alice")
+    ok, detail = project_cli.set_item_assignee(SAMPLE_SSOT, VALID_PVTI, "@alice")
     assert ok
     assert detail == "alice"
     assert calls[0][:3] == ["issue", "edit", "42"]

--- a/tests/modules/install/test_project_cli_coverage.py
+++ b/tests/modules/install/test_project_cli_coverage.py
@@ -1,0 +1,2328 @@
+"""
+File: test_project_cli_coverage.py
+Path: tests/modules/install/test_project_cli_coverage.py
+Role: Bulk unit tests for project_cli.py helpers and command edge paths toward 100% coverage.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/project_cli.py
+ - tests/modules/install/test_project_cli.py (SAMPLE_SSOT)
+Notes:
+ - Monkeypatches run_gh, load_project_ssot, GraphQL helpers — no live board.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PKG_DIR = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+if str(_PKG_DIR) not in sys.path:
+    sys.path.insert(0, str(_PKG_DIR))
+
+import project_cli  # noqa: E402
+from test_project_cli import SAMPLE_SSOT, VALID_PVTI, _write_collab  # noqa: E402
+
+VALID_ITEM = VALID_PVTI
+VALID_ITEM_B = "PVTI_lAHOBl46-84A9KZxcli02"
+VALID_ITEM_C = "PVTI_lAHOBl46-84A9KZxcli03"
+
+
+def _ensure_pr_scripts(tmp_path: Path) -> None:
+    """Copy user_settings package so load_project_ssot can import it."""
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr"
+    dst = tmp_path / ".ai_infra" / "scripts" / "pr"
+    dst.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "user_settings.py",
+        "user_settings_load.py",
+        "user_settings_resolve.py",
+        "user_settings_render.py",
+        "local_workflow_paths.py",
+    ):
+        file_src = src / name
+        if file_src.is_file():
+            (dst / name).write_text(file_src.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _ssot(**overrides: object) -> dict:
+    data = json.loads(json.dumps(SAMPLE_SSOT))
+    data["conventions"] = {
+        **data.get("conventions", {}),
+        "body_sections": ["Acceptance", "Rollback", "Notes"],
+        "require_attribution_on_exit": True,
+        "one_in_progress_per_assignee": True,
+        "claim": "set_assignee",
+    }
+    data.update(overrides)
+    if "conventions" in overrides:
+        data["conventions"] = {**data["conventions"], **overrides["conventions"]}  # type: ignore[arg-type]
+    return data
+
+
+def _board_item(
+    item_id: str = VALID_ITEM,
+    *,
+    status: str = "Ready",
+    body: str | None = None,
+    title: str = "Slice",
+) -> dict:
+    default_body = (
+        "## Acceptance\n\nx\n\n## Rollback\n\ny\n\n## Notes\n\n- @test/implementer · claimed\n"
+    )
+    return {
+        "id": item_id,
+        "title": title,
+        "status": status,
+        "content": {"body": body if body is not None else default_body},
+    }
+
+
+def _patch_ssot(monkeypatch: pytest.MonkeyPatch, ssot: dict | None = None) -> dict:
+    cfg = ssot or _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (cfg, []))
+    return cfg
+
+
+# --- helpers / low-level ---
+
+
+def test_validate_card_body_skips_blank_section() -> None:
+    assert project_cli.validate_card_body("## Acceptance\n", ["", "Acceptance"]) == []
+
+
+def test_load_card_template_unknown_and_missing(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown template"):
+        project_cli.load_card_template(REPO_ROOT, "nope")
+    missing_dir = tmp_path / ".ai_infra" / "templates" / "project-board"
+    missing_dir.mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        project_cli.load_card_template(tmp_path, "slice")
+
+
+def test_load_last_item_id_corrupt_and_empty(tmp_path: Path) -> None:
+    path = project_cli.session_last_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("not-json", encoding="utf-8")
+    assert project_cli.load_last_item_id(tmp_path) is None
+    path.write_text('["not", "dict"]', encoding="utf-8")
+    assert project_cli.load_last_item_id(tmp_path) is None
+    path.write_text('{"item_id": "  "}', encoding="utf-8")
+    assert project_cli.load_last_item_id(tmp_path) is None
+
+
+def test_is_placeholder_item_id_edges() -> None:
+    assert project_cli.is_placeholder_item_id("")
+    assert project_cli.is_placeholder_item_id("PVTI_")
+    assert project_cli.is_placeholder_item_id("DI_short")
+    assert project_cli.is_placeholder_item_id("PVTI_short")
+
+
+def test_resolve_item_id_arg_edges(tmp_path: Path) -> None:
+    project_cli.save_last_item_id(tmp_path, VALID_ITEM)
+    ns = argparse.Namespace(id=VALID_ITEM, last=True)
+    iid, code = project_cli.resolve_item_id_arg(tmp_path, ns, "test")
+    assert iid is None and code == project_cli.EXIT_USAGE
+    ns2 = argparse.Namespace(id="", last=True)
+    iid2, code2 = project_cli.resolve_item_id_arg(tmp_path / "empty", ns2, "test")
+    assert iid2 is None and code2 == project_cli.EXIT_USAGE
+    ns3 = argparse.Namespace(id="", last=False)
+    iid3, code3 = project_cli.resolve_item_id_arg(tmp_path, ns3, "test")
+    assert iid3 is None and code3 == project_cli.EXIT_USAGE
+
+
+def test_load_project_ssot_paths(tmp_path: Path) -> None:
+    ssot, errs = project_cli.load_project_ssot(tmp_path)
+    assert ssot is None
+    assert errs and "missing" in errs[0]
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, _ssot())
+    ssot2, errs2 = project_cli.load_project_ssot(tmp_path)
+    assert errs2 == []
+    assert ssot2 is not None and ssot2.get("enabled") is True
+
+
+def test_load_project_ssot_missing_block(tmp_path: Path) -> None:
+    path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text(yaml.safe_dump({"version": 1, "owner": {"github_user": "@x"}}), encoding="utf-8")
+    ssot, errs = project_cli.load_project_ssot(tmp_path)
+    assert ssot is None
+    assert any("project_ssot" in e for e in errs)
+
+
+def test_require_enabled_missing_keys_and_no_fallback_msg() -> None:
+    ssot = {**SAMPLE_SSOT, "enabled": True, "owner": ""}
+    assert project_cli.require_enabled(ssot)
+    ssot2 = {**SAMPLE_SSOT, "enabled": False, "fallback": "none"}
+    msg = project_cli.require_enabled(ssot2)[0]
+    assert "fallback" not in msg
+
+
+def test_normalize_github_handle_empty() -> None:
+    assert project_cli.normalize_github_handle("") == ""
+    assert project_cli.normalize_github_handle("alice") == "@alice"
+
+
+def test_resolve_human_github_user(tmp_path: Path) -> None:
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, _ssot())
+    assert project_cli.resolve_human_github_user(tmp_path) == "@test"
+
+
+def test_format_agent_attribution_errors(tmp_path: Path) -> None:
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "")
+    with pytest.raises(ValueError, match="github_user missing"):
+        project_cli.format_agent_attribution(tmp_path, "implementer")
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    with pytest.raises(ValueError, match="agent name required"):
+        project_cli.format_agent_attribution(tmp_path, "")
+    monkeypatch.undo()
+
+
+def test_set_item_assignee_edges(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: (None, None, None, "resolve failed"),
+    )
+    ok, detail = project_cli.set_item_assignee(_ssot(), VALID_ITEM, "alice")
+    assert not ok and "resolve failed" in detail
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("issue", "1", {"repo": "o/r"}, None),
+    )
+    ok2, detail2 = project_cli.set_item_assignee(_ssot(), VALID_ITEM, "")
+    assert not ok2 and "login empty" in detail2
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="assignee fail"),
+    )
+    ok3, detail3 = project_cli.set_item_assignee(_ssot(), VALID_ITEM, "alice")
+    assert not ok3 and "assignee fail" in detail3
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("other", "x", {}, None),
+    )
+    ok4, detail4 = project_cli.set_item_assignee(_ssot(), VALID_ITEM, "alice")
+    assert not ok4 and "unsupported content kind" in detail4
+
+
+def test_resolve_field_option_id_and_status_field_id_errors() -> None:
+    ssot_no_field = json.loads(json.dumps(_ssot()))
+    del ssot_no_field["fields"]["priority"]
+    with pytest.raises(KeyError, match="fields.priority missing"):
+        project_cli.resolve_field_option_id(ssot_no_field, "priority", "p1")
+    ssot = json.loads(json.dumps(_ssot()))
+    ssot["fields"]["priority"] = {"options": {"p0": "x"}}
+    with pytest.raises(KeyError, match="field_id missing"):
+        project_cli.resolve_field_option_id(ssot, "priority", "p0")
+    with pytest.raises(KeyError, match="unknown size"):
+        project_cli.resolve_field_option_id(_ssot(), "size", "xxl")
+    ssot2 = json.loads(json.dumps(_ssot()))
+    del ssot2["fields"]["status"]["field_id"]
+    with pytest.raises(KeyError, match="status.field_id missing"):
+        project_cli.status_field_id(ssot2)
+
+
+def test_create_draft_item_regex_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout=f"created {VALID_ITEM_B}", stderr=""
+        ),
+    )
+    item_id, raw, err = project_cli.create_draft_item(_ssot(), "T", "")
+    assert err is None
+    assert item_id == VALID_ITEM_B
+    assert raw is not None
+
+
+def test_create_draft_item_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="create failed"),
+    )
+    item_id, raw, err = project_cli.create_draft_item(_ssot(), "T", "body")
+    assert item_id is None and raw is None and "create failed" in (err or "")
+
+
+def test_in_progress_conflicts_assignee_shapes() -> None:
+    items = [
+        "not-a-dict",
+        {
+            "id": VALID_ITEM_B,
+            "status": "In Progress",
+            "title": "Other",
+            "content": {"body": ""},
+            "assignees": [{"login": "test"}, "bob"],
+        },
+        {
+            "id": VALID_ITEM_C,
+            "status": "In Progress",
+            "title": "@test/implementer work",
+            "content": {"body": ""},
+            "assignees": "single-string",
+        },
+    ]
+    conflicts = project_cli.in_progress_conflicts_for_user(
+        items, user_handle="@test", exclude_id=VALID_ITEM
+    )
+    assert len(conflicts) == 2
+
+
+def test_append_notes_helper_edges(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    ssot_off = {**ssot, "conventions": {**ssot["conventions"], "require_attribution_on_exit": False}}
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "list failed"),
+    )
+    ok, detail, code = project_cli.append_notes_helper(
+        tmp_path, ssot_off, VALID_ITEM, agent="", text="plain", limit=10
+    )
+    assert not ok and code == project_cli.EXIT_GH
+    monkeypatch.setattr(project_cli, "fetch_project_items", lambda *a, **k: ([], None))
+    ok2, detail2, code2 = project_cli.append_notes_helper(
+        tmp_path, ssot, VALID_ITEM, agent="", text="x", limit=10
+    )
+    assert not ok2 and code2 == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_human_github_user",
+        lambda root: "",
+    )
+    ok3, detail3, code3 = project_cli.append_notes_helper(
+        tmp_path, ssot, VALID_ITEM, agent="implementer", text="x", limit=10
+    )
+    assert not ok3 and code3 == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    ok4, detail4, code4 = project_cli.append_notes_helper(
+        tmp_path, ssot, "PVTI_lAHOBl46-84A9KZxmissing", agent="implementer", text="x", limit=10
+    )
+    assert not ok4 and code4 == project_cli.EXIT_NOT_FOUND
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (False, "edit boom"),
+    )
+    ok5, detail5, code5 = project_cli.append_notes_helper(
+        tmp_path, ssot, VALID_ITEM, agent="implementer", text="new note", limit=10
+    )
+    assert not ok5 and code5 == project_cli.EXIT_GH
+
+
+def test_latest_notes_line_and_attributed() -> None:
+    assert project_cli.latest_notes_line("no notes section") is None
+    body = "## Notes\n\nhello\n\n## Other\n\n- bullet"
+    assert project_cli.latest_notes_line(body) is None
+    assert not project_cli.notes_line_attributed(None)
+    assert not project_cli.notes_line_attributed("plain text")
+
+
+def test_normalize_status_and_item_helpers() -> None:
+    assert project_cli._normalize_status("in progress") == "in_progress"
+    assert project_cli._normalize_status("review") == "in_review"
+    assert project_cli._item_body({"body": "flat"}) == "flat"
+    assert project_cli._item_body({"content": {"body": 123}}) == ""
+    assert project_cli._item_title({"content": {"title": "nested"}}) == "nested"
+    assert project_cli._item_title({}) == ""
+
+
+def test_append_notes_to_body_empty_and_before_heading() -> None:
+    body, changed = project_cli.append_notes_to_body("x", "  ")
+    assert not changed
+    src = "## Notes\n\n- first\n\n## Acceptance\n\nrest"
+    new_body, changed2 = project_cli.append_notes_to_body(src, "second")
+    assert changed2
+    assert "- second" in new_body
+    assert new_body.index("- second") < new_body.index("## Acceptance")
+
+
+def test_find_items_mentioning_pr_no_match() -> None:
+    items = [_board_item(body="unrelated")]
+    assert project_cli.find_items_mentioning_pr(items, pr_number="999", pr_url="") == []
+
+
+def test_fetch_project_items_edges(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="list err"),
+    )
+    items, err = project_cli.fetch_project_items(_ssot(), limit=5)
+    assert items == [] and "list err" in (err or "")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
+    )
+    items2, err2 = project_cli.fetch_project_items(_ssot(), limit=5)
+    assert items2 == [] and "invalid JSON" in (err2 or "")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout='{"items": "bad"}', stderr=""),
+    )
+    items3, err3 = project_cli.fetch_project_items(_ssot(), limit=5)
+    assert items3 == [] and err3 is None
+
+
+def test_resolve_item_content_di_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"data": {"node": {"id": "DI_x", "title": "Draft T"}}}),
+            stderr="",
+        ),
+    )
+    kind, cid, meta, err = project_cli.resolve_item_content(_ssot(), "DI_lAHOBl46-84A9KZx01")
+    assert kind == "draft" and cid == "DI_lAHOBl46-84A9KZx01" and err is None
+
+
+def test_resolve_item_content_graphql_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="gql down"),
+    )
+    kind, cid, meta, err = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind is None and "gql down" in (err or "")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="bad", stderr=""),
+    )
+    kind2, _, _, err2 = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind2 is None and "invalid graphql JSON" in (err2 or "")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"errors": [{"message": "not found"}]}),
+            stderr="",
+        ),
+    )
+    kind3, _, _, err3 = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind3 is None and err3 == "not found"
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout=json.dumps({"data": {"node": None}}), stderr=""
+        ),
+    )
+    kind4, _, _, err4 = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind4 is None and "not found" in (err4 or "")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"data": {"node": {"content": None}}}),
+            stderr="",
+        ),
+    )
+    kind5, _, _, err5 = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind5 is None and "no content" in (err5 or "")
+
+
+def test_resolve_item_content_draft_bad_id_and_issue_edges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gql_draft = {
+        "data": {
+            "node": {
+                "content": {
+                    "__typename": "DraftIssue",
+                    "id": "NOT_DI",
+                    "title": "T",
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout=json.dumps(gql_draft), stderr=""),
+    )
+    kind, _, _, err = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind is None and "unexpected draft id" in (err or "")
+    gql_issue = {
+        "data": {
+            "node": {
+                "content": {
+                    "__typename": "Issue",
+                    "number": None,
+                    "title": "I",
+                    "repository": {},
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout=json.dumps(gql_issue), stderr=""),
+    )
+    kind2, _, _, err2 = project_cli.resolve_item_content(_ssot(), VALID_ITEM)
+    assert kind2 is None and "missing number" in (err2 or "")
+
+
+def test_resolve_draft_content_not_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("issue", "1", {}, None),
+    )
+    cid, title, err = project_cli.resolve_draft_content(_ssot(), VALID_ITEM)
+    assert cid is None and "not a DraftIssue" in (err or "")
+
+
+def test_edit_item_body_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("draft", "DI_x", {"title": "T"}, None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="draft edit fail"),
+    )
+    ok, detail = project_cli.edit_item_body(_ssot(), VALID_ITEM, "body")
+    assert not ok and "draft edit fail" in detail
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("issue", "9", {"repo": "o/r"}, None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="issue edit fail"),
+    )
+    ok2, detail2 = project_cli.edit_item_body(_ssot(), VALID_ITEM, "body")
+    assert not ok2 and "issue edit fail" in detail2
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("weird", "x", {}, None),
+    )
+    ok3, detail3 = project_cli.edit_item_body(_ssot(), VALID_ITEM, "body")
+    assert not ok3 and "unsupported content kind" in detail3
+
+
+def test_set_item_status_key_error_and_gh_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    ok, detail = project_cli.set_item_status(_ssot(), VALID_ITEM, "nope")
+    assert not ok and "unknown status" in detail
+    monkeypatch.setattr(project_cli, "resolve_status_option_id", lambda *a, **k: "oid")
+    monkeypatch.setattr(project_cli, "status_field_id", lambda *a, **k: "fid")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="status fail"),
+    )
+    ok2, detail2 = project_cli.set_item_status(_ssot(), VALID_ITEM, "ready")
+    assert not ok2 and "status fail" in detail2
+
+
+def test_build_export_snapshot_long_body() -> None:
+    long_body = "x" * 600
+    snap = project_cli.build_export_snapshot(_ssot(), [_board_item(body=long_body)])
+    assert snap["totalCount"] == 1
+    assert snap["items"][0]["body_excerpt"].endswith("...")
+
+
+def test_resolve_item_id_for_pr_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="pr view fail"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "fetch fail"),
+    )
+    iid, cands, err = project_cli.resolve_item_id_for_pr(_ssot(), pr="7")
+    assert iid is None and "fetch fail" in (err or "")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"body": "", "url": "https://github.com/o/r/pull/7", "number": 7}),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: (
+            [
+                _board_item(item_id=VALID_ITEM_B, body="pull/7"),
+                _board_item(item_id=VALID_ITEM_C, body="also /pull/7"),
+            ],
+            None,
+        ),
+    )
+    iid2, cands2, err2 = project_cli.resolve_item_id_for_pr(_ssot(), pr="7")
+    assert iid2 is None and len(cands2) == 2 and "ambiguous" in (err2 or "")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    iid3, cands3, err3 = project_cli.resolve_item_id_for_pr(_ssot(), pr="7")
+    assert iid3 is None and "no project item found" in (err3 or "")
+
+
+# --- commands ---
+
+
+def test_cmd_status_text_and_enabled_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = {**SAMPLE_SSOT, "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(directory=tmp_path, json=False)
+    assert project_cli.cmd_status(args) == project_cli.EXIT_USAGE
+    out = capsys.readouterr()
+    assert "enabled:" in out.out
+    assert "note:" in out.err
+
+
+def test_cmd_status_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ssot(monkeypatch)
+    args = argparse.Namespace(directory=tmp_path, json=True)
+    assert project_cli.cmd_status(args) == project_cli.EXIT_OK
+
+
+def test_cmd_list_text_filters_and_edges(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = {
+        "items": [
+            {"id": "a", "title": "A", "status": "In Progress"},
+            "bad-item",
+            {"id": "b", "title": "B", "status": "In Review"},
+        ]
+    }
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr=""),
+    )
+    args = argparse.Namespace(directory=tmp_path, status="inprogress", limit=10, json=False)
+    assert project_cli.cmd_list(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "a\t" in out
+    args2 = argparse.Namespace(directory=tmp_path, status="review", limit=10, json=False)
+    project_cli.cmd_list(args2)
+    args3 = argparse.Namespace(directory=tmp_path, status="done", limit=10, json=False)
+    project_cli.cmd_list(args3)
+    out3 = capsys.readouterr().out
+    assert "(no items)" in out3
+
+
+def test_cmd_list_invalid_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="bad", stderr=""),
+    )
+    args = argparse.Namespace(directory=tmp_path, status="", limit=10, json=True)
+    assert project_cli.cmd_list(args) == project_cli.EXIT_GH
+
+
+def test_cmd_create_and_template_route(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    routed: list[str] = []
+
+    def fake_template(args: argparse.Namespace) -> int:
+        routed.append("template")
+        return 0
+
+    monkeypatch.setattr(project_cli, "cmd_create_from_template", fake_template)
+    args = argparse.Namespace(directory=tmp_path, template="slice", title="T", body="")
+    assert project_cli.cmd_create(args) == 0
+    assert routed == ["template"]
+
+
+def test_cmd_create_plain(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(
+        project_cli,
+        "create_draft_item",
+        lambda *a, **k: (VALID_ITEM, '{"id":"x"}', None),
+    )
+    args = argparse.Namespace(directory=tmp_path, template=None, title="T", body="")
+    assert project_cli.cmd_create(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert f"item_id={VALID_ITEM}" in out
+    assert project_cli.load_last_item_id(tmp_path) == VALID_ITEM
+
+
+def test_cmd_create_from_template_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "load_card_template",
+        lambda *a, **k: (_ for _ in ()).throw(ValueError("bad tmpl")),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        template="slice",
+        title="T",
+        acceptance="a",
+        rollback="r",
+        notes="",
+        status="",
+    )
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_create_from_template_gh_and_status_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(project_cli, "load_card_template", lambda *a, **k: "## Acceptance\n\n{{acceptance}}\n\n## Rollback\n\n{{rollback}}\n\n## Notes\n\n{{notes}}\n")
+    monkeypatch.setattr(
+        project_cli,
+        "create_draft_item",
+        lambda *a, **k: (None, None, "create err"),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        template="slice",
+        title="T",
+        acceptance="a",
+        rollback="r",
+        notes="",
+        status="ready",
+    )
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli,
+        "create_draft_item",
+        lambda *a, **k: (VALID_ITEM, "", None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (False, "status err"),
+    )
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_GH
+
+
+def test_cmd_set_status_resolve_id_and_print(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    args = argparse.Namespace(
+        directory=tmp_path, id="", last=False, to="ready", agent="implementer"
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    args2 = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, to="ready", agent="implementer"
+    )
+    assert project_cli.cmd_set_status(args2) == project_cli.EXIT_OK
+    assert "set-status:" in capsys.readouterr().out
+
+
+def test_cmd_set_field(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    args_bad = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, field="nope", to="p1"
+    )
+    assert project_cli.cmd_set_field(args_bad) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="field fail"),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, field="priority", to="p1"
+    )
+    assert project_cli.cmd_set_field(args) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    assert project_cli.cmd_set_field(args) == project_cli.EXIT_OK
+    assert "set-field:" in capsys.readouterr().out
+
+
+def test_cmd_get_text_and_fetch_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    args = argparse.Namespace(directory=tmp_path, id="", last=True, limit=10, json=False)
+    assert project_cli.cmd_get(args) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "get list fail"),
+    )
+    args2 = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, limit=10, json=False
+    )
+    assert project_cli.cmd_get(args2) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    assert project_cli.cmd_get(args2) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "--- body ---" in out
+
+
+def test_cmd_append_notes_idempotent_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "idempotent", project_cli.EXIT_OK),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, text="x", agent="implementer", limit=50
+    )
+    assert project_cli.cmd_append_notes(args) == project_cli.EXIT_OK
+    assert "idempotent skip" in capsys.readouterr().out
+
+
+def test_cmd_set_assignee_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    pr_dir = tmp_path / ".ai_infra" / "scripts" / "pr"
+    pr_dir.mkdir(parents=True)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        login="alice",
+        agent="implementer",
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_assignee",
+        lambda *a, **k: (True, "alice"),
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_OK
+    assert "set-assignee:" in capsys.readouterr().out
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_assignee",
+        lambda *a, **k: (False, "DraftIssue has no GitHub Assignees"),
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_VALIDATION
+    ssot_outbox = {**ssot, "outbox": {"enabled": True, "path": "outbox/q.jsonl"}}
+    _patch_ssot(monkeypatch, ssot_outbox)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_assignee",
+        lambda *a, **k: (False, "rate limit exceeded"),
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_set_assignee_no_login_no_user(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "")
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, login="", agent="implementer"
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_claim_edges(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="",
+        text="claimed",
+        limit=50,
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "")
+    args2 = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="claimed",
+        limit=50,
+    )
+    assert project_cli.cmd_claim(args2) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "claim fetch fail"),
+    )
+    assert project_cli.cmd_claim(args2) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (False, "unknown status 'nope'"),
+    )
+    assert project_cli.cmd_claim(args2) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (True, "oid"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_assignee",
+        lambda *a, **k: (True, "test"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "notes fail", project_cli.EXIT_GH),
+    )
+    assert project_cli.cmd_claim(args2) == project_cli.EXIT_GH
+
+
+def test_cmd_claim_notes_queued_after_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(project_cli, "set_item_assignee", lambda *a, **k: (True, "test"))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "API rate limit exceeded", project_cli.EXIT_GH),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="claimed",
+        limit=50,
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_QUEUED
+    assert "Notes QUEUED" in capsys.readouterr().err
+
+
+def test_cmd_handoff_edges(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="in_review",
+        text="note",
+        limit=50,
+    )
+    assert (
+        project_cli.cmd_handoff(
+            argparse.Namespace(**{**base, "agent": "", "next": "verifier"})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    assert (
+        project_cli.cmd_handoff(
+            argparse.Namespace(**{**base, "agent": "implementer", "next": ""})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "handoff fetch fail"),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item(status="In Progress")], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (False, "unknown status 'bad'"),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (True, "oid"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "notes err", project_cli.EXIT_VALIDATION),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_VALIDATION
+
+
+def test_cmd_validate_item_extra_problems(monkeypatch: pytest.MonkeyPatch) -> None:
+    ssot = _ssot()
+    _patch_ssot(monkeypatch, ssot)
+    bad_body = "## Acceptance\n\n## Rollback\n\n## Notes\n\n- plain un attributed line\n"
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: (
+            [_board_item(body=bad_body, status="WeirdStatus")],
+            None,
+        ),
+    )
+    args = argparse.Namespace(directory=REPO_ROOT, id=VALID_ITEM, last=False, limit=50)
+    assert project_cli.cmd_validate_item(args) == project_cli.EXIT_VALIDATION
+
+
+def test_cmd_last_and_load_enabled_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(directory=tmp_path)
+    assert project_cli.cmd_last(args) == project_cli.EXIT_USAGE
+    project_cli.save_last_item_id(tmp_path, VALID_ITEM)
+    assert project_cli.cmd_last(args) == project_cli.EXIT_OK
+    assert capsys.readouterr().out.strip() == VALID_ITEM
+    monkeypatch.setattr(
+        project_cli,
+        "load_project_ssot",
+        lambda root: (None, ["missing ssot"]),
+    )
+    args2 = argparse.Namespace(directory=tmp_path, status="", limit=10, json=False)
+    assert project_cli.cmd_list(args2) == project_cli.EXIT_USAGE
+
+
+def test_cmd_queue_all_ops(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="x",
+        to="ready",
+        next="verifier",
+        login="alice",
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "set-status", "to": ""})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "handoff", "next": ""})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    assert (
+        project_cli.cmd_queue(argparse.Namespace(**{**base, "op": "claim"}))
+        == project_cli.EXIT_QUEUED
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "set-assignee", "login": ""})
+        )
+        == project_cli.EXIT_QUEUED
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "set-status", "to": "ready"})
+        )
+        == project_cli.EXIT_QUEUED
+    )
+
+
+def test_cmd_outbox_status_graphql_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import project_outbox  # noqa: E402
+
+    ssot = _ssot()
+    ssot["outbox"] = {"enabled": True, "path": "outbox/t.jsonl"}
+    _patch_ssot(monkeypatch, ssot)
+
+    def _rl_err() -> dict:
+        return {"remaining": None, "limit": None, "reset_epoch": None, "error": "timeout"}
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _rl_err)
+    args = argparse.Namespace(directory=tmp_path)
+    assert project_cli.cmd_outbox_status(args) == project_cli.EXIT_OK
+    assert "graphql: error" in capsys.readouterr().out
+
+
+def test_cmd_doctor_edges(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import project_outbox  # noqa: E402
+
+    ssot = _ssot()
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    ssot_bad = json.loads(json.dumps(ssot))
+    del ssot_bad["fields"]["status"]["options"]["ready"]
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot_bad, []))
+    args = argparse.Namespace(directory=REPO_ROOT)
+    assert project_cli.cmd_doctor(args) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+
+    def _rl_low() -> dict:
+        return {"remaining": 10, "limit": 5000, "reset_epoch": 1700000000, "error": None}
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _rl_low)
+    assert project_cli.cmd_doctor(args) == project_cli.EXIT_OK
+    err = capsys.readouterr().err
+    assert "skipping live gh" in err or "low GraphQL quota" in err
+
+    monkeypatch.setattr(
+        project_outbox,
+        "graphql_rate_limit",
+        lambda: {"remaining": 5000, "limit": 5000, "reset_epoch": 1700000000, "error": None},
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=1, stdout="", stderr="API rate limit exceeded"
+        ),
+    )
+    assert project_cli.cmd_doctor(args) == project_cli.EXIT_OK
+    assert "rate-limited" in capsys.readouterr().err
+
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="network down"),
+    )
+    assert project_cli.cmd_doctor(args) == project_cli.EXIT_GH
+
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout='{"items":[]}', stderr=""),
+    )
+    monkeypatch.setattr(
+        project_outbox,
+        "graphql_rate_limit",
+        lambda: {"remaining": "bad", "limit": 5000, "reset_epoch": 1700000000, "error": None},
+    )
+    assert project_cli.cmd_doctor(args) == project_cli.EXIT_OK
+
+
+def test_cmd_find_by_pr_and_export_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: (None, ["a", "b"], "ambiguous"),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, pr="7", repo="", limit=50, json=False
+    )
+    assert project_cli.cmd_find_by_pr(args) == project_cli.EXIT_NOT_FOUND
+    err = capsys.readouterr().err
+    assert "candidates:" in err
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: (VALID_ITEM, [VALID_ITEM], None),
+    )
+    args_json = argparse.Namespace(
+        directory=tmp_path, pr="7", repo="", limit=50, json=True
+    )
+    assert project_cli.cmd_find_by_pr(args_json) == project_cli.EXIT_OK
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    out_file = tmp_path / "snap.json"
+    args_export = argparse.Namespace(
+        directory=tmp_path,
+        output=str(out_file),
+        limit=50,
+        json=True,
+        stdout=False,
+    )
+    assert project_cli.cmd_export(args_export) == project_cli.EXIT_OK
+    assert out_file.is_file()
+    out = capsys.readouterr().out
+    assert "Wrote" in out
+    assert '"schema"' in out
+
+
+# --- residual coverage toward 100% ---
+
+
+def test_is_placeholder_pvti_punctuation_only() -> None:
+    assert project_cli.is_placeholder_item_id("PVTI_---")
+
+
+def test_load_project_ssot_empty_cfg_and_bad_block(tmp_path: Path) -> None:
+    _ensure_pr_scripts(tmp_path)
+    path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text(yaml.safe_dump({"version": 1}), encoding="utf-8")
+    ssot, errs = project_cli.load_project_ssot(tmp_path)
+    assert ssot is None and any("empty" in e or "missing" in e for e in errs)
+    path.write_text(
+        yaml.safe_dump({"version": 1, "project_ssot": "not-a-dict"}),
+        encoding="utf-8",
+    )
+    ssot2, errs2 = project_cli.load_project_ssot(tmp_path)
+    assert ssot2 is None and any("missing block" in e for e in errs2)
+
+
+def test_format_note_line_attr_with_dot_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fixed_ts = "2026-07-18T10:14:40Z"
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(project_cli, "utc_note_timestamp", lambda: fixed_ts)
+    line = project_cli.format_note_line(
+        tmp_path, "implementer", "@test/implementer · extra tail"
+    )
+    assert line == f"@test/implementer · {fixed_ts} · extra tail"
+    line2 = project_cli.format_note_line(tmp_path, "implementer", "@test/implementer · ")
+    assert line2 == f"@test/implementer · {fixed_ts}"
+
+
+def test_normalize_status_inprogress_alias() -> None:
+    assert project_cli._normalize_status("inprogress") == "in_progress"
+
+
+def test_load_project_ssot_cfg_none(tmp_path: Path) -> None:
+    _ensure_pr_scripts(tmp_path)
+    path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text("", encoding="utf-8")
+    ssot, errs = project_cli.load_project_ssot(tmp_path)
+    assert ssot is None and errs
+
+
+def test_cmd_create_from_template_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path,
+        template="slice",
+        title="T",
+        acceptance="a",
+        rollback="r",
+        notes="",
+        status="",
+    )
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_set_assignee_ssot_and_id_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, login="alice", agent="implementer"
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    args2 = argparse.Namespace(
+        directory=tmp_path, id="", last=False, login="alice", agent="implementer"
+    )
+    assert project_cli.cmd_set_assignee(args2) == project_cli.EXIT_USAGE
+
+
+def test_cmd_claim_ssot_none_and_user_resolve_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="claimed",
+        limit=50,
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_human_github_user",
+        lambda root: (_ for _ in ()).throw(RuntimeError("no user")),
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_claim_fetch_queued_and_status_gh_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    ssot_out = {**ssot, "outbox": {"enabled": True, "path": "outbox/c.jsonl"}}
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot_out)
+    _patch_ssot(monkeypatch, ssot_out)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="claimed",
+        limit=50,
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "API rate limit exceeded"),
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_QUEUED
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (False, "network down"),
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_GH
+
+
+def test_cmd_handoff_ssot_id_and_fetch_queue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="in_review",
+        text="note",
+        limit=50,
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_USAGE
+    ssot_out = {**_ssot(), "outbox": {"enabled": True, "path": "outbox/h2.jsonl"}}
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot_out)
+    _patch_ssot(monkeypatch, ssot_out)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    assert (
+        project_cli.cmd_handoff(
+            argparse.Namespace(**{**base, "id": "", "last": False})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "API rate limit exceeded"),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_handoff_status_gh_fail_non_rate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item(status="In Progress")], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (False, "network down"),
+    )
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="in_review",
+        text="note",
+        limit=50,
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_GH
+
+
+def test_cmd_validate_item_id_resolve_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_ssot(monkeypatch)
+    args = argparse.Namespace(directory=tmp_path, id="", last=False, limit=50)
+    assert project_cli.cmd_validate_item(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_queue_ssot_id_handoff_and_enqueue_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="note",
+        to="in_review",
+        next="verifier",
+        login="alice",
+    )
+    assert (
+        project_cli.cmd_queue(argparse.Namespace(**{**base, "op": "append-notes"}))
+        == project_cli.EXIT_USAGE
+    )
+    _patch_ssot(monkeypatch)
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "id": "", "op": "append-notes", "text": "x"})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(
+                **{
+                    **base,
+                    "op": "handoff",
+                    "next": "verifier",
+                    "text": "handoff note",
+                    "to": "in_review",
+                }
+            )
+        )
+        == project_cli.EXIT_QUEUED
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_human_github_user",
+        lambda root: (_ for _ in ()).throw(ValueError("bad user")),
+    )
+    import project_outbox  # noqa: E402
+
+    monkeypatch.setattr(
+        project_outbox,
+        "enqueue_op",
+        lambda *a, **k: (None, "validation failed"),
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "append-notes", "text": "x"})
+        )
+        == project_cli.EXIT_VALIDATION
+    )
+
+
+def test_cmd_doctor_require_enabled_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    assert project_cli.cmd_doctor(argparse.Namespace(directory=tmp_path)) == project_cli.EXIT_USAGE
+
+
+def test_run_gh_invokes_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        captured.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    proc = project_cli.run_gh(["version"])
+    assert proc.returncode == 0
+    assert captured[0][:2] == ["gh", "version"]
+
+
+def test_load_enabled_ssot_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = {**SAMPLE_SSOT, "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    out, code = project_cli._load_enabled_ssot(tmp_path, "list")
+    assert out is None and code == project_cli.EXIT_USAGE
+
+
+def test_in_progress_conflicts_skips_non_in_progress() -> None:
+    items = [
+        {
+            "id": VALID_ITEM_B,
+            "status": "Ready",
+            "title": "@test/implementer todo",
+            "content": {"body": ""},
+        },
+        {
+            "id": VALID_ITEM_C,
+            "status": "In Progress",
+            "title": "@test/implementer active",
+            "content": {"body": ""},
+        },
+    ]
+    conflicts = project_cli.in_progress_conflicts_for_user(
+        items, user_handle="@test", exclude_id=VALID_ITEM
+    )
+    assert len(conflicts) == 1
+    assert conflicts[0]["id"] == VALID_ITEM_C
+
+
+def test_cmd_handoff_bad_agent_attribution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+
+    def _bad_attr(root: Path, agent: str) -> str:
+        if agent == "bad-next":
+            raise ValueError("bad agent name")
+        return "@test/implementer"
+
+    monkeypatch.setattr(project_cli, "format_agent_attribution", _bad_attr)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        next="bad-next",
+        to="in_review",
+        text="note",
+        limit=50,
+    )
+    assert project_cli.cmd_handoff(args) == project_cli.EXIT_USAGE
+
+
+def test_in_progress_conflicts_excludes_target() -> None:
+    items = [
+        {
+            "id": VALID_ITEM,
+            "status": "In Progress",
+            "title": "@test/implementer",
+            "content": {"body": ""},
+        }
+    ]
+    assert (
+        project_cli.in_progress_conflicts_for_user(
+            items, user_handle="@test", exclude_id=VALID_ITEM
+        )
+        == []
+    )
+
+
+def test_cmd_status_load_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        project_cli, "load_project_ssot", lambda root: (None, ["boom"])
+    )
+    assert project_cli.cmd_status(argparse.Namespace(directory=tmp_path, json=False)) == 2
+
+
+def test_cmd_list_non_list_items(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout='{"items": 1}', stderr=""),
+    )
+    assert (
+        project_cli.cmd_list(
+            argparse.Namespace(directory=tmp_path, status="", limit=5, json=True)
+        )
+        == 0
+    )
+
+
+def test_cmd_create_disabled_and_gh_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(directory=tmp_path, template=None, title="T", body="")
+    assert project_cli.cmd_create(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "create_draft_item",
+        lambda *a, **k: (None, None, "create failed"),
+    )
+    assert project_cli.cmd_create(args) == project_cli.EXIT_GH
+
+
+def test_cmd_create_from_template_missing_sections(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    ssot["conventions"]["body_sections"] = ["ExtraSection"]
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(
+        project_cli,
+        "load_card_template",
+        lambda *a, **k: "## Acceptance\n\nonly\n",
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        template="slice",
+        title="T",
+        acceptance="a",
+        rollback="r",
+        notes="",
+        status="",
+    )
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_VALIDATION
+
+
+def test_cmd_set_status_disabled_and_non_rate_gh_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, to="ready", agent="implementer"
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="network down"),
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_GH
+
+
+def test_cmd_set_field_resolve_and_key_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, field="priority", to="p1"
+    )
+    assert project_cli.cmd_set_field(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    args2 = argparse.Namespace(
+        directory=tmp_path, id="", last=False, field="priority", to="p1"
+    )
+    assert project_cli.cmd_set_field(args2) == project_cli.EXIT_USAGE
+    ssot_bad = json.loads(json.dumps(_ssot()))
+    ssot_bad["fields"]["priority"]["options"] = {}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot_bad, []))
+    args3 = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, field="priority", to="p1"
+    )
+    assert project_cli.cmd_set_field(args3) == project_cli.EXIT_USAGE
+
+
+def test_resolve_item_id_for_pr_single_match_and_bad_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item(item_id=VALID_ITEM_B, body="pull/42")], None),
+    )
+    iid, cands, err = project_cli.resolve_item_id_for_pr(_ssot(), pr="42", repo="o/r")
+    assert iid == VALID_ITEM_B and err is None
+
+
+def test_resolve_item_content_di_json_decode_and_issue_default_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="bad-json", stderr=""),
+    )
+    kind, _, _, err = project_cli.resolve_item_content(_ssot(), "DI_lAHOBl46-84A9KZx01")
+    assert kind == "draft" and err is None
+    gql_issue = {
+        "data": {
+            "node": {
+                "content": {
+                    "__typename": "Issue",
+                    "number": 1,
+                    "title": "I",
+                    "body": "b",
+                    "repository": {},
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout=json.dumps(gql_issue), stderr=""),
+    )
+    kind2, cid2, meta2, err2 = project_cli.resolve_item_content(
+        {**_ssot(), "default_repo": "SavinRazvan/repo"}, VALID_ITEM
+    )
+    assert kind2 == "issue" and cid2 == "1" and err2 is None
+    assert meta2 is not None
+    assert meta2.get("title") == "I"
+    assert meta2.get("repo") == "SavinRazvan/repo"
+
+
+def test_resolve_draft_content_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: (None, None, None, "boom"),
+    )
+    cid, title, err = project_cli.resolve_draft_content(_ssot(), VALID_ITEM)
+    assert cid is None and err == "boom"
+
+
+def test_cmd_get_and_append_notes_load_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    assert (
+        project_cli.cmd_get(
+            argparse.Namespace(
+                directory=tmp_path, id=VALID_ITEM, last=False, limit=10, json=True
+            )
+        )
+        == project_cli.EXIT_USAGE
+    )
+    assert (
+        project_cli.cmd_append_notes(
+            argparse.Namespace(
+                directory=tmp_path,
+                id=VALID_ITEM,
+                last=False,
+                text="x",
+                agent="implementer",
+                limit=10,
+            )
+        )
+        == project_cli.EXIT_USAGE
+    )
+    _patch_ssot(monkeypatch)
+    assert (
+        project_cli.cmd_append_notes(
+            argparse.Namespace(
+                directory=tmp_path, id="", last=False, text="x", agent="implementer", limit=10
+            )
+        )
+        == project_cli.EXIT_USAGE
+    )
+
+
+def test_cmd_set_assignee_resolve_login_and_gh_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_human_github_user",
+        lambda root: (_ for _ in ()).throw(RuntimeError("no user")),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, login="", agent="implementer"
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_assignee",
+        lambda *a, **k: (False, "network down"),
+    )
+    assert project_cli.cmd_set_assignee(
+        argparse.Namespace(
+            directory=tmp_path, id=VALID_ITEM, last=False, login="alice", agent="implementer"
+        )
+    ) == project_cli.EXIT_GH
+
+
+def test_cmd_claim_not_found_and_assignee_ok(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="claimed",
+        limit=50,
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_NOT_FOUND
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(project_cli, "set_item_assignee", lambda *a, **k: (True, "test"))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_OK
+    assert "assignee=@test" in capsys.readouterr().out
+
+
+def test_cmd_handoff_not_found_and_queued_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    ssot_out = {**ssot, "outbox": {"enabled": True, "path": "outbox/h.jsonl"}}
+    _write_collab(tmp_path, ssot_out)
+    _patch_ssot(monkeypatch, ssot_out)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="in_review",
+        text="note",
+        limit=50,
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_NOT_FOUND
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item(status="In Progress")], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda *a, **k: (False, "API rate limit exceeded"),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_QUEUED
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "API rate limit exceeded", project_cli.EXIT_GH),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_validate_item_load_and_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(directory=tmp_path, id=VALID_ITEM, last=False, limit=50)
+    assert project_cli.cmd_validate_item(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "validate list fail"),
+    )
+    assert project_cli.cmd_validate_item(args) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    assert project_cli.cmd_validate_item(args) == project_cli.EXIT_NOT_FOUND
+
+
+def test_cmd_queue_append_notes_and_resolve_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    _patch_ssot(monkeypatch, ssot)
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="",
+        to="ready",
+        next="verifier",
+        login="",
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "append-notes", "text": ""})
+        )
+        == project_cli.EXIT_USAGE
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_human_github_user",
+        lambda root: (_ for _ in ()).throw(RuntimeError("no login")),
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**{**base, "op": "set-assignee", "login": ""})
+        )
+        == project_cli.EXIT_USAGE
+    )
+
+
+def test_cmd_outbox_and_doctor_load_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    assert (
+        project_cli.cmd_outbox_status(argparse.Namespace(directory=tmp_path))
+        == project_cli.EXIT_USAGE
+    )
+    assert (
+        project_cli.cmd_outbox_flush(
+            argparse.Namespace(directory=tmp_path, max=None, limit=100)
+        )
+        == project_cli.EXIT_USAGE
+    )
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (None, ["missing"]))
+    assert project_cli.cmd_doctor(argparse.Namespace(directory=tmp_path)) == project_cli.EXIT_USAGE
+
+
+def test_cmd_doctor_missing_user_and_template(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    _patch_ssot(monkeypatch, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "")
+    assert project_cli.cmd_doctor(argparse.Namespace(directory=REPO_ROOT)) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "project_templates_dir",
+        lambda root: tmp_path / "missing-templates",
+    )
+    assert project_cli.cmd_doctor(argparse.Namespace(directory=REPO_ROOT)) == project_cli.EXIT_USAGE
+
+
+def test_cmd_doctor_graphql_error_in_summary(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import project_outbox  # noqa: E402
+
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout='{"items":[]}', stderr=""),
+    )
+    monkeypatch.setattr(
+        project_outbox,
+        "graphql_rate_limit",
+        lambda: {"remaining": None, "limit": None, "reset_epoch": None, "error": "timeout"},
+    )
+    assert project_cli.cmd_doctor(argparse.Namespace(directory=REPO_ROOT)) == project_cli.EXIT_OK
+    assert "rate_limit: timeout" in capsys.readouterr().err
+
+
+def test_cmd_find_by_pr_disabled_and_export_fetch_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    assert (
+        project_cli.cmd_find_by_pr(
+            argparse.Namespace(directory=tmp_path, pr="1", repo="", limit=50, json=True)
+        )
+        == project_cli.EXIT_USAGE
+    )
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: (VALID_ITEM, [VALID_ITEM], None),
+    )
+    args_text = argparse.Namespace(
+        directory=tmp_path, pr="1", repo="", limit=50, json=False
+    )
+    assert project_cli.cmd_find_by_pr(args_text) == project_cli.EXIT_OK
+    assert capsys.readouterr().out.strip() == VALID_ITEM
+    ssot_off = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot_off, []))
+    assert (
+        project_cli.cmd_export(
+            argparse.Namespace(
+                directory=tmp_path, output=None, limit=50, json=False, stdout=True
+            )
+        )
+        == project_cli.EXIT_USAGE
+    )
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "export fail"),
+    )
+    assert (
+        project_cli.cmd_export(
+            argparse.Namespace(
+                directory=tmp_path, output=None, limit=50, json=False, stdout=True
+            )
+        )
+        == project_cli.EXIT_GH
+    )
+
+
+# --- residual lines toward 100% ---
+
+
+def test_load_project_ssot_empty_collab_file(tmp_path: Path) -> None:
+    _ensure_pr_scripts(tmp_path)
+    path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text("", encoding="utf-8")
+    ssot, errs = project_cli.load_project_ssot(tmp_path)
+    assert ssot is None
+    assert errs and "missing or empty" in errs[0]
+
+
+def test_format_note_line_attr_prefix_empty_rest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(project_cli, "utc_note_timestamp", lambda: "2026-01-01T00:00:00Z")
+    out = project_cli.format_note_line(tmp_path, "implementer", "@test/implementer")
+    assert out == "@test/implementer · 2026-01-01T00:00:00Z"
+
+
+def test_normalize_status_inprogress_alias() -> None:
+    assert project_cli._normalize_status("inprogress") == "in_progress"
+    assert project_cli._normalize_status("review") == "in_review"
+
+
+def test_in_progress_conflicts_skips_non_in_progress() -> None:
+    items = [
+        {"id": VALID_ITEM_B, "status": "Ready", "title": "@test/x", "content": {"body": ""}},
+        {
+            "id": VALID_ITEM,
+            "status": "In Progress",
+            "title": "keep",
+            "content": {"body": "@test/implementer"},
+        },
+    ]
+    conflicts = project_cli.in_progress_conflicts_for_user(
+        items, user_handle="@test", exclude_id=VALID_ITEM
+    )
+    assert conflicts == []
+
+
+def test_cmd_create_from_template_ssot_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path,
+        title="T",
+        template="slice",
+        acceptance="a",
+        rollback="r",
+        notes="",
+        status="ready",
+    )
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_set_assignee_early_exits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, login="alice", agent="x"
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    args2 = argparse.Namespace(
+        directory=tmp_path, id="", last=False, login="alice", agent="x"
+    )
+    assert project_cli.cmd_set_assignee(args2) == project_cli.EXIT_USAGE
+
+
+def test_cmd_claim_resolve_user_exception_and_gh_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_human_github_user",
+        lambda root: (_ for _ in ()).throw(RuntimeError("no user")),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, agent="implementer", text="x", limit=10
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(project_cli, "in_progress_conflicts_for_user", lambda *a, **k: [])
+    monkeypatch.setattr(
+        project_cli, "set_item_status", lambda *a, **k: (False, "board down")
+    )
+    monkeypatch.setattr(project_cli, "_try_queue_rate_limit", lambda *a, **k: None)
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_GH
+
+
+def test_cmd_claim_rate_limit_queues(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(project_cli, "in_progress_conflicts_for_user", lambda *a, **k: [])
+    monkeypatch.setattr(
+        project_cli, "set_item_status", lambda *a, **k: (False, "rate limit")
+    )
+    monkeypatch.setattr(
+        project_cli, "_try_queue_rate_limit", lambda *a, **k: project_cli.EXIT_QUEUED
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, id=VALID_ITEM, last=False, agent="implementer", text="x", limit=10
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_handoff_early_and_format_and_gh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="in_review",
+        text="",
+        limit=10,
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_USAGE
+    _patch_ssot(monkeypatch)
+    args_bad_id = argparse.Namespace(**{**base, "id": ""})
+    assert project_cli.cmd_handoff(args_bad_id) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli,
+        "format_agent_attribution",
+        lambda *a, **k: (_ for _ in ()).throw(ValueError("bad attr")),
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_cli, "format_agent_attribution", lambda *a, **k: "@test/verifier"
+    )
+    monkeypatch.setattr(project_cli, "format_note_line", lambda *a, **k: "note")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([_board_item()], None),
+    )
+    monkeypatch.setattr(
+        project_cli, "set_item_status", lambda *a, **k: (False, "fail status")
+    )
+    monkeypatch.setattr(project_cli, "_try_queue_rate_limit", lambda *a, **k: None)
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_GH
+    monkeypatch.setattr(
+        project_cli, "_try_queue_rate_limit", lambda *a, **k: project_cli.EXIT_QUEUED
+    )
+    assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_validate_item_bad_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ssot(monkeypatch)
+    args = argparse.Namespace(directory=tmp_path, id="", last=False, limit=10)
+    assert project_cli.cmd_validate_item(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_queue_early_and_validation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import project_outbox  # noqa: E402
+
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM,
+        last=False,
+        agent="implementer",
+        text="x",
+        to="ready",
+        next="verifier",
+        login="alice",
+        op="claim",
+    )
+    assert project_cli.cmd_queue(argparse.Namespace(**base)) == project_cli.EXIT_USAGE
+    ssot2 = _ssot()
+    ssot2["outbox"] = {"enabled": True, "path": "outbox/t.jsonl"}
+    _patch_ssot(monkeypatch, ssot2)
+    args_bad = argparse.Namespace(**{**base, "id": ""})
+    assert project_cli.cmd_queue(args_bad) == project_cli.EXIT_USAGE
+    monkeypatch.setattr(
+        project_outbox, "enqueue_op", lambda *a, **k: (None, "enqueue boom")
+    )
+    assert (
+        project_cli.cmd_queue(argparse.Namespace(**{**base, "op": "handoff"}))
+        == project_cli.EXIT_VALIDATION
+    )
+
+
+def test_cmd_doctor_enabled_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    assert (
+        project_cli.cmd_doctor(argparse.Namespace(directory=tmp_path))
+        == project_cli.EXIT_USAGE
+    )
+
+
+def test_cmd_find_by_pr_prints_plain_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _patch_ssot(monkeypatch)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: (VALID_ITEM, [], None),
+    )
+    args = argparse.Namespace(directory=tmp_path, pr="9", repo="", limit=20, json=False)
+    assert project_cli.cmd_find_by_pr(args) == project_cli.EXIT_OK
+    assert capsys.readouterr().out.strip() == VALID_ITEM
+
+
+def test_cmd_export_ssot_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = {**_ssot(), "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    assert (
+        project_cli.cmd_export(
+            argparse.Namespace(
+                directory=tmp_path, output=None, limit=10, json=False, stdout=True
+            )
+        )
+        == project_cli.EXIT_USAGE
+    )

--- a/tests/modules/install/test_project_outbox.py
+++ b/tests/modules/install/test_project_outbox.py
@@ -1,0 +1,1270 @@
+"""
+File: test_project_outbox.py
+Path: tests/modules/install/test_project_outbox.py
+Role: Unit tests for board rate-limit outbox (project_outbox.py).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/project_outbox.py
+ - .ai_infra/install/cursor_workflow/project_cli.py
+Notes:
+ - All outbox paths use tmp_path; never touches real .local/generated-data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PKG_DIR = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+if str(_PKG_DIR) not in sys.path:
+    sys.path.insert(0, str(_PKG_DIR))
+
+import project_cli  # noqa: E402
+import project_outbox  # noqa: E402
+from test_project_cli import SAMPLE_SSOT  # noqa: E402
+
+VALID_ITEM_ID = "PVTI_lAHOBl46-84A9KZxtest01"
+SHORT_PVTI = "PVTI_stub"
+DI_ITEM_ID = "DI_draftitem01"
+
+
+def _outbox_ssot(tmp_path: Path, **outbox_overrides: object) -> dict:
+    rel = "outbox/test-outbox.jsonl"
+    outbox = {
+        "enabled": True,
+        "path": rel,
+        "min_graphql_remaining": 200,
+        "max_flush_per_run": 10,
+        "retry_backoff_seconds": 0,
+        **outbox_overrides,
+    }
+    return {**SAMPLE_SSOT, "outbox": outbox}
+
+
+def _write_collab(tmp: Path, ssot: dict) -> None:
+    path = tmp / ".local" / "user_settings" / "github.collaboration.yaml"
+    path.parent.mkdir(parents=True)
+    data = {
+        "version": 1,
+        "owner": {"display_name": "Test User", "github_user": "@test"},
+        "project_ssot": ssot,
+        "commit_provenance": {"ai_disclosure_mode": "assisted_by"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _outbox_file(tmp_path: Path, ssot: dict) -> Path:
+    cfg = project_outbox.load_outbox_config(ssot)
+    return project_outbox.outbox_path(tmp_path, cfg)
+
+
+def _valid_entry(**overrides: object) -> dict:
+    base: dict = {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "ts": "2026-07-18T10:00:00Z",
+        "agent": "implementer",
+        "github_user": "@test",
+        "op": "append-notes",
+        "item_id": VALID_ITEM_ID,
+        "payload": {"text": "queued note"},
+        "status": "pending",
+        "attempts": 0,
+        "last_error": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_graphql(monkeypatch: pytest.MonkeyPatch, *, remaining: int = 5000, error: str | None = None) -> None:
+    if error:
+
+        def _fail() -> dict:
+            return {
+                "remaining": None,
+                "limit": None,
+                "reset_epoch": None,
+                "error": error,
+            }
+
+        monkeypatch.setattr(project_outbox, "graphql_rate_limit", _fail)
+    else:
+
+        def _ok() -> dict:
+            return {
+                "remaining": remaining,
+                "limit": 5000,
+                "reset_epoch": 1700000000,
+                "error": None,
+            }
+
+        monkeypatch.setattr(project_outbox, "graphql_rate_limit", _ok)
+
+
+# --- load_outbox_config ---
+
+
+def test_load_outbox_config_defaults() -> None:
+    cfg = project_outbox.load_outbox_config({})
+    assert cfg["enabled"] is True
+    assert cfg["path"] == ".local/generated-data/board-outbox.jsonl"
+    assert cfg["min_graphql_remaining"] == 200
+    assert cfg["max_flush_per_run"] == 10
+    assert cfg["retry_backoff_seconds"] == 30
+
+
+def test_load_outbox_config_custom_and_disabled() -> None:
+    ssot = {
+        "outbox": {
+            "enabled": False,
+            "path": "/tmp/custom.jsonl",
+            "min_graphql_remaining": 50,
+            "max_flush_per_run": 3,
+            "retry_backoff_seconds": 5,
+        }
+    }
+    cfg = project_outbox.load_outbox_config(ssot)
+    assert cfg["enabled"] is False
+    assert cfg["path"] == "/tmp/custom.jsonl"
+    assert cfg["min_graphql_remaining"] == 50
+    assert cfg["max_flush_per_run"] == 3
+    assert cfg["retry_backoff_seconds"] == 5
+
+
+def test_load_outbox_config_missing_outbox_key() -> None:
+    cfg = project_outbox.load_outbox_config({"enabled": True})
+    assert cfg["enabled"] is True
+    assert cfg["path"].endswith("board-outbox.jsonl")
+
+
+# --- is_rate_limit_error ---
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("API rate limit exceeded", True),
+        ("secondary rate limit hit", True),
+        ("Rate Limit: too many requests", True),
+        ("network timeout", False),
+        ("", False),
+        ("item not found", False),
+    ],
+)
+def test_is_rate_limit_error(text: str, expected: bool) -> None:
+    assert project_outbox.is_rate_limit_error(text) is expected
+
+
+# --- graphql_rate_limit ---
+
+
+def test_graphql_rate_limit_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps({"remaining": 4999, "limit": 5000, "reset": 1700000000})
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        assert cmd[:3] == ["gh", "api", "rate_limit"]
+        return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rl = project_outbox.graphql_rate_limit()
+    assert rl["remaining"] == 4999
+    assert rl["limit"] == 5000
+    assert rl["reset_epoch"] == 1700000000
+    assert rl["error"] is None
+
+
+def test_graphql_rate_limit_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="gh auth required"),
+    )
+    rl = project_outbox.graphql_rate_limit()
+    assert rl["remaining"] is None
+    assert "gh auth required" in (rl["error"] or "")
+
+
+def test_graphql_rate_limit_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*a: object, **k: object) -> SimpleNamespace:
+        raise subprocess.TimeoutExpired(cmd=["gh"], timeout=30)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rl = project_outbox.graphql_rate_limit()
+    assert rl["error"] is not None
+
+
+def test_graphql_rate_limit_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*a: object, **k: object) -> SimpleNamespace:
+        raise OSError("no gh binary")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rl = project_outbox.graphql_rate_limit()
+    assert "no gh binary" in (rl["error"] or "")
+
+
+def test_graphql_rate_limit_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
+    )
+    rl = project_outbox.graphql_rate_limit()
+    assert "invalid JSON" in (rl["error"] or "")
+
+
+def test_graphql_rate_limit_non_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout='"string"', stderr=""),
+    )
+    rl = project_outbox.graphql_rate_limit()
+    assert "not an object" in (rl["error"] or "")
+
+
+def test_format_reset_iso() -> None:
+    assert project_outbox.format_reset_iso(1700000000).startswith("2023-")
+    assert project_outbox.format_reset_iso("bad") == "(unknown)"
+
+
+# --- validate_outbox_entry ---
+
+
+def test_validate_outbox_entry_happy() -> None:
+    assert project_outbox.validate_outbox_entry(_valid_entry()) == []
+
+
+def test_validate_outbox_entry_missing_fields() -> None:
+    entry = _valid_entry()
+    del entry["agent"]
+    errs = project_outbox.validate_outbox_entry(entry)
+    assert any("missing agent" in e for e in errs)
+
+
+def test_validate_outbox_entry_bad_item_id() -> None:
+    errs = project_outbox.validate_outbox_entry(_valid_entry(item_id=SHORT_PVTI))
+    assert any("bad item_id" in e for e in errs)
+    errs_di = project_outbox.validate_outbox_entry(_valid_entry(item_id=DI_ITEM_ID))
+    assert any("bad item_id" in e for e in errs_di)
+
+
+def test_validate_outbox_entry_unknown_op_and_status() -> None:
+    errs = project_outbox.validate_outbox_entry(_valid_entry(op="nope"))
+    assert any("unknown op" in e for e in errs)
+    errs2 = project_outbox.validate_outbox_entry(_valid_entry(status="queued"))
+    assert any("bad status" in e for e in errs2)
+
+
+def test_validate_outbox_entry_payload_rules() -> None:
+    assert any(
+        "append-notes payload.text required" in e
+        for e in project_outbox.validate_outbox_entry(
+            _valid_entry(payload={"text": "  "})
+        )
+    )
+    assert any(
+        "set-status payload.to required" in e
+        for e in project_outbox.validate_outbox_entry(
+            _valid_entry(op="set-status", payload={"to": ""})
+        )
+    )
+    assert any(
+        "handoff payload.next required" in e
+        for e in project_outbox.validate_outbox_entry(
+            _valid_entry(op="handoff", payload={"next": ""})
+        )
+    )
+    assert any(
+        "set-assignee payload.login required" in e
+        for e in project_outbox.validate_outbox_entry(
+            _valid_entry(op="set-assignee", payload={"login": ""})
+        )
+    )
+    assert any(
+        "payload must be object" in e
+        for e in project_outbox.validate_outbox_entry(_valid_entry(payload="x"))
+    )
+    assert any(
+        "attempts must be non-negative int" in e
+        for e in project_outbox.validate_outbox_entry(_valid_entry(attempts=-1))
+    )
+
+
+# --- enqueue_op ---
+
+
+def test_enqueue_op_writes_jsonl(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "hello"},
+    )
+    assert err == ""
+    assert entry is not None
+    path = _outbox_file(tmp_path, ssot)
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["op"] == "append-notes"
+    assert parsed["status"] == "pending"
+    assert parsed["item_id"] == VALID_ITEM_ID
+
+
+def test_enqueue_op_rejects_placeholder_and_short_pvti(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id="PVTI_…",
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert entry is None
+    assert "placeholder" in err
+    entry2, err2 = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=SHORT_PVTI,
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert entry2 is None
+    assert "bad item_id" in err2 or "placeholder" in err2
+
+
+def test_enqueue_op_rejects_di_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=DI_ITEM_ID,
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert entry is None
+    assert "bad item_id" in err
+
+
+def test_enqueue_op_unknown_op_and_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="delete-all",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert entry is None
+    assert "unknown op" in err
+    disabled = _outbox_ssot(tmp_path, enabled=False)
+    entry2, err2 = project_outbox.enqueue_op(
+        tmp_path,
+        disabled,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert entry2 is None
+    assert "enabled is false" in err2
+
+
+def test_enqueue_op_resolve_user_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+
+    def _boom(root: Path) -> str:
+        raise RuntimeError("no user settings")
+
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", _boom)
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "x"},
+        github_user="",
+    )
+    assert entry is None
+    assert "no user settings" in err
+
+
+def test_enqueue_op_empty_github_user_after_normalize(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "   ")
+    monkeypatch.setattr(project_cli, "normalize_github_handle", lambda raw: "")
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert entry is None
+    assert "github_user missing" in err
+
+
+def test_enqueue_op_requires_agent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    entry, err = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="",
+        payload={"text": "x"},
+    )
+    assert entry is None
+    assert "agent required" in err
+
+
+# --- count_outbox ---
+
+
+def test_count_outbox_tallies_and_corrupt(tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps(_valid_entry(status="pending")),
+        json.dumps(_valid_entry(status="done", id="2")),
+        json.dumps(_valid_entry(status="failed", id="3")),
+        "not valid json",
+        "",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    counts = project_outbox.count_outbox(path)
+    assert counts == {"pending": 1, "done": 1, "failed": 1, "total": 3}
+
+
+def test_count_outbox_empty_missing(tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    counts = project_outbox.count_outbox(path)
+    assert counts == {"pending": 0, "done": 0, "failed": 0, "total": 0}
+
+
+# --- maybe_enqueue_on_gh_fail ---
+
+
+def test_maybe_enqueue_rate_limit_returns_queued(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    code = project_outbox.maybe_enqueue_on_gh_fail(
+        tmp_path,
+        ssot,
+        cmd="append-notes",
+        err_detail="API rate limit exceeded",
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "queued"},
+    )
+    assert code == project_outbox.EXIT_QUEUED
+    err = capsys.readouterr().err
+    assert "QUEUED" in err
+
+
+def test_maybe_enqueue_non_rate_limit_returns_none() -> None:
+    ssot = _outbox_ssot(Path("/tmp/unused"))
+    assert (
+        project_outbox.maybe_enqueue_on_gh_fail(
+            Path("/tmp/unused"),
+            ssot,
+            cmd="append-notes",
+            err_detail="network down",
+            op="append-notes",
+            item_id=VALID_ITEM_ID,
+            agent="implementer",
+            payload={"text": "x"},
+        )
+        is None
+    )
+
+
+def test_maybe_enqueue_failure_returns_gh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    code = project_outbox.maybe_enqueue_on_gh_fail(
+        tmp_path,
+        ssot,
+        cmd="append-notes",
+        err_detail="rate limit",
+        op="append-notes",
+        item_id=SHORT_PVTI,
+        agent="implementer",
+        payload={"text": "x"},
+    )
+    assert code == project_outbox.EXIT_GH
+    assert "enqueue failed" in capsys.readouterr().err
+
+
+def test_maybe_enqueue_disabled_returns_none() -> None:
+    ssot = _outbox_ssot(Path("/tmp/unused"), enabled=False)
+    assert (
+        project_outbox.maybe_enqueue_on_gh_fail(
+            Path("/tmp/unused"),
+            ssot,
+            cmd="append-notes",
+            err_detail="rate limit",
+            op="append-notes",
+            item_id=VALID_ITEM_ID,
+            agent="implementer",
+            payload={"text": "x"},
+        )
+        is None
+    )
+
+
+# --- apply_outbox_entry ---
+
+
+def test_apply_outbox_entry_append_notes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path, ssot, _valid_entry(op="append-notes")
+    )
+    assert ok
+    assert detail == "updated"
+
+
+def test_apply_outbox_entry_append_notes_idempotent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "idempotent", project_cli.EXIT_OK),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path, ssot, _valid_entry(op="append-notes")
+    )
+    assert ok
+    assert detail == "idempotent"
+
+
+def test_apply_outbox_entry_set_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (True, "47fc9ee4"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-status", payload={"to": "in_progress"}),
+    )
+    assert ok
+    assert detail == "47fc9ee4"
+
+
+def test_apply_outbox_entry_set_assignee(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_assignee",
+        lambda ssot, iid, login: (True, "alice"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-assignee", payload={"login": "alice"}),
+    )
+    assert ok
+    assert detail == "alice"
+
+
+def test_apply_outbox_entry_claim(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (True, "47fc9ee4"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(
+            op="claim",
+            payload={"to": "in_progress", "text": "claimed (outbox flush)"},
+        ),
+    )
+    assert ok
+    assert detail == "claimed"
+
+
+def test_apply_outbox_entry_handoff(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (True, "4cc61d42"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "format_agent_attribution",
+        lambda root, agent: "@test/verifier",
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(
+            op="handoff",
+            payload={"next": "verifier", "to": "in_review", "note": "done slice"},
+        ),
+    )
+    assert ok
+    assert detail == "updated"
+
+
+def test_apply_outbox_entry_handoff_bad_next(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+
+    def _raise_bad_agent(root: Path, agent: str) -> str:
+        raise ValueError("bad agent")
+
+    monkeypatch.setattr(project_cli, "format_agent_attribution", _raise_bad_agent)
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="handoff", payload={"next": "bad", "note": "x"}),
+    )
+    assert not ok
+    assert "bad agent" in detail
+
+
+def test_apply_outbox_entry_invalid_op(tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path, ssot, _valid_entry(op="bogus")
+    )
+    assert not ok
+    assert "unsupported op" in detail
+
+
+def test_apply_outbox_entry_claim_status_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (False, "status failed"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="claim", payload={"to": "in_progress", "text": "claimed"}),
+    )
+    assert not ok
+    assert detail == "status failed"
+
+
+def test_apply_outbox_entry_claim_notes_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (True, "47fc9ee4"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "notes boom", project_cli.EXIT_GH),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="claim", payload={"to": "in_progress", "text": "claimed"}),
+    )
+    assert not ok
+    assert "Notes failed" in detail
+
+
+def test_apply_outbox_entry_handoff_status_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (False, "handoff status fail"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(
+            op="handoff",
+            payload={"next": "verifier", "to": "in_review", "note": "x"},
+        ),
+    )
+    assert not ok
+    assert detail == "handoff status fail"
+
+
+# --- flush_outbox ---
+
+
+def test_flush_outbox_refuses_low_remaining(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _mock_graphql(monkeypatch, remaining=50)
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_GH
+    assert "remaining=50" in summary
+    assert "refuse flush" in summary
+
+
+def test_flush_outbox_invalid_remaining_type(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+
+    def _bad_rl() -> dict:
+        return {
+            "remaining": "not-a-number",
+            "limit": 5000,
+            "reset_epoch": 1700000000,
+            "error": None,
+        }
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _bad_rl)
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_GH
+    assert "refuse flush" in summary
+
+
+def test_flush_outbox_cap_minimum_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path, max_flush_per_run=0)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    _mock_graphql(monkeypatch, remaining=5000)
+    applied: list[str] = []
+
+    def track_apply(root: Path, ssot: dict, entry: dict, **k: object) -> tuple[bool, str]:
+        applied.append(str(entry.get("id")))
+        return True, "ok"
+
+    monkeypatch.setattr(project_outbox, "apply_outbox_entry", track_apply)
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot, max_ops=0)
+    assert code == project_outbox.EXIT_OK
+    assert len(applied) == 1
+    assert "done=1" in summary
+
+
+def test_flush_outbox_graphql_remaining_typeerror_mid_batch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    calls = {"n": 0}
+
+    def _rl_bad_mid() -> dict:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {
+                "remaining": 5000,
+                "limit": 5000,
+                "reset_epoch": 1700000000,
+                "error": None,
+            }
+        return {
+            "remaining": {"bad": "type"},
+            "limit": 5000,
+            "reset_epoch": 1700000000,
+            "error": None,
+        }
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _rl_bad_mid)
+    monkeypatch.setattr(
+        project_outbox,
+        "apply_outbox_entry",
+        lambda *a, **k: (True, "ok"),
+    )
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_OK
+    assert project_outbox.read_outbox_entries(path)[0]["status"] == "done"
+
+
+def test_flush_outbox_stops_mid_batch_low_quota(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(
+        path,
+        [
+            _valid_entry(id="batch-a"),
+            _valid_entry(id="batch-b", payload={"text": "two"}),
+        ],
+    )
+    calls = {"n": 0}
+
+    def _rl_sequence() -> dict:
+        calls["n"] += 1
+        # call 1: pre-loop quota check; call 2: first batch iteration; call 3+: low quota
+        if calls["n"] <= 2:
+            return {
+                "remaining": 5000,
+                "limit": 5000,
+                "reset_epoch": 1700000000,
+                "error": None,
+            }
+        return {
+            "remaining": 10,
+            "limit": 5000,
+            "reset_epoch": 1700000000,
+            "error": None,
+        }
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _rl_sequence)
+    monkeypatch.setattr(
+        project_outbox,
+        "apply_outbox_entry",
+        lambda *a, **k: (True, "ok"),
+    )
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot, max_ops=5)
+    assert code == project_outbox.EXIT_OK
+    assert "stopped early" in summary
+    entries = project_outbox.read_outbox_entries(path)
+    done = [e for e in entries if e["status"] == "done"]
+    pending = [e for e in entries if e["status"] == "pending"]
+    assert len(done) == 1
+    assert len(pending) == 1
+
+
+def test_flush_outbox_refuses_rate_limit_read_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _mock_graphql(monkeypatch, error="timeout")
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_GH
+    assert "cannot read rate_limit" in summary
+
+
+def test_flush_outbox_disabled(tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path, enabled=False)
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_USAGE
+    assert "enabled is false" in summary
+
+
+def test_flush_outbox_applies_and_marks_done(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    _mock_graphql(monkeypatch, remaining=5000)
+    monkeypatch.setattr(
+        project_outbox,
+        "apply_outbox_entry",
+        lambda *a, **k: (True, "updated"),
+    )
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_OK
+    assert "done=1" in summary
+    entries = project_outbox.read_outbox_entries(path)
+    assert entries[0]["status"] == "done"
+    assert entries[0]["attempts"] == 1
+
+
+def test_flush_outbox_marks_failed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    _mock_graphql(monkeypatch, remaining=5000)
+    monkeypatch.setattr(
+        project_outbox,
+        "apply_outbox_entry",
+        lambda *a, **k: (False, "item not found"),
+    )
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_OK
+    assert "failed=1" in summary
+    entries = project_outbox.read_outbox_entries(path)
+    assert entries[0]["status"] == "failed"
+    assert entries[0]["last_error"] == "item not found"
+
+
+def test_flush_outbox_stops_on_rate_limit_during_apply(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(
+        path,
+        [_valid_entry(id="a"), _valid_entry(id="b", payload={"text": "two"})],
+    )
+    _mock_graphql(monkeypatch, remaining=5000)
+
+    def flaky_apply(*a: object, **k: object) -> tuple[bool, str]:
+        return False, "secondary rate limit exceeded"
+
+    monkeypatch.setattr(project_outbox, "apply_outbox_entry", flaky_apply)
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot, max_ops=5)
+    assert code == project_outbox.EXIT_GH
+    assert "rate-limit" in summary
+    entries = project_outbox.read_outbox_entries(path)
+    assert entries[0]["status"] == "pending"
+    assert entries[0]["attempts"] == 1
+
+
+def test_flush_outbox_respects_max_flush_per_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path, max_flush_per_run=2)
+    path = _outbox_file(tmp_path, ssot)
+    entries = [
+        _valid_entry(id=f"id-{i}", payload={"text": f"n{i}"}) for i in range(3)
+    ]
+    project_outbox.write_outbox_entries(path, entries)
+    _mock_graphql(monkeypatch, remaining=5000)
+    applied: list[str] = []
+
+    def track_apply(root: Path, ssot: dict, entry: dict, **k: object) -> tuple[bool, str]:
+        applied.append(str(entry.get("id")))
+        return True, "ok"
+
+    monkeypatch.setattr(project_outbox, "apply_outbox_entry", track_apply)
+    code, summary = project_outbox.flush_outbox(tmp_path, ssot)
+    assert code == project_outbox.EXIT_OK
+    assert len(applied) == 2
+    assert "pending_left=1" in summary
+    stored = project_outbox.read_outbox_entries(path)
+    done = [e for e in stored if e["status"] == "done"]
+    pending = [e for e in stored if e["status"] == "pending"]
+    assert len(done) == 2
+    assert len(pending) == 1
+
+
+def test_queued_message() -> None:
+    msg = project_outbox.queued_message("queue", _valid_entry())
+    assert "QUEUED" in msg
+    assert "outbox flush" in msg
+
+
+# --- CLI integration (monkeypatch, no network) ---
+
+
+def test_cmd_queue_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM_ID,
+        last=False,
+        agent="implementer",
+        op="append-notes",
+        text="manual queue",
+        to=None,
+        next=None,
+        login=None,
+    )
+    assert project_cli.cmd_queue(args) == project_cli.EXIT_QUEUED
+    out = capsys.readouterr().out
+    assert "QUEUED" in out
+    assert _outbox_file(tmp_path, ssot).is_file()
+
+
+def test_cmd_queue_missing_agent_and_bad_op(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    base = dict(
+        directory=tmp_path,
+        id=VALID_ITEM_ID,
+        last=False,
+        text="x",
+        to=None,
+        next=None,
+        login=None,
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**base, agent="", op="append-notes")
+        )
+        == project_cli.EXIT_USAGE
+    )
+    assert (
+        project_cli.cmd_queue(
+            argparse.Namespace(**base, agent="implementer", op="bad-op")
+        )
+        == project_cli.EXIT_USAGE
+    )
+
+
+def test_cmd_outbox_status_prints_counts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    _mock_graphql(monkeypatch, remaining=4500)
+    args = argparse.Namespace(directory=tmp_path)
+    assert project_cli.cmd_outbox_status(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "pending=1" in out
+    assert "graphql: remaining=4500" in out
+
+
+def test_cmd_outbox_flush_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    path = _outbox_file(tmp_path, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    _mock_graphql(monkeypatch, remaining=5000)
+    monkeypatch.setattr(
+        project_outbox,
+        "flush_outbox",
+        lambda *a, **k: (project_outbox.EXIT_OK, "flushed done=1 failed=0 pending_left=0"),
+    )
+    args = argparse.Namespace(directory=tmp_path, max=None, limit=100)
+    assert project_cli.cmd_outbox_flush(args) == project_cli.EXIT_OK
+    assert "flushed done=1" in capsys.readouterr().out
+
+
+def test_cmd_outbox_flush_refuses_low_remaining(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_outbox,
+        "flush_outbox",
+        lambda *a, **k: (
+            project_outbox.EXIT_GH,
+            "GraphQL remaining=50 < min=200; refuse flush until 2026-01-01T00:00:00Z",
+        ),
+    )
+    args = argparse.Namespace(directory=tmp_path, max=None, limit=100)
+    assert project_cli.cmd_outbox_flush(args) == project_cli.EXIT_GH
+
+
+def _board_item(item_id: str = VALID_ITEM_ID) -> dict:
+    return {
+        "id": item_id,
+        "title": "Slice",
+        "status": "Ready",
+        "content": {"body": "## Acceptance\n\nx\n\n## Rollback\n\ny\n\n## Notes\n\n"},
+    }
+
+
+def test_cmd_append_notes_auto_queues_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "API rate limit exceeded", project_cli.EXIT_GH),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM_ID,
+        last=False,
+        text="note",
+        agent="implementer",
+        limit=50,
+    )
+    assert project_cli.cmd_append_notes(args) == project_cli.EXIT_QUEUED
+    assert _outbox_file(tmp_path, ssot).is_file()
+
+
+def test_cmd_set_status_auto_queues_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda args, *, timeout_s=60.0: SimpleNamespace(
+            returncode=1, stdout="", stderr="rate limit exceeded for graphql"
+        ),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM_ID,
+        last=False,
+        to="in_progress",
+        agent="implementer",
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_claim_auto_queues_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot, limit=100: ([_board_item()], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (False, "secondary rate limit"),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM_ID,
+        last=False,
+        agent="implementer",
+        text="claimed",
+        limit=50,
+    )
+    assert project_cli.cmd_claim(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_handoff_auto_queues_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot, limit=100: ([_board_item()], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_status",
+        lambda ssot, iid, to: (False, "API rate limit exceeded"),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_ITEM_ID,
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="in_review",
+        text="handoff note",
+        limit=50,
+    )
+    assert project_cli.cmd_handoff(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_doctor_warns_low_remaining_and_pending(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(REPO_ROOT)
+    path = _outbox_file(REPO_ROOT, ssot)
+    project_outbox.write_outbox_entries(path, [_valid_entry()])
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda args, *, timeout_s=60.0: SimpleNamespace(
+            returncode=0, stdout='{"items":[]}', stderr=""
+        ),
+    )
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(directory=REPO_ROOT)
+    try:
+        assert project_cli.cmd_doctor(args) == project_cli.EXIT_OK
+        err = capsys.readouterr().err
+        assert "WARN" in err
+        assert "min_graphql_remaining" in err or "low GraphQL quota" in err
+        assert "pending outbox ops" in err
+    finally:
+        if path.is_file():
+            path.unlink()

--- a/tests/modules/install/test_project_recipes.py
+++ b/tests/modules/install/test_project_recipes.py
@@ -84,7 +84,7 @@ def test_cmd_create_from_template(
         if args[:2] == ["project", "item-create"]:
             return SimpleNamespace(
                 returncode=0,
-                stdout=json.dumps({"id": "PVTI_new"}),
+                stdout=json.dumps({"id": "PVTI_lAHOBl46-84A9KZxnew001"}),
                 stderr="",
             )
         if args[:2] == ["project", "item-edit"]:
@@ -104,7 +104,7 @@ def test_cmd_create_from_template(
     )
     assert project_cli.cmd_create_from_template(args) == 0
     out = capsys.readouterr().out
-    assert "item_id=PVTI_new" in out
+    assert "item_id=PVTI_lAHOBl46-84A9KZxnew001" in out
     assert any(c[:2] == ["project", "item-create"] for c in calls)
     assert any("--single-select-option-id" in c for c in calls)
 
@@ -121,7 +121,7 @@ def test_cmd_claim_draft_warns_assignee(
         lambda ssot, limit=100: (
             [
                 {
-                    "id": "PVTI_claim",
+                    "id": "PVTI_lAHOBl46-84A9KZxclaim1",
                     "title": "Work",
                     "status": "Ready",
                     "content": {
@@ -144,12 +144,12 @@ def test_cmd_claim_draft_warns_assignee(
         lambda *a, **k: (True, "ok"),
     )
     args = argparse.Namespace(
-        directory=REPO_ROOT, id="PVTI_claim", agent="implementer", text="claimed", limit=100
+        directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxclaim1", agent="implementer", text="claimed", limit=100
     )
     assert project_cli.cmd_claim(args) == 0
     captured = capsys.readouterr()
     assert "WARN" in captured.err
-    assert "item_id=PVTI_claim" in captured.out
+    assert "item_id=PVTI_lAHOBl46-84A9KZxclaim1" in captured.out
     assert "@test/implementer" in captured.out
 
 
@@ -163,13 +163,13 @@ def test_cmd_claim_conflict_one_in_progress(monkeypatch: pytest.MonkeyPatch) -> 
         lambda ssot, limit=100: (
             [
                 {
-                    "id": "PVTI_other",
+                    "id": "PVTI_lAHOBl46-84A9KZxother1",
                     "title": "Other",
                     "status": "In Progress",
                     "content": {"body": "## Notes\n\n- @test/implementer · claimed\n"},
                 },
                 {
-                    "id": "PVTI_new",
+                    "id": "PVTI_lAHOBl46-84A9KZxnew001",
                     "title": "New",
                     "status": "Ready",
                     "content": {"body": "## Acceptance\n\n## Rollback\n\n## Notes\n"},
@@ -179,7 +179,7 @@ def test_cmd_claim_conflict_one_in_progress(monkeypatch: pytest.MonkeyPatch) -> 
         ),
     )
     args = argparse.Namespace(
-        directory=REPO_ROOT, id="PVTI_new", agent="implementer", text="claimed", limit=100
+        directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxnew001", agent="implementer", text="claimed", limit=100
     )
     assert project_cli.cmd_claim(args) == project_cli.EXIT_VALIDATION
 
@@ -197,7 +197,7 @@ def test_cmd_handoff_prefixes_next(
         project_cli,
         "fetch_project_items",
         lambda ssot, limit=100: (
-            [{"id": "PVTI_h", "title": "H", "status": "In Progress", "content": body_box}],
+            [{"id": "PVTI_lAHOBl46-84A9KZxhand01", "title": "H", "status": "In Progress", "content": body_box}],
             None,
         ),
     )
@@ -210,7 +210,7 @@ def test_cmd_handoff_prefixes_next(
     monkeypatch.setattr(project_cli, "edit_item_body", fake_edit)
     args = argparse.Namespace(
         directory=REPO_ROOT,
-        id="PVTI_h",
+        id="PVTI_lAHOBl46-84A9KZxhand01",
         agent="implementer",
         next="verifier",
         to="in_review",
@@ -231,11 +231,11 @@ def test_cmd_validate_item_missing_section(monkeypatch: pytest.MonkeyPatch) -> N
         project_cli,
         "fetch_project_items",
         lambda ssot, limit=100: (
-            [{"id": "PVTI_v", "title": "V", "status": "Ready", "content": {"body": "# only\n"}}],
+            [{"id": "PVTI_lAHOBl46-84A9KZxval001", "title": "V", "status": "Ready", "content": {"body": "# only\n"}}],
             None,
         ),
     )
-    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_v", limit=100)
+    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxval001", limit=100)
     assert project_cli.cmd_validate_item(args) == project_cli.EXIT_VALIDATION
 
 
@@ -248,7 +248,7 @@ def test_cmd_validate_item_ok(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda ssot, limit=100: (
             [
                 {
-                    "id": "PVTI_ok",
+                    "id": "PVTI_lAHOBl46-84A9KZxok0001",
                     "title": "OK",
                     "status": "Ready",
                     "content": {
@@ -262,7 +262,7 @@ def test_cmd_validate_item_ok(monkeypatch: pytest.MonkeyPatch) -> None:
             None,
         ),
     )
-    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_ok", limit=100)
+    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxok0001", limit=100)
     assert project_cli.cmd_validate_item(args) == 0
 
 
@@ -285,13 +285,13 @@ def test_cmd_get_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         project_cli, "fetch_project_items", lambda ssot, limit=100: ([], None)
     )
-    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_missing", limit=100, json=False)
+    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxmiss01", limit=100, json=False)
     assert project_cli.cmd_get(args) == project_cli.EXIT_NOT_FOUND
 
 
 def test_cmd_set_status_unknown_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
-    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_x", to="nope")
+    args = argparse.Namespace(directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxstub01", to="nope")
     assert project_cli.cmd_set_status(args) == project_cli.EXIT_USAGE
 
 
@@ -311,7 +311,7 @@ def test_cmd_list_gh_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_append_notes_requires_agent_code(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
     args = argparse.Namespace(
-        directory=REPO_ROOT, id="PVTI_x", text="hi", agent="", limit=100
+        directory=REPO_ROOT, id="PVTI_lAHOBl46-84A9KZxstub01", text="hi", agent="", limit=100
     )
     assert project_cli.cmd_append_notes(args) == project_cli.EXIT_USAGE
 
@@ -342,14 +342,14 @@ def test_claim_uses_last(
     ssot = _ssot()
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
     monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
-    project_cli.save_last_item_id(tmp_path, "PVTI_lastitem01", title="T", action="create")
+    project_cli.save_last_item_id(tmp_path, "PVTI_lAHOBl46-84A9KZxlast01", title="T", action="create")
     monkeypatch.setattr(
         project_cli,
         "fetch_project_items",
         lambda ssot, limit=100: (
             [
                 {
-                    "id": "PVTI_lastitem01",
+                    "id": "PVTI_lAHOBl46-84A9KZxlast01",
                     "title": "T",
                     "status": "Ready",
                     "content": {"body": "## Acceptance\n\nx\n\n## Rollback\n\ny\n\n## Notes\n\n"},
@@ -369,15 +369,15 @@ def test_claim_uses_last(
         directory=tmp_path, id="", last=True, agent="implementer", text="claimed", limit=100
     )
     assert project_cli.cmd_claim(args) == 0
-    assert project_cli.load_last_item_id(tmp_path) == "PVTI_lastitem01"
+    assert project_cli.load_last_item_id(tmp_path) == "PVTI_lAHOBl46-84A9KZxlast01"
 
 
 def test_cmd_guide_prints_last(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    project_cli.save_last_item_id(tmp_path, "PVTI_guidetest01")
+    project_cli.save_last_item_id(tmp_path, "PVTI_lAHOBl46-84A9KZxguide1")
     args = argparse.Namespace(directory=tmp_path, agent="implementer", next="verifier")
     assert project_cli.cmd_guide(args) == 0
     out = capsys.readouterr().out
     assert "--last" in out
     assert "PVTI_…" not in out
-    assert "PVTI_guidetest01" in out
+    assert "PVTI_lAHOBl46-84A9KZxguide1" in out
 

--- a/tests/modules/pr_workflow/test_merge_board_sync.py
+++ b/tests/modules/pr_workflow/test_merge_board_sync.py
@@ -163,3 +163,116 @@ def test_sync_board_notes_via_edit_item_body(
     assert "Merged:" in edited[0][1]
     assert "abc123" in edited[0][1]
     assert "@test/merge.py" in edited[0][1]
+
+
+def test_pr_url_passthrough_http(tmp_path: Path) -> None:
+    url = "https://github.com/org/repo/pull/99"
+    assert merge_mod._pr_url(tmp_path, url, "") == url
+
+
+def test_pr_url_builds_from_gh_repo_view(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        merge_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout="acme/kit\n", stderr=""
+        ),
+    )
+    assert merge_mod._pr_url(tmp_path, "42", "") == "https://github.com/acme/kit/pull/42"
+
+
+def test_pr_url_fallback_without_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        merge_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="fail"),
+    )
+    assert merge_mod._pr_url(tmp_path, "#7", "") == "PR #7"
+
+
+def test_sync_board_import_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocker(name, *args, **kwargs):
+        if name == "project_cli" or name.endswith(".project_cli"):
+            raise ImportError("blocked")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocker)
+    # Force re-import path inside sync by temporarily removing from sys.modules
+    saved = sys.modules.pop("project_cli", None)
+    try:
+        line = merge_mod.sync_board_after_merge(root=tmp_path, pr="1", merge_sha="x")
+    finally:
+        if saved is not None:
+            sys.modules["project_cli"] = saved
+    assert "project_cli unavailable" in line
+
+
+def test_sync_board_candidates_in_warn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: (None, ["PVTI_a", "PVTI_b"], "ambiguous"),
+    )
+    line = merge_mod.sync_board_after_merge(root=tmp_path, pr="3", merge_sha="sha")
+    assert "warn" in line
+    assert "candidates=PVTI_a,PVTI_b" in line
+    assert "candidates=" in capsys.readouterr().err
+
+
+def test_sync_board_set_status_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(
+        project_cli, "set_item_status", lambda *a, **k: (False, "rate limited")
+    )
+    line = merge_mod.sync_board_after_merge(
+        root=tmp_path, pr="1", merge_sha="abc", item_id="PVTI_x"
+    )
+    assert "set-status failed" in line
+    assert "rate limited" in line
+    assert "[WARN] board sync set-status failed" in capsys.readouterr().err
+
+
+def test_sync_board_list_failure_after_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(
+        project_cli, "fetch_project_items", lambda *a, **k: ([], "list boom")
+    )
+    line = merge_mod.sync_board_after_merge(
+        root=tmp_path, pr="1", merge_sha="abc", item_id="PVTI_x"
+    )
+    assert "status→done on PVTI_x" in line
+    assert "notes warn (list boom)" in line
+    assert "append-notes list failed" in capsys.readouterr().err
+
+
+def test_merge_reload_sys_path_bootstrap() -> None:
+    """Re-exec merge module body after stripping CW path (covers line 33 when absent)."""
+    import importlib
+
+    cw_resolved = _CW_DIR.resolve()
+    sys.path[:] = [
+        p for p in sys.path if not (p and Path(p).resolve() == cw_resolved)
+    ]
+    reloaded = importlib.reload(merge_mod)
+    assert hasattr(reloaded, "sync_board_after_merge")
+    # Ensure project_cli remains importable for later tests in this module
+    if not any(p and Path(p).resolve() == cw_resolved for p in sys.path):
+        sys.path.insert(0, str(cw_resolved))
+    globals()["merge_mod"] = reloaded
+

--- a/tests/modules/workflow_drift/test_drift004b_session_board.py
+++ b/tests/modules/workflow_drift/test_drift004b_session_board.py
@@ -1,0 +1,162 @@
+"""
+File: test_drift004b_session_board.py
+Path: tests/modules/workflow_drift/test_drift004b_session_board.py
+Role: Tests for DRIFT-004b session-pointer Board vs export snapshot.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/workflow/drift_checks.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".ai_infra" / "scripts" / "workflow"
+if str(WORKFLOW_DIR) not in sys.path:
+    sys.path.insert(0, str(WORKFLOW_DIR))
+
+from drift_checks import (  # noqa: E402
+    check_drift004b,
+    drift_paths,
+    _parse_session_board_field,
+)
+
+
+def _scaffold(
+    tmp: Path,
+    *,
+    enabled: bool = True,
+    policy: str = "board_only",
+    board_cell: str = "",
+    snapshot: dict | None = None,
+    write_snapshot: bool = True,
+) -> Path:
+    planning = tmp / ".local" / "index-and-planning" / "current"
+    planning.mkdir(parents=True)
+    session = "# Session\n\n| Field | Value |\n|-------|--------|\n"
+    if board_cell:
+        session += f"| **Board** | {board_cell} |\n"
+    (planning / "session-pointer.md").write_text(session, encoding="utf-8")
+    (planning / "work-tracker.md").write_text(
+        "# Work Tracker\n\n## Active\n\n(none)\n",
+        encoding="utf-8",
+    )
+    (planning / "plan.md").write_text("# Plan\n\n## Current focus\n\n- x\n", encoding="utf-8")
+    settings = tmp / ".local" / "user_settings"
+    settings.mkdir(parents=True)
+    data = {
+        "version": 1,
+        "owner": {"display_name": "T", "github_user": "@t"},
+        "project_ssot": {
+            "enabled": enabled,
+            "sync_policy": policy,
+            "default_repo": "SavinRazvan/mas-workflow-kit-project-ssot",
+        },
+        "commit_provenance": {"ai_disclosure_mode": "none"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }
+    (settings / "github.collaboration.yaml").write_text(
+        yaml.safe_dump(data), encoding="utf-8"
+    )
+    if write_snapshot and snapshot is not None:
+        gen = tmp / ".local" / "generated-data"
+        gen.mkdir(parents=True)
+        (gen / "project-board-snapshot.json").write_text(
+            json.dumps(snapshot), encoding="utf-8"
+        )
+    return tmp
+
+
+def test_parse_session_board_field() -> None:
+    iid, st = _parse_session_board_field(
+        "PVTI_lAHOBl46-84A9KZxzgzRK20 In progress"
+    )
+    assert iid == "PVTI_lAHOBl46-84A9KZxzgzRK20"
+    assert "progress" in st.lower()
+
+
+def test_drift004b_skips_without_snapshot(tmp_path: Path) -> None:
+    root = _scaffold(
+        tmp_path,
+        board_cell="PVTI_abc In progress",
+        snapshot=None,
+        write_snapshot=False,
+    )
+    result = check_drift004b(drift_paths(root))
+    assert result.passed
+    assert "skipped" in result.detail
+
+
+def test_drift004b_skips_when_disabled(tmp_path: Path) -> None:
+    root = _scaffold(
+        tmp_path,
+        enabled=False,
+        board_cell="PVTI_abc In progress",
+        snapshot={"items": []},
+    )
+    result = check_drift004b(drift_paths(root))
+    assert result.passed
+    assert "disabled" in result.detail
+
+
+def test_drift004b_fails_stale_in_progress_vs_done(tmp_path: Path) -> None:
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": "PVTI_stale",
+                "title": "Old",
+                "status": "Done",
+                "status_normalized": "done",
+            }
+        ],
+    }
+    root = _scaffold(
+        tmp_path,
+        board_cell="PVTI_stale In progress",
+        snapshot=snap,
+    )
+    result = check_drift004b(drift_paths(root))
+    assert not result.passed
+    assert "PVTI_stale" in result.detail
+    assert "done" in result.detail
+
+
+def test_drift004b_passes_matching_in_progress(tmp_path: Path) -> None:
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": "PVTI_ok",
+                "title": "Active",
+                "status": "In progress",
+                "status_normalized": "in_progress",
+            }
+        ],
+    }
+    root = _scaffold(
+        tmp_path,
+        board_cell="PVTI_ok In progress",
+        snapshot=snap,
+    )
+    result = check_drift004b(drift_paths(root))
+    assert result.passed
+    assert "aligns" in result.detail
+
+
+def test_drift004b_fails_missing_item(tmp_path: Path) -> None:
+    snap = {"schema": "project-board-snapshot/v1", "items": []}
+    root = _scaffold(
+        tmp_path,
+        board_cell="PVTI_gone In progress",
+        snapshot=snap,
+    )
+    result = check_drift004b(drift_paths(root))
+    assert not result.passed
+    assert "missing" in result.detail

--- a/tests/modules/workflow_drift/test_drift_coverage_edges.py
+++ b/tests/modules/workflow_drift/test_drift_coverage_edges.py
@@ -1,0 +1,480 @@
+"""
+File: test_drift_coverage_edges.py
+Path: tests/modules/workflow_drift/test_drift_coverage_edges.py
+Role: Edge-case coverage for drift_checks helpers and DRIFT-009/010 defensive paths.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/workflow/drift_checks.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".ai_infra" / "scripts" / "workflow"
+if str(WORKFLOW_DIR) not in sys.path:
+    sys.path.insert(0, str(WORKFLOW_DIR))
+
+import drift_checks  # noqa: E402
+from drift_checks import (  # noqa: E402
+    _load_board_snapshot,
+    _open_pr_bodies,
+    _parse_session_board_field,
+    _path_exists,
+    check_drift004b,
+    check_drift009,
+    check_drift010,
+    drift_paths,
+)
+
+
+def _write_collab(
+    tmp: Path,
+    *,
+    enabled: bool = True,
+    policy: str = "board_only",
+    raw: str | None = None,
+    default_repo: str = "SavinRazvan/mas-workflow-kit-project-ssot",
+) -> None:
+    settings = tmp / ".local" / "user_settings"
+    settings.mkdir(parents=True, exist_ok=True)
+    path = settings / "github.collaboration.yaml"
+    if raw is not None:
+        path.write_text(raw, encoding="utf-8")
+        return
+    data = {
+        "version": 1,
+        "owner": {"display_name": "T", "github_user": "@t"},
+        "project_ssot": {
+            "enabled": enabled,
+            "sync_policy": policy,
+            "default_repo": default_repo,
+        },
+        "commit_provenance": {"ai_disclosure_mode": "none"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _planning(tmp: Path, tracker: str = "# Work Tracker\n\n## Active\n\n(none)\n") -> None:
+    planning = tmp / ".local" / "index-and-planning" / "current"
+    planning.mkdir(parents=True, exist_ok=True)
+    (planning / "work-tracker.md").write_text(tracker, encoding="utf-8")
+    (planning / "session-pointer.md").write_text(
+        "| Field | Value |\n|-------|--------|\n| **Board** | |\n",
+        encoding="utf-8",
+    )
+
+
+def test_path_exists_glob(tmp_path: Path) -> None:
+    nested = tmp_path / "tests" / "modules" / "x"
+    nested.mkdir(parents=True)
+    (nested / "foo.py").write_text("#\n", encoding="utf-8")
+    assert _path_exists(tmp_path, "tests/**/foo.py") is True
+    assert _path_exists(tmp_path, "tests/**/missing.py") is False
+
+
+def test_parse_session_board_no_pvti() -> None:
+    assert _parse_session_board_field("Ready only") == (None, "")
+    assert _parse_session_board_field("") == (None, "")
+
+
+def test_load_ssot_policy_parse_and_non_mapping(tmp_path: Path) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, raw=": not: valid: [[[")
+    ssot, detail = drift_checks._load_ssot_policy(drift_paths(tmp_path))
+    assert ssot is None
+    assert "cannot parse" in detail
+
+    _write_collab(tmp_path, raw="- just a list\n")
+    ssot, detail = drift_checks._load_ssot_policy(drift_paths(tmp_path))
+    assert ssot is None
+    assert "not a mapping" in detail
+
+
+def test_load_ssot_policy_pyyaml_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path)
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocker(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocker)
+    ssot, detail = drift_checks._load_ssot_policy(drift_paths(tmp_path))
+    assert ssot is None
+    assert "PyYAML missing" in detail
+
+
+def test_drift004b_skips_non_board_only(tmp_path: Path) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, policy="mirror")
+    result = check_drift004b(drift_paths(tmp_path))
+    assert result.passed
+    assert "board/session check skipped" in result.detail
+
+
+def test_drift009_skips_non_board_only(tmp_path: Path) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, policy="local")
+    result = check_drift009(drift_paths(tmp_path))
+    assert result.passed
+    assert "dual-write check skipped" in result.detail
+
+
+def test_drift009_fails_yaml_parse(tmp_path: Path) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, raw="{broken")
+    result = check_drift009(drift_paths(tmp_path))
+    assert not result.passed
+    assert "cannot parse" in result.detail
+
+
+def test_drift009_pyyaml_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path)
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocker(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocker)
+    result = check_drift009(drift_paths(tmp_path))
+    assert result.passed
+    assert "PyYAML missing" in result.detail
+
+
+def test_load_board_snapshot_bad_json_and_non_object(tmp_path: Path) -> None:
+    _planning(tmp_path)
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text("not-json", encoding="utf-8")
+    data, detail = _load_board_snapshot(drift_paths(tmp_path))
+    assert data is None
+    assert "cannot read snapshot" in detail
+
+    (gen / "project-board-snapshot.json").write_text("[1,2]", encoding="utf-8")
+    data, detail = _load_board_snapshot(drift_paths(tmp_path))
+    assert data is None
+    assert "not an object" in detail
+
+
+def test_open_pr_bodies_gh_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="gh pr list failed"),
+    )
+    prs, err = _open_pr_bodies("o/r")
+    assert prs == []
+    assert err and "gh pr list failed" in err
+
+
+def test_open_pr_bodies_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    prs, err = _open_pr_bodies("o/r")
+    assert prs == []
+    assert err
+
+
+def test_open_pr_bodies_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="{", stderr=""),
+    )
+    prs, err = _open_pr_bodies("o/r")
+    assert prs == []
+    assert err and "invalid JSON" in err
+
+
+def test_open_pr_bodies_non_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout=json.dumps({"x": 1}), stderr=""
+        ),
+    )
+    prs, err = _open_pr_bodies("o/r")
+    assert prs == []
+    assert err and "did not return a list" in err
+
+
+def test_open_pr_bodies_success_filters_non_dicts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps([{"number": 1, "body": "ok"}, "skip", 3]),
+            stderr="",
+        ),
+    )
+    prs, err = _open_pr_bodies("o/r")
+    assert err is None
+    assert prs == [{"number": 1, "body": "ok"}]
+
+
+def test_drift010_board_item_linked_via_pr_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Hit Board-Item: regex path (line ~712) when in_review is properly linked."""
+    _planning(tmp_path)
+    _write_collab(tmp_path)
+    item = "PVTI_lAHOBl46-84A9KZxlinked1"
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": item,
+                "title": "Linked review",
+                "status_normalized": "in_review",
+                "body_excerpt": "PR open",
+            }
+        ],
+    }
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    monkeypatch.setattr(
+        drift_checks,
+        "_open_pr_bodies",
+        lambda repo: (
+            [
+                {
+                    "number": 11,
+                    "body": f"Board-Item: {item}\n## Summary",
+                    "url": "https://x/y/pull/11",
+                }
+            ],
+            None,
+        ),
+    )
+    result = check_drift010(drift_paths(tmp_path))
+    assert result.passed
+    assert "no mismatches" in result.detail
+
+
+def test_drift010_flags_in_review_without_open_pr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path)
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": "PVTI_lAHOBl46-84A9KZxinrev1",
+                "title": "Review me",
+                "status_normalized": "in_review",
+                "body_excerpt": "working",
+            },
+            "skip-me",
+        ],
+    }
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    monkeypatch.setattr(
+        drift_checks,
+        "_open_pr_bodies",
+        lambda repo: (
+            [{"number": 9, "body": "unrelated PR", "url": "https://x/y/pull/9"}],
+            None,
+        ),
+    )
+    result = check_drift010(drift_paths(tmp_path))
+    assert not result.passed
+    assert "in_review without open PR" in result.detail
+
+
+def test_drift010_flags_stale_in_progress(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path)
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "items": [
+            {
+                "id": "PVTI_lAHOBl46-84A9KZxstale1",
+                "title": "Abandoned",
+                "status_normalized": "in_progress",
+                "body_excerpt": "(TBD)",
+            }
+        ],
+    }
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    monkeypatch.setattr(
+        drift_checks,
+        "_open_pr_bodies",
+        lambda repo: (
+            [{"number": 2, "body": "other", "url": "https://x/y/pull/2"}],
+            None,
+        ),
+    )
+    result = check_drift010(drift_paths(tmp_path))
+    assert not result.passed
+    assert "stale in_progress" in result.detail
+
+
+def test_drift010_skips_when_pr_list_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path)
+    snap = {"schema": "project-board-snapshot/v1", "items": []}
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    monkeypatch.setattr(
+        drift_checks, "_open_pr_bodies", lambda repo: ([], "network down")
+    )
+    result = check_drift010(drift_paths(tmp_path))
+    assert result.passed
+    assert "cannot list open PRs" in result.detail
+
+
+def test_drift010_repo_from_snapshot_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, default_repo="")
+    snap = {
+        "schema": "project-board-snapshot/v1",
+        "project": {"default_repo": "org/from-snap"},
+        "items": [],
+    }
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    seen: list[str] = []
+
+    def capture(repo: str):
+        seen.append(repo)
+        return [], None
+
+    monkeypatch.setattr(drift_checks, "_open_pr_bodies", capture)
+    result = check_drift010(drift_paths(tmp_path))
+    assert result.passed
+    assert seen == ["org/from-snap"]
+
+
+def test_drift010_skips_non_board_only(tmp_path: Path) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, policy="mirror")
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(
+        json.dumps({"items": []}), encoding="utf-8"
+    )
+    result = check_drift010(drift_paths(tmp_path))
+    assert result.passed
+    assert "board/PR check skipped" in result.detail
+
+
+def test_drift010_pyyaml_and_parse_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _planning(tmp_path)
+    _write_collab(tmp_path, raw="{")
+    result = check_drift010(drift_paths(tmp_path))
+    assert not result.passed
+    assert "cannot parse" in result.detail
+
+    _write_collab(tmp_path)
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocker(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocker)
+    result = check_drift010(drift_paths(tmp_path))
+    assert result.passed
+    assert "PyYAML missing" in result.detail
+
+
+def test_drift004b_fails_status_mismatch(tmp_path: Path) -> None:
+    planning = tmp_path / ".local" / "index-and-planning" / "current"
+    planning.mkdir(parents=True)
+    (planning / "work-tracker.md").write_text(
+        "# Work Tracker\n\n## Active\n\n(none)\n", encoding="utf-8"
+    )
+    (planning / "session-pointer.md").write_text(
+        "| Field | Value |\n|-------|--------|\n"
+        "| **Board** | PVTI_lAHOBl46-84A9KZxboard1 Ready |\n",
+        encoding="utf-8",
+    )
+    _write_collab(tmp_path)
+    snap = {
+        "items": [
+            {
+                "id": "PVTI_lAHOBl46-84A9KZxboard1",
+                "status_normalized": "in_progress",
+                "status": "In Progress",
+            }
+        ]
+    }
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    result = check_drift004b(drift_paths(tmp_path))
+    assert not result.passed
+    assert "vs snapshot" in result.detail
+
+
+def test_drift004b_passes_empty_pointer_status(tmp_path: Path) -> None:
+    planning = tmp_path / ".local" / "index-and-planning" / "current"
+    planning.mkdir(parents=True)
+    (planning / "work-tracker.md").write_text(
+        "# Work Tracker\n\n## Active\n\n(none)\n", encoding="utf-8"
+    )
+    (planning / "session-pointer.md").write_text(
+        "| Field | Value |\n|-------|--------|\n"
+        "| **Board** | PVTI_lAHOBl46-84A9KZxboard2 |\n",
+        encoding="utf-8",
+    )
+    _write_collab(tmp_path)
+    snap = {
+        "items": [
+            {
+                "id": "PVTI_lAHOBl46-84A9KZxboard2",
+                "status_normalized": "ready",
+            }
+        ]
+    }
+    gen = tmp_path / ".local" / "generated-data"
+    gen.mkdir(parents=True)
+    (gen / "project-board-snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+    result = check_drift004b(drift_paths(tmp_path))
+    assert result.passed
+


### PR DESCRIPTION
## Summary
- Auto-stamp board Notes as `@user/agent · ISO-8601-UTC · text` via claim/handoff/append-notes
- Local `continuity-index.md` (≥3-day rolling) + exemplar; board Notes keep full card lifetime
- Rate-limit **outbox** (`project outbox status|flush`, EXIT_QUEUED=6) — local buffer, not a second Status SSOT
- Agent/skill/template alignment (slice vs bug routing, `--last`, STANDALONE, canonical handoff lines)
- Entry docs (HANDOFF, AGENTS, ADR-008, IMPLEMENTATION-STATUS Tests: 901) aligned; payload synced

Board: `PVTI_lAHOBl46-84A9KZxzgzRbNs` ([SHIP] CONT-TS docs+outbox PR)

## Test plan
- [x] `pytest --collect-only` = 901; DOC-006 green
- [x] `make sync-plugin` / `make check-plugin`
- [x] `make doc-validate` + governance + debrand
- [ ] `prepare.py` gates on this PR
- [ ] Full `pytest -q` in prepare (expect ~900 passed, 1 skipped)


Made with [Cursor](https://cursor.com)