### PR TITLE
docs(agents): sync Tier-1 and promote lifecycle across agents and canvases

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-18 (COV-100 — scoped coverage)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 926
+**Last updated:** 2026-07-18 (DOC-AGENT-SYNC — DOC-007 Board rights)  
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 929
 
 ## Shipped (confirmed in repo)
 
@@ -47,7 +47,7 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 926 | `tests/modules/` |
+| Tests | 929 | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/scripts/architecture/doc_facts_checks.py
+++ b/.ai_infra/scripts/architecture/doc_facts_checks.py
@@ -1,7 +1,7 @@
 """
 File: doc_facts_checks.py
 Path: .ai_infra/scripts/architecture/doc_facts_checks.py
-Role: Individual DOC-001…006 checks for canonical doc vs repo fact parity.
+Role: Individual DOC-001…007 checks for canonical doc vs repo fact parity.
 Used By:
  - .ai_infra/scripts/architecture/check_doc_facts.py
 Depends On:
@@ -342,6 +342,43 @@ def check_doc006_implementation_test_count(paths: DocFactsPaths) -> CheckResult:
     )
 
 
+def check_doc007_agent_board_rights(paths: DocFactsPaths) -> CheckResult:
+    """Every agent Anchor Board rights must mention promote-to-issue and mention-pr."""
+    agents_dir = paths.agents_dir
+    if not agents_dir.is_dir():
+        return CheckResult(
+            check_id="DOC-007",
+            severity=Severity.P1,
+            passed=False,
+            detail="missing .cursor/agents/",
+        )
+    missing: list[str] = []
+    for path in sorted(agents_dir.glob("*.md")):
+        text = _read(path)
+        agent_id = path.stem
+        if "**Board rights:**" not in text:
+            missing.append(f"{agent_id}: missing Board rights")
+            continue
+        # Scope to Board rights paragraph (until next blank line after the marker)
+        start = text.index("**Board rights:**")
+        rest = text[start:]
+        para = rest.split("\n\n", 1)[0]
+        for needle in ("promote-to-issue", "mention-pr"):
+            if needle not in para:
+                missing.append(f"{agent_id}: Board rights missing {needle}")
+    passed = not missing
+    return CheckResult(
+        check_id="DOC-007",
+        severity=Severity.P1,
+        passed=passed,
+        detail=(
+            "all agents Board rights include promote-to-issue + mention-pr"
+            if passed
+            else "; ".join(missing[:8])
+        ),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_doc001_agent_roster,
     check_doc002_status_agent_count,
@@ -349,4 +386,5 @@ KIT_DEV_CHECKS = (
     check_doc004_rules_count,
     check_doc005_prepare_gate_facts,
     check_doc006_implementation_test_count,
+    check_doc007_agent_board_rights,
 )

--- a/.ai_infra/templates/project-board/README.md
+++ b/.ai_infra/templates/project-board/README.md
@@ -40,10 +40,13 @@ Card bodies always include `## Acceptance`, `## Rollback`, and `## Notes` so `va
 python3 -m cursor_workflow project guide --agent implementer
 python3 -m cursor_workflow project create-from-template --title "[SLICE] short-name" --template slice --status ready
 python3 -m cursor_workflow project claim --last --agent implementer
+python3 -m cursor_workflow project set-field --field estimate --to 3 --last
+python3 -m cursor_workflow project promote-to-issue --last --agent implementer
+python3 -m cursor_workflow project mention-pr --pr <n> --last --agent implementer
 python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review
 ```
 
-`--last` reads `.local/generated-data/project-last-item.json` (machine-local pointer, not a second Status SSOT).
+`--last` reads `.local/generated-data/project-last-item.json` (machine-local pointer, not a second Status SSOT). Claim does **not** auto-promote; `mention-pr` auto-promotes Draft when `promote_to_issue_on_pr` (default true).
 
 **Rate-limit outbox (do not hammer GraphQL):**
 

--- a/.cursor/agents/enterprise-auditor.md
+++ b/.cursor/agents/enterprise-auditor.md
@@ -14,6 +14,8 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent enterprise-auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …"` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
+
 **Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -18,11 +18,14 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 1. Prefer recipe: `python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review` (or `--to done`).
 2. Claim with `project claim --last --agent implementer` (after create-from-template; never paste docs placeholder ids).
-3. Append `change-index.md`; one line in `history/updates-log.md`.
-4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+3. Before opening a shippable PR: `promote-to-issue --last` **or** `mention-pr --pr N` (auto-promotes when `promote_to_issue_on_pr`). Claim does **not** promote.
+4. Append `change-index.md`; one line in `history/updates-log.md`.
+5. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
+6. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card may set Priority/Size/Estimate via `set-field`. Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 

--- a/.cursor/agents/integrator-mas-agent.md
+++ b/.cursor/agents/integrator-mas-agent.md
@@ -20,6 +20,8 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
+
 **Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 **STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -14,6 +14,8 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent project-board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards set Priority/Size/Estimate via `set-field`. Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
+
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 ## Role

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -14,6 +14,8 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
+
 **Templates:** skill § Template routing when a research card is needed; Notes timestamps via CLI; do not hand-forge times.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -16,6 +16,8 @@ description: Module-focused tests, regressions, coverage.
 
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
+**Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.
+
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.
 - Run **smallest** pytest scope first; widen when needed. For risky `src/**` slices: `pytest --cov=src --cov-report=term-missing` as appropriate.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -16,6 +16,8 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
+**Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes.
+
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.
 3. Run the **smallest** checks that disprove the claim; expand if still uncertain:

--- a/.cursor/agents/workflow-drift-guard.md
+++ b/.cursor/agents/workflow-drift-guard.md
@@ -14,6 +14,8 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent workflow-drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
+
 **Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -20,4 +20,4 @@ alwaysApply: true
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
 - Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 - Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.
+- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,20 @@ Abbreviations: [`.ai_infra/docs/operations/abbreviations-notepad.md`](.ai_infra/
 
 **After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. Notes attribution: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`.
 
+### Board SSOT (Pattern A + Tier-1)
+
+When `project_ssot.enabled`, prefer CLI recipes over multi-step atomics (`project guide --agent <name>`):
+
+| Step | Command | Notes |
+|------|---------|--------|
+| Claim | `project claim --last --agent <name>` | In progress; may set **Start date** (UTC) |
+| Triage | `project set-field --field priority\|size\|estimate --to … --last` | Agents may set on triage/own cards; humans own Ready *ordering* |
+| Promote | `project promote-to-issue --last --agent <name>` | Draft→Issue (same `PVTI_`); claim does **not** auto-promote |
+| PR link | `project mention-pr --pr N --last --agent <name>` | Notes + auto-promote when `promote_to_issue_on_pr` (default true) |
+| Handoff | `project handoff --last --agent <name> --next <peer> --to in_review` | Status + Notes for next agent |
+
+Do **not** leave shippable work as Draft through merge. Canon: `.cursor/skills/project-board-ssot/SKILL.md`; visual hub: `canvases/agent-board-collaboration.canvas.tsx`.
+
 Token contract: [`.ai_infra/docs/operations/token-efficiency.md`](.ai_infra/docs/operations/token-efficiency.md).
 
 Sequence: `plan → interfaces → implementation → tests → evidence → docs update` (plan lives on the **board card body** when SSOT enabled).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -288,6 +288,7 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 |----------|-------|
 | Board-only vs dual mirror? | **Board wins — only writable SSOT.** Offline fallback only; no dual writers “for safety.” |
 | DraftIssue vs real Issues? | Default Draft (`item_kind_default: draft`); promote via `python3 -m cursor_workflow project promote-to-issue --last --agent <name>` or `mention-pr` auto when `promote_to_issue_on_pr` (default true). Issue-at-create when `item_kind_default: issue`. Do not leave shippable work as Draft through merge. |
+| Tier-1 board fields? | **Start date** may set on `claim` (UTC). **Estimate** (and Priority/Size) via `set-field` on triage/own cards. **PR URL** via `mention-pr`. Iteration / Labels / Reviewers / End date out of scope for agents by default. Humans own Ready prioritization. |
 | Consumer installs? | Install plugin from **this** repo: `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` |
 | Offline / no `gh`? | `fallback: local_trackers` then resume board sync. |
 | GraphQL rate-limit? | `project_ssot.outbox` — EXIT_QUEUED (6); `outbox flush` after reset. Never hammer API; outbox ≠ Status SSOT. |
@@ -314,14 +315,14 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 - [x] Confirm `gh` has `project` scope  
 - [x] Open board URL  
 - [x] Mirror / merge upstream kit into this repo (done historically)  
-- [x] BOARD-SPIKE / ANCHOR / ROLL / A→B→C / FIX-NOTES-DI / BOARD-PROMOTE shipped  
+- [x] BOARD-SPIKE / ANCHOR / ROLL / A→B→C / FIX-NOTES-DI / BOARD-TIER1 / BOARD-PROMOTE shipped  
 - [x] **STANDALONE 2026-07-18** — no upstream port  
 - [ ] Update this file’s “Last agent / Last updated” when you finish a slice  
 
 **Last agent (writer):** implementer (Cursor) · **Last updated:** 2026-07-18  
 **Next agent:** any agent — Entry=`project status`; Ready backlog includes EA-010.
 
-**Implemented:** `cursor_workflow project` CLI, `project-board` agent/skill, ADR-008, all agent Anchors board-first, DRIFT-009/010, merge.py board sync, FIX-NOTES-DI, BOARD-PROMOTE (`promote-to-issue` + `mention-pr` auto), payload sync, `project-ssot-precedence` overlay.
+**Implemented:** `cursor_workflow project` CLI, `project-board` agent/skill, ADR-008, all agent Anchors board-first, DRIFT-009/010, merge.py board sync, FIX-NOTES-DI, BOARD-TIER1 (claim Start date + Estimate `set-field` + `mention-pr`), BOARD-PROMOTE (`promote-to-issue` + `mention-pr` auto), payload sync, `project-ssot-precedence` overlay.
 
 ### STANDALONE decision (human)
 

--- a/agents/enterprise-auditor.md
+++ b/agents/enterprise-auditor.md
@@ -14,6 +14,8 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent enterprise-auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …"` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
+
 **Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -18,11 +18,14 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 1. Prefer recipe: `python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review` (or `--to done`).
 2. Claim with `project claim --last --agent implementer` (after create-from-template; never paste docs placeholder ids).
-3. Append `change-index.md`; one line in `history/updates-log.md`.
-4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+3. Before opening a shippable PR: `promote-to-issue --last` **or** `mention-pr --pr N` (auto-promotes when `promote_to_issue_on_pr`). Claim does **not** promote.
+4. Append `change-index.md`; one line in `history/updates-log.md`.
+5. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
+6. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card may set Priority/Size/Estimate via `set-field`. Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 

--- a/agents/integrator-mas-agent.md
+++ b/agents/integrator-mas-agent.md
@@ -20,6 +20,8 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
+
 **Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 **STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -14,6 +14,8 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent project-board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards set Priority/Size/Estimate via `set-field`. Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
+
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 ## Role

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -14,6 +14,8 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
+
 **Templates:** skill § Template routing when a research card is needed; Notes timestamps via CLI; do not hand-forge times.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -16,6 +16,8 @@ description: Module-focused tests, regressions, coverage.
 
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
+**Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.
+
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.
 - Run **smallest** pytest scope first; widen when needed. For risky `src/**` slices: `pytest --cov=src --cov-report=term-missing` as appropriate.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -16,6 +16,8 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
+**Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes.
+
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.
 3. Run the **smallest** checks that disprove the claim; expand if still uncertain:

--- a/agents/workflow-drift-guard.md
+++ b/agents/workflow-drift-guard.md
@@ -14,6 +14,8 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent workflow-drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
+
 **Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)

--- a/canvases/agent-enterprise-auditor.canvas.tsx
+++ b/canvases/agent-enterprise-auditor.canvas.tsx
@@ -92,6 +92,8 @@ const READ_FIRST = [
 
 const PATTERNS = [
   ["create-from-template", "slice [AUDIT] then claim --last"],
+  ["Board lifecycle", "Notes = artifact paths; Status in_review/done"],
+  ["Tier-1", "Shared Board rights; Start date on claim"],
   ["Tracker etiquette", "Propose edits in audit-actions; implementer applies"],
   ["Attribution", "@owner.github_user/enterprise-auditor via --agent"],
 ];

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -40,6 +40,7 @@ const BOARD_NODES = [
   { id: "code" },
   { id: "gates" },
   { id: "evidence" },
+  { id: "promote" },
   { id: "handoff" },
   { id: "next" },
 ];
@@ -50,7 +51,8 @@ const BOARD_EDGES = [
   { from: "claim", to: "code" },
   { from: "code", to: "gates" },
   { from: "gates", to: "evidence" },
-  { from: "evidence", to: "handoff" },
+  { from: "evidence", to: "promote" },
+  { from: "promote", to: "handoff" },
   { from: "handoff", to: "next" },
 ];
 
@@ -76,10 +78,11 @@ const FALLBACK_EDGES = [
 const BOARD_LABELS: Record<string, string> = {
   yaml: "project_ssot YAML",
   status: "project status",
-  claim: "claim / Ready list",
+  claim: "claim (+ Start date)",
   code: "contracts → code → tests",
   gates: "prepare.py GATES",
   evidence: "change-index + updates-log",
+  promote: "promote / mention-pr",
   handoff: "handoff --next verifier",
   next: "verifier (typical)",
 };
@@ -139,6 +142,8 @@ const ARTIFACTS = [
 
 const PATTERNS = [
   ["Pattern A recipes", "claim --last / handoff --last / create-from-template"],
+  ["Tier-1", "claim → Start date; set-field estimate on own card"],
+  ["Promote before PR", "promote-to-issue OR mention-pr (auto when promote_to_issue_on_pr)"],
   ["Templates", "slice (feature/chore) · bug (defect/fix)"],
   ["Module headers", "file-docstring-header-relations.mdc on new sources"],
   ["Commit trailers", "Author + GitHub-User via contributors commit-trailers"],

--- a/canvases/agent-integrator-mas-agent.canvas.tsx
+++ b/canvases/agent-integrator-mas-agent.canvas.tsx
@@ -94,6 +94,8 @@ const READ_FIRST = [
 
 const PATTERNS = [
   ["Pattern A", "claim --last / handoff --last / create-from-template"],
+  ["Promote before PR", "promote-to-issue OR mention-pr when shipping integration"],
+  ["Tier-1", "claim → Start date; set-field estimate on own card"],
   ["STANDALONE", "Product lives only in mas-workflow-kit-project-ssot"],
   ["Attribution", "@owner.github_user/integrator-mas-agent via --agent"],
 ];

--- a/canvases/agent-project-board.canvas.tsx
+++ b/canvases/agent-project-board.canvas.tsx
@@ -89,6 +89,8 @@ const READ_FIRST = [
 const PATTERNS = [
   ["Independent-governed", "Not in default PR pipelines"],
   ["Loop", "status → list ready → create-from-template + claim --last → handoff"],
+  ["Triage Tier-1", "set-field Priority/Size/Estimate on new/moved cards"],
+  ["Promote", "promote-to-issue before PR if shipping triage work as Issue"],
   ["Attribution", "@owner.github_user/project-board via --agent"],
 ];
 

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -87,6 +87,8 @@ const READ_FIRST = [
 
 const PATTERNS = [
   ["Hard stop", "Write only _research_results/"],
+  ["Board lifecycle", "Research card → done + corpus paths in Notes"],
+  ["Tier-1", "Shared Board rights; read-only board if no research card"],
   ["Forbidden", "No src/tests/scripts; no git commit/push/PR"],
   ["Attribution", "@owner.github_user/researcher via --agent"],
 ];

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -196,6 +196,11 @@ export default function AgentRosterCanvas() {
           Explicit handoff edges from agent cards only. researcher is non-product —
           redirects to product agents.
         </Text>
+        <Callout tone="info" title="Board lifecycle (all 8)">
+          Tier-1: claim may set Start date; triage/own card may set Estimate.
+          Promote Draft→Issue via promote-to-issue or mention-pr before shippable PR
+          (claim does not auto-promote). See agent-board-collaboration canvas.
+        </Callout>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
         </Text>

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -101,6 +101,8 @@ const READ_FIRST = [
 
 const PATTERNS = [
   ["Consume only", "No create-from-template"],
+  ["Board lifecycle", "Exit in_review if tests gate PR else done"],
+  ["Tier-1", "Shared Board rights; promote only if opening a shippable PR"],
   ["Module layout", "tests/modules/<module>/ matching source boundaries"],
   ["Attribution", "@owner.github_user/test-runner via --agent test-runner"],
 ];

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -96,6 +96,8 @@ const READ_FIRST = [
 
 const PATTERNS = [
   ["Consume only", "Do NOT create-from-template"],
+  ["Board lifecycle", "Evidence on handed-off card; promote not primary path"],
+  ["Tier-1", "Shared Board rights; Start date on claim if reclaiming"],
   ["Checks", "pytest · GATES category · governance · verify_publish"],
   ["Merge gate", "Do not approve merge without pr/ artifacts when maintainer workflow active"],
   ["Attribution", "@owner.github_user/verifier via --agent verifier"],

--- a/canvases/agent-workflow-drift-guard.canvas.tsx
+++ b/canvases/agent-workflow-drift-guard.canvas.tsx
@@ -95,6 +95,8 @@ const READ_FIRST = [
 
 const PATTERNS = [
   ["Write scope", "Drift artifacts only — no product-code"],
+  ["Board lifecycle", "list --status in_progress; close drift-pass → done"],
+  ["Tier-1", "Shared Board rights; no silent tracker dual-write"],
   ["Dual-write remediation", "Notes or handoff to project-board / implementer via Ready"],
   ["Attribution", "@owner.github_user/workflow-drift-guard via --agent"],
 ];

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -594,6 +594,11 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">Edge-case tests: focused 36+; collect ~669</Text>
               <Text size="small">DRIFT validate P0=0 P1=0 P2=0</Text>
               <Text size="small">STANDALONE decided — this repo is the product</Text>
+              <Text size="small">
+                BOARD-PROMOTE: Draft→Issue via promote-to-issue / mention-pr auto
+                (promote_to_issue_on_pr default true); claim does not auto-promote
+              </Text>
+              <Text size="small">BOARD-TIER1: claim Start date + Estimate set-field + mention-pr</Text>
             </Stack>
           </CardBody>
         </Card>
@@ -603,9 +608,7 @@ export default function BoardSsotVsKitCanvas() {
           </CardHeader>
           <CardBody>
             <Stack gap={4}>
-              <Text size="small">STANDALONE decided — no upstream port</Text>
               <Text size="small">EA-010 Ready — ICC read-only board panel</Text>
-              <Text size="small">promote_to_issue_on_pr — optional future</Text>
               <Text size="small">Install screenshot asset TBD if UI text differs</Text>
             </Stack>
           </CardBody>

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -20,4 +20,4 @@ alwaysApply: true
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
 - Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 - Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.
+- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.

--- a/payload/.ai_infra/scripts/architecture/doc_facts_checks.py
+++ b/payload/.ai_infra/scripts/architecture/doc_facts_checks.py
@@ -1,7 +1,7 @@
 """
 File: doc_facts_checks.py
 Path: .ai_infra/scripts/architecture/doc_facts_checks.py
