### PR TITLE
feat(icc): EA-010 read-only Project Board snapshot tab

### DIFF
--- a/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/.ai_infra/docs/operations/local-workspace-layout.md
@@ -54,7 +54,7 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | `workflow-artifacts/release/` | Optional RC sign-off (`rc-signoff.md`) |
 | `workflow-artifacts/audit/` | `preflight.json`, `doc-facts-preflight.json` (verify-all / doc validate) |
 | `user_settings/` | Gitignored YAML worksheets: GitHub collaboration + MCP agent wiring (from kit exemplars) |
-| `generated-data/` | Coverage JSON and similar machine output |
+| `generated-data/` | Coverage JSON, `project-board-snapshot.json` (read-only board export for ICC), and similar machine output |
 
 ## Git commits vs `.local` markdown
 
@@ -80,6 +80,8 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 ## Templates (versioned in git)
 
 Copy from **`.ai_infra/templates/local-workspace/`** into `.local/` at scaffold (`exemplars/`, `artifact-stubs/`). Dashboard HTML, assets, `module-audit.html`, and `pages.json` refresh from templates on every scaffold/activate (idempotent re-activate included).
+
+**Implementation Control Center:** manifest tab **Project Board** (`format: project-board-snapshot`) renders `.local/generated-data/project-board-snapshot.json` via `local-board-snapshot.js`. Refresh snapshot with `python3 -m cursor_workflow project export`. The panel is **read-only** — it never writes GitHub Project Status.
 
 **User settings:** copy from **`.ai_infra/templates/user-settings/exemplars/`** into **`.local/user_settings/`** (`github.collaboration.yaml`, `mcp.agents.yaml`). See [RENDERED-EXAMPLES.md](../../templates/user-settings/RENDERED-EXAMPLES.md).
 

--- a/.ai_infra/scripts/install/scaffold.py
+++ b/.ai_infra/scripts/install/scaffold.py
@@ -68,7 +68,12 @@ AUDIT_EXEMPLARS = (
     "agent-governance-todos.md",
 )
 DASHBOARD_HTML = ("index.html", "implementation-control-center.html")
-DASHBOARD_ASSETS = ("site-nav.js", "local-shell.css", "local-markdown.js")
+DASHBOARD_ASSETS = (
+    "site-nav.js",
+    "local-shell.css",
+    "local-markdown.js",
+    "local-board-snapshot.js",
+)
 ARTIFACT_TAB_STUBS: dict[str, tuple[str, ...]] = {
     "pr": ("review.md", "prep.md", "merge.md"),
     "alignment": ("alignment-audit.md", "alignment-todos.md"),

--- a/.ai_infra/templates/local-workspace/implementation-control-center.html
+++ b/.ai_infra/templates/local-workspace/implementation-control-center.html
@@ -5,7 +5,7 @@ Role: Template dashboard — copy to `.local/agents-control-center/dashboards/` 
 Used By:
  - Local preview (file:// or static server)
 Depends On:
- - local-shell.css, site-nav.js, local-markdown.js
+ - local-shell.css, site-nav.js, local-markdown.js, local-board-snapshot.js
  - ../config/pages.json (after copy: `.local/agents-control-center/config/pages.json`)
  - Paths declared inside pages.json (`.local/...` and `docs/...`)
 Notes:
@@ -37,6 +37,7 @@ Notes:
   </div>
 
   <script src="local-markdown.js"></script>
+  <script src="local-board-snapshot.js"></script>
   <script>
     const MANIFEST = "../config/pages.json";
     let PAGES = [];
@@ -87,6 +88,10 @@ Notes:
       return "";
     }
 
+    function isProjectBoardSnapshot(page) {
+      return page && page.format === "project-board-snapshot";
+    }
+
     async function refreshActivePage() {
       const page = PAGES.find((entry) => entry.id === activePage);
       if (!page) return;
@@ -95,13 +100,30 @@ Notes:
         const filePath = normalizePageFile(page.file);
         const response = await fetch(filePath + "?t=" + Date.now(), { cache: "no-store" });
         if (!response.ok) {
+          if (isProjectBoardSnapshot(page) && response.status === 404) {
+            contentEl.innerHTML = LocalBoardSnapshot.renderMissingExport();
+            refreshEl.textContent = "refresh: " + new Date().toLocaleString();
+            return;
+          }
           throw new Error("Failed to load " + filePath + " (" + response.status + ")");
         }
-        const markdown = await response.text();
-        contentEl.innerHTML = renderMarkdown(markdown);
+        if (isProjectBoardSnapshot(page)) {
+          const snapshot = await response.json();
+          contentEl.innerHTML = LocalBoardSnapshot.render(snapshot);
+        } else {
+          const markdown = await response.text();
+          contentEl.innerHTML = renderMarkdown(markdown);
+        }
         refreshEl.textContent = "refresh: " + new Date().toLocaleString();
       } catch (error) {
-        contentEl.innerHTML = "<p class=\"status-bad\">Could not load markdown: " + escapeHtml(String(error.message || error)) + "</p>";
+        if (isProjectBoardSnapshot(page)) {
+          contentEl.innerHTML = LocalBoardSnapshot.renderMissingExport();
+        } else {
+          contentEl.innerHTML =
+            "<p class=\"status-bad\">Could not load markdown: " +
+            escapeHtml(String(error.message || error)) +
+            "</p>";
+        }
       }
     }
 

