### PR TITLE
Add facts-only agent workflow and board collaboration canvases

### DIFF
--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -1,0 +1,465 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type FlowMode = "slice" | "side";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  "project-board-collaboration.md · project-board-ssot/SKILL.md · .cursor/agents/*.md · agent-roster edges";
+
+const STATUS_STEPS = ["Ready", "In progress", "In review", "Done"];
+
+const ROSTER_NODES = [
+  { id: "project-board" },
+  { id: "implementer" },
+  { id: "verifier" },
+  { id: "workflow-drift-guard" },
+  { id: "enterprise-auditor" },
+  { id: "integrator-mas-agent" },
+  { id: "test-runner" },
+];
+
+const ROSTER_EDGES = [
+  { from: "project-board", to: "implementer" },
+  { from: "implementer", to: "verifier" },
+  { from: "implementer", to: "workflow-drift-guard" },
+  { from: "workflow-drift-guard", to: "project-board" },
+  { from: "workflow-drift-guard", to: "implementer" },
+  { from: "enterprise-auditor", to: "implementer" },
+  { from: "integrator-mas-agent", to: "implementer" },
+  { from: "integrator-mas-agent", to: "test-runner" },
+  { from: "integrator-mas-agent", to: "enterprise-auditor" },
+];
+
+const EDGE_LABELS: Record<string, string> = {
+  "project-board→implementer": "handoff next=implementer",
+  "implementer→verifier": "Exit --next verifier",
+  "implementer→workflow-drift-guard": "P0/P1 after drift-validate",
+  "workflow-drift-guard→project-board": "dual-write remediation",
+  "workflow-drift-guard→implementer": "dual-write remediation",
+  "enterprise-auditor→implementer": "Notes + artifact paths",
+  "integrator-mas-agent→implementer": "escalate product src/",
+  "integrator-mas-agent→test-runner": "escalate coverage",
+  "integrator-mas-agent→enterprise-auditor": "escalate architecture",
+};
+
+const PER_AGENT_ENTRY_EXIT = [
+  [
+    "project-board",
+    "status + list",
+    "Full triage; handoff to implementer",
+  ],
+  [
+    "implementer",
+    "status + claim --agent implementer",
+    "handoff --agent implementer --next … --to in_review or →Done",
+  ],
+  [
+    "test-runner",
+    "status + slice card",
+    "→In review or →Done; --agent test-runner",
+  ],
+  [
+    "verifier",
+    "status + related card",
+    "→Done or leave In review; --agent verifier",
+  ],
+  [
+    "integrator-mas-agent",
+    "status + claim",
+    "→Done; --agent integrator-mas-agent",
+  ],
+  [
+    "enterprise-auditor",
+    "status + audit card",
+    "→In review/Done; --agent enterprise-auditor + artifact paths",
+  ],
+  [
+    "workflow-drift-guard",
+    "Must status + list In progress",
+    "Drift card →Done; --agent workflow-drift-guard; remediation via Notes/Ready — no silent tracker edits",
+  ],
+  [
+    "researcher",
+    "status (+ research card)",
+    "Research card →Done; --agent researcher + corpus paths",
+  ],
+];
+
+const ARTIFACT_FLOWS = [
+  [
+    "Board card body (Acceptance / Rollback / Notes)",
+    "All agents (Exit append-notes --agent)",
+    "Entry read; Exit handoff",
+    "All agents",
+    "Continuation index; @user/agent · UTC · …; next=@user/agent",
+  ],
+  [
+    ".local/index-and-planning/current/change-index.md",
+    "implementer, project-board, integrator, verifier, test-runner, enterprise-auditor (Exit)",
+    "Slice close / triage",
+    "Next agents, humans, ICC",
+    "Append row; scope pointer for continuation",
+  ],
+  [
+    ".local/index-and-planning/history/updates-log.md",
+    "All agents (Exit one-liner)",
+    "Slice close",
+    "Drift / continuity readers",
+    "One UTC line per close",
+  ],
+  [
+    ".local/index-and-planning/current/test-index.md / test-plan.md",
+    "test-runner",
+    "When tests or ownership change",
+    "test-runner (Entry); implementer when slice touches tests",
+    "Test scope and coverage tracking",
+  ],
+  [
+    ".local/workflow-artifacts/drift/drift-audit.md + drift-todos.md",
+    "workflow-drift-guard",
+    "After drift validate pass",
+    "project-board, implementer (via Notes / Ready)",
+    "Dual-write evidence; remediation handoff — no silent tracker edits",
+  ],
+  [
+    ".local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md + enterprise-audit-actions.md",
+    "enterprise-auditor",
+    "Audit complete",
+    "implementer",
+    "implementer applies tracker actions from Notes paths",
+  ],
+  [
+    ".local/workflow-artifacts/alignment/alignment-audit.md + alignment-todos.md",
+    "enterprise-auditor (optional)",
+    "Governance drift findings",
+    "implementer (advisory)",
+    "Optional alignment pass; no auto-remediation",
+  ],
+  [
+    ".local/workflow-artifacts/pr/ (review.md, prep.md, merge.md)",
+    "Maintainer PR scripts (local)",
+    "PR Pattern A phases",
+    "verifier",
+    "Required for merge readiness when maintainer workflow in play",
+  ],
+  [
+    "_research_results/",
+    "researcher only",
+    "Research corpus work",
+    "researcher",
+    "Local gitignored corpus; no product handoff edges",
+  ],
+  [
+    ".local/generated-data/board-outbox.jsonl",
+    "cursor_workflow project CLI",
+    "EXIT_QUEUED (6) on rate-limit",
+    "Any agent / human (outbox flush)",
+    "Local buffer — not a second Status SSOT",
+  ],
+  [
+    ".local/generated-data/project-board-snapshot.json",
+    "project export (read-only)",
+    "DRIFT-010 refresh",
+    "workflow-drift-guard",
+    "Read-only export; never writes Status",
+  ],
+  [
+    "session-pointer.md / plan.md / work-tracker.md",
+    "Fallback trackers (offline only)",
+    "When board disabled or CLI fallback",
+    "All agents (offline Entry)",
+    "Offline SSOT only — resume board sync when available",
+  ],
+];
+
+const NEXT_AGENT_STEPS = [
+  "List Ready / In progress / In review on board (project status · project list)",
+  "Read Notes: @owner.github_user/agent · YYYY-MM-DDTHH:MM:SSZ · …",
+  "Follow handoff line: item_id=… · Status=a→b · next=@user/agent",
+  "Follow artifact paths in Notes (e.g. enterprise-auditor → implementer)",
+  "Claim with project claim --last --agent <this-agent> after create",
+];
+
+const SLICE_FLOW = [
+  "project-board: status + list → triage Ready → handoff next=implementer",
+  "implementer: claim --agent implementer → code + gates → handoff --next verifier (typical)",
+  "test-runner (when tests gate PR): status + slice card → test-index / test-plan → in_review",
+  "verifier: status + related card → evidence check → done or in_review with failure Notes",
+];
+
+const SIDE_FLOW = [
+  "enterprise-auditor: audit card → write .local/workflow-artifacts/… → Notes paths → implementer",
+  "implementer: make drift-validate → P0/P1 → hand off workflow-drift-guard",
+  "workflow-drift-guard: must read board In progress → drift artifacts → drift card done; remediation via Notes/Ready to project-board or implementer",
+  "integrator-mas-agent: integration card → validate → escalate to implementer | test-runner | enterprise-auditor",
+];
+
+function CollaborationDag({
+  tokens,
+}: {
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const layout = computeDAGLayout(ROSTER_NODES, ROSTER_EDGES, {
+    direction: "horizontal",
+    nodeWidth: 130,
+    nodeHeight: 40,
+    rankGap: 48,
+    nodeGap: 20,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 24;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 24;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 960 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        const label = EDGE_LABELS[`${e.from}→${e.to}`] ?? "";
+        const mx = (x1 + x2) / 2;
+        const my = (y1 + y2) / 2 - 6;
+        return (
+          <g key={i}>
+            <line
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke={tokens.stroke.secondary}
+              strokeWidth={1.5}
+            />
+            {label ? (
+              <text
+                x={mx}
+                y={my}
+                textAnchor="middle"
+                fill={tokens.text.tertiary}
+                fontSize={8}
+              >
+                {label.length > 28 ? label.slice(0, 26) + "…" : label}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={
+              n.id === "project-board"
+                ? tokens.fill.primary
+                : tokens.fill.secondary
+            }
+            stroke={
+              n.id === "project-board"
+                ? tokens.accent.primary
+                : tokens.stroke.primary
+            }
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={9}
+          >
+            {n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentBoardCollaborationCanvas() {
+  const { tokens } = useHostTheme();
+  const [flowMode, setFlowMode] = useCanvasState<FlowMode>("flowMode", "slice");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>Agent × Project board collaboration</H1>
+          <Pill tone="info" size="sm">
+            board SSOT
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          How kit agents collaborate via GitHub Project Status, roster handoffs,
+          and local evidence artifacts.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Callout tone="info" title="SSOT tiers (board_only)">
+        <Stack gap={6}>
+          <Text>
+            GitHub Project = only writable Status SSOT when project_ssot.enabled
+            and sync_policy: board_only.
+          </Text>
+          <Text>
+            Local evidence (.local/workflow-artifacts/, change-index, PR artifacts)
+            stays local — never competes with board Status.
+          </Text>
+          <Text>
+            .local/generated-data/board-outbox.jsonl = EXIT_QUEUED buffer on
+            rate-limit — flush later; not a second Status SSOT.
+          </Text>
+        </Stack>
+      </Callout>
+
+      <Grid columns={4} gap={10}>
+        {STATUS_STEPS.map((step, i) => (
+          <Stat
+            key={step}
+            value={String(i + 1)}
+            label={step}
+            tone={i === STATUS_STEPS.length - 1 ? "success" : "neutral"}
+          />
+        ))}
+      </Grid>
+      <Text tone="tertiary" size="small">
+        Status path: Ready → In progress → In review → Done
+      </Text>
+
+      <Divider />
+
+      <Card>
+        <CardHeader>Collaboration DAG (board-centered roster edges)</CardHeader>
+        <CardBody>
+          <Callout tone="neutral" title="GitHub Project = continuation hub">
+            Every agent Entry reads board Status + card body; Exit updates Status
+            and attributed Notes. DAG edges are explicit handoffs from agent cards
+            — all paths route through board Status/Notes.
+          </Callout>
+          <Spacer size={10} />
+          <CollaborationDag tokens={tokens} />
+          <Text tone="tertiary" size="small">
+            researcher: no product handoff edges — redirects only (see
+            agent-roster canvas).
+          </Text>
+        </CardBody>
+      </Card>
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Flow paths</H2>
+          <Toggle
+            checked={flowMode === "slice"}
+            onChange={(on) => setFlowMode(on ? "slice" : "side")}
+            label={
+              flowMode === "slice"
+                ? "Typical slice flow"
+                : "Audit / drift side paths"
+            }
+          />
+        </Row>
+        <CollapsibleSection
+          title={
+            flowMode === "slice"
+              ? "Typical slice (project-board-ssot SKILL § Multi-agent handoffs)"
+              : "Audit / drift side paths"
+          }
+          defaultOpen
+        >
+          <Stack gap={6}>
+            {(flowMode === "slice" ? SLICE_FLOW : SIDE_FLOW).map((line) => (
+              <Text key={line}>• {line}</Text>
+            ))}
+            {flowMode === "slice" ? (
+              <Text tone="secondary" size="small">
+                Chain from skill: implementer → test-runner → verifier (test-runner
+                optional when tests gate the PR).
+              </Text>
+            ) : null}
+          </Stack>
+        </CollapsibleSection>
+      </Stack>
+
+      <Card>
+        <CardHeader>
+          Per-agent board Entry / Exit (project-board-collaboration.md)
+        </CardHeader>
+        <CardBody>
+          <Table
+            headers={["Agent", "Entry", "Exit (board)"]}
+            rows={PER_AGENT_ENTRY_EXIT}
+          />
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>Artifact flows (agent cards + ops doc paths only)</CardHeader>
+        <CardBody>
+          <Table
+            headers={[
+              "Artifact",
+              "Written by",
+              "When",
+              "Read / used by",
+              "How used",
+            ]}
+            rows={ARTIFACT_FLOWS}
+          />
+        </CardBody>
+      </Card>
+
+      <Callout tone="info" title="How the next agent finds work">
+        <Stack gap={6}>
+          {NEXT_AGENT_STEPS.map((step) => (
+            <Text key={step}>• {step}</Text>
+          ))}
+        </Stack>
+      </Callout>
+
+      <Callout tone="warning" title="Human-only surfaces">
+        Views, workflows, Insights, Project README, status updates, Ready
+        prioritization / product roadmap. Paste README from
+        .ai_infra/templates/project-board/project-readme.md in GitHub UI only —
+        agents never edit these.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Peer view: canvases/agent-roster.canvas.tsx (explicit handoff edges only)
+      </Text>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact
+        paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-enterprise-auditor.canvas.tsx
+++ b/canvases/agent-enterprise-auditor.canvas.tsx
@@ -1,0 +1,331 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/enterprise-auditor.md · enterprise-architecture-audit/SKILL.md · project-board-ssot/SKILL.md";
+
+const GOALS = [
+  "Evidence-only enterprise architecture audit",
+  "Writes workflow artifacts and tracker hooks for other agents",
+  "Propose edits in audit-actions; implementer applies",
+];
+
+const BOARD_NODES = [
+  { id: "status" },
+  { id: "create" },
+  { id: "claim" },
+  { id: "audit" },
+  { id: "artifacts" },
+  { id: "notes" },
+  { id: "handoff" },
+];
+
+const BOARD_EDGES = [
+  { from: "status", to: "create" },
+  { from: "create", to: "claim" },
+  { from: "claim", to: "audit" },
+  { from: "audit", to: "artifacts" },
+  { from: "artifacts", to: "notes" },
+  { from: "notes", to: "handoff" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "audit" },
+  { id: "artifacts" },
+  { id: "close" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "audit" },
+  { from: "audit", to: "artifacts" },
+  { from: "artifacts", to: "close" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  status: "project status",
+  create: "create [AUDIT] slice",
+  claim: "claim --last",
+  audit: "evidence-only audit",
+  artifacts: "audit + alignment",
+  notes: "artifact paths",
+  handoff: "→ implementer",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  audit: "evidence-only audit",
+  artifacts: "audit + alignment",
+  close: "updates-log",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/enterprise-architecture-audit/SKILL.md", "Audit canon"],
+  [".cursor/skills/audit-module-map/SKILL.md", "Optional deep map"],
+  [".cursor/skills/audit-orchestration/SKILL.md", "Optional orchestration"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
+  [".ai_infra/docs/roadmap/alignment-audit-schema.md", "Alignment schema"],
+];
+
+const PATTERNS = [
+  ["create-from-template", "slice [AUDIT] then claim --last"],
+  ["Tracker etiquette", "Propose edits in audit-actions; implementer applies"],
+  ["Attribution", "@owner.github_user/enterprise-auditor via --agent"],
+];
+
+const ARTIFACTS = [
+  [
+    ".local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md",
+    "Exit",
+    "implementer / maintainers",
+  ],
+  [
+    ".local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md",
+    "Exit",
+    "implementer applies",
+  ],
+  [
+    ".local/workflow-artifacts/alignment/alignment-audit.md",
+    "Optional (merge workflow)",
+    "implementer / maintainers",
+  ],
+  [
+    ".local/workflow-artifacts/alignment/alignment-todos.md",
+    "Optional (merge workflow)",
+    "implementer applies",
+  ],
+  ["change-index.md", "Exit", "Next agents / humans"],
+  ["history/updates-log.md", "Exit", "Continuity readers"],
+  ["Board Status + Notes", "in_review / done", "implementer"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Outbound", "implementer", "Continue from Notes with artifact paths"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentEnterpriseAuditorCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>enterprise-auditor</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            evidence only
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Evidence-only enterprise architecture audit; writes workflow artifacts and
+          tracker hooks for other agents.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="Entry→Exit" label="Board-first Anchor" />
+        <Stat value="implementer" label="Typical next (Notes)" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "Entry: project status; may create-from-template slice [AUDIT] then claim."
+            : "Fallback: session-pointer. Audits write .local/ artifacts only."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>1. project status; create [AUDIT] slice card if needed; claim.</Text>
+          <Text>2. Evidence-only audit per enterprise-architecture-audit/SKILL.md.</Text>
+          <Text>
+            3. Write enterprise-architecture-audit.md + enterprise-audit-actions.md;
+            optional alignment artifacts for merge workflow.
+          </Text>
+          <Text>4. Propose tracker edits in audit-actions — implementer applies.</Text>
+          <Text>
+            5. Exit: artifacts + change-index + updates-log; Status in_review/done;
+            Notes with artifact paths for implementer.
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Audits are advisory — findings only; implementer applies tracker edits.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              May create-from-template --template slice [AUDIT] then claim --last.
+            </Text>
+            <Text>
+              Exit: Status in_review or done; Notes with artifact paths for
+              implementer.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Kit server workflow-kit for audit scripts — prefer cursor_workflow project for
+        board. External: only servers listed for this agent in mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -1,0 +1,385 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/implementer.md · implementation-execution-loop/SKILL.md · project-board-ssot/SKILL.md § Continuation";
+
+const GOALS = [
+  "Disciplined implementation slices with trackers and Pattern A gates",
+  "Small, reversible slices with production quality",
+  "Clear module boundaries, tests, and board Status (or fallback trackers)",
+];
+
+const BOARD_NODES = [
+  { id: "yaml" },
+  { id: "status" },
+  { id: "claim" },
+  { id: "code" },
+  { id: "gates" },
+  { id: "evidence" },
+  { id: "handoff" },
+  { id: "next" },
+];
+
+const BOARD_EDGES = [
+  { from: "yaml", to: "status" },
+  { from: "status", to: "claim" },
+  { from: "claim", to: "code" },
+  { from: "code", to: "gates" },
+  { from: "gates", to: "evidence" },
+  { from: "evidence", to: "handoff" },
+  { from: "handoff", to: "next" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "plan" },
+  { id: "tracker" },
+  { id: "code" },
+  { id: "gates" },
+  { id: "evidence" },
+  { id: "close" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "plan" },
+  { from: "plan", to: "tracker" },
+  { from: "tracker", to: "code" },
+  { from: "code", to: "gates" },
+  { from: "gates", to: "evidence" },
+  { from: "evidence", to: "close" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  yaml: "project_ssot YAML",
+  status: "project status",
+  claim: "claim / Ready list",
+  code: "contracts → code → tests",
+  gates: "prepare.py GATES",
+  evidence: "change-index + updates-log",
+  handoff: "handoff --next verifier",
+  next: "verifier (typical)",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  plan: "plan.md",
+  tracker: "work-tracker.md",
+  code: "contracts → code → tests",
+  gates: "prepare.py GATES",
+  evidence: "change-index + updates-log",
+  close: "close tracker (offline)",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/implementation-execution-loop/SKILL.md", "Slice lifecycle"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
+  [".ai_infra/templates/project-board/README.md", "When creating cards"],
+  [".local/user_settings/github.collaboration.yaml", "project_ssot block"],
+  [".local/index-and-planning/current/architecture.md", "Architecture stub"],
+  ["session-pointer / plan / work-tracker", "Fallback only"],
+  ["test-plan.md / test-index.md", "When tests or ownership change"],
+];
+
+const ARTIFACTS = [
+  [
+    "change-index.md",
+    "Exit / close",
+    "Next agents, humans",
+  ],
+  [
+    "history/updates-log.md",
+    "One line per close",
+    "Drift / continuity readers",
+  ],
+  [
+    "test-plan.md / test-index.md",
+    "When tests change",
+    "test-runner",
+  ],
+  [
+    "coverage-index (make coverage-index)",
+    "When coverage mattered",
+    "ICC / maintainers",
+  ],
+  [
+    "Board Status + Notes",
+    "Exit (board_only)",
+    "verifier / next agent",
+  ],
+  [
+    ".local/generated-data/board-outbox.jsonl",
+    "EXIT_QUEUED (6)",
+    "Later flush (any agent/human)",
+  ],
+];
+
+const PATTERNS = [
+  ["Pattern A recipes", "claim --last / handoff --last / create-from-template"],
+  ["Templates", "slice (feature/chore) · bug (defect/fix)"],
+  ["Module headers", "file-docstring-header-relations.mdc on new sources"],
+  ["Commit trailers", "Author + GitHub-User via contributors commit-trailers"],
+  ["Gates", "prepare.py GATES; check_governance_consistency when policy docs change"],
+  ["Attribution", "@owner.github_user/implementer via --agent implementer"],
+];
+
+const PEERS = [
+  ["Outbound", "verifier", "handoff --next verifier (Exit recipe)"],
+  ["Outbound", "workflow-drift-guard", "When make drift-validate finds P0/P1 needing artifacts"],
+  ["Inbound", "project-board", "Triage hands Ready cards for implementation"],
+  ["Inbound", "enterprise-auditor", "Audit Notes / artifact paths for implementer to apply"],
+  ["Escalation (integrator)", "integrator may hand product src/ to implementer", "integrator card"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentImplementerCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>implementer</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            STANDALONE product
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Disciplined implementation slices with trackers and Pattern A gates.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="Entry→Exit" label="Board-first Anchor" />
+        <Stat value="verifier" label="Typical next (Exit recipe)" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "GitHub Project is the only writable Status SSOT. Do not dual-write work-tracker in_progress."
+            : "Read session-pointer then plan/work-tracker. Resume board sync when available."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>
+            1. One primary claimed card (in_progress) when SSOT on; else one
+            in_progress in work-tracker.md. Scope on card body or plan.md.
+          </Text>
+          <Text>
+            2. Contracts → implementation → tests. New sources: module header
+            (file-docstring-header-relations.mdc).
+          </Text>
+          <Text>
+            3. Gates: python .ai_infra/scripts/pr/prepare.py (or its GATES). Add
+            check_governance_consistency.py if governance/policy docs changed.
+          </Text>
+          <Text>
+            4. Commits: contributors commit-trailers. Optional Assisted-by. No
+            tool-generated human sign-off.
+          </Text>
+          <Text>
+            5. Close: board Status via CLI; change-index + updates-log; make
+            drift-validate; hand off to workflow-drift-guard on P0/P1 findings.
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+              rowTone={READ_FIRST.map(() => "neutral" as const)}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path", "When", "Consumed by"]}
+              rows={ARTIFACTS}
+            />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Tier 2 .local/workflow-artifacts/ (PR/audit) stay local — implementer
+              is not primary writer of review/prep/merge artifacts.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              Rights: Status + Notes on the card you touch. Prefer claim --last /
+              handoff --last --agent implementer → @owner.github_user/implementer.
+            </Text>
+            <Text>
+              Exit recipe: project handoff --last --agent implementer --next
+              verifier --to in_review (or --to done).
+            </Text>
+            <Text>
+              Templates: create-from-template --template slice|bug then claim
+              --last. Project README is human-only.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; continue local
+              evidence; do not hammer GraphQL.
+            </Text>
+            <Text>
+              CLI helper: project guide. Canon: project-board-ssot/SKILL.md §
+              Continuation.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table
+          headers={["Direction", "Agent", "Evidence"]}
+          rows={PEERS}
+        />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Kit server workflow-kit for PR scripts/gates — prefer cursor_workflow
+        project for board. External: only servers listed for this agent in
+        mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact
+        paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-integrator-mas-agent.canvas.tsx
+++ b/canvases/agent-integrator-mas-agent.canvas.tsx
@@ -1,0 +1,318 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/integrator-mas-agent.md · mas-infrastructure-integration/SKILL.md · project-board-ssot/SKILL.md";
+
+const GOALS = [
+  "Integrates new agents, skills, MCP, and infrastructure expansions",
+  "Procedural, evidence-only, Pattern A",
+  "Escalate to enterprise-auditor, test-runner, implementer, PR maintainer skills",
+];
+
+const BOARD_NODES = [
+  { id: "status" },
+  { id: "skill" },
+  { id: "claim" },
+  { id: "intake" },
+  { id: "wire" },
+  { id: "verify" },
+  { id: "handoff" },
+];
+
+const BOARD_EDGES = [
+  { from: "status", to: "skill" },
+  { from: "skill", to: "claim" },
+  { from: "claim", to: "intake" },
+  { from: "intake", to: "wire" },
+  { from: "wire", to: "verify" },
+  { from: "verify", to: "handoff" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "intake" },
+  { id: "wire" },
+  { id: "verify" },
+  { id: "handoff" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "intake" },
+  { from: "intake", to: "wire" },
+  { from: "wire", to: "verify" },
+  { from: "verify", to: "handoff" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  status: "project status",
+  skill: "mas-infrastructure",
+  claim: "claim / create card",
+  intake: "Intake → Plan",
+  wire: "templates → wire",
+  verify: "validate + gates",
+  handoff: "escalate / close",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  intake: "Intake → Plan",
+  wire: "templates → wire",
+  verify: "validate + gates",
+  handoff: "escalate / close",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/mas-infrastructure-integration/SKILL.md", "Integration canon"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
+  ["python3 -m cursor_workflow integrate validate", "Wire verification"],
+  ["check_governance_consistency.py", "When policy docs change"],
+];
+
+const PATTERNS = [
+  ["Pattern A", "claim --last / handoff --last / create-from-template"],
+  ["STANDALONE", "Product lives only in mas-workflow-kit-project-ssot"],
+  ["Attribution", "@owner.github_user/integrator-mas-agent via --agent"],
+];
+
+const ARTIFACTS = [
+  ["change-index.md", "Exit", "Next agents / humans"],
+  ["history/updates-log.md", "Exit", "Continuity readers"],
+  ["Board Status + Notes", "Exit (validate outcomes)", "implementer / escalations"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Escalation", "enterprise-auditor", "Architecture-impacting integration"],
+  ["Escalation", "test-runner", "Coverage work"],
+  ["Escalation", "implementer", "Product src/ handoff"],
+  ["Escalation", "PR maintainer skills", "pr-workflow pipeline"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentIntegratorMasAgentCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>integrator-mas-agent</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            STANDALONE product
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Integrates new agents, skills, MCP, and infrastructure expansions —
+          procedural, evidence-only, Pattern A.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="Entry→Exit" label="Board-first Anchor" />
+        <Stat value="integrate validate" label="Wire verification" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "Entry: project status + mas-infrastructure-integration skill; claim/create card."
+            : "Fallback: session-pointer. Resume board sync when available."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>1. Intake: read integration request; project status + skill.</Text>
+          <Text>2. Plan: board card with scope and acceptance criteria.</Text>
+          <Text>3. Templates → wire agents/skills/MCP into kit structure.</Text>
+          <Text>
+            4. Verify: contributors validate, gates, governance consistency,
+            integrate validate.
+          </Text>
+          <Text>
+            5. Handoff: Status done or in_review if verify failed; Notes with
+            validate outcomes; change-index; updates-log.
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Escalates product src/, coverage, audits, and PR work to peer agents.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              Entry: project status + mas-infrastructure-integration skill;
+              claim/create card.
+            </Text>
+            <Text>
+              Exit: Status done or in_review if verify failed; Notes with validate
+              outcomes.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Kit server workflow-kit for integrate validate — prefer cursor_workflow
+        project for board. External: only servers listed for this agent in
+        mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-project-board.canvas.tsx
+++ b/canvases/agent-project-board.canvas.tsx
@@ -1,0 +1,307 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/project-board.md · project-board-ssot/SKILL.md · ADR-006";
+
+const GOALS = [
+  "Independent-governed helper for GitHub Project SSOT",
+  "List/create/move cards via project_ssot CLI",
+  "Triage Ready cards and hand off to implementer",
+];
+
+const BOARD_NODES = [
+  { id: "yaml" },
+  { id: "status" },
+  { id: "list" },
+  { id: "triage" },
+  { id: "create" },
+  { id: "claim" },
+  { id: "handoff" },
+];
+
+const BOARD_EDGES = [
+  { from: "yaml", to: "status" },
+  { from: "status", to: "list" },
+  { from: "list", to: "triage" },
+  { from: "triage", to: "create" },
+  { from: "create", to: "claim" },
+  { from: "claim", to: "handoff" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "trackers" },
+  { id: "close" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "trackers" },
+  { from: "trackers", to: "close" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  yaml: "project_ssot YAML",
+  status: "project status",
+  list: "list ready",
+  triage: "move Status",
+  create: "create-from-template",
+  claim: "claim --last",
+  handoff: "→ implementer",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  trackers: "local trackers",
+  close: "updates-log",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/project-board-ssot/SKILL.md", "Board SSOT canon"],
+  [".local/user_settings/github.collaboration.yaml", "project_ssot block"],
+  [".ai_infra/templates/project-board/README.md", "Card templates"],
+  ["ADR-006", "Independent-governed agent"],
+];
+
+const PATTERNS = [
+  ["Independent-governed", "Not in default PR pipelines"],
+  ["Loop", "status → list ready → create-from-template + claim --last → handoff"],
+  ["Attribution", "@owner.github_user/project-board via --agent"],
+];
+
+const ARTIFACTS = [
+  ["change-index.md", "Exit", "Next agents / humans"],
+  ["history/updates-log.md", "Exit", "Continuity readers"],
+  ["Board Status + Notes", "Every triage", "implementer / next agent"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Outbound", "implementer", "handoff next=implementer (typical)"],
+  ["Inbound", "workflow-drift-guard", "Dual-write remediation via Ready"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentProjectBoardCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>project-board</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            independent-governed
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Independent-governed helper — list/create/move GitHub Project SSOT cards via
+          project_ssot CLI.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="Entry→Exit" label="Board SSOT triage" />
+        <Stat value="implementer" label="Typical handoff next" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "Entry: YAML + skill + project status + list. Primary board triage agent."
+            : "Fallback: session-pointer + local trackers. Resume board sync when available."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>1. Read YAML + project-board-ssot skill; project status.</Text>
+          <Text>2. list --status ready (or other triage views).</Text>
+          <Text>3. create-from-template + claim --last for new work.</Text>
+          <Text>4. Move Status for every triage action.</Text>
+          <Text>
+            5. Exit: Status for every triage; change-index; updates-log; handoff
+            next=implementer|….
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Primary writer of board Status/Notes during triage — not product code.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              Rights: list/create/move GitHub Project SSOT cards via cursor_workflow
+              project CLI.
+            </Text>
+            <Text>
+              Exit: Status for every triage; change-index; updates-log; handoff
+              --next implementer (typical).
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+            <Text>CLI helper: project guide. ADR-006 independent-governed.</Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Prefer cursor_workflow project for all board operations. External: only
+        servers listed for this agent in mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -1,0 +1,302 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · _research_results/RESEARCH_BOUNDARIES.md";
+
+const GOALS = [
+  "Optional local research corpus",
+  "Hard-stop on product code without explicit scope",
+  "Write only _research_results/ — no src/tests/scripts/git/PR",
+];
+
+const BOARD_NODES = [
+  { id: "status" },
+  { id: "list" },
+  { id: "boundaries" },
+  { id: "corpus" },
+  { id: "done" },
+  { id: "notes" },
+];
+
+const BOARD_EDGES = [
+  { from: "status", to: "list" },
+  { from: "list", to: "boundaries" },
+  { from: "boundaries", to: "corpus" },
+  { from: "corpus", to: "done" },
+  { from: "done", to: "notes" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "boundaries" },
+  { id: "corpus" },
+  { id: "close" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "boundaries" },
+  { from: "boundaries", to: "corpus" },
+  { from: "corpus", to: "close" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  status: "project status",
+  list: "research card list",
+  boundaries: "RESEARCH_BOUNDARIES",
+  corpus: "_research_results/",
+  done: "set-status done",
+  notes: "corpus paths",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  boundaries: "RESEARCH_BOUNDARIES",
+  corpus: "_research_results/",
+  close: "local close",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/research-corpus-execution/SKILL.md", "Research canon"],
+  ["_research_results/RESEARCH_BOUNDARIES.md", "Hard-stop boundaries"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
+];
+
+const PATTERNS = [
+  ["Hard stop", "Write only _research_results/"],
+  ["Forbidden", "No src/tests/scripts; no git commit/push/PR"],
+  ["Attribution", "@owner.github_user/researcher via --agent"],
+];
+
+const ARTIFACTS = [
+  ["_research_results/", "Exit", "Humans / implementer (read-only input)"],
+  ["Board Status + Notes", "Research card done + corpus paths", "Next agents"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Use instead", "implementer", "Product code changes"],
+  ["Use instead", "pr-workflow", "Git commit/push/PR"],
+  ["Use instead", "enterprise-auditor", "Architecture audits"],
+  ["Use instead", "verifier", "Claims vs evidence"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentResearcherCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>researcher</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="warning" size="sm">
+            optional / off by default
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Optional local research corpus; hard-stop on product code without explicit
+          scope.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="_research_results/" label="Only write target" />
+        <Stat value="hard stop" label="No product code" tone="warning" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout tone="warning" title="Hard stop">
+          Write only _research_results/. No src/tests/scripts. No git commit/push/PR.
+          Use implementer, pr-workflow, enterprise-auditor, or verifier instead for
+          those tasks.
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>
+            1. Entry: project status (+ research card list); else session-pointer.
+          </Text>
+          <Text>2. Read _research_results/RESEARCH_BOUNDARIES.md and research-corpus-execution skill.</Text>
+          <Text>3. Produce corpus under _research_results/ only.</Text>
+          <Text>
+            4. If research card: set-status done + Notes with corpus paths.
+          </Text>
+          <Text>5. Do not touch product code, tests, scripts, or git/PR workflows.</Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Research output is read-only input for humans and product agents —
+              not shipped product code.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>Entry: project status + research card list when board on.</Text>
+            <Text>
+              Exit: corpus under _research_results/; research card set-status done +
+              Notes with corpus paths.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        External research MCP only when listed for this agent in mcp.registry.yaml.
+        Prefer cursor_workflow project for board when research card exists.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -1,0 +1,281 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Stack,
+  Table,
+  Text,
+  computeDAGLayout,
+  useHostTheme,
+} from "cursor/canvas";
+
+const VERIFIED = "2026-07-18";
+const SOURCES = "Aggregated from .cursor/agents/*.md";
+
+const AGENTS = [
+  {
+    id: "implementer",
+    description: "Disciplined implementation slices with trackers and Pattern A gates",
+  },
+  {
+    id: "verifier",
+    description: "Claims vs evidence; minimal high-signal checks",
+  },
+  {
+    id: "test-runner",
+    description: "Module-focused tests, regressions, coverage",
+  },
+  {
+    id: "workflow-drift-guard",
+    description:
+      "Operational workflow drift detection; plan/tracker/session coherence and handoff parity",
+  },
+  {
+    id: "enterprise-auditor",
+    description:
+      "Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents",
+  },
+  {
+    id: "project-board",
+    description:
+      "Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI",
+  },
+  {
+    id: "integrator-mas-agent",
+    description:
+      "Integrates new agents, skills, MCP, and infrastructure expansions — procedural, evidence-only, Pattern A",
+  },
+  {
+    id: "researcher",
+    description:
+      "Optional local research corpus; hard-stop on product code without explicit scope",
+  },
+];
+
+const ROSTER_NODES = [
+  { id: "project-board" },
+  { id: "implementer" },
+  { id: "verifier" },
+  { id: "workflow-drift-guard" },
+  { id: "enterprise-auditor" },
+  { id: "integrator-mas-agent" },
+  { id: "test-runner" },
+  { id: "researcher" },
+];
+
+const ROSTER_EDGES = [
+  { from: "project-board", to: "implementer" },
+  { from: "implementer", to: "verifier" },
+  { from: "implementer", to: "workflow-drift-guard" },
+  { from: "workflow-drift-guard", to: "project-board" },
+  { from: "workflow-drift-guard", to: "implementer" },
+  { from: "enterprise-auditor", to: "implementer" },
+  { from: "integrator-mas-agent", to: "implementer" },
+  { from: "integrator-mas-agent", to: "test-runner" },
+  { from: "integrator-mas-agent", to: "enterprise-auditor" },
+];
+
+const EDGE_LABELS: Record<string, string> = {
+  "project-board→implementer": "handoff next=implementer",
+  "implementer→verifier": "Exit --next verifier",
+  "implementer→workflow-drift-guard": "P0/P1 after drift-validate",
+  "workflow-drift-guard→project-board": "dual-write remediation",
+  "workflow-drift-guard→implementer": "dual-write remediation",
+  "enterprise-auditor→implementer": "Notes + artifact paths",
+  "integrator-mas-agent→implementer": "escalate product src/",
+  "integrator-mas-agent→test-runner": "escalate coverage",
+  "integrator-mas-agent→enterprise-auditor": "escalate architecture",
+};
+
+const RESEARCHER_REDIRECTS = [
+  ["implementer", "Product code changes"],
+  ["verifier", "Claims vs evidence"],
+  ["enterprise-auditor", "Architecture audits"],
+  ["pr-workflow", "Git commit/push/PR (not researcher)"],
+];
+
+function RosterDag({ tokens }: { tokens: ReturnType<typeof useHostTheme>["tokens"] }) {
+  const layout = computeDAGLayout(ROSTER_NODES, ROSTER_EDGES, {
+    direction: "horizontal",
+    nodeWidth: 130,
+    nodeHeight: 40,
+    rankGap: 48,
+    nodeGap: 20,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 24;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 24;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 960 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        const label = EDGE_LABELS[`${e.from}→${e.to}`] ?? "";
+        const mx = (x1 + x2) / 2;
+        const my = (y1 + y2) / 2 - 6;
+        return (
+          <g key={i}>
+            <line
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke={tokens.stroke.secondary}
+              strokeWidth={1.5}
+            />
+            {label ? (
+              <text
+                x={mx}
+                y={my}
+                textAnchor="middle"
+                fill={tokens.text.tertiary}
+                fontSize={8}
+              >
+                {label.length > 28 ? label.slice(0, 26) + "…" : label}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={
+              n.id === "researcher"
+                ? tokens.fill.tertiary
+                : tokens.fill.secondary
+            }
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={9}
+          >
+            {n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentRosterCanvas() {
+  const { tokens } = useHostTheme();
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>Kit agent roster</H1>
+          <Pill tone="info" size="sm">
+            8 agents
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Explicit handoff edges from agent cards only. researcher is non-product —
+          redirects to product agents.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Card>
+        <CardHeader>Handoff DAG (explicit edges only)</CardHeader>
+        <CardBody>
+          <RosterDag tokens={tokens} />
+          <Text tone="tertiary" size="small">
+            researcher has no product handoff edges — see redirects below.
+          </Text>
+        </CardBody>
+      </Card>
+
+      <Divider />
+
+      <Stack gap={8}>
+        <H2>Goals (one-liner per agent)</H2>
+        <Grid columns={2} gap={10}>
+          {AGENTS.map((a) => (
+            <Stack key={a.id} gap={4}>
+              <Text>{a.id}</Text>
+              <Text tone="secondary" size="small">
+                {a.description}
+              </Text>
+            </Stack>
+          ))}
+        </Grid>
+      </Stack>
+
+      <Card>
+        <CardHeader>researcher → use instead</CardHeader>
+        <CardBody>
+          <Table
+            headers={["Agent", "When"]}
+            rows={RESEARCHER_REDIRECTS}
+          />
+          <Callout tone="warning" title="Non-product agent">
+            researcher writes only _research_results/. No src/tests/scripts; no
+            git/PR. Not connected in product handoff DAG.
+          </Callout>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Edge evidence (card citations)</H2>
+        <Table
+          headers={["From", "To", "Evidence"]}
+          rows={[
+            ["implementer", "verifier", "Exit recipe --next verifier"],
+            [
+              "implementer",
+              "workflow-drift-guard",
+              "P0/P1 after make drift-validate",
+            ],
+            ["project-board", "implementer", "handoff next=implementer"],
+            [
+              "workflow-drift-guard",
+              "project-board | implementer",
+              "Dual-write remediation via Ready",
+            ],
+            [
+              "enterprise-auditor",
+              "implementer",
+              "Notes with artifact paths for implementer",
+            ],
+            [
+              "integrator-mas-agent",
+              "implementer | test-runner | enterprise-auditor",
+              "Escalation table on integrator card",
+            ],
+          ]}
+        />
+      </Stack>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact
+        paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -1,0 +1,318 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/test-runner.md · test-module-coverage/SKILL.md · project-board-ssot/SKILL.md";
+
+const GOALS = [
+  "Module-focused tests, regressions, coverage",
+  "Run targeted module tests before full suite",
+  "Update test-index and test-plan when tests change",
+];
+
+const BOARD_NODES = [
+  { id: "status" },
+  { id: "claim" },
+  { id: "index" },
+  { id: "tests" },
+  { id: "coverage" },
+  { id: "artifacts" },
+  { id: "handoff" },
+  { id: "next" },
+];
+
+const BOARD_EDGES = [
+  { from: "status", to: "claim" },
+  { from: "claim", to: "index" },
+  { from: "index", to: "tests" },
+  { from: "tests", to: "coverage" },
+  { from: "coverage", to: "artifacts" },
+  { from: "artifacts", to: "handoff" },
+  { from: "handoff", to: "next" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "index" },
+  { id: "tests" },
+  { id: "coverage" },
+  { id: "artifacts" },
+  { id: "handoff" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "index" },
+  { from: "index", to: "tests" },
+  { from: "tests", to: "coverage" },
+  { from: "coverage", to: "artifacts" },
+  { from: "artifacts", to: "handoff" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  status: "project status",
+  claim: "claim card",
+  index: "test-index.md",
+  tests: "tests/modules/",
+  coverage: "pytest --cov",
+  artifacts: "test-plan + change-index",
+  handoff: "handoff",
+  next: "next agent",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  index: "test-index.md",
+  tests: "tests/modules/",
+  coverage: "pytest --cov",
+  artifacts: "test-plan + change-index",
+  handoff: "handoff / close",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/test-module-coverage/SKILL.md", "Test lifecycle canon"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
+  [".local/index-and-planning/current/test-index.md", "When tests change"],
+  [".local/index-and-planning/current/test-plan.md", "When tests change"],
+  ["check_testing_artifacts.py", "Before PR path"],
+];
+
+const PATTERNS = [
+  ["Consume only", "No create-from-template"],
+  ["Module layout", "tests/modules/<module>/ matching source boundaries"],
+  ["Attribution", "@owner.github_user/test-runner via --agent test-runner"],
+];
+
+const ARTIFACTS = [
+  ["tests/modules/<module>/", "Implementation / regression", "CI / prepare.py"],
+  ["test-index.md", "When tests change", "test-runner / implementer"],
+  ["test-plan.md", "When tests change", "test-runner / implementer"],
+  ["change-index.md", "Exit", "Next agents / humans"],
+  ["Board Status + Notes", "Exit", "Next agent"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Outbound", "next (generic)", "handoff format per card"],
+  ["Inbound", "integrator-mas-agent", "Escalates coverage work to test-runner"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentTestRunnerCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>test-runner</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            consume only
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Module-focused tests, regressions, coverage.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="Entry→Exit" label="Board-first Anchor" />
+        <Stat value="in_review" label="When tests gate PR" tone="warning" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "Entry: project status + claim. Read test-index when tests change."
+            : "Entry: session-pointer.md. Read test-index when tests change."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>1. Claim card (board) or read session-pointer (fallback).</Text>
+          <Text>2. Read test-index / test-plan when tests or ownership change.</Text>
+          <Text>3. Run module-focused tests; regressions; coverage when required.</Text>
+          <Text>4. check_testing_artifacts.py before PR path.</Text>
+          <Text>
+            5. Exit: Status in_review if tests gate PR else done; update
+            change-index + test-index/test-plan.
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Primary writer of tests/modules/ and test tracker updates for owned
+              slices.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>Entry: project status + claim. Consume only — no create-from-template.</Text>
+            <Text>
+              Exit: must Status in_review if tests gate PR else done; change-index +
+              test-index/test-plan.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Kit server workflow-kit for PR scripts/gates — prefer cursor_workflow project
+        for board. External: only servers listed for this agent in mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -1,0 +1,317 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES = ".cursor/agents/verifier.md · project-board-ssot/SKILL.md § Continuation";
+
+const GOALS = [
+  "Claims vs evidence; minimal high-signal checks",
+  "Restate claim, gather evidence, run smallest decisive checks",
+  "Verdict: Verified | Partial | Not verified with one next action",
+];
+
+const BOARD_NODES = [
+  { id: "status" },
+  { id: "notes" },
+  { id: "claim" },
+  { id: "restate" },
+  { id: "checks" },
+  { id: "verdict" },
+  { id: "handoff" },
+  { id: "next" },
+];
+
+const BOARD_EDGES = [
+  { from: "status", to: "notes" },
+  { from: "notes", to: "claim" },
+  { from: "claim", to: "restate" },
+  { from: "restate", to: "checks" },
+  { from: "checks", to: "verdict" },
+  { from: "verdict", to: "handoff" },
+  { from: "handoff", to: "next" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "restate" },
+  { id: "checks" },
+  { id: "verdict" },
+  { id: "handoff" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "restate" },
+  { from: "restate", to: "checks" },
+  { from: "checks", to: "verdict" },
+  { from: "verdict", to: "handoff" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  status: "project status",
+  notes: "board card Notes",
+  claim: "claim card",
+  restate: "restate claim",
+  checks: "smallest checks",
+  verdict: "Verified|Partial|Not",
+  handoff: "handoff / claim",
+  next: "next agent",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  restate: "restate claim",
+  checks: "smallest checks",
+  verdict: "Verified|Partial|Not",
+  handoff: "handoff / close",
+};
+
+const READ_FIRST = [
+  [".cursor/agents/verifier.md", "Agent card (canon)"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
+  [".local/index-and-planning/current/session-pointer.md", "Fallback Entry"],
+  [".local/workflow-artifacts/pr/", "When maintainer workflow in play"],
+];
+
+const PATTERNS = [
+  ["Consume only", "Do NOT create-from-template"],
+  ["Checks", "pytest · GATES category · governance · verify_publish"],
+  ["Merge gate", "Do not approve merge without pr/ artifacts when maintainer workflow active"],
+  ["Attribution", "@owner.github_user/verifier via --agent verifier"],
+];
+
+const ARTIFACTS = [
+  ["change-index.md", "If findings change status", "Next agents / humans"],
+  ["Board Status + Notes", "Exit (done or in_review + failure Notes)", "Next agent"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Outbound", "next (generic)", "handoff format per card"],
+  ["Inbound", "implementer", "Exit recipe prefers --next verifier"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentVerifierCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>verifier</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            consume only
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Claims vs evidence; minimal high-signal checks.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="Entry→Exit" label="Board-first Anchor" />
+        <Stat value="consume only" label="No create-from-template" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "Entry: project status + board card Notes. Always verify claims vs evidence. No dual-write."
+            : "Entry: session-pointer.md. Always verify claims vs evidence."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>1. Restate the claim under verification.</Text>
+          <Text>2. Gather evidence from repo, artifacts, and board Notes.</Text>
+          <Text>
+            3. Run smallest decisive checks (pytest, GATES category, governance,
+            verify_publish).
+          </Text>
+          <Text>4. Verdict: Verified | Partial | Not verified.</Text>
+          <Text>5. One next action; handoff/claim. Status done or in_review with failure Notes.</Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Verifier consumes artifacts; does not create-from-template or dual-write
+              tracker Status.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              Entry: project status + board card Notes. Claim card for verification
+              work.
+            </Text>
+            <Text>
+              Exit: handoff/claim; Status done or leave in_review with failure Notes.
+            </Text>
+            <Text>
+              change-index if findings change status. Do not dual-write work-tracker
+              Status under board_only.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Kit server workflow-kit for PR scripts/gates — prefer cursor_workflow project
+        for board. External: only servers listed for this agent in mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-workflow-drift-guard.canvas.tsx
+++ b/canvases/agent-workflow-drift-guard.canvas.tsx
@@ -1,0 +1,317 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+type SsotMode = "board" | "fallback";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/workflow-drift-guard.md · workflow-drift-audit/SKILL.md · project-board-ssot/SKILL.md";
+
+const GOALS = [
+  "Operational workflow drift detection",
+  "Plan/tracker/session coherence and handoff parity",
+  "Write drift artifacts only — no product code",
+];
+
+const BOARD_NODES = [
+  { id: "status" },
+  { id: "list" },
+  { id: "validate" },
+  { id: "audit" },
+  { id: "todos" },
+  { id: "card" },
+  { id: "handoff" },
+];
+
+const BOARD_EDGES = [
+  { from: "status", to: "list" },
+  { from: "list", to: "validate" },
+  { from: "validate", to: "audit" },
+  { from: "audit", to: "todos" },
+  { from: "todos", to: "card" },
+  { from: "card", to: "handoff" },
+];
+
+const FALLBACK_NODES = [
+  { id: "session" },
+  { id: "validate" },
+  { id: "audit" },
+  { id: "todos" },
+  { id: "close" },
+];
+
+const FALLBACK_EDGES = [
+  { from: "session", to: "validate" },
+  { from: "validate", to: "audit" },
+  { from: "audit", to: "todos" },
+  { from: "todos", to: "close" },
+];
+
+const BOARD_LABELS: Record<string, string> = {
+  status: "project status",
+  list: "list in_progress",
+  validate: "drift validate",
+  audit: "drift-audit.md",
+  todos: "drift-todos.md",
+  card: "drift-pass card",
+  handoff: "Ready / Notes",
+};
+
+const FALLBACK_LABELS: Record<string, string> = {
+  session: "session-pointer.md",
+  validate: "drift validate",
+  audit: "drift-audit.md",
+  todos: "drift-todos.md",
+  close: "updates-log",
+};
+
+const READ_FIRST = [
+  [".cursor/skills/workflow-drift-audit/SKILL.md", "Drift audit canon"],
+  [".cursor/skills/project-board-ssot/SKILL.md", "Board SSOT when enabled"],
+  ["python3 -m cursor_workflow drift validate", "CLI entry"],
+  ["DRIFT-009 / DRIFT-010", "Board vs tracker checks"],
+  ["project export", "DRIFT-010 evidence"],
+];
+
+const PATTERNS = [
+  ["Write scope", "Drift artifacts only — no product-code"],
+  ["Dual-write remediation", "Notes or handoff to project-board / implementer via Ready"],
+  ["Attribution", "@owner.github_user/workflow-drift-guard via --agent"],
+];
+
+const ARTIFACTS = [
+  [".local/workflow-artifacts/drift/drift-audit.md", "Exit", "Maintainers / implementer"],
+  [".local/workflow-artifacts/drift/drift-todos.md", "Exit", "Maintainers / implementer"],
+  ["history/updates-log.md", "Exit", "Continuity readers"],
+  ["Board drift-pass card Status", "done / in_review", "project-board / implementer"],
+  [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+];
+
+const PEERS = [
+  ["Outbound", "project-board", "Dual-write remediation via Ready"],
+  ["Outbound", "implementer", "Dual-write remediation via Ready"],
+  ["Inbound", "implementer", "Invokes on P0/P1 after drift-validate"],
+];
+
+function DagPanel({
+  mode,
+  tokens,
+}: {
+  mode: SsotMode;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
+  const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
+  const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
+  const layout = computeDAGLayout(nodes, edges, {
+    direction: "horizontal",
+    nodeWidth: 118,
+    nodeHeight: 36,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
+  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
+      {layout.edges.map((e, i) => {
+        const a = byId[e.from];
+        const b = byId[e.to];
+        if (!a || !b) return null;
+        const x1 = a.x + a.width;
+        const y1 = a.y + a.height / 2;
+        const x2 = b.x;
+        const y2 = b.y + b.height / 2;
+        return (
+          <line
+            key={i}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke={tokens.stroke.secondary}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => (
+        <g key={n.id}>
+          <rect
+            x={n.x}
+            y={n.y}
+            width={n.width}
+            height={n.height}
+            rx={4}
+            fill={tokens.fill.secondary}
+            stroke={tokens.stroke.primary}
+          />
+          <text
+            x={n.x + n.width / 2}
+            y={n.y + n.height / 2 + 4}
+            textAnchor="middle"
+            fill={tokens.text.primary}
+            fontSize={10}
+          >
+            {labels[n.id] ?? n.id}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+export default function AgentWorkflowDriftGuardCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>workflow-drift-guard</H1>
+          <Pill tone="info" size="sm">
+            kit agent
+          </Pill>
+          <Pill tone="warning" size="sm">
+            drift artifacts only
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          Operational workflow drift detection; plan/tracker/session coherence and
+          handoff parity.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED} · facts only
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="MUST status" label="Entry when board on" />
+        <Stat value="DRIFT-009/010" label="Board vs tracker" />
+        <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
+      </Grid>
+
+      <Stack gap={8}>
+        <H2>Goals</H2>
+        {GOALS.map((g) => (
+          <Text key={g}>• {g}</Text>
+        ))}
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={10}>
+        <Row gap={12} style={{ alignItems: "center" }}>
+          <H2 style={{ margin: 0 }}>Workflow</H2>
+          <Toggle
+            checked={mode === "board"}
+            onChange={(on) => setMode(on ? "board" : "fallback")}
+            label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
+          />
+        </Row>
+        <Callout
+          tone="info"
+          title={mode === "board" ? "project_ssot.enabled" : "Offline / disabled"}
+        >
+          {mode === "board"
+            ? "Entry MUST: project status + list in_progress when board on."
+            : "Fallback: session-pointer. Resume board sync when available."}
+        </Callout>
+        <DagPanel mode={mode} tokens={tokens} />
+      </Stack>
+
+      <CollapsibleSection title="Loop steps (canon)" defaultOpen>
+        <Stack gap={6}>
+          <Text>1. project status + list in_progress (board required when on).</Text>
+          <Text>2. Run drift validate; check DRIFT-009 / DRIFT-010.</Text>
+          <Text>3. project export for DRIFT-010 evidence when needed.</Text>
+          <Text>
+            4. Write drift-audit.md + drift-todos.md under
+            .local/workflow-artifacts/drift/.
+          </Text>
+          <Text>
+            5. drift-pass card done/in_review; dual-write → Notes or handoff to
+            project-board/implementer via Ready; updates-log.
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Files & patterns</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Path / pattern", "Role"]}
+              rows={[...READ_FIRST, ...PATTERNS]}
+            />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Artifacts</CardHeader>
+          <CardBody>
+            <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
+            <Spacer size={8} />
+            <Text tone="tertiary" size="small">
+              Write scope limited to drift artifacts — no product-code changes.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Card>
+        <CardHeader>Board interaction</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              Entry MUST: project status + list in_progress when board SSOT enabled.
+            </Text>
+            <Text>
+              Exit: drift-pass card Status done/in_review; dual-write findings → Notes
+              or handoff to project-board/implementer via Ready.
+            </Text>
+            <Text>
+              Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
+              GraphQL.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Peers</H2>
+        <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
+      </Stack>
+
+      <Callout tone="neutral" title="MCP">
+        Kit server workflow-kit for drift validate — prefer cursor_workflow project
+        for board. External: only servers listed for this agent in mcp.registry.yaml.
+      </Callout>
+
+      <Text tone="tertiary" size="small">
+        Caption: {SOURCES} · verified {VERIFIED}. No invented peers or artifact paths.
+      </Text>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Add 8 per-agent workflow canvases (goals, Entry/Exit, artifacts, board CLI, peers)
- Add agent roster hub DAG with verified handoff edges
- Add board-collaboration canvas: SSOT, Status path, artifact write→read flows

## Test plan
- [ ] Open `canvases/agent-implementer.canvas.tsx` and `agent-board-collaboration.canvas.tsx` beside chat
- [ ] Spot-check roster edges vs `.cursor/agents/*.md`
- [ ] Confirm no `coverage.json` in the PR


Made with [Cursor](https://cursor.com)