### PR TITLE
docs(canvas): align canvases and entry docs to shipped SSOT (DOC-CANVAS)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -31,9 +31,9 @@ Notes:
 | PR scripts + prepare gates | Pattern A — **2** universal; **4** on kit-dev (drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` |
 | Governance + debrand scanners | CI-ready | `.ai_infra/scripts/architecture/` |
 | Workflow drift validate | ADR-007 (+ DRIFT-004b) | `.ai_infra/scripts/workflow/check_drift.py` |
-| Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_cli.py` + skill § Notes |
+| Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_recipes.py` / `project_cli.py` + skill § Notes |
 | Local continuity-index | Rolling ≥3-day UTC rows; board Notes = full card lifetime | `history/continuity-index.md` (+ exemplar) |
-| Board outbox (rate-limit) | `project queue` / `outbox status|flush`; EXIT_QUEUED=6; **58 mocked unit tests** | `project_outbox.py` + `project_cli.py` + `tests/modules/install/test_project_outbox.py` |
+| Board outbox (rate-limit) | `project queue` / `outbox status|flush`; EXIT_QUEUED=6; **58 mocked unit tests** | `project_outbox.py` + `project_atomics.py` / `project_cli.py` + `tests/modules/install/test_project_outbox.py` |
 | Doc facts validate | DOC-001…007 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |
 | Anchoring | session-pointer, change-index | `.local/.../current/` |
@@ -47,13 +47,15 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 929 | `tests/modules/` |
+| Tests | 929 collected (928 passed + 1 skipped on full run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18
-(COV-100): **5352 statements, 100%** on a full suite pass (928 passed, 1 skipped).
+(COV-100): **5352 statements, 100%** on a full suite pass (**929 collected**;
+928 passed, 1 skipped). The **Tests** row uses collected count; executed pass/skip
+may differ by marker or import-order skips.
 One import-order `sys.path` bootstrap in `merge.py` is `# pragma: no cover`.
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,
 `check_debrand.py`, `check_consumer_purity.py`, `check_file_headers.py`) have

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -202,7 +202,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07):** Verified `plugin.json` `description`, the Description row above, and README consumer sections (`What you get`, agent/skill/rule counts) against `IMPLEMENTATION-STATUS.md` on `main` — 633 tests (post DRIFT-005 slice), DOC-006 PASS, coverage scope 3588 stmts / 100% on `--cov=.ai_infra --cov=cursor_workflow`. No stale test or coverage numbers in marketplace-facing copy; feature counts (8 agents, 11 skills, 5 PR skills, 7 rules) match shipped inventory.
 
-**Listing copy refresh (2026-07-18 DOC-ALIGN):** Re-verified README/AGENTS.md/repository-map against shipped tree — **692** tests, ~4396 stmts / ~94% coverage per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633-test line above is archival only.
+**Listing copy refresh (2026-07-18 DOC-CANVAS):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree — **929** tests collected (928 passed + 1 skipped on full suite), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633/692 lines above are archival only.
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Record: `.local/workflow-artifacts/release/smoke-consumer-smart-notes-2026-07-08.md`.
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -52,7 +52,7 @@ mas-workflow-kit-project-ssot/
 ├── cursor_workflow/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (GATES live in prepare.py)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (633+)
