### PR TITLE
chore: workspace clean — agent-relations + DOC-008

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-18 (DOC-AGENT-SYNC — DOC-007 Board rights)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 929
+**Last updated:** 2026-07-18 (WORKSPACE-CLEAN — DOC-008 canvas roster)  
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 931
 
 ## Shipped (confirmed in repo)
 
@@ -34,7 +34,7 @@ Notes:
 | Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_recipes.py` / `project_cli.py` + skill § Notes |
 | Local continuity-index | Rolling ≥3-day UTC rows; board Notes = full card lifetime | `history/continuity-index.md` (+ exemplar) |
 | Board outbox (rate-limit) | `project queue` / `outbox status|flush`; EXIT_QUEUED=6; **58 mocked unit tests** | `project_outbox.py` + `project_atomics.py` / `project_cli.py` + `tests/modules/install/test_project_outbox.py` |
-| Doc facts validate | DOC-001…007 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
+| Doc facts validate | DOC-001…008 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |
 | Anchoring | session-pointer, change-index | `.local/.../current/` |
 | MCP tools + resources | 20 tools + 6 resources | `.ai_infra/mcp_servers/workflow_mcp/` |
@@ -47,14 +47,14 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 929 collected (928 passed + 1 skipped on full run) | `tests/modules/` |
+| Tests | 931 collected (930 passed + 1 skipped on full run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18
-(COV-100): **5352 statements, 100%** on a full suite pass (**929 collected**;
-928 passed, 1 skipped). The **Tests** row uses collected count; executed pass/skip
+(COV-100): **5352 statements, 100%** on a full suite pass (**931 collected**;
+930 passed, 1 skipped). The **Tests** row uses collected count; executed pass/skip
 may differ by marker or import-order skips.
 One import-order `sys.path` bootstrap in `merge.py` is `# pragma: no cover`.
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -202,7 +202,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07):** Verified `plugin.json` `description`, the Description row above, and README consumer sections (`What you get`, agent/skill/rule counts) against `IMPLEMENTATION-STATUS.md` on `main` — 633 tests (post DRIFT-005 slice), DOC-006 PASS, coverage scope 3588 stmts / 100% on `--cov=.ai_infra --cov=cursor_workflow`. No stale test or coverage numbers in marketplace-facing copy; feature counts (8 agents, 11 skills, 5 PR skills, 7 rules) match shipped inventory.
 
-**Listing copy refresh (2026-07-18 DOC-CANVAS):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree — **929** tests collected (928 passed + 1 skipped on full suite), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633/692 lines above are archival only.
+**Listing copy refresh (2026-07-18 WORKSPACE-CLEAN):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633/692 lines above are archival only.
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Record: `.local/workflow-artifacts/release/smoke-consumer-smart-notes-2026-07-08.md`.
 

--- a/.ai_infra/docs/maintainer/local-anchoring-patterns.md
+++ b/.ai_infra/docs/maintainer/local-anchoring-patterns.md
@@ -27,6 +27,14 @@ Path SSOT: `.ai_infra/scripts/pr/local_workflow_paths.py`.
 
 ## Session entry (every agent slice)
 
+When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true`:
+
+1. `python -m cursor_workflow project status` — board health + active card
+2. Claim or read In progress card; Acceptance/Rollback on **card body** (`body_sections`)
+3. `.cursor/skills/project-board-ssot/SKILL.md` § Continuation — Pattern A claim/handoff/mention-pr/promote
+
+**Offline fallback** (`project_ssot` disabled or board unreachable with `fallback: local_trackers`):
+
 1. `.local/index-and-planning/current/session-pointer.md` — what to read next
 2. `plan.md` — active slice scope and acceptance criteria
 3. `work-tracker.md` — exactly one primary `in_progress` task

--- a/.ai_infra/docs/operations/gate-matrix.md
+++ b/.ai_infra/docs/operations/gate-matrix.md
@@ -20,7 +20,7 @@ Three gate surfaces exist by design (Pattern A).
 |---------|------|-------|-----------------|
 | **`prepare.py` GATES** | PR merge prep | **2** universal (testing artifacts + pytest); **4** on kit-dev (auto-appends drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` `resolve_gates()` |
 | **`cursor-workflow gates`** | Kit dev / maintainer hygiene | 5: testing artifacts + pytest + governance + debrand + doc facts | `.ai_infra/install/cursor_workflow/cli.py` |
