### PR TITLE
fix: make pyright blocking for cursor_workflow (EA-004)

### DIFF
--- a/.github/workflows/kit-quality.yml
+++ b/.github/workflows/kit-quality.yml
@@ -44,6 +44,5 @@ jobs:
       - name: Install dry-run
         run: make install-dry-run
 
-      - name: Type check (non-blocking)
-        continue-on-error: true
+      - name: Type check
         run: .venv/bin/pyright


### PR DESCRIPTION
## Summary
- Rename CI step to **Type check** and remove `continue-on-error` so pyright failures block kit-quality
- Local pyright already reports 0 errors; no type-ignore sprawl

## Test plan
- [x] `.venv/bin/pyright` → 0 errors
- [x] `pytest tests/modules/install/` → 406 passed, 1 skipped
- [x] YAML has no `continue-on-error` on Type check