+├── tests/                      Kit-dev only — full pytest suite (929)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (empty in core kit)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (633), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `scripts/ci/`, `scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (929), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `scripts/ci/`, `scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -13,6 +13,10 @@ Used By:
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/install/cursor_workflow/project_atomics.py
+ - .ai_infra/install/cursor_workflow/gh_project_adapter.py
+ - .ai_infra/install/cursor_workflow/project_recipes.py
+ - .ai_infra/install/cursor_workflow/project_outbox.py
  - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -212,7 +212,7 @@ const ARTIFACT_FLOWS = [
     ".local/generated-data/project-board-snapshot.json",
     "project export (read-only)",
     "DRIFT-010 refresh",
-    "workflow-drift-guard",
+    "workflow-drift-guard · ICC (EA-010)",
     "Read-only export; never writes Status",
   ],
   [
@@ -499,7 +499,8 @@ export default function AgentBoardCollaborationCanvas() {
       </Callout>
 
       <Text tone="tertiary" size="small">
-        Peer view: canvases/agent-roster.canvas.tsx (explicit handoff edges only)
+        Peer views: canvases/agent-relations.canvas.tsx (handoff graph) ·
+        agent-roster.canvas.tsx (explicit card edges)
       </Text>
 
       <Text tone="tertiary" size="small">

--- a/canvases/agent-enterprise-auditor.canvas.tsx
+++ b/canvases/agent-enterprise-auditor.canvas.tsx
@@ -95,6 +95,7 @@ const PATTERNS = [
   ["Board lifecycle", "Notes = artifact paths; Status in_review/done"],
   ["Tier-1", "Shared Board rights; Start date on claim"],
   ["Tracker etiquette", "Propose edits in audit-actions; implementer applies"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/enterprise-auditor via --agent"],
 ];
 
@@ -122,6 +123,11 @@ const ARTIFACTS = [
   ["change-index.md", "Exit", "Next agents / humans"],
   ["history/updates-log.md", "Exit", "Continuity readers"],
   ["Board Status + Notes", "in_review / done", "implementer"],
+  [
+    ".local/generated-data/project-board-snapshot.json",
+    "project export (read-only)",
+    "ICC (EA-010) board panel — read-only",
+  ],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
 ];
 

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -148,6 +148,7 @@ const PATTERNS = [
   ["Module headers", "file-docstring-header-relations.mdc on new sources"],
   ["Commit trailers", "Author + GitHub-User via contributors commit-trailers"],
   ["Gates", "prepare.py GATES; check_governance_consistency when policy docs change"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/implementer via --agent implementer"],
 ];
 

--- a/canvases/agent-integrator-mas-agent.canvas.tsx
+++ b/canvases/agent-integrator-mas-agent.canvas.tsx
@@ -97,6 +97,7 @@ const PATTERNS = [
   ["Promote before PR", "promote-to-issue OR mention-pr when shipping integration"],
   ["Tier-1", "claim → Start date; set-field estimate on own card"],
   ["STANDALONE", "Product lives only in mas-workflow-kit-project-ssot"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/integrator-mas-agent via --agent"],
 ];
 

--- a/canvases/agent-project-board.canvas.tsx
+++ b/canvases/agent-project-board.canvas.tsx
@@ -90,7 +90,8 @@ const PATTERNS = [
   ["Independent-governed", "Not in default PR pipelines"],
   ["Loop", "status → list ready → create-from-template + claim --last → handoff"],
   ["Triage Tier-1", "set-field Priority/Size/Estimate on new/moved cards"],
-  ["Promote", "promote-to-issue before PR if shipping triage work as Issue"],
+  ["Promote", "promote-to-issue OR mention-pr auto (promote_to_issue_on_pr) before shippable PR"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/project-board via --agent"],
 ];
 

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -1,0 +1,454 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Select,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+const VERIFIED = "2026-07-18";
+const SOURCES =
+  ".cursor/agents/*.md PEERS · project-board-ssot § Continuation · agent-roster edges";
+
+const NODE_W = 128;
+const NODE_H = 40;
+
+type AgentId =
+  | "project-board"
+  | "implementer"
+  | "verifier"
+  | "test-runner"
+  | "integrator-mas-agent"
+  | "enterprise-auditor"
+  | "workflow-drift-guard"
+  | "researcher"
+  | "all";
+
+const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
+  {
+    id: "project-board",
+    role: "Triage Ready; create cards; hand off work",
+    lane: "Coordination",
+  },
+  {
+    id: "implementer",
+    role: "Ship slices: code, tests, promote, PR path",
+    lane: "Delivery",
+  },
+  {
+    id: "test-runner",
+    role: "Module tests / coverage on existing card",
+    lane: "Delivery",
+  },
+  {
+    id: "verifier",
+    role: "Claims vs evidence; no implement",
+    lane: "Delivery",
+  },
+  {
+    id: "integrator-mas-agent",
+    role: "Wire agents/skills/MCP into the kit",
+    lane: "Infrastructure",
+  },
+  {
+    id: "enterprise-auditor",
+    role: "Evidence-only architecture audit artifacts",
+    lane: "Quality",
+  },
+  {
+    id: "workflow-drift-guard",
+    role: "Drift validate; dual-write remediation",
+    lane: "Quality",
+  },
+  {
+    id: "researcher",
+    role: "Local research corpus only (no product PRs)",
+    lane: "Optional",
+  },
+];
+
+/** Handoff edges from agent cards; test-runner→verifier also in skill chain when tests gate PR. */
+const RELATIONS: {
+  from: Exclude<AgentId, "all">;
+  to: Exclude<AgentId, "all">;
+  via: string;
+  when: string;
+}[] = [
+  {
+    from: "project-board",
+    to: "implementer",
+    via: "handoff next=implementer",
+    when: "After triage / create-from-template + claim",
+  },
+  {
+    from: "implementer",
+    to: "verifier",
+    via: "handoff --next verifier --to in_review",
+    when: "PR-ready or slice ready for evidence check",
+  },
+  {
+    from: "implementer",
+    to: "test-runner",
+    via: "handoff / Notes",
+    when: "Tests or coverage needed before merge",
+  },
+  {
+    from: "implementer",
+    to: "workflow-drift-guard",
+    via: "invoke after drift-validate",
+    when: "P0/P1 findings need drift artifacts",
+  },
+  {
+    from: "workflow-drift-guard",
+    to: "project-board",
+    via: "Ready / Notes remediation",
+    when: "Confirmed dual-write — triage card",
+  },
+  {
+    from: "workflow-drift-guard",
+    to: "implementer",
+    via: "Ready / Notes remediation",
+    when: "Confirmed dual-write — fix in slice",
+  },
+  {
+    from: "enterprise-auditor",
+    to: "implementer",
+    via: "Notes + artifact paths",
+    when: "Audit card closed; implementer applies actions",
+  },
+  {
+    from: "integrator-mas-agent",
+    to: "implementer",
+    via: "escalate product src/",
+    when: "Integration needs product code",
+  },
+  {
+    from: "integrator-mas-agent",
+    to: "test-runner",
+    via: "escalate coverage",
+    when: "Integration needs test module work",
+  },
+  {
+    from: "integrator-mas-agent",
+    to: "enterprise-auditor",
+    via: "escalate architecture",
+    when: "Integration is architecture-impacting",
+  },
+  {
+    from: "test-runner",
+    to: "verifier",
+    via: "handoff --to in_review",
+    when: "Tests gate the PR",
+  },
+  {
+    from: "verifier",
+    to: "implementer",
+    via: "stay in_review + failure Notes",
+    when: "Not verified — implementer fixes",
+  },
+];
+
+const RESEARCHER_REDIRECTS: [string, string][] = [
+  ["implementer", "Product code / commits / PRs"],
+  ["verifier", "Claims vs evidence checks"],
+  ["enterprise-auditor", "Architecture audits"],
+  ["workflow-drift-guard", "Drift / tracker coherence"],
+];
+
+const HAPPY_PATH = [
+  ["1", "project-board", "Ready card; Priority/Size/Estimate triage"],
+  ["2", "implementer", "claim → code/tests → promote or mention-pr"],
+  ["3", "test-runner", "Optional: coverage on same card"],
+  ["4", "verifier", "Evidence check → done or back to implementer"],
+  ["5", "merge.py", "Post-merge Status → Done (Pattern A)"],
+];
+
+const LANES: [string, string][] = [
+  ["Coordination", "project-board"],
+  ["Delivery", "implementer · test-runner · verifier"],
+  ["Infrastructure", "integrator-mas-agent"],
+  ["Quality", "enterprise-auditor · workflow-drift-guard"],
+  ["Optional", "researcher"],
+];
+
+const DAG_NODES = AGENTS.filter((a) => a.id !== "researcher").map((a) => ({
+  id: a.id,
+}));
+
+const DAG_EDGES = RELATIONS.filter(
+  (r) => r.from !== "researcher" && r.to !== "researcher",
+).map((r) => ({ from: r.from, to: r.to }));
+
+function RelationDag({
+  focus,
+  tokens,
+}: {
+  focus: AgentId;
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const layout = computeDAGLayout({
+    nodes: DAG_NODES,
+    edges: DAG_EDGES,
+    direction: "horizontal",
+    nodeWidth: NODE_W,
+    nodeHeight: NODE_H,
+    rankGap: 44,
+    nodeGap: 18,
+  });
+  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
+
+  const related = new Set<string>();
+  if (focus !== "all") {
+    related.add(focus);
+    for (const r of RELATIONS) {
+      if (r.from === focus) related.add(r.to);
+      if (r.to === focus) related.add(r.from);
+    }
+  }
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 980 }}
+    >
+      {layout.edges.map((e, i) => {
+        const active =
+          focus === "all" ||
+          (related.has(e.from) &&
+            related.has(e.to) &&
+            (e.from === focus || e.to === focus));
+        const dimmed = focus !== "all" && !active;
+        return (
+          <line
+            key={`${e.from}-${e.to}-${i}`}
+            x1={e.sourceX}
+            y1={e.sourceY}
+            x2={e.targetX}
+            y2={e.targetY}
+            stroke={
+              dimmed
+                ? tokens.stroke.tertiary
+                : active
+                  ? tokens.accent.primary
+                  : tokens.stroke.secondary
+            }
+            strokeWidth={active && focus !== "all" ? 2.5 : 1.5}
+            strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+            opacity={dimmed ? 0.25 : 1}
+          />
+        );
+      })}
+      {layout.nodes.map((n) => {
+        const dimmed = focus !== "all" && !related.has(n.id);
+        const isFocus = n.id === focus;
+        const label =
+          n.id.length > 16 ? `${n.id.slice(0, 14)}…` : n.id;
+        return (
+          <g key={n.id} opacity={dimmed ? 0.3 : 1}>
+            <rect
+              x={n.x}
+              y={n.y}
+              width={NODE_W}
+              height={NODE_H}
+              rx={6}
+              fill={isFocus ? tokens.fill.secondary : tokens.fill.tertiary}
+              stroke={
+                isFocus ? tokens.accent.primary : tokens.stroke.secondary
+              }
+              strokeWidth={isFocus ? 2 : 1}
+            />
+            <text
+              x={n.x + NODE_W / 2}
+              y={n.y + NODE_H / 2 + 4}
+              textAnchor="middle"
+              fill={tokens.text.primary}
+              fontSize={11}
+              fontFamily="ui-sans-serif, system-ui, sans-serif"
+            >
+              {label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function AgentRelationsCanvas() {
+  const { tokens } = useHostTheme();
+  const [focus, setFocus] = useCanvasState<AgentId>("focus", "all");
+
+  const focusedRows =
+    focus === "all"
+      ? RELATIONS.map((r) => [r.from, "→", r.to, r.via, r.when])
+      : RELATIONS.filter((r) => r.from === focus || r.to === focus).map((r) => [
+          r.from,
+          r.from === focus ? "→ out" : "← in",
+          r.to,
+          r.via,
+          r.when,
+        ]);
+
+  const focusMeta = AGENTS.find((a) => a.id === focus);
+
+  const outbound =
+    focus === "all"
+      ? RELATIONS.length
+      : RELATIONS.filter((r) => r.from === focus).length;
+  const inbound =
+    focus === "all"
+      ? RELATIONS.length
+      : RELATIONS.filter((r) => r.to === focus).length;
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 1000 }}>
+      <Stack gap={8}>
+        <Row gap={10} style={{ alignItems: "center" }}>
+          <H1 style={{ margin: 0 }}>Agent relations</H1>
+          <Pill tone="info" size="sm">
+            8 agents
+          </Pill>
+        </Row>
+        <Text tone="secondary">
+          How kit agents hand off work — edges from agent cards plus skill chain
+          (e.g. test-runner→verifier when tests gate the PR). Select an agent to
+          highlight its neighbors.
+        </Text>
+        <Text tone="tertiary" size="small">
+          Source: {SOURCES} · verified {VERIFIED}
+        </Text>
+      </Stack>
+
+      <Row gap={12} style={{ alignItems: "center", flexWrap: "wrap" }}>
+        <Text weight="semibold" size="small">
+          Focus
+        </Text>
+        <Select
+          value={focus}
+          onChange={(v) => setFocus(v as AgentId)}
+          options={[
+            { value: "all", label: "All relations" },
+            ...AGENTS.map((a) => ({ value: a.id, label: a.id })),
+          ]}
+        />
+        {focusMeta ? (
+          <Text tone="secondary" size="small">
+            {focusMeta.lane} · {focusMeta.role}
+          </Text>
+        ) : null}
+      </Row>
+
+      <Grid columns={3} gap={12}>
+        <Stat value={String(AGENTS.length)} label="Agents" />
+        <Stat
+          value={String(focus === "all" ? RELATIONS.length : outbound)}
+          label={focus === "all" ? "Handoff edges" : "Outbound"}
+        />
+        <Stat
+          value={String(focus === "all" ? "4" : inbound)}
+          label={focus === "all" ? "Lanes" : "Inbound"}
+        />
+      </Grid>
+
+      <Card>
+        <CardHeader
+          trailing={
+            <Pill size="sm" tone="neutral">
+              DAG
+            </Pill>
+          }
+        >
+          Collaboration graph (researcher omitted — redirects only)
+        </CardHeader>
+        <CardBody>
+          <RelationDag focus={focus} tokens={tokens} />
+          <Text tone="tertiary" size="small">
+            Accent edges = selected agent’s handoffs. Dashed = back-edge (cycle).
+            researcher has no product edges — see redirects below.
+          </Text>
+        </CardBody>
+      </Card>
+
+      <Stack gap={8}>
+        <H2>Happy path (typical slice)</H2>
+        <Table
+          headers={["Step", "Actor", "What happens"]}
+          rows={HAPPY_PATH}
+        />
+      </Stack>
+
+      <Divider />
+
+      <Stack gap={8}>
+        <H2>
+          {focus === "all"
+            ? "All handoff relations"
+            : `Relations for ${focus}`}
+        </H2>
+        {focusedRows.length === 0 ? (
+          <Callout tone="neutral" title="No direct handoff edges">
+            This agent redirects to product agents or is consume-only with
+            generic next. See role cards and researcher redirects.
+          </Callout>
+        ) : (
+          <Table
+            headers={["From", "Dir", "To", "Via", "When"]}
+            rows={focusedRows}
+          />
+        )}
+      </Stack>
+
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>Lanes</CardHeader>
+          <CardBody>
+            <Table headers={["Lane", "Agents"]} rows={LANES} />
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>researcher redirects</CardHeader>
+          <CardBody>
+            <Table
+              headers={["Hand to", "Why"]}
+              rows={RESEARCHER_REDIRECTS}
+            />
+            <Spacer />
+            <Text size="small" tone="tertiary">
+              Hard stop: write only under _research_results/; no product
+              commit/push/PR.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <Callout tone="info" title="Shared board contract">
+        Every agent: Entry = project status / claim; Exit = Status + Notes.
+        Tier-1: claim may set Start date; triage may set Estimate. Promote
+        Draft→Issue via promote-to-issue or mention-pr (auto when
+        promote_to_issue_on_pr) before shippable PR — claim does not auto-promote.
+        Notes: @owner.github_user/&lt;agent&gt; · YYYY-MM-DDTHH:MM:SSZ · … via
+        append-notes --agent. Board is the only writable Status SSOT when board_only.
+      </Callout>
+
+      <Text size="small" tone="tertiary">
+        Peer canvases: agent-roster (card edges) · agent-board-collaboration
+        (board SSOT hub) · per-agent canvases under canvases/agent-*.canvas.tsx
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -90,6 +90,7 @@ const PATTERNS = [
   ["Board lifecycle", "Research card → done + corpus paths in Notes"],
   ["Tier-1", "Shared Board rights; read-only board if no research card"],
   ["Forbidden", "No src/tests/scripts; no git commit/push/PR"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/researcher via --agent"],
 ];
 

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -193,13 +193,16 @@ export default function AgentRosterCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Explicit handoff edges from agent cards only. researcher is non-product —
-          redirects to product agents.
+          Explicit handoff edges from agent cards (skill chain test-runner→verifier
+          when tests gate PR). researcher is non-product — redirects to product
+          agents.
         </Text>
         <Callout tone="info" title="Board lifecycle (all 8)">
           Tier-1: claim may set Start date; triage/own card may set Estimate.
-          Promote Draft→Issue via promote-to-issue or mention-pr before shippable PR
-          (claim does not auto-promote). See agent-board-collaboration canvas.
+          Promote Draft→Issue via promote-to-issue or mention-pr (auto when
+          promote_to_issue_on_pr) before shippable PR — claim does not auto-promote.
+          Notes: @owner.github_user/&lt;agent&gt; · YYYY-MM-DDTHH:MM:SSZ · … via
+          append-notes --agent. See agent-board-collaboration canvas.
         </Callout>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -104,6 +104,7 @@ const PATTERNS = [
   ["Board lifecycle", "Exit in_review if tests gate PR else done"],
   ["Tier-1", "Shared Board rights; promote only if opening a shippable PR"],
   ["Module layout", "tests/modules/<module>/ matching source boundaries"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/test-runner via --agent test-runner"],
 ];
 

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -100,6 +100,7 @@ const PATTERNS = [
   ["Tier-1", "Shared Board rights; Start date on claim if reclaiming"],
   ["Checks", "pytest · GATES category · governance · verify_publish"],
   ["Merge gate", "Do not approve merge without pr/ artifacts when maintainer workflow active"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/verifier via --agent verifier"],
 ];
 

--- a/canvases/agent-workflow-drift-guard.canvas.tsx
+++ b/canvases/agent-workflow-drift-guard.canvas.tsx
@@ -98,6 +98,7 @@ const PATTERNS = [
   ["Board lifecycle", "list --status in_progress; close drift-pass → done"],
   ["Tier-1", "Shared Board rights; no silent tracker dual-write"],
   ["Dual-write remediation", "Notes or handoff to project-board / implementer via Ready"],
+  ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/workflow-drift-guard via --agent"],
 ];
 
@@ -106,6 +107,11 @@ const ARTIFACTS = [
   [".local/workflow-artifacts/drift/drift-todos.md", "Exit", "Maintainers / implementer"],
   ["history/updates-log.md", "Exit", "Continuity readers"],
   ["Board drift-pass card Status", "done / in_review", "project-board / implementer"],
+  [
+    ".local/generated-data/project-board-snapshot.json",
+    "project export",
+    "DRIFT-010 · ICC (EA-010) read-only",
+  ],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
 ];
 

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -127,12 +127,10 @@ const FOLLOWUP_SLICES = [
     card: "FIX-NOTES-DI",
     title: "append-notes on DraftIssue",
     color: "green" as const,
-    status: "local" as const,
     items: [
       "Resolves PVTI_ → DI_ + title for DraftIssue content",
       "Status stays on PVTI_; Issue-backed via gh issue edit",
-      "Smoke OK; board card Done",
-      "Local / pending PR (not yet on main)",
+      "Shipped on main (PR #3)",
     ],
   },
   {
@@ -140,11 +138,10 @@ const FOLLOWUP_SLICES = [
     card: "Edge-case tests",
     title: "CLI + merge coverage",
     color: "blue" as const,
-    status: "local" as const,
     items: [
       "Issue body, GraphQL errors, merge Notes warn",
-      "set_item_status PVTI-only paths",
-      "Focused suite 36+; collect ~669",
+      "set_item_status PVTI-only paths; outbox queue/flush",
+      "929 tests collected; drift validate green",
     ],
   },
   {
@@ -152,27 +149,43 @@ const FOLLOWUP_SLICES = [
     card: "Doc-drift residuals",
     title: "Skill board_only caveats",
     color: "blue" as const,
-    status: "local" as const,
     items: [
       "audit-orchestration, workflow-activate",
       "mas-infrastructure-integration, test-module-coverage",
       "review-pr board_only caveats",
-      "DRIFT validate P0=0 P1=0 P2=0",
+      "DRIFT validate P0=0 P1=0 P2=0 — shipped on main",
     ],
   },
 ];
 
-const CLI_ROWS = [
-  ["status", "Board health + config"],
+const CLI_RECIPE_ROWS = [
+  ["claim", "Pattern A — In progress + Start date + Notes @user/agent · UTC"],
+  ["handoff", "Pattern A — Status + Notes + next=@user/agent"],
+  ["create-from-template", "Pattern A — slice/bug card + body sections"],
+  ["mention-pr", "Pattern A — PR Notes; auto-promote when promote_to_issue_on_pr"],
+  ["promote-to-issue", "Pattern A — Draft→Issue (same PVTI_; claim does not auto-promote)"],
+  ["guide", "Copy-safe recipes for --agent <name>"],
+  ["last", "Resolve --last item_id after create"],
+  ["validate-item", "Card body / field sanity check"],
+];
+
+const CLI_ATOMIC_ROWS = [
+  ["status", "Board health + project_ssot config"],
   ["list", "Filter by Status / assignee"],
-  ["create", "New slice card"],
-  ["set-status", "Claim / In review / Done (PVTI_ only)"],
-  ["set-field", "Priority, Size, etc."],
+  ["create", "New slice card (low-level)"],
+  ["set-status", "In progress / In review / Done (PVTI_ only)"],
+  ["set-field", "Priority, Size, Estimate, etc."],
   ["get", "Card body + fields"],
   ["append-notes", "Handoff lines; DraftIssue DI_ resolve + Issue edit"],
+  ["set-assignee", "Human assignee (UI or PAT)"],
   ["find-by-pr", "Resolve card from PR number"],
-  ["export", "Read-only snapshot (no Status write)"],
+  ["export", "Read-only snapshot → project-board-snapshot.json"],
+  ["doctor", "Config / PAT / field-id diagnostics"],
+  ["queue", "Enqueue deferred board write"],
+  ["outbox", "status | flush — EXIT_QUEUED (6) buffer"],
 ];
+
+const CLI_ROWS = [...CLI_RECIPE_ROWS, ...CLI_ATOMIC_ROWS];
 
 function FlowDiagram({ mode }: { mode: "classic" | "shipped" }) {
   const theme = useHostTheme();
@@ -315,8 +328,8 @@ export default function BoardSsotVsKitCanvas() {
         <H1>MAS Workflow Kit → Board SSOT (shipped)</H1>
         <Text tone="secondary">
           Before/after comparison for mas-workflow-kit-project-ssot as of 2026-07-18.
-          PR #2 merged A→B→C on main; FIX-NOTES-DI + doc-drift residuals + expanded
-          tests are done locally and pending PR.
+          PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift residuals, EA-001/004,
+          and expanded tests (929 collected) are shipped on main.
         </Text>
       </Stack>
 
@@ -381,7 +394,7 @@ export default function BoardSsotVsKitCanvas() {
         ))}
       </Grid>
 
-      <H2>Post A→B→C follow-ups (local / pending PR)</H2>
+      <H2>Post A→B→C follow-ups (shipped on main)</H2>
       <TodoListCard
         defaultExpanded
         todos={FOLLOWUP_SLICES.map((s) => ({
@@ -398,7 +411,7 @@ export default function BoardSsotVsKitCanvas() {
                 <Row gap={6} align="center">
                   <Swatch color={slice.color} />
                   <Pill size="sm" active>
-                    Local
+                    Done
                   </Pill>
                 </Row>
               }
@@ -481,12 +494,24 @@ export default function BoardSsotVsKitCanvas() {
 
       <Divider />
 
-      <H2>project CLI (shipped surface)</H2>
+      <H2>project CLI — 21 subcommands (shipped)</H2>
+      <Callout tone="info" title="Module split (EA-001 shipped)">
+        Dispatcher: project_cli.py · atomics: project_atomics.py · GraphQL adapter:
+        gh_project_adapter.py · Pattern A recipes: project_recipes.py · rate-limit
+        buffer: project_outbox.py → .local/generated-data/board-outbox.jsonl
+        (EXIT_QUEUED=6).
+      </Callout>
       <Table
         headers={["Command", "Role"]}
         rows={CLI_ROWS}
         striped
       />
+      <Text tone="tertiary" size="small">
+        Full list: status · list · create · create-from-template · set-status ·
+        set-field · get · append-notes · claim · mention-pr · promote-to-issue ·
+        handoff · validate-item · last · guide · doctor · set-assignee · find-by-pr ·
+        export · queue · outbox
+      </Text>
 
       <Grid columns={2} gap={12}>
         <Card>
@@ -587,18 +612,19 @@ export default function BoardSsotVsKitCanvas() {
           <CardBody>
             <Stack gap={4}>
               <Text size="small">project_ssot + board_only in collab YAML</Text>
-              <Text size="small">cursor_workflow project CLI (9 commands)</Text>
+              <Text size="small">cursor_workflow project CLI (21 subcommands)</Text>
               <Text size="small">8 agent Anchors + continuation contract</Text>
               <Text size="small">ADR-008 + project-ssot-precedence overlay</Text>
               <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI on main (PR #3)</Text>
-              <Text size="small">Edge-case tests: focused 36+; collect ~669</Text>
-              <Text size="small">DRIFT validate P0=0 P1=0 P2=0</Text>
+              <Text size="small">929 tests collected; DRIFT validate P0=0 P1=0 P2=0</Text>
               <Text size="small">STANDALONE decided — this repo is the product</Text>
               <Text size="small">
                 BOARD-PROMOTE: Draft→Issue via promote-to-issue / mention-pr auto
                 (promote_to_issue_on_pr default true); claim does not auto-promote
               </Text>
               <Text size="small">BOARD-TIER1: claim Start date + Estimate set-field + mention-pr</Text>
+              <Text size="small">EA-001: project_cli split (atomics/adapter/recipes/outbox)</Text>
+              <Text size="small">EA-004: pyright blocking in kit-quality CI</Text>
               <Text size="small">EA-010: ICC Project Board tab (read-only export snapshot)</Text>
             </Stack>
           </CardBody>
@@ -610,7 +636,7 @@ export default function BoardSsotVsKitCanvas() {
           <CardBody>
             <Stack gap={4}>
               <Text size="small">Install screenshot asset TBD if UI text differs</Text>
-              <Text size="small">EA-001 split project_cli / EA-004 pyright (audit P1)</Text>
+              <Text size="small">Consumer marketplace publish channel TBD</Text>
             </Stack>
           </CardBody>
         </Card>

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -13,6 +13,10 @@ Used By:
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/install/cursor_workflow/project_atomics.py
+ - .ai_infra/install/cursor_workflow/gh_project_adapter.py
+ - .ai_infra/install/cursor_workflow/project_recipes.py
+ - .ai_infra/install/cursor_workflow/project_outbox.py
  - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -13,6 +13,10 @@ Used By:
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/install/cursor_workflow/project_atomics.py
+ - .ai_infra/install/cursor_workflow/gh_project_adapter.py
+ - .ai_infra/install/cursor_workflow/project_recipes.py
+ - .ai_infra/install/cursor_workflow/project_outbox.py
  - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:


### PR DESCRIPTION
## Summary
- Align all agent/board canvases with shipped reality: 8 agents, CLI split (atomics/adapter/recipes/outbox), 929 tests, EA-010/001/004 shipped.
- Track `agent-relations.canvas.tsx`; refresh repository-map / IMPLEMENTATION-STATUS / marketplace-publish + project-board-ssot Depends On.
- Board card `PVTI_…SeEs`.

## Test plan
- [x] doc validate / drift validate / integrate validate (P0=0)
- [ ] CI Kit Quality

## Rollback
Revert canvas/doc commits.


Made with [Cursor](https://cursor.com)