-| **`make doc-validate`** | After doc/agent/rule changes | DOC-001…006 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
+| **`make doc-validate`** | After doc/agent/rule changes | DOC-001…008 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | **`make verify-all`** | Pre-audit / release readiness | 7 (+ optional ci-seed): sync-plugin → gates → drift → integrate → check-plugin → health → contributors | `.ai_infra/scripts/architecture/verify_all.py` |
 | **`scaffold --verify`** | Post-install smoke on consumer | 4: testing artifacts + pytest + governance + debrand (no doc facts) | `.ai_infra/scripts/install/scaffold.py` `_run_verify` |
 | **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…010 + 004b on kit-dev; consumer profile subset) | `.ai_infra/scripts/workflow/check_drift.py` |

--- a/.ai_infra/mcp_servers/workflow_mcp/README.md
+++ b/.ai_infra/mcp_servers/workflow_mcp/README.md
@@ -39,7 +39,7 @@ External servers: [connect-external-mcp.md](../../docs/operations/connect-extern
 | `workflow_integrate_validate` | `.ai_infra/scripts/integration/validate.py` (INT-001…014) |
 | `workflow_drift_validate` | `.ai_infra/scripts/workflow/check_drift.py` (DRIFT-001…010 kit-dev; consumer subset) |
 | `workflow_activate` | `.ai_infra/install/cursor_workflow/activate_cli.py` (three-plane install) |
-| `workflow_doc_facts_validate` | `.ai_infra/scripts/architecture/check_doc_facts.py` (DOC-001…006) |
+| `workflow_doc_facts_validate` | `.ai_infra/scripts/architecture/check_doc_facts.py` (DOC-001…008) |
 | `workflow_verify_all` | `.ai_infra/scripts/architecture/verify_all.py` (maintainer matrix) |
 
 ## P1 resources

--- a/.ai_infra/scripts/architecture/doc_facts_checks.py
+++ b/.ai_infra/scripts/architecture/doc_facts_checks.py
@@ -1,7 +1,7 @@
 """
 File: doc_facts_checks.py
 Path: .ai_infra/scripts/architecture/doc_facts_checks.py
-Role: Individual DOC-001…007 checks for canonical doc vs repo fact parity.
+Role: Individual DOC-001…008 checks for canonical doc vs repo fact parity.
 Used By:
  - .ai_infra/scripts/architecture/check_doc_facts.py
 Depends On:
@@ -379,6 +379,174 @@ def check_doc007_agent_board_rights(paths: DocFactsPaths) -> CheckResult:
     )
 
 
+CANVAS_ROSTER_FILES = (
+    "agent-relations.canvas.tsx",
+    "agent-roster.canvas.tsx",
+    "agent-board-collaboration.canvas.tsx",
+)
+
+CANVAS_ROSTER_HUBS = (
+    "agent-relations.canvas.tsx",
+    "agent-roster.canvas.tsx",
+)
+
+# Flow/UI tokens in canvases — not agent ids (DOC-008 allowlist).
+_CANVAS_NON_AGENT_TOKENS = frozenset(
+    {
+        "all",
+        "agent",
+        "a",
+        "b",
+        "c",
+        "board",
+        "claim",
+        "cli",
+        "close",
+        "code",
+        "corpus",
+        "create",
+        "doc-drift",
+        "done",
+        "export",
+        "fix-notes",
+        "gates",
+        "handoff",
+        "index",
+        "list",
+        "merge",
+        "next",
+        "notes",
+        "plan",
+        "pr",
+        "session",
+        "skill",
+        "snapshot",
+        "status",
+        "tests",
+        "tracker",
+        "trackers",
+        "close",
+        "triage",
+        "validate",
+        "verdict",
+        "yaml",
+        "audit",
+        "artifacts",
+        "boundaries",
+        "checks",
+        "coverage",
+        "evidence",
+        "intake",
+        "promote",
+        "restate",
+        "todo",
+        "todos",
+        "card",
+        "wire",
+        "verify",
+        "pr-workflow",
+    }
+)
+
+
+def _canvas_paths(root: Path) -> list[Path]:
+    canvases = root / "canvases"
+    if not canvases.is_dir():
+        return []
+    paths: list[Path] = []
+    for name in CANVAS_ROSTER_FILES:
+        path = canvases / name
+        if path.is_file():
+            paths.append(path)
+    paths.extend(sorted(canvases.glob("agent-*.canvas.tsx")))
+    # Dedupe while preserving order
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in paths:
+        key = path.as_posix()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def _parse_agents_array_ids(text: str) -> set[str]:
+    """Extract `id: \"agent-id\"` entries from AGENTS / AgentId roster blocks."""
+    ids: set[str] = set()
+    for match in re.finditer(r'\bid:\s*"([a-z][a-z0-9-]*)"', text):
+        ids.add(match.group(1))
+    return ids
+
+
+def _canvas_agent_refs(text: str) -> set[str]:
+    refs: set[str] = set()
+    for match in re.finditer(
+        r'(?:from|to|value|label):\s*"([a-z][a-z0-9-]*)"', text
+    ):
+        refs.add(match.group(1))
+    for match in re.finditer(
+        r'\|\s*"([a-z][a-z0-9-]+)"\s*\|', text
+    ):
+        refs.add(match.group(1))
+    return refs
+
+
+def check_doc008_canvas_roster(paths: DocFactsPaths) -> CheckResult:
+    """Canvas agent ids must match .cursor/agents roster; hub canvases list all live agents."""
+    live = set(list_agent_ids(paths))
+    if not live:
+        return CheckResult(
+            check_id="DOC-008",
+            severity=Severity.P2,
+            passed=False,
+            detail="missing .cursor/agents/*.md",
+        )
+    canvas_paths = _canvas_paths(paths.root)
+    if not canvas_paths:
+        return CheckResult(
+            check_id="DOC-008",
+            severity=Severity.P2,
+            passed=False,
+            detail="missing canvases/agent-*.canvas.tsx",
+        )
+
+    unknown: list[str] = []
+    missing_roster: list[str] = []
+    for path in canvas_paths:
+        rel = path.relative_to(paths.root).as_posix()
+        text = _read(path)
+        for ref in sorted(_canvas_agent_refs(text)):
+            if ref in _CANVAS_NON_AGENT_TOKENS or ref in live:
+                continue
+            unknown.append(f"{rel}: unknown agent {ref}")
+
+    for hub_name in CANVAS_ROSTER_HUBS:
+        hub = paths.root / "canvases" / hub_name
+        if not hub.is_file():
+            missing_roster.append(f"{hub_name}: file missing")
+            continue
+        listed = _parse_agents_array_ids(_read(hub))
+        for agent_id in sorted(live):
+            if agent_id not in listed:
+                missing_roster.append(f"{hub_name}: missing {agent_id}")
+
+    passed = not unknown and not missing_roster
+    if passed:
+        detail = f"canvas roster aligned ({len(live)} agents, {len(canvas_paths)} canvases)"
+    else:
+        parts = unknown[:4] + missing_roster[:4]
+        detail = "; ".join(parts)
+        if len(unknown) + len(missing_roster) > 4:
+            detail += f"; +{len(unknown) + len(missing_roster) - 4} more"
+    return CheckResult(
+        check_id="DOC-008",
+        severity=Severity.P2,
+        passed=passed,
+        detail=detail,
+    )
+
+
 KIT_DEV_CHECKS = (
     check_doc001_agent_roster,
     check_doc002_status_agent_count,
@@ -387,4 +555,5 @@ KIT_DEV_CHECKS = (
     check_doc005_prepare_gate_facts,
     check_doc006_implementation_test_count,
     check_doc007_agent_board_rights,
+    check_doc008_canvas_roster,
 )

--- a/.cursor/rules/implementation-workflow-governance.mdc
+++ b/.cursor/rules/implementation-workflow-governance.mdc
@@ -11,7 +11,7 @@ alwaysApply: true
 - Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
 - When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m cursor_workflow project status` / claim card); local trackers are offline fallback only.
 - Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
-- Exactly one primary task `in_progress` in `work-tracker.md`; do not implement without scope in `plan.md`.
+- Exactly one primary `in_progress` **Status on the Project** when `board_only`; `work-tracker.md` `in_progress` only when SSOT disabled or offline fallback. Do not implement without scope on the board card body (or `plan.md` when fallback).
 - Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.
 
 ## Tests

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -246,7 +246,7 @@ python3 -m cursor_workflow project claim --last --agent implementer
 1. Verify consumer CLI / gates vs kit 0.4.0; recreate clean `v0.4.0` release (upstream).
 2. Prove Cursor agent can drive GitHub Projects with `project` scope → **yes**.
 3. Isolate in **sibling repo**; mirror full kit (**done** — this workspace).
-4. **North star:** replace local tracker Status SSOT with Project board; configure board in **`github.collaboration.yaml`**; **all agent procedures** create/load/update tasks on that Project.
+4. **North star (achieved 2026-07-18):** Project board is the writable Status SSOT when `board_only`; local trackers are offline fallback only. Board configured in **`github.collaboration.yaml`**; **all agent procedures** create/load/update tasks on that Project.
 5. **STANDALONE 2026-07-18:** this repo is the permanent product — **no** port back to `mas-workflow-kit`.
 
 ---

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -22,7 +22,7 @@ import {
 
 const VERIFIED = "2026-07-18";
 const SOURCES =
-  ".cursor/agents/*.md PEERS · project-board-ssot § Continuation · agent-roster edges";
+  ".cursor/agents/*.md PEERS · audit-orchestration Phase 3 · project-board-ssot § Continuation · agent-roster edges";
 
 const NODE_W = 128;
 const NODE_H = 40;
@@ -129,6 +129,18 @@ const RELATIONS: {
     to: "implementer",
     via: "Notes + artifact paths",
     when: "Audit card closed; implementer applies actions",
+  },
+  {
+    from: "enterprise-auditor",
+    to: "workflow-drift-guard",
+    via: "audit-orchestration Phase 3",
+    when: "After tracker/doc edits; P0/P1 drift findings",
+  },
+  {
+    from: "enterprise-auditor",
+    to: "verifier",
+    via: "audit-orchestration Phase 3",
+    when: "Spot-check top audit claims vs preflight + repo paths",
   },
   {
     from: "integrator-mas-agent",

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -541,7 +541,7 @@ export default function BoardSsotVsKitCanvas() {
 
       <H2>Classic vs shipped</H2>
       <Table
-        headers={["Concern", "Classic kit", "Shipped experiment"]}
+        headers={["Concern", "Classic kit", "STANDALONE product"]}
         rows={[
           ["Backlog / status SSOT", "Local markdown trackers", "GitHub Project"],
           [
@@ -607,7 +607,7 @@ export default function BoardSsotVsKitCanvas() {
       <Grid columns={2} gap={12}>
         <Card>
           <CardHeader trailing={<Pill size="sm" active>Done</Pill>}>
-            Shipped on experiment
+            Shipped on product (STANDALONE)
           </CardHeader>
           <CardBody>
             <Stack gap={4}>

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -9,7 +9,7 @@ Per-project rules and optional docs that **extend** the universal **MAS Workflow
 | `overlays/rules/*.mdc` | Product- or domain-specific Cursor rules (install → target `.cursor/rules/`) |
 | `overlays/docs/` | Optional ops docs merged into project `docs/` at install |
 
-**Core ships exactly 6 universal rules** in `.cursor/rules/`. Overlays add constraints for *your* product (adapter walls, layer policies, protected paths, etc.).
+**Kit-dev (this product repo) ships 7 rules** in `.cursor/rules/` — 6 universal kit rules plus `project-ssot-precedence.mdc`. **Consumer activate** copies **6** rules from `payload/.cursor/rules/` (no product-only overlay). **Overlays** add project-specific `.mdc` files at install for *your* app (adapter walls, layer policies, protected paths, etc.).
 
 ## Install
 

--- a/payload/.ai_infra/docs/operations/gate-matrix.md
+++ b/payload/.ai_infra/docs/operations/gate-matrix.md
@@ -20,7 +20,7 @@ Three gate surfaces exist by design (Pattern A).
 |---------|------|-------|-----------------|
 | **`prepare.py` GATES** | PR merge prep | **2** universal (testing artifacts + pytest); **4** on kit-dev (auto-appends drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` `resolve_gates()` |
 | **`cursor-workflow gates`** | Kit dev / maintainer hygiene | 5: testing artifacts + pytest + governance + debrand + doc facts | `.ai_infra/install/cursor_workflow/cli.py` |
-| **`make doc-validate`** | After doc/agent/rule changes | DOC-001…006 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
+| **`make doc-validate`** | After doc/agent/rule changes | DOC-001…008 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | **`make verify-all`** | Pre-audit / release readiness | 7 (+ optional ci-seed): sync-plugin → gates → drift → integrate → check-plugin → health → contributors | `.ai_infra/scripts/architecture/verify_all.py` |
 | **`scaffold --verify`** | Post-install smoke on consumer | 4: testing artifacts + pytest + governance + debrand (no doc facts) | `.ai_infra/scripts/install/scaffold.py` `_run_verify` |
 | **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…010 + 004b on kit-dev; consumer profile subset) | `.ai_infra/scripts/workflow/check_drift.py` |

--- a/payload/.ai_infra/mcp_servers/workflow_mcp/README.md
+++ b/payload/.ai_infra/mcp_servers/workflow_mcp/README.md
@@ -39,7 +39,7 @@ External servers: [connect-external-mcp.md](../../docs/operations/connect-extern
 | `workflow_integrate_validate` | `.ai_infra/scripts/integration/validate.py` (INT-001…014) |
 | `workflow_drift_validate` | `.ai_infra/scripts/workflow/check_drift.py` (DRIFT-001…010 kit-dev; consumer subset) |
 | `workflow_activate` | `.ai_infra/install/cursor_workflow/activate_cli.py` (three-plane install) |
-| `workflow_doc_facts_validate` | `.ai_infra/scripts/architecture/check_doc_facts.py` (DOC-001…006) |
+| `workflow_doc_facts_validate` | `.ai_infra/scripts/architecture/check_doc_facts.py` (DOC-001…008) |
 | `workflow_verify_all` | `.ai_infra/scripts/architecture/verify_all.py` (maintainer matrix) |
 
 ## P1 resources

--- a/payload/.ai_infra/scripts/architecture/doc_facts_checks.py
+++ b/payload/.ai_infra/scripts/architecture/doc_facts_checks.py
@@ -1,7 +1,7 @@
 """
 File: doc_facts_checks.py
 Path: .ai_infra/scripts/architecture/doc_facts_checks.py
-Role: Individual DOC-001…007 checks for canonical doc vs repo fact parity.
+Role: Individual DOC-001…008 checks for canonical doc vs repo fact parity.
 Used By:
  - .ai_infra/scripts/architecture/check_doc_facts.py
 Depends On:
@@ -379,6 +379,174 @@ def check_doc007_agent_board_rights(paths: DocFactsPaths) -> CheckResult:
     )
 
 