--- a/.ai_infra/templates/local-workspace/local-board-snapshot.js
+++ b/.ai_infra/templates/local-workspace/local-board-snapshot.js
@@ -1,0 +1,174 @@
+/**
+ * File: local-board-snapshot.js
+ * Path: .ai_infra/templates/local-workspace/local-board-snapshot.js
+ * Role: Read-only renderer for project-board-snapshot JSON in Implementation Control Center.
+ * Used By:
+ *  - implementation-control-center.html
+ * Depends On:
+ *  - local-markdown.js (escapeHtml)
+ * Notes:
+ *  - Reads `.local/generated-data/project-board-snapshot.json` only; never writes board Status.
+ *  - Copy to `.local/agents-control-center/dashboards/` with other dashboard assets.
+ */
+(function (global) {
+  "use strict";
+
+  function escapeHtml(value) {
+    if (global.LocalMarkdown && typeof global.LocalMarkdown.escapeHtml === "function") {
+      return global.LocalMarkdown.escapeHtml(value);
+    }
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function displayCell(value) {
+    if (value === null || value === undefined || value === "") {
+      return '<span class="local-board-empty">—</span>';
+    }
+    return escapeHtml(String(value));
+  }
+
+  function statusClass(status) {
+    const normalized = String(status || "")
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-");
+    return normalized ? " local-board-status-" + normalized : "";
+  }
+
+  function renderHeader(project, totalCount) {
+    const name = project && project.name ? escapeHtml(project.name) : "Project";
+    const count = typeof totalCount === "number" ? totalCount : 0;
+    const url = project && project.url ? String(project.url) : "";
+    let titleHtml = name;
+    if (url) {
+      const safeUrl = escapeHtml(url);
+      titleHtml =
+        '<a href="' +
+        safeUrl +
+        '" target="_blank" rel="noopener noreferrer">' +
+        name +
+        "</a>";
+    }
+    return (
+      '<header class="local-board-head">' +
+      "<h2>" +
+      titleHtml +
+      "</h2>" +
+      '<p class="local-board-meta">' +
+      "<span>Total items: <strong>" +
+      escapeHtml(String(count)) +
+      "</strong></span>" +
+      '<span class="local-pill local-board-readonly">read-only snapshot</span>' +
+      "</p>" +
+      "</header>"
+    );
+  }
+
+  function renderEmptyItems() {
+    return (
+      '<div class="local-board-empty-state">' +
+      "<p>No board items in this snapshot.</p>" +
+      "<p>Run <code>python3 -m cursor_workflow project export</code> after updating cards on GitHub.</p>" +
+      "</div>"
+    );
+  }
+
+  function renderRow(item, index) {
+    const excerpt = item && item.body_excerpt ? String(item.body_excerpt) : "";
+    let excerptHtml = "";
+    if (excerpt.trim()) {
+      excerptHtml =
+        '<details class="local-board-excerpt">' +
+        "<summary>Body excerpt</summary>" +
+        "<pre>" +
+        escapeHtml(excerpt) +
+        "</pre>" +
+        "</details>";
+    }
+    return (
+      "<tr>" +
+      "<td>" +
+      displayCell(item && item.title) +
+      "</td>" +
+      '<td><span class="local-board-status' +
+      statusClass(item && item.status_normalized) +
+      '">' +
+      displayCell(item && item.status_normalized) +
+      "</span></td>" +
+      "<td>" +
+      displayCell(item && item.priority) +
+      "</td>" +
+      "<td>" +
+      displayCell(item && item.size) +
+      "</td>" +
+      "<td>" +
+      displayCell(item && item.estimate) +
+      "</td>" +
+      "<td>" +
+      displayCell(item && item.updated_at) +
+      "</td>" +
+      "<td>" +
+      excerptHtml +
+      "</td>" +
+      "</tr>"
+    );
+  }
+
+  function renderTable(items) {
+    if (!items.length) {
+      return renderEmptyItems();
+    }
+    let html =
+      '<div class="local-board-table-wrap">' +
+      "<table>" +
+      "<thead><tr>" +
+      "<th>Title</th>" +
+      "<th>Status</th>" +
+      "<th>Priority</th>" +
+      "<th>Size</th>" +
+      "<th>Estimate</th>" +
+      "<th>Updated</th>" +
+      "<th>Excerpt</th>" +
+      "</tr></thead><tbody>";
+    for (let i = 0; i < items.length; i += 1) {
+      html += renderRow(items[i], i);
+    }
+    html += "</tbody></table></div>";
+    return html;
+  }
+
+  function renderSnapshot(snapshot) {
+    const data = snapshot && typeof snapshot === "object" ? snapshot : {};
+    const project = data.project || {};
+    const items = Array.isArray(data.items) ? data.items : [];
+    const totalCount =
+      typeof data.totalCount === "number" ? data.totalCount : items.length;
+    return (
+      '<div class="local-board-panel">' +
+      renderHeader(project, totalCount) +
+      renderTable(items) +
+      "</div>"
+    );
+  }
+
+  function renderMissingExport() {
+    return (
+      '<div class="local-board-missing">' +
+      '<p class="status-bad">Project board snapshot not found.</p>' +
+      "<p>Export a read-only snapshot from the CLI:</p>" +
+      "<pre><code>python3 -m cursor_workflow project export</code></pre>" +
+      "<p>Output path: <code>.local/generated-data/project-board-snapshot.json</code></p>" +
+      "</div>"
+    );
+  }
+
+  global.LocalBoardSnapshot = {
+    render: renderSnapshot,
+    renderMissingExport: renderMissingExport,
+    escapeHtml: escapeHtml,
+  };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/.ai_infra/templates/local-workspace/local-shell.css
+++ b/.ai_infra/templates/local-workspace/local-shell.css
@@ -391,6 +391,125 @@ code,
   color: var(--bad);
 }
 
+/* Project board snapshot (read-only ICC tab) */
+.local-board-panel {
+  color: var(--muted);
+}
+
+.local-board-head h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+  color: #dce8ff;
+}
+
+.local-board-head h2 a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.local-board-head h2 a:hover {
+  text-decoration: underline;
+}
+
+.local-board-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin: 0 0 14px;
+  font-size: 0.92rem;
+}
+
+.local-board-readonly {
+  color: var(--ok);
+}
+
+.local-board-table-wrap {
+  overflow: auto;
+}
+
+.local-board-panel table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.local-board-panel th,
+.local-board-panel td {
+  border: 1px solid var(--line);
+  padding: 8px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.local-board-panel th {
+  background: #13254a;
+  color: var(--text);
+}
+
+.local-board-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  font-size: 0.82rem;
+  text-transform: lowercase;
+}
+
+.local-board-status-done {
+  border-color: rgba(66, 211, 146, 0.5);
+  color: var(--ok);
+}
+
+.local-board-status-in-progress,
+.local-board-status-in_review {
+  border-color: rgba(97, 178, 255, 0.5);
+  color: var(--accent);
+}
+
+.local-board-status-ready {
+  border-color: rgba(255, 209, 102, 0.5);
+  color: var(--warn);
+}
+
+.local-board-empty {
+  color: #7a8bb8;
+}
+
+.local-board-excerpt {
+  margin: 0;
+  max-width: 28rem;
+}
+
+.local-board-excerpt summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.local-board-excerpt pre {
+  margin: 8px 0 0;
+  max-height: 12rem;
+  overflow: auto;
+  background: var(--code-bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.local-board-empty-state,
+.local-board-missing {
+  padding: 12px 0;
+}
+
+.local-board-empty-state p,
+.local-board-missing p {
+  margin: 0.45em 0;
+}
+
 @media (max-width: 900px) {
   .local-tabs {
     grid-template-columns: 1fr 1fr;

--- a/.ai_infra/templates/local-workspace/pages.json
+++ b/.ai_infra/templates/local-workspace/pages.json
@@ -42,6 +42,12 @@
       "file": "../../index-and-planning/current/work-tracker.md"
     },
     {
+      "id": "project-board",
+      "title": "Project Board",
+      "file": "../../generated-data/project-board-snapshot.json",
+      "format": "project-board-snapshot"
+    },
+    {
       "id": "pr-review",
       "title": "PR Review",
       "file": "../../workflow-artifacts/pr/review.md"

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -274,9 +274,12 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 - [x] `project_ssot` + CLI + `project-board` + ADR-008
 - [x] All agent Anchors board-first; DRIFT-009/010; A→B→C; FIX-NOTES-DI
 
-### E. Explicitly defer (product backlog — not a port gate)
+### E. Shipped (EA-010)
 
-- ICC Control Center board tab (EA-010 Ready)
+- [x] ICC Control Center **Project Board** tab — read-only panel from `project export` snapshot (`.local/generated-data/project-board-snapshot.json`); never writes board Status
+
+### E. Explicitly defer (product backlog)
+
 - Always-on GitHub Actions bot
 - Requiring GitHub MCP before `gh` path works
 
@@ -293,7 +296,7 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 | Offline / no `gh`? | `fallback: local_trackers` then resume board sync. |
 | GraphQL rate-limit? | `project_ssot.outbox` — EXIT_QUEUED (6); `outbox flush` after reset. Never hammer API; outbox ≠ Status SSOT. |
 | Card → which repo? | Convention: Repository field or body path; default = this product repo. |
-| Control Center dashboards? | **Deferred (EA-010).** Read-only `project export` may land first; ICC panel that *reads* the export is future — never a second writer. |
+| Control Center dashboards? | **Project Board tab (EA-010 shipped).** ICC reads `.local/generated-data/project-board-snapshot.json` from `python3 -m cursor_workflow project export` — read-only; never a second Status writer. |
 | Who updates the Project? | **Every agent** Entry=read board; Exit=update Status/Notes. Post-merge Done = Pattern A (`merge.py`). Rights: `project-board-ssot` skill § Continuation; ops `project-board-collaboration.md`. **You:** views, workflows, Insights, README, status updates, Ready prioritization / product roadmap. |
 
 ---
@@ -320,7 +323,7 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 - [ ] Update this file’s “Last agent / Last updated” when you finish a slice  
 
 **Last agent (writer):** implementer (Cursor) · **Last updated:** 2026-07-18  
-**Next agent:** any agent — Entry=`project status`; Ready backlog includes EA-010.
+**Next agent:** any agent — Entry=`project status`; EA-010 ICC board panel shipped.
 
 **Implemented:** `cursor_workflow project` CLI, `project-board` agent/skill, ADR-008, all agent Anchors board-first, DRIFT-009/010, merge.py board sync, FIX-NOTES-DI, BOARD-TIER1 (claim Start date + Estimate `set-field` + `mention-pr`), BOARD-PROMOTE (`promote-to-issue` + `mention-pr` auto), payload sync, `project-ssot-precedence` overlay.
 
@@ -331,4 +334,4 @@ Do **not** run upstream marketplace publish from this repo against `mas-workflow
 | **Status** | **STANDALONE decided** 2026-07-18 |
 | **Board card** | Was `[PORT-GATE] …` · `PVTI_lAHOBl46-84A9KZxzgzOZuE` → **Done** |
 | **Decision** | This repo is the permanent product. **No** port to `mas-workflow-kit`. Board = only writable SSOT; local = evidence. |
-| **Next** | Ready backlog (e.g. EA-010) / normal slices |
+| **Next** | Normal slices / Ready backlog |

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -116,7 +116,7 @@ const ABC_SLICES = [
       "project export → read-only snapshot",
       ".local/generated-data/project-board-snapshot.json",
       "Never writes Status — DRIFT-010 stale PR / board drift",
-      "ICC panel deferred to EA-010 (future)",
+      "ICC Project Board tab (EA-010) reads export only",
     ],
   },
 ];
@@ -573,7 +573,7 @@ export default function BoardSsotVsKitCanvas() {
               ["Audit / PR artifacts under .local/", "Evidence bundles stay in-repo"],
               ["Export snapshot under generated-data/", "Read-only cache — not SSOT"],
               ["Offline fallback trackers", "Only when project_ssot disabled or no gh"],
-              ["ICC board panel", "EA-010 Ready — reads export only"],
+              ["ICC board panel", "EA-010 shipped — reads export only"],
             ]}
           />
         </Stack>
@@ -599,6 +599,7 @@ export default function BoardSsotVsKitCanvas() {
                 (promote_to_issue_on_pr default true); claim does not auto-promote
               </Text>
               <Text size="small">BOARD-TIER1: claim Start date + Estimate set-field + mention-pr</Text>
+              <Text size="small">EA-010: ICC Project Board tab (read-only export snapshot)</Text>
             </Stack>
           </CardBody>
         </Card>
@@ -608,8 +609,8 @@ export default function BoardSsotVsKitCanvas() {
           </CardHeader>
           <CardBody>
             <Stack gap={4}>
-              <Text size="small">EA-010 Ready — ICC read-only board panel</Text>
               <Text size="small">Install screenshot asset TBD if UI text differs</Text>
+              <Text size="small">EA-001 split project_cli / EA-004 pyright (audit P1)</Text>
             </Stack>
           </CardBody>
         </Card>

--- a/payload/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/payload/.ai_infra/docs/operations/local-workspace-layout.md
@@ -54,7 +54,7 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | `workflow-artifacts/release/` | Optional RC sign-off (`rc-signoff.md`) |
 | `workflow-artifacts/audit/` | `preflight.json`, `doc-facts-preflight.json` (verify-all / doc validate) |
 | `user_settings/` | Gitignored YAML worksheets: GitHub collaboration + MCP agent wiring (from kit exemplars) |
-| `generated-data/` | Coverage JSON and similar machine output |
+| `generated-data/` | Coverage JSON, `project-board-snapshot.json` (read-only board export for ICC), and similar machine output |
 
 ## Git commits vs `.local` markdown
 
@@ -80,6 +80,8 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 ## Templates (versioned in git)
 
 Copy from **`.ai_infra/templates/local-workspace/`** into `.local/` at scaffold (`exemplars/`, `artifact-stubs/`). Dashboard HTML, assets, `module-audit.html`, and `pages.json` refresh from templates on every scaffold/activate (idempotent re-activate included).
+
+**Implementation Control Center:** manifest tab **Project Board** (`format: project-board-snapshot`) renders `.local/generated-data/project-board-snapshot.json` via `local-board-snapshot.js`. Refresh snapshot with `python3 -m cursor_workflow project export`. The panel is **read-only** — it never writes GitHub Project Status.
 
 **User settings:** copy from **`.ai_infra/templates/user-settings/exemplars/`** into **`.local/user_settings/`** (`github.collaboration.yaml`, `mcp.agents.yaml`). See [RENDERED-EXAMPLES.md](../../templates/user-settings/RENDERED-EXAMPLES.md).
 

--- a/payload/.ai_infra/scripts/install/scaffold.py
+++ b/payload/.ai_infra/scripts/install/scaffold.py
@@ -68,7 +68,12 @@ AUDIT_EXEMPLARS = (
     "agent-governance-todos.md",
 )
 DASHBOARD_HTML = ("index.html", "implementation-control-center.html")
-DASHBOARD_ASSETS = ("site-nav.js", "local-shell.css", "local-markdown.js")
+DASHBOARD_ASSETS = (
+    "site-nav.js",
+    "local-shell.css",
+    "local-markdown.js",
+    "local-board-snapshot.js",
+)
 ARTIFACT_TAB_STUBS: dict[str, tuple[str, ...]] = {
     "pr": ("review.md", "prep.md", "merge.md"),
     "alignment": ("alignment-audit.md", "alignment-todos.md"),

--- a/payload/.ai_infra/templates/local-workspace/implementation-control-center.html
+++ b/payload/.ai_infra/templates/local-workspace/implementation-control-center.html
@@ -5,7 +5,7 @@ Role: Template dashboard — copy to `.local/agents-control-center/dashboards/` 
 Used By:
  - Local preview (file:// or static server)
 Depends On:
- - local-shell.css, site-nav.js, local-markdown.js
+ - local-shell.css, site-nav.js, local-markdown.js, local-board-snapshot.js
  - ../config/pages.json (after copy: `.local/agents-control-center/config/pages.json`)
  - Paths declared inside pages.json (`.local/...` and `docs/...`)
 Notes:
@@ -37,6 +37,7 @@ Notes:
   </div>
 
   <script src="local-markdown.js"></script>
+  <script src="local-board-snapshot.js"></script>
   <script>
     const MANIFEST = "../config/pages.json";
     let PAGES = [];
@@ -87,6 +88,10 @@ Notes:
       return "";
     }
 
+    function isProjectBoardSnapshot(page) {
+      return page && page.format === "project-board-snapshot";
+    }
+
     async function refreshActivePage() {
       const page = PAGES.find((entry) => entry.id === activePage);
       if (!page) return;
@@ -95,13 +100,30 @@ Notes:
         const filePath = normalizePageFile(page.file);
         const response = await fetch(filePath + "?t=" + Date.now(), { cache: "no-store" });
         if (!response.ok) {
+          if (isProjectBoardSnapshot(page) && response.status === 404) {
+            contentEl.innerHTML = LocalBoardSnapshot.renderMissingExport();
+            refreshEl.textContent = "refresh: " + new Date().toLocaleString();
+            return;
+          }
           throw new Error("Failed to load " + filePath + " (" + response.status + ")");
         }
-        const markdown = await response.text();
-        contentEl.innerHTML = renderMarkdown(markdown);
+        if (isProjectBoardSnapshot(page)) {
+          const snapshot = await response.json();
+          contentEl.innerHTML = LocalBoardSnapshot.render(snapshot);
+        } else {
+          const markdown = await response.text();
+          contentEl.innerHTML = renderMarkdown(markdown);
+        }
         refreshEl.textContent = "refresh: " + new Date().toLocaleString();
       } catch (error) {
-        contentEl.innerHTML = "<p class=\"status-bad\">Could not load markdown: " + escapeHtml(String(error.message || error)) + "</p>";
+        if (isProjectBoardSnapshot(page)) {
+          contentEl.innerHTML = LocalBoardSnapshot.renderMissingExport();
+        } else {
+          contentEl.innerHTML =
+            "<p class=\"status-bad\">Could not load markdown: " +
+            escapeHtml(String(error.message || error)) +
+            "</p>";
+        }
       }
     }
 

--- a/payload/.ai_infra/templates/local-workspace/local-board-snapshot.js
+++ b/payload/.ai_infra/templates/local-workspace/local-board-snapshot.js
@@ -1,0 +1,174 @@
+/**
+ * File: local-board-snapshot.js
+ * Path: .ai_infra/templates/local-workspace/local-board-snapshot.js
+ * Role: Read-only renderer for project-board-snapshot JSON in Implementation Control Center.
+ * Used By:
+ *  - implementation-control-center.html
+ * Depends On:
+ *  - local-markdown.js (escapeHtml)
+ * Notes:
+ *  - Reads `.local/generated-data/project-board-snapshot.json` only; never writes board Status.
+ *  - Copy to `.local/agents-control-center/dashboards/` with other dashboard assets.
+ */
+(function (global) {
+  "use strict";
+
+  function escapeHtml(value) {
+    if (global.LocalMarkdown && typeof global.LocalMarkdown.escapeHtml === "function") {
+      return global.LocalMarkdown.escapeHtml(value);
+    }
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function displayCell(value) {
+    if (value === null || value === undefined || value === "") {
+      return '<span class="local-board-empty">—</span>';
+    }
+    return escapeHtml(String(value));
+  }
+
+  function statusClass(status) {
+    const normalized = String(status || "")
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-");
+    return normalized ? " local-board-status-" + normalized : "";
+  }
+
+  function renderHeader(project, totalCount) {
+    const name = project && project.name ? escapeHtml(project.name) : "Project";
+    const count = typeof totalCount === "number" ? totalCount : 0;
+    const url = project && project.url ? String(project.url) : "";
+    let titleHtml = name;
+    if (url) {
+      const safeUrl = escapeHtml(url);
+      titleHtml =
+        '<a href="' +
+        safeUrl +
+        '" target="_blank" rel="noopener noreferrer">' +
+        name +
+        "</a>";
+    }
+    return (
+      '<header class="local-board-head">' +
+      "<h2>" +
+      titleHtml +
+      "</h2>" +
+      '<p class="local-board-meta">' +
+      "<span>Total items: <strong>" +
+      escapeHtml(String(count)) +
+      "</strong></span>" +
+      '<span class="local-pill local-board-readonly">read-only snapshot</span>' +
+      "</p>" +
+      "</header>"
+    );
+  }
+
+  function renderEmptyItems() {
+    return (
+      '<div class="local-board-empty-state">' +
+      "<p>No board items in this snapshot.</p>" +
+      "<p>Run <code>python3 -m cursor_workflow project export</code> after updating cards on GitHub.</p>" +
+      "</div>"
+    );
+  }
+
+  function renderRow(item, index) {
+    const excerpt = item && item.body_excerpt ? String(item.body_excerpt) : "";
+    let excerptHtml = "";
+    if (excerpt.trim()) {
+      excerptHtml =
+        '<details class="local-board-excerpt">' +
+        "<summary>Body excerpt</summary>" +
+        "<pre>" +
+        escapeHtml(excerpt) +
+        "</pre>" +
+        "</details>";
+    }
+    return (
+      "<tr>" +
+      "<td>" +
+      displayCell(item && item.title) +
+      "</td>" +
+      '<td><span class="local-board-status' +
+      statusClass(item && item.status_normalized) +
+      '">' +
+      displayCell(item && item.status_normalized) +
+      "</span></td>" +
+      "<td>" +
+      displayCell(item && item.priority) +
+      "</td>" +
+      "<td>" +
+      displayCell(item && item.size) +
+      "</td>" +
+      "<td>" +
+      displayCell(item && item.estimate) +
+      "</td>" +
+      "<td>" +
+      displayCell(item && item.updated_at) +
+      "</td>" +
+      "<td>" +
+      excerptHtml +
+      "</td>" +
+      "</tr>"
+    );
+  }
+
+  function renderTable(items) {
+    if (!items.length) {
+      return renderEmptyItems();
+    }
+    let html =
+      '<div class="local-board-table-wrap">' +
+      "<table>" +
+      "<thead><tr>" +
+      "<th>Title</th>" +
+      "<th>Status</th>" +
+      "<th>Priority</th>" +
+      "<th>Size</th>" +
+      "<th>Estimate</th>" +
+      "<th>Updated</th>" +
+      "<th>Excerpt</th>" +
+      "</tr></thead><tbody>";
+    for (let i = 0; i < items.length; i += 1) {
+      html += renderRow(items[i], i);
+    }
+    html += "</tbody></table></div>";
+    return html;
+  }
+
+  function renderSnapshot(snapshot) {
+    const data = snapshot && typeof snapshot === "object" ? snapshot : {};
+    const project = data.project || {};
+    const items = Array.isArray(data.items) ? data.items : [];
+    const totalCount =
+      typeof data.totalCount === "number" ? data.totalCount : items.length;
+    return (
+      '<div class="local-board-panel">' +
+      renderHeader(project, totalCount) +
+      renderTable(items) +
+      "</div>"
+    );
+  }
+
+  function renderMissingExport() {
+    return (
+      '<div class="local-board-missing">' +
+      '<p class="status-bad">Project board snapshot not found.</p>' +
+      "<p>Export a read-only snapshot from the CLI:</p>" +
+      "<pre><code>python3 -m cursor_workflow project export</code></pre>" +
+      "<p>Output path: <code>.local/generated-data/project-board-snapshot.json</code></p>" +
+      "</div>"
+    );
+  }
+
+  global.LocalBoardSnapshot = {
+    render: renderSnapshot,
+    renderMissingExport: renderMissingExport,
+    escapeHtml: escapeHtml,
+  };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/payload/.ai_infra/templates/local-workspace/local-shell.css
+++ b/payload/.ai_infra/templates/local-workspace/local-shell.css
@@ -391,6 +391,125 @@ code,
   color: var(--bad);
 }
 
+/* Project board snapshot (read-only ICC tab) */
+.local-board-panel {
+  color: var(--muted);
+}
+
+.local-board-head h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+  color: #dce8ff;
+}
+
+.local-board-head h2 a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.local-board-head h2 a:hover {
+  text-decoration: underline;
+}
+
+.local-board-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin: 0 0 14px;
+  font-size: 0.92rem;
+}
+
+.local-board-readonly {
+  color: var(--ok);
+}
+
+.local-board-table-wrap {
+  overflow: auto;
+}
+
+.local-board-panel table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.local-board-panel th,
+.local-board-panel td {
+  border: 1px solid var(--line);
+  padding: 8px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.local-board-panel th {
+  background: #13254a;
+  color: var(--text);
+}
+
+.local-board-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  font-size: 0.82rem;
+  text-transform: lowercase;
+}
+
+.local-board-status-done {
+  border-color: rgba(66, 211, 146, 0.5);
+  color: var(--ok);
+}
+
+.local-board-status-in-progress,
+.local-board-status-in_review {
+  border-color: rgba(97, 178, 255, 0.5);
+  color: var(--accent);
+}
+
+.local-board-status-ready {
+  border-color: rgba(255, 209, 102, 0.5);
+  color: var(--warn);
+}
+
+.local-board-empty {
+  color: #7a8bb8;
+}
+
+.local-board-excerpt {
+  margin: 0;
+  max-width: 28rem;
+}
+
+.local-board-excerpt summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.local-board-excerpt pre {
+  margin: 8px 0 0;
+  max-height: 12rem;
+  overflow: auto;
+  background: var(--code-bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.local-board-empty-state,
+.local-board-missing {
+  padding: 12px 0;
+}
+
+.local-board-empty-state p,
+.local-board-missing p {
+  margin: 0.45em 0;
+}
+
 @media (max-width: 900px) {
   .local-tabs {
     grid-template-columns: 1fr 1fr;

--- a/payload/.ai_infra/templates/local-workspace/pages.json
+++ b/payload/.ai_infra/templates/local-workspace/pages.json
@@ -42,6 +42,12 @@
       "file": "../../index-and-planning/current/work-tracker.md"
     },
     {
+      "id": "project-board",
+      "title": "Project Board",
+      "file": "../../generated-data/project-board-snapshot.json",
+      "format": "project-board-snapshot"
+    },
+    {
       "id": "pr-review",
       "title": "PR Review",
       "file": "../../workflow-artifacts/pr/review.md"

--- a/tests/modules/install/test_scaffold.py
+++ b/tests/modules/install/test_scaffold.py
@@ -95,10 +95,12 @@ def test_scaffold_creates_dashboards(tmp_path: Path) -> None:
     assert (dash / "site-nav.js").is_file()
     assert (dash / "local-shell.css").is_file()
     assert (dash / "local-markdown.js").is_file()
+    assert (dash / "local-board-snapshot.js").is_file()
     audit_html = target / ".local" / "agents-control-center" / "audits" / "module-audit.html"
     assert audit_html.is_file()
     icc = (dash / "implementation-control-center.html").read_text(encoding="utf-8")
     assert "local-markdown.js" in icc
+    assert "local-board-snapshot.js" in icc
 
 
 def test_scaffold_refreshes_dashboards_on_repeat(tmp_path: Path) -> None:
@@ -169,7 +171,7 @@ def test_scaffold_pages_json_includes_artifact_tabs(tmp_path: Path) -> None:
         )
     )
     page_ids = {page["id"] for page in pages["pages"]}
-    assert {"pr-review", "drift-audit", "ea-audit"}.issubset(page_ids)
+    assert {"pr-review", "drift-audit", "ea-audit", "project-board"}.issubset(page_ids)
 
 
 def test_scaffold_pages_json_tier1_paths_resolve(tmp_path: Path) -> None:
@@ -182,6 +184,8 @@ def test_scaffold_pages_json_tier1_paths_resolve(tmp_path: Path) -> None:
     for page in pages["pages"]:
         rel = page["file"]
         if rel.startswith("../../workflow-artifacts/"):
+            continue
+        if rel.startswith("../../generated-data/"):
             continue
         resolved = (config / rel).resolve()
         assert resolved.is_file(), f"{page['id']}: {rel} -> missing at {resolved}"


### PR DESCRIPTION
## Summary
- Add ICC **Project Board** tab that reads `.local/generated-data/project-board-snapshot.json` only (`local-board-snapshot.js` + `pages.json` format branch).
- Wire `local-board-snapshot.js` into scaffold `DASHBOARD_ASSETS`; scaffold tests skip runtime `generated-data/` paths.
- Docs/HANDOFF mark EA-010 shipped; canvas aligned (AA-CANVAS-001).
- Board card: Issue [#17](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/issues/17) · `PVTI_lAHOBl46-84A9KZxzgzPAZ4`.

## Acceptance
- [x] ICC reads export snapshot only — never writes board Status
- [x] Missing snapshot prompts `project export`
- [x] Rollback = remove panel + pages entry

## Test plan
- [x] `pytest tests/modules/install/test_scaffold.py -q` (25 passed)
- [x] `make gates` / `make doc-validate` (DOC-006=929)
- [x] Drift validate P0=0; focused alignment P0=0
- [ ] Manual: `python3 -m http.server 8000` → Control Center → Project Board tab

## Rollback
Revert commits; remove `project-board` tab; Project UI remains dashboard.


Made with [Cursor](https://cursor.com)