-Role: Individual DOC-001…006 checks for canonical doc vs repo fact parity.
+Role: Individual DOC-001…007 checks for canonical doc vs repo fact parity.
 Used By:
  - .ai_infra/scripts/architecture/check_doc_facts.py
 Depends On:
@@ -342,6 +342,43 @@ def check_doc006_implementation_test_count(paths: DocFactsPaths) -> CheckResult:
     )
 
 
+def check_doc007_agent_board_rights(paths: DocFactsPaths) -> CheckResult:
+    """Every agent Anchor Board rights must mention promote-to-issue and mention-pr."""
+    agents_dir = paths.agents_dir
+    if not agents_dir.is_dir():
+        return CheckResult(
+            check_id="DOC-007",
+            severity=Severity.P1,
+            passed=False,
+            detail="missing .cursor/agents/",
+        )
+    missing: list[str] = []
+    for path in sorted(agents_dir.glob("*.md")):
+        text = _read(path)
+        agent_id = path.stem
+        if "**Board rights:**" not in text:
+            missing.append(f"{agent_id}: missing Board rights")
+            continue
+        # Scope to Board rights paragraph (until next blank line after the marker)
+        start = text.index("**Board rights:**")
+        rest = text[start:]
+        para = rest.split("\n\n", 1)[0]
+        for needle in ("promote-to-issue", "mention-pr"):
+            if needle not in para:
+                missing.append(f"{agent_id}: Board rights missing {needle}")
+    passed = not missing
+    return CheckResult(
+        check_id="DOC-007",
+        severity=Severity.P1,
+        passed=passed,
+        detail=(
+            "all agents Board rights include promote-to-issue + mention-pr"
+            if passed
+            else "; ".join(missing[:8])
+        ),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_doc001_agent_roster,
     check_doc002_status_agent_count,
@@ -349,4 +386,5 @@ KIT_DEV_CHECKS = (
     check_doc004_rules_count,
     check_doc005_prepare_gate_facts,
     check_doc006_implementation_test_count,
+    check_doc007_agent_board_rights,
 )

--- a/payload/.ai_infra/templates/project-board/README.md
+++ b/payload/.ai_infra/templates/project-board/README.md
@@ -40,10 +40,13 @@ Card bodies always include `## Acceptance`, `## Rollback`, and `## Notes` so `va
 python3 -m cursor_workflow project guide --agent implementer
 python3 -m cursor_workflow project create-from-template --title "[SLICE] short-name" --template slice --status ready
 python3 -m cursor_workflow project claim --last --agent implementer
+python3 -m cursor_workflow project set-field --field estimate --to 3 --last
+python3 -m cursor_workflow project promote-to-issue --last --agent implementer
+python3 -m cursor_workflow project mention-pr --pr <n> --last --agent implementer
 python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review
 ```
 
-`--last` reads `.local/generated-data/project-last-item.json` (machine-local pointer, not a second Status SSOT).
+`--last` reads `.local/generated-data/project-last-item.json` (machine-local pointer, not a second Status SSOT). Claim does **not** auto-promote; `mention-pr` auto-promotes Draft when `promote_to_issue_on_pr` (default true).
 
 **Rate-limit outbox (do not hammer GraphQL):**
 

--- a/payload/.cursor/agents/enterprise-auditor.md
+++ b/payload/.cursor/agents/enterprise-auditor.md
@@ -14,6 +14,8 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent enterprise-auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …"` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
+
 **Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -18,11 +18,14 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 1. Prefer recipe: `python3 -m cursor_workflow project handoff --last --agent implementer --next verifier --to in_review` (or `--to done`).
 2. Claim with `project claim --last --agent implementer` (after create-from-template; never paste docs placeholder ids).
-3. Append `change-index.md`; one line in `history/updates-log.md`.
-4. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-5. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+3. Before opening a shippable PR: `promote-to-issue --last` **or** `mention-pr --pr N` (auto-promotes when `promote_to_issue_on_pr`). Claim does **not** promote.
+4. Append `change-index.md`; one line in `history/updates-log.md`.
+5. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
+6. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+
+**Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card may set Priority/Size/Estimate via `set-field`. Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 

--- a/payload/.cursor/agents/integrator-mas-agent.md
+++ b/payload/.cursor/agents/integrator-mas-agent.md
@@ -20,6 +20,8 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
+
 **Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 **STANDALONE:** this product lives only in `mas-workflow-kit-project-ssot` — do not mutate or merge doctrine into upstream `mas-workflow-kit`.

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -14,6 +14,8 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent project-board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards set Priority/Size/Estimate via `set-field`. Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
+
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
 
 ## Role

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -14,6 +14,8 @@ description: Optional local research corpus; hard-stop on product code without e
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
+
 **Templates:** skill § Template routing when a research card is needed; Notes timestamps via CLI; do not hand-forge times.
 
 Build and maintain a **local research corpus** with verified evidence. **Off by default** in the universal kit core — enable per project via overlay and `_research_results/` scaffold.

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -16,6 +16,8 @@ description: Module-focused tests, regressions, coverage.
 
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
+**Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.
+
 - Map changes → `tests/modules/<module>/`; one clear responsibility per file.
 - Cover happy, failure, edge, and regression cases for touched behavior.
 - Run **smallest** pytest scope first; widen when needed. For risky `src/**` slices: `pytest --cov=src --cov-report=term-missing` as appropriate.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -16,6 +16,8 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
+**Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes.
+
 1. Restate what was claimed done.
 2. Point to files/lines or command output as evidence.
 3. Run the **smallest** checks that disprove the claim; expand if still uncertain:

--- a/payload/.cursor/agents/workflow-drift-guard.md
+++ b/payload/.cursor/agents/workflow-drift-guard.md
@@ -14,6 +14,8 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent workflow-drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
+
 **Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -20,4 +20,4 @@ alwaysApply: true
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
 - Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 - Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.
+- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -20,4 +20,4 @@ alwaysApply: true
 - This product lives only in `mas-workflow-kit-project-ssot`. Do not mutate upstream `mas-workflow-kit`. Board = only writable SSOT; local = evidence/fallback.
 - Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 - Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.
+- Tier-1 board fields: claim may set Start date (UTC when configured); triage/own card may set Estimate via `set-field`; Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` (Linked PRs column derived) — Iteration, Labels, Reviewers, End date out of scope for agents by default.

--- a/tests/modules/architecture_scripts/test_doc_facts_full.py
+++ b/tests/modules/architecture_scripts/test_doc_facts_full.py
@@ -256,6 +256,35 @@ def test_check_doc006_passes_when_counts_match(tmp_path: Path, monkeypatch: pyte
     assert "583" in result.detail
 
 
+def test_check_doc007_passes_on_kit_agents(tmp_path: Path) -> None:
+    _copy_minimal_kit(tmp_path)
+    paths = dfc.doc_facts_paths(tmp_path)
+    result = dfc.check_doc007_agent_board_rights(paths)
+    assert result.passed
+    assert "promote-to-issue" in result.detail
+
+
+def test_check_doc007_fails_when_board_rights_missing_promote(tmp_path: Path) -> None:
+    _copy_minimal_kit(tmp_path)
+    agent = tmp_path / ".cursor" / "agents" / "implementer.md"
+    text = agent.read_text(encoding="utf-8")
+    agent.write_text(
+        text.replace("promote-to-issue", "PROMOTE_REMOVED"),
+        encoding="utf-8",
+    )
+    paths = dfc.doc_facts_paths(tmp_path)
+    result = dfc.check_doc007_agent_board_rights(paths)
+    assert not result.passed
+    assert "implementer" in result.detail
+
+
+def test_check_doc007_missing_agents_dir(tmp_path: Path) -> None:
+    paths = dfc.doc_facts_paths(tmp_path)
+    result = dfc.check_doc007_agent_board_rights(paths)
+    assert not result.passed
+    assert "missing" in result.detail
+
+
 # ---------------------------------------------------------------------------
 # check_doc_facts.py
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Role-specific **Board lifecycle** bullets on all 8 agents; shared Tier-1 / promote Board rights preserved
- North-star docs: AGENTS.md Pattern A table, HANDOFF BOARD-TIER1, overlay `promote-to-issue`, template safe-flow
- Canvases: fix stale promote-as-future; per-agent Tier-1/promote rows; roster legend; DOC-007 Board-rights check (929 tests)

## Test plan
- [x] `check_doc_facts.py` DOC-001…007 green
- [x] `sync_plugin_bundle --check` green
- [x] Verifier checklist (promote Done card placement fixed)
- [ ] `prepare.py` gates on PR

Closes #15

Made with [Cursor](https://cursor.com)