+CANVAS_ROSTER_FILES = (
+    "agent-relations.canvas.tsx",
+    "agent-roster.canvas.tsx",
+    "agent-board-collaboration.canvas.tsx",
+)
+
+CANVAS_ROSTER_HUBS = (
+    "agent-relations.canvas.tsx",
+    "agent-roster.canvas.tsx",
+)
+
+# Flow/UI tokens in canvases — not agent ids (DOC-008 allowlist).
+_CANVAS_NON_AGENT_TOKENS = frozenset(
+    {
+        "all",
+        "agent",
+        "a",
+        "b",
+        "c",
+        "board",
+        "claim",
+        "cli",
+        "close",
+        "code",
+        "corpus",
+        "create",
+        "doc-drift",
+        "done",
+        "export",
+        "fix-notes",
+        "gates",
+        "handoff",
+        "index",
+        "list",
+        "merge",
+        "next",
+        "notes",
+        "plan",
+        "pr",
+        "session",
+        "skill",
+        "snapshot",
+        "status",
+        "tests",
+        "tracker",
+        "trackers",
+        "close",
+        "triage",
+        "validate",
+        "verdict",
+        "yaml",
+        "audit",
+        "artifacts",
+        "boundaries",
+        "checks",
+        "coverage",
+        "evidence",
+        "intake",
+        "promote",
+        "restate",
+        "todo",
+        "todos",
+        "card",
+        "wire",
+        "verify",
+        "pr-workflow",
+    }
+)
+
+
+def _canvas_paths(root: Path) -> list[Path]:
+    canvases = root / "canvases"
+    if not canvases.is_dir():
+        return []
+    paths: list[Path] = []
+    for name in CANVAS_ROSTER_FILES:
+        path = canvases / name
+        if path.is_file():
+            paths.append(path)
+    paths.extend(sorted(canvases.glob("agent-*.canvas.tsx")))
+    # Dedupe while preserving order
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in paths:
+        key = path.as_posix()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def _parse_agents_array_ids(text: str) -> set[str]:
+    """Extract `id: \"agent-id\"` entries from AGENTS / AgentId roster blocks."""
+    ids: set[str] = set()
+    for match in re.finditer(r'\bid:\s*"([a-z][a-z0-9-]*)"', text):
+        ids.add(match.group(1))
+    return ids
+
+
+def _canvas_agent_refs(text: str) -> set[str]:
+    refs: set[str] = set()
+    for match in re.finditer(
+        r'(?:from|to|value|label):\s*"([a-z][a-z0-9-]*)"', text
+    ):
+        refs.add(match.group(1))
+    for match in re.finditer(
+        r'\|\s*"([a-z][a-z0-9-]+)"\s*\|', text
+    ):
+        refs.add(match.group(1))
+    return refs
+
+
+def check_doc008_canvas_roster(paths: DocFactsPaths) -> CheckResult:
+    """Canvas agent ids must match .cursor/agents roster; hub canvases list all live agents."""
+    live = set(list_agent_ids(paths))
+    if not live:
+        return CheckResult(
+            check_id="DOC-008",
+            severity=Severity.P2,
+            passed=False,
+            detail="missing .cursor/agents/*.md",
+        )
+    canvas_paths = _canvas_paths(paths.root)
+    if not canvas_paths:
+        return CheckResult(
+            check_id="DOC-008",
+            severity=Severity.P2,
+            passed=False,
+            detail="missing canvases/agent-*.canvas.tsx",
+        )
+
+    unknown: list[str] = []
+    missing_roster: list[str] = []
+    for path in canvas_paths:
+        rel = path.relative_to(paths.root).as_posix()
+        text = _read(path)
+        for ref in sorted(_canvas_agent_refs(text)):
+            if ref in _CANVAS_NON_AGENT_TOKENS or ref in live:
+                continue
+            unknown.append(f"{rel}: unknown agent {ref}")
+
+    for hub_name in CANVAS_ROSTER_HUBS:
+        hub = paths.root / "canvases" / hub_name
+        if not hub.is_file():
+            missing_roster.append(f"{hub_name}: file missing")
+            continue
+        listed = _parse_agents_array_ids(_read(hub))
+        for agent_id in sorted(live):
+            if agent_id not in listed:
+                missing_roster.append(f"{hub_name}: missing {agent_id}")
+
+    passed = not unknown and not missing_roster
+    if passed:
+        detail = f"canvas roster aligned ({len(live)} agents, {len(canvas_paths)} canvases)"
+    else:
+        parts = unknown[:4] + missing_roster[:4]
+        detail = "; ".join(parts)
+        if len(unknown) + len(missing_roster) > 4:
+            detail += f"; +{len(unknown) + len(missing_roster) - 4} more"
+    return CheckResult(
+        check_id="DOC-008",
+        severity=Severity.P2,
+        passed=passed,
+        detail=detail,
+    )
+
+
 KIT_DEV_CHECKS = (
     check_doc001_agent_roster,
     check_doc002_status_agent_count,
@@ -387,4 +555,5 @@ KIT_DEV_CHECKS = (
     check_doc005_prepare_gate_facts,
     check_doc006_implementation_test_count,
     check_doc007_agent_board_rights,
+    check_doc008_canvas_roster,
 )

--- a/payload/.cursor/rules/implementation-workflow-governance.mdc
+++ b/payload/.cursor/rules/implementation-workflow-governance.mdc
@@ -11,7 +11,7 @@ alwaysApply: true
 - Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
 - When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m cursor_workflow project status` / claim card); local trackers are offline fallback only.
 - Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
-- Exactly one primary task `in_progress` in `work-tracker.md`; do not implement without scope in `plan.md`.
+- Exactly one primary `in_progress` **Status on the Project** when `board_only`; `work-tracker.md` `in_progress` only when SSOT disabled or offline fallback. Do not implement without scope on the board card body (or `plan.md` when fallback).
 - Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.
 
 ## Tests

--- a/rules/implementation-workflow-governance.mdc
+++ b/rules/implementation-workflow-governance.mdc
@@ -11,7 +11,7 @@ alwaysApply: true
 - Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
 - When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m cursor_workflow project status` / claim card); local trackers are offline fallback only.
 - Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
-- Exactly one primary task `in_progress` in `work-tracker.md`; do not implement without scope in `plan.md`.
+- Exactly one primary `in_progress` **Status on the Project** when `board_only`; `work-tracker.md` `in_progress` only when SSOT disabled or offline fallback. Do not implement without scope on the board card body (or `plan.md` when fallback).
 - Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.
 
 ## Tests

--- a/tests/modules/architecture_scripts/test_check_doc_facts.py
+++ b/tests/modules/architecture_scripts/test_check_doc_facts.py
@@ -1,7 +1,7 @@
 """
 File: test_check_doc_facts.py
 Path: tests/modules/architecture_scripts/test_check_doc_facts.py
-Role: Tests for canonical doc fact validation (DOC-001…006).
+Role: Tests for canonical doc fact validation (DOC-001…008).
 Used By:
  - pytest
 Depends On:
@@ -59,6 +59,43 @@ def test_consumer_profile_skips_doc_facts(tmp_path: Path) -> None:
     assert exit_code_for(results) == 0
 
 
+def test_unknown_agent_in_canvas_fails_doc008(tmp_path: Path) -> None:
+    _copy_minimal_kit(tmp_path)
+    relations = tmp_path / "canvases" / "agent-relations.canvas.tsx"
+    relations.write_text(
+        relations.read_text(encoding="utf-8").replace(
+            'from: "project-board"',
+            'from: "ghost-agent"',
+        ),
+        encoding="utf-8",
+    )
+    results = run_checks(tmp_path)
+    doc008 = next(r for r in results if r.check_id == "DOC-008")
+    assert not doc008.passed
+    assert "ghost-agent" in doc008.detail
+
+
+def test_missing_agent_in_roster_hub_fails_doc008(tmp_path: Path) -> None:
+    _copy_minimal_kit(tmp_path)
+    relations = tmp_path / "canvases" / "agent-relations.canvas.tsx"
+    relations.write_text(
+        relations.read_text(encoding="utf-8").replace(
+            """  {
+    id: "researcher",
+    role: "Local research corpus only (no product PRs)",
+    lane: "Optional",
+  },
+""",
+            "",
+        ),
+        encoding="utf-8",
+    )
+    results = run_checks(tmp_path)
+    doc008 = next(r for r in results if r.check_id == "DOC-008")
+    assert not doc008.passed
+    assert "researcher" in doc008.detail
+
+
 def _copy_minimal_kit(target: Path) -> None:
     import shutil
 
@@ -74,6 +111,7 @@ def _copy_minimal_kit(target: Path) -> None:
         ".ai_infra/templates/local-workspace/exemplars",
         ".ai_infra/bootstrap.py",
         ".ai_infra/paths.py",
+        "canvases",
     ):
         src = REPO_ROOT / rel
         dst = target / rel


### PR DESCRIPTION
## Summary
- Refresh `agent-relations` canvas (audit-orchestration Phase 3 edges) and STANDALONE framing on `board-ssot-vs-kit`
- Qualify `board_only` in implementation-workflow-governance; align anchoring/HANDOFF/overlays docs
- Add **DOC-008** canvas↔agent roster check (closes EA-008 lite); tests **931**
- Remove pytest-cache debris (local); sync-plugin mirrors updated

## Test plan
- [x] `doc validate` 8/8 PASS (DOC-007 + DOC-008)
- [x] `drift validate` 11/11 PASS
- [x] `pytest tests/modules/architecture_scripts/test_check_doc_facts.py` 6 passed
- [x] `sync_plugin_bundle.py --check` PASS
- [x] Verifier: verification-workspace-clean.md 6/6
- [x] Focused alignment: P0=0 P1=0