### PR TITLE
[EA-RESEARCH-INTAKE] Adaptive researcher chat/agent intake

### DIFF
--- a/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/.agents/skills/RESEARCH_WORKFLOW.md
@@ -6,10 +6,10 @@ Versioned hub (in git). Corpus boundaries: `_research_results/RESEARCH_BOUNDARIE
 
 ## Order (active)
 
-1. `.cursor/agents/researcher.md`
+1. `.cursor/agents/researcher.md` — **Adaptive intake** (chat / peer agents / board)
 2. `.cursor/skills/research-corpus-execution/SKILL.md`
-3. Pack `BRIEF.md` + `SOURCE.md` under `_research_results/sources/<slug>/`
-4. CLI: `python3 -m cursor_workflow research init|fetch|validate`
+3. Normalize source → `research init` → `research fetch` → rounds → `validate`
+4. Pack `BRIEF.md` + `SOURCE.md` under `_research_results/sources/<slug>/`
 
 Agent: **`.cursor/agents/researcher.md`**.
 
@@ -23,11 +23,12 @@ No product repo edits; no git commits for research packs; writes only `_research
 |---|--------|
 | D0 | No edits outside `_research_results/` |
 | D1 | No git commits / PRs for research-only work |
-| D2 | External runs require a Research Brief |
+| D2 | External runs require a Brief — **derive from chat/handoff/card** if not pasted formally |
 | D3 | Pin every pack (path or commit SHA) in `SOURCE.md` |
 | D4 | Consumers read `AGENT_BRIEF.md` + `INDEX.json`, not the whole foreign tree |
 | D5 | CLI owns init/fetch/validate; agent owns rounds 1–6 prose evidence |
-| D6 | Host `mode: self` is optional; default is `external` when Brief present |
+| D6 | Host `mode: self` is optional; default is `external` when a source is present |
+| D7 | Accept HTTPS GitHub URLs and terse `/researcher <url>` chat; apply skill defaults |
 
 ## Forbidden
 
@@ -35,9 +36,10 @@ No product repo edits; no git commits for research packs; writes only `_research
 |--------|-----|
 | `git commit` / PR for research | D1 |
 | Edit outside `_research_results/` | D0 |
-| External run without Brief | D2 |
+| External run without any source (and not self) | D2 |
 | Invent evidence without path/~Lnn | Evidence contract |
 | Implement fixes in product tree during research | → implementer |
+| Refuse terse chat that clearly names a GitHub/local source | D7 — adapt + defaults |
 
 ## Pack outputs
 

--- a/.ai_infra/install/cursor_workflow/research_cli.py
+++ b/.ai_infra/install/cursor_workflow/research_cli.py
@@ -93,22 +93,51 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+_GITHUB_HTTPS_RE = re.compile(
+    r"^https?://(?:www\.)?github\.com/"
+    r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s#?]+?)"
+    r"(?:\.git)?(?:/(?:tree|blob)/(?P<ref>[^/\s#?]+)(?:/.*)?)?(?:[?#].*)?$",
+    re.IGNORECASE,
+)
+
+
+def _parse_github_locator(rest: str) -> tuple[str, str | None]:
+    """Parse owner/repo[@ref] → (owner/repo, ref)."""
+    text = rest.strip()
+    ref = None
+    if "@" in text:
+        text, ref = text.rsplit("@", 1)
+        ref = ref.strip() or None
+    parts = text.split("/")
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        raise ValueError("github source must be owner/repo[@ref]")
+    return f"{parts[0]}/{parts[1]}", ref
+
+
 def _parse_source(raw: str) -> tuple[str, str, str | None]:
-    """Return (kind, locator, ref) where kind is path|github."""
+    """Return (kind, locator, ref) where kind is path|github.
+
+    Accepts:
+    - path:/abs/or/rel
+    - github:owner/repo[@ref]
+    - https://github.com/owner/repo[.git][/tree/ref/...]
+    - bare local path
+    """
     text = (raw or "").strip()
     if not text:
         raise ValueError("empty --source")
     if text.startswith("path:"):
         return "path", text[5:].strip(), None
     if text.startswith("github:"):
-        rest = text[7:].strip()
-        ref = None
-        if "@" in rest:
-            rest, ref = rest.rsplit("@", 1)
-            ref = ref.strip() or None
-        if "/" not in rest or not rest.split("/")[0] or not rest.split("/")[1]:
-            raise ValueError("github source must be owner/repo[@ref]")
-        return "github", rest, ref
+        locator, ref = _parse_github_locator(text[7:])
+        return "github", locator, ref
+    m = _GITHUB_HTTPS_RE.match(text)
+    if m:
+        repo = m.group("repo")
+        if repo.endswith(".git"):
+            repo = repo[: -len(".git")]
+        locator = f"{m.group('owner')}/{repo}"
+        return "github", locator, m.group("ref")
     # Bare path convenience
     return "path", text, None
 
@@ -489,7 +518,10 @@ def register_research_subparser(sub: argparse._SubParsersAction) -> None:
     fetch_cmd.add_argument(
         "--source",
         required=True,
-        help="path:/abs/or/rel | github:owner/repo[@ref] | bare path",
+        help=(
+            "path:/abs/or/rel | github:owner/repo[@ref] | "
+            "https://github.com/owner/repo[/tree/ref] | bare path"
+        ),
     )
     fetch_cmd.add_argument("--force", action="store_true", help="Replace existing cache/")
     fetch_cmd.set_defaults(func=cmd_research_fetch)

--- a/.ai_infra/templates/research-corpus/README.md
+++ b/.ai_infra/templates/research-corpus/README.md
@@ -20,8 +20,11 @@ Copy into `_research_results/` via:
 python3 -m cursor_workflow research init --slug <slug> [--brief path/to/brief.md]
 python3 -m cursor_workflow research fetch --slug <slug> --source path:/abs/or/rel
 # or: --source github:owner/repo[@ref]
+# or: --source https://github.com/owner/repo[/tree/ref]
 python3 -m cursor_workflow research validate --slug <slug>
 ```
+
+Terse chat (`/researcher https://github.com/owner/repo`) is valid: agent derives Brief defaults per skill § Intake.
 
 | File | Role |
 |------|------|

--- a/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
+++ b/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
@@ -18,7 +18,7 @@ Notes:
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
 2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files from the researcher.
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External runs require a Brief** (`sources/<slug>/BRIEF.md`) — no brief → refuse `mode: external`.
+4. **External runs need a Brief** — derive from user chat, peer agent handoff/Notes, or board card; persist as `sources/<slug>/BRIEF.md`. Terse `/researcher <url>` is enough (skill defaults apply).
 5. Pin every pack to a **path or commit SHA** in `SOURCE.md`; do not invent evidence.
 
 ## Modes

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -20,29 +20,61 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 Build and maintain a **local research corpus** of verified packs. **Off by default** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
 
+## Adaptive intake (mandatory before research)
+
+Normalize a **Research Brief** from whatever channel started you — do **not** refuse a usable chat/handoff just because fields are informal.
+
+| Source | What to read | How to adapt |
+|--------|--------------|--------------|
+| **User chat** | Current message (+ prior turns in thread) | Extract URL / `github:owner/repo` / local path; question from prose; lenses if named else defaults |
+| **Other agents** | Board Notes, handoff line, `AGENT_BRIEF` / pack path, implementer/integrator request | Treat their question + source as Brief; name them in `consumers` |
+| **Board research card** | Card body Brief table + Notes | Prefer card fields; fill gaps from chat |
+| **Explicit Brief** | `BRIEF.md` or pasted contract | Use as-is |
+
+**Normalize sources** before CLI:
+
+- `https://github.com/owner/repo` → acceptable (CLI accepts HTTPS); prefer also recording `github:owner/repo`
+- `github:owner/repo[@ref]` → canonical
+- Absolute/relative local path → `path:…` or bare path
+
+**Defaults when user is terse** (e.g. `/researcher https://github.com/owner/repo`):
+
+- `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
+- `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
+- `slug`: repo name lowercased (`grok-build`)
+- `consumers`: implementer, integrator-mas-agent
+- `rounds_max`: 6
+
+**Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
+
+Then write `BRIEF.md` via `research init` and proceed with the skill loop.
+
 ## Hard stop (when enabled)
 
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
 2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files without explicit user request.
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External mode requires a Brief** (`BRIEF.md`) — refuse external runs without one.
+4. **External mode requires a Brief** — derive it from chat/agents/card (see Adaptive intake); then persist as `BRIEF.md`.
 
 **Read-only** on the rest of the repo (and on foreign sources) unless the user directs otherwise.
 
 ## Read first
 
-1. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
-2. `.cursor/skills/research-corpus-execution/SKILL.md`
+1. `.cursor/skills/research-corpus-execution/SKILL.md` (intake + rounds)
+2. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
 3. `.agents/skills/RESEARCH_WORKFLOW.md`
 4. Pack `BRIEF.md` + `SOURCE.md` when continuing a slug
+5. Any pack path or handoff cited by another agent / board Notes
 
 ## CLI (procedural)
 
 ```bash
-python3 -m cursor_workflow research init --slug <slug> --source 'path:…|github:owner/repo[@ref]' --question '…'
-python3 -m cursor_workflow research fetch --slug <slug> --source 'path:…|github:owner/repo[@ref]'
+python3 -m cursor_workflow research init --slug <slug> --source '…' --question '…'
+python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 python3 -m cursor_workflow research validate --slug <slug>
 ```
+
+`--source` accepts `github:owner/repo[@ref]`, `https://github.com/owner/repo[/tree/ref]`, `path:…`, or bare local path.
 
 Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, and INDEX validation.
 
@@ -50,8 +82,8 @@ Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, 
 
 | Mode | Trigger | Output |
 |------|---------|--------|
-| `external` | Brief with `source:` (default) | Multi-round pack + `AGENT_BRIEF.md` |
-| `self` | Host corpus / DEPTH_BACKLOG (optional) | Same write root; no foreign fetch |
+| `external` | Source found in chat/card/handoff (default) | Multi-round pack + `AGENT_BRIEF.md` |
+| `self` | User asks host deepening / DEPTH_BACKLOG | Same write root; no foreign fetch |
 
 ## Not this agent
 

--- a/.cursor/skills/research-corpus-execution/SKILL.md
+++ b/.cursor/skills/research-corpus-execution/SKILL.md
@@ -7,7 +7,7 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 ## When
 
-- External research: user or board card supplies a **Research Brief** (source + question + lenses).
+- External research: user chat, another agent’s handoff/Notes, or a board research card names a source.
 - Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` when present under `_research_results/`.
 
 **Not for:** product code changes, PR merge, `.local/` implementation — use `implementer` / `.agents/skills/pr-workflow/SKILL.md`.
@@ -18,22 +18,53 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 ## Read first
 
-1. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
-2. Pack `BRIEF.md` (required for `mode: external`)
-3. This skill + templates under `.ai_infra/templates/research-corpus/`
+1. This skill (intake → rounds)
+2. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
+3. Incoming chat / board card / peer handoff (see Intake)
+4. Pack `BRIEF.md` when continuing a slug
 
-## Brief contract (external)
+## Intake (adapt — do not require a formal paste)
+
+Build a Brief from **any** of:
+
+1. **User chat** — including terse forms like `/researcher https://github.com/owner/repo`
+2. **Peer agents** — board Notes, handoff line, cited `AGENT_BRIEF.md` / pack path, implementer/integrator ask
+3. **Board card** — `create-from-template --template research` body Brief table
+4. **Existing** `sources/<slug>/BRIEF.md`
+
+### Normalize source
+
+| Input | Normalized |
+|-------|------------|
+| `https://github.com/owner/repo` | OK for CLI; also record `github:owner/repo` |
+| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` (CLI accepts HTTPS tree URLs) |
+| `github:owner/repo[@ref]` | Canonical |
+| Local path | `path:…` or bare path |
+
+### Defaults (terse chat)
+
+If only a link/path is given:
+
+- **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
+- **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
+- **slug:** repo (or directory) name, lowercase with hyphens
+- **consumers:** implementer, integrator-mas-agent (plus the requesting agent if known)
+- **rounds_max:** 6
+
+Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
+
+### Brief contract (persisted)
+
+Write via `research init` into `BRIEF.md`:
 
 ```text
-source: github:owner/repo@ref | path:/abs/or/rel
-question: <what MAS needs>
+source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
+question: <what MAS / requesting agent needs>
 lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
 rounds_max: 6
-consumers: [implementer, integrator-mas-agent, ...]
-slug: <optional>
+consumers: [implementer, integrator-mas-agent, …]
+slug: <derived or explicit>
 ```
-
-No brief → **refuse** external run.
 
 ## Procedural setup
 
@@ -42,7 +73,7 @@ python3 -m cursor_workflow research init --slug <slug> --source '…' --question
 python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 ```
 
-Fetch pins `SOURCE.md` (path or shallow clone under `_research_results/cache/<slug>/`).
+`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch pins `SOURCE.md` (shallow clone under `_research_results/cache/<slug>/` when remote).
 
 ## Multi-round loop (active)
 
@@ -55,11 +86,11 @@ Work only under `_research_results/sources/<slug>/`. Read foreign trees read-onl
 5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
 6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed`).
 7. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer.
+8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known).
 
 ## Mode: self (optional)
 
-If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only. Prefer external Brief packs for cross-repo learning.
+If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only.
 
 ## Lenses (default)
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -20,29 +20,61 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 Build and maintain a **local research corpus** of verified packs. **Off by default** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
 
+## Adaptive intake (mandatory before research)
+
+Normalize a **Research Brief** from whatever channel started you — do **not** refuse a usable chat/handoff just because fields are informal.
+
+| Source | What to read | How to adapt |
+|--------|--------------|--------------|
+| **User chat** | Current message (+ prior turns in thread) | Extract URL / `github:owner/repo` / local path; question from prose; lenses if named else defaults |
+| **Other agents** | Board Notes, handoff line, `AGENT_BRIEF` / pack path, implementer/integrator request | Treat their question + source as Brief; name them in `consumers` |
+| **Board research card** | Card body Brief table + Notes | Prefer card fields; fill gaps from chat |
+| **Explicit Brief** | `BRIEF.md` or pasted contract | Use as-is |
+
+**Normalize sources** before CLI:
+
+- `https://github.com/owner/repo` → acceptable (CLI accepts HTTPS); prefer also recording `github:owner/repo`
+- `github:owner/repo[@ref]` → canonical
+- Absolute/relative local path → `path:…` or bare path
+
+**Defaults when user is terse** (e.g. `/researcher https://github.com/owner/repo`):
+
+- `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
+- `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
+- `slug`: repo name lowercased (`grok-build`)
+- `consumers`: implementer, integrator-mas-agent
+- `rounds_max`: 6
+
+**Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
+
+Then write `BRIEF.md` via `research init` and proceed with the skill loop.
+
 ## Hard stop (when enabled)
 
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
 2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files without explicit user request.
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External mode requires a Brief** (`BRIEF.md`) — refuse external runs without one.
+4. **External mode requires a Brief** — derive it from chat/agents/card (see Adaptive intake); then persist as `BRIEF.md`.
 
 **Read-only** on the rest of the repo (and on foreign sources) unless the user directs otherwise.
 
 ## Read first
 
-1. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
-2. `.cursor/skills/research-corpus-execution/SKILL.md`
+1. `.cursor/skills/research-corpus-execution/SKILL.md` (intake + rounds)
+2. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
 3. `.agents/skills/RESEARCH_WORKFLOW.md`
 4. Pack `BRIEF.md` + `SOURCE.md` when continuing a slug
+5. Any pack path or handoff cited by another agent / board Notes
 
 ## CLI (procedural)
 
 ```bash
-python3 -m cursor_workflow research init --slug <slug> --source 'path:…|github:owner/repo[@ref]' --question '…'
-python3 -m cursor_workflow research fetch --slug <slug> --source 'path:…|github:owner/repo[@ref]'
+python3 -m cursor_workflow research init --slug <slug> --source '…' --question '…'
+python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 python3 -m cursor_workflow research validate --slug <slug>
 ```
+
+`--source` accepts `github:owner/repo[@ref]`, `https://github.com/owner/repo[/tree/ref]`, `path:…`, or bare local path.
 
 Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, and INDEX validation.
 
@@ -50,8 +82,8 @@ Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, 
 
 | Mode | Trigger | Output |
 |------|---------|--------|
-| `external` | Brief with `source:` (default) | Multi-round pack + `AGENT_BRIEF.md` |
-| `self` | Host corpus / DEPTH_BACKLOG (optional) | Same write root; no foreign fetch |
+| `external` | Source found in chat/card/handoff (default) | Multi-round pack + `AGENT_BRIEF.md` |
+| `self` | User asks host deepening / DEPTH_BACKLOG | Same write root; no foreign fetch |
 
 ## Not this agent
 

--- a/payload/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/payload/.agents/skills/RESEARCH_WORKFLOW.md
@@ -6,10 +6,10 @@ Versioned hub (in git). Corpus boundaries: `_research_results/RESEARCH_BOUNDARIE
 
 ## Order (active)
 
-1. `.cursor/agents/researcher.md`
+1. `.cursor/agents/researcher.md` — **Adaptive intake** (chat / peer agents / board)
 2. `.cursor/skills/research-corpus-execution/SKILL.md`
-3. Pack `BRIEF.md` + `SOURCE.md` under `_research_results/sources/<slug>/`
-4. CLI: `python3 -m cursor_workflow research init|fetch|validate`
+3. Normalize source → `research init` → `research fetch` → rounds → `validate`
+4. Pack `BRIEF.md` + `SOURCE.md` under `_research_results/sources/<slug>/`
 
 Agent: **`.cursor/agents/researcher.md`**.
 
@@ -23,11 +23,12 @@ No product repo edits; no git commits for research packs; writes only `_research
 |---|--------|
 | D0 | No edits outside `_research_results/` |
 | D1 | No git commits / PRs for research-only work |
-| D2 | External runs require a Research Brief |
+| D2 | External runs require a Brief — **derive from chat/handoff/card** if not pasted formally |
 | D3 | Pin every pack (path or commit SHA) in `SOURCE.md` |
 | D4 | Consumers read `AGENT_BRIEF.md` + `INDEX.json`, not the whole foreign tree |
 | D5 | CLI owns init/fetch/validate; agent owns rounds 1–6 prose evidence |
-| D6 | Host `mode: self` is optional; default is `external` when Brief present |
+| D6 | Host `mode: self` is optional; default is `external` when a source is present |
+| D7 | Accept HTTPS GitHub URLs and terse `/researcher <url>` chat; apply skill defaults |
 
 ## Forbidden
 
@@ -35,9 +36,10 @@ No product repo edits; no git commits for research packs; writes only `_research
 |--------|-----|
 | `git commit` / PR for research | D1 |
 | Edit outside `_research_results/` | D0 |
-| External run without Brief | D2 |
+| External run without any source (and not self) | D2 |
 | Invent evidence without path/~Lnn | Evidence contract |
 | Implement fixes in product tree during research | → implementer |
+| Refuse terse chat that clearly names a GitHub/local source | D7 — adapt + defaults |
 
 ## Pack outputs
 

--- a/payload/.ai_infra/install/cursor_workflow/research_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/research_cli.py
@@ -93,22 +93,51 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+_GITHUB_HTTPS_RE = re.compile(
+    r"^https?://(?:www\.)?github\.com/"
+    r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s#?]+?)"
+    r"(?:\.git)?(?:/(?:tree|blob)/(?P<ref>[^/\s#?]+)(?:/.*)?)?(?:[?#].*)?$",
+    re.IGNORECASE,
+)
+
+
+def _parse_github_locator(rest: str) -> tuple[str, str | None]:
+    """Parse owner/repo[@ref] → (owner/repo, ref)."""
+    text = rest.strip()
+    ref = None
+    if "@" in text:
+        text, ref = text.rsplit("@", 1)
+        ref = ref.strip() or None
+    parts = text.split("/")
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        raise ValueError("github source must be owner/repo[@ref]")
+    return f"{parts[0]}/{parts[1]}", ref
+
+
 def _parse_source(raw: str) -> tuple[str, str, str | None]:
-    """Return (kind, locator, ref) where kind is path|github."""
+    """Return (kind, locator, ref) where kind is path|github.
+
+    Accepts:
+    - path:/abs/or/rel
+    - github:owner/repo[@ref]
+    - https://github.com/owner/repo[.git][/tree/ref/...]
+    - bare local path
+    """
     text = (raw or "").strip()
     if not text:
         raise ValueError("empty --source")
     if text.startswith("path:"):
         return "path", text[5:].strip(), None
     if text.startswith("github:"):
-        rest = text[7:].strip()
-        ref = None
-        if "@" in rest:
-            rest, ref = rest.rsplit("@", 1)
-            ref = ref.strip() or None
-        if "/" not in rest or not rest.split("/")[0] or not rest.split("/")[1]:
-            raise ValueError("github source must be owner/repo[@ref]")
-        return "github", rest, ref
+        locator, ref = _parse_github_locator(text[7:])
+        return "github", locator, ref
+    m = _GITHUB_HTTPS_RE.match(text)
+    if m:
+        repo = m.group("repo")
+        if repo.endswith(".git"):
+            repo = repo[: -len(".git")]
+        locator = f"{m.group('owner')}/{repo}"
+        return "github", locator, m.group("ref")
     # Bare path convenience
     return "path", text, None
 
@@ -489,7 +518,10 @@ def register_research_subparser(sub: argparse._SubParsersAction) -> None:
     fetch_cmd.add_argument(
         "--source",
         required=True,
-        help="path:/abs/or/rel | github:owner/repo[@ref] | bare path",
+        help=(
+            "path:/abs/or/rel | github:owner/repo[@ref] | "
+            "https://github.com/owner/repo[/tree/ref] | bare path"
+        ),
     )
     fetch_cmd.add_argument("--force", action="store_true", help="Replace existing cache/")
     fetch_cmd.set_defaults(func=cmd_research_fetch)

--- a/payload/.ai_infra/templates/research-corpus/README.md
+++ b/payload/.ai_infra/templates/research-corpus/README.md
@@ -20,8 +20,11 @@ Copy into `_research_results/` via:
 python3 -m cursor_workflow research init --slug <slug> [--brief path/to/brief.md]
 python3 -m cursor_workflow research fetch --slug <slug> --source path:/abs/or/rel
 # or: --source github:owner/repo[@ref]
+# or: --source https://github.com/owner/repo[/tree/ref]
 python3 -m cursor_workflow research validate --slug <slug>
 ```
+
+Terse chat (`/researcher https://github.com/owner/repo`) is valid: agent derives Brief defaults per skill § Intake.
 
 | File | Role |
 |------|------|

--- a/payload/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
+++ b/payload/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
@@ -18,7 +18,7 @@ Notes:
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
 2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files from the researcher.
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External runs require a Brief** (`sources/<slug>/BRIEF.md`) — no brief → refuse `mode: external`.
+4. **External runs need a Brief** — derive from user chat, peer agent handoff/Notes, or board card; persist as `sources/<slug>/BRIEF.md`. Terse `/researcher <url>` is enough (skill defaults apply).
 5. Pin every pack to a **path or commit SHA** in `SOURCE.md`; do not invent evidence.
 
 ## Modes

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -20,29 +20,61 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 Build and maintain a **local research corpus** of verified packs. **Off by default** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
 
+## Adaptive intake (mandatory before research)
+
+Normalize a **Research Brief** from whatever channel started you — do **not** refuse a usable chat/handoff just because fields are informal.
+
+| Source | What to read | How to adapt |
+|--------|--------------|--------------|
+| **User chat** | Current message (+ prior turns in thread) | Extract URL / `github:owner/repo` / local path; question from prose; lenses if named else defaults |
+| **Other agents** | Board Notes, handoff line, `AGENT_BRIEF` / pack path, implementer/integrator request | Treat their question + source as Brief; name them in `consumers` |
+| **Board research card** | Card body Brief table + Notes | Prefer card fields; fill gaps from chat |
+| **Explicit Brief** | `BRIEF.md` or pasted contract | Use as-is |
+
+**Normalize sources** before CLI:
+
+- `https://github.com/owner/repo` → acceptable (CLI accepts HTTPS); prefer also recording `github:owner/repo`
+- `github:owner/repo[@ref]` → canonical
+- Absolute/relative local path → `path:…` or bare path
+
+**Defaults when user is terse** (e.g. `/researcher https://github.com/owner/repo`):
+
+- `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
+- `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
+- `slug`: repo name lowercased (`grok-build`)
+- `consumers`: implementer, integrator-mas-agent
+- `rounds_max`: 6
+
+**Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
+
+Then write `BRIEF.md` via `research init` and proceed with the skill loop.
+
 ## Hard stop (when enabled)
 
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
 2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files without explicit user request.
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External mode requires a Brief** (`BRIEF.md`) — refuse external runs without one.
+4. **External mode requires a Brief** — derive it from chat/agents/card (see Adaptive intake); then persist as `BRIEF.md`.
 
 **Read-only** on the rest of the repo (and on foreign sources) unless the user directs otherwise.
 
 ## Read first
 
-1. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
-2. `.cursor/skills/research-corpus-execution/SKILL.md`
+1. `.cursor/skills/research-corpus-execution/SKILL.md` (intake + rounds)
+2. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
 3. `.agents/skills/RESEARCH_WORKFLOW.md`
 4. Pack `BRIEF.md` + `SOURCE.md` when continuing a slug
+5. Any pack path or handoff cited by another agent / board Notes
 
 ## CLI (procedural)
 
 ```bash
-python3 -m cursor_workflow research init --slug <slug> --source 'path:…|github:owner/repo[@ref]' --question '…'
-python3 -m cursor_workflow research fetch --slug <slug> --source 'path:…|github:owner/repo[@ref]'
+python3 -m cursor_workflow research init --slug <slug> --source '…' --question '…'
+python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 python3 -m cursor_workflow research validate --slug <slug>
 ```
+
+`--source` accepts `github:owner/repo[@ref]`, `https://github.com/owner/repo[/tree/ref]`, `path:…`, or bare local path.
 
 Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, and INDEX validation.
 
@@ -50,8 +82,8 @@ Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, 
 
 | Mode | Trigger | Output |
 |------|---------|--------|
-| `external` | Brief with `source:` (default) | Multi-round pack + `AGENT_BRIEF.md` |
-| `self` | Host corpus / DEPTH_BACKLOG (optional) | Same write root; no foreign fetch |
+| `external` | Source found in chat/card/handoff (default) | Multi-round pack + `AGENT_BRIEF.md` |
+| `self` | User asks host deepening / DEPTH_BACKLOG | Same write root; no foreign fetch |
 
 ## Not this agent
 

--- a/payload/.cursor/skills/research-corpus-execution/SKILL.md
+++ b/payload/.cursor/skills/research-corpus-execution/SKILL.md
@@ -7,7 +7,7 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 ## When
 
-- External research: user or board card supplies a **Research Brief** (source + question + lenses).
+- External research: user chat, another agent’s handoff/Notes, or a board research card names a source.
 - Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` when present under `_research_results/`.
 
 **Not for:** product code changes, PR merge, `.local/` implementation — use `implementer` / `.agents/skills/pr-workflow/SKILL.md`.
@@ -18,22 +18,53 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 ## Read first
 
-1. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
-2. Pack `BRIEF.md` (required for `mode: external`)
-3. This skill + templates under `.ai_infra/templates/research-corpus/`
+1. This skill (intake → rounds)
+2. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
+3. Incoming chat / board card / peer handoff (see Intake)
+4. Pack `BRIEF.md` when continuing a slug
 
-## Brief contract (external)
+## Intake (adapt — do not require a formal paste)
+
+Build a Brief from **any** of:
+
+1. **User chat** — including terse forms like `/researcher https://github.com/owner/repo`
+2. **Peer agents** — board Notes, handoff line, cited `AGENT_BRIEF.md` / pack path, implementer/integrator ask
+3. **Board card** — `create-from-template --template research` body Brief table
+4. **Existing** `sources/<slug>/BRIEF.md`
+
+### Normalize source
+
+| Input | Normalized |
+|-------|------------|
+| `https://github.com/owner/repo` | OK for CLI; also record `github:owner/repo` |
+| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` (CLI accepts HTTPS tree URLs) |
+| `github:owner/repo[@ref]` | Canonical |
+| Local path | `path:…` or bare path |
+
+### Defaults (terse chat)
+
+If only a link/path is given:
+
+- **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
+- **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
+- **slug:** repo (or directory) name, lowercase with hyphens
+- **consumers:** implementer, integrator-mas-agent (plus the requesting agent if known)
+- **rounds_max:** 6
+
+Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
+
+### Brief contract (persisted)
+
+Write via `research init` into `BRIEF.md`:
 
 ```text
-source: github:owner/repo@ref | path:/abs/or/rel
-question: <what MAS needs>
+source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
+question: <what MAS / requesting agent needs>
 lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
 rounds_max: 6
-consumers: [implementer, integrator-mas-agent, ...]
-slug: <optional>
+consumers: [implementer, integrator-mas-agent, …]
+slug: <derived or explicit>
 ```
-
-No brief → **refuse** external run.
 
 ## Procedural setup
 
@@ -42,7 +73,7 @@ python3 -m cursor_workflow research init --slug <slug> --source '…' --question
 python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 ```
 
-Fetch pins `SOURCE.md` (path or shallow clone under `_research_results/cache/<slug>/`).
+`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch pins `SOURCE.md` (shallow clone under `_research_results/cache/<slug>/` when remote).
 
 ## Multi-round loop (active)
 
@@ -55,11 +86,11 @@ Work only under `_research_results/sources/<slug>/`. Read foreign trees read-onl
 5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
 6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed`).
 7. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer.
+8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known).
 
 ## Mode: self (optional)
 
-If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only. Prefer external Brief packs for cross-repo learning.
+If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only.
 
 ## Lenses (default)
 

--- a/skills/research-corpus-execution/SKILL.md
+++ b/skills/research-corpus-execution/SKILL.md
@@ -7,7 +7,7 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 ## When
 
-- External research: user or board card supplies a **Research Brief** (source + question + lenses).
+- External research: user chat, another agent’s handoff/Notes, or a board research card names a source.
 - Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` when present under `_research_results/`.
 
 **Not for:** product code changes, PR merge, `.local/` implementation — use `implementer` / `.agents/skills/pr-workflow/SKILL.md`.
@@ -18,22 +18,53 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 ## Read first
 
-1. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
-2. Pack `BRIEF.md` (required for `mode: external`)
-3. This skill + templates under `.ai_infra/templates/research-corpus/`
+1. This skill (intake → rounds)
+2. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
+3. Incoming chat / board card / peer handoff (see Intake)
+4. Pack `BRIEF.md` when continuing a slug
 
-## Brief contract (external)
+## Intake (adapt — do not require a formal paste)
+
+Build a Brief from **any** of:
+
+1. **User chat** — including terse forms like `/researcher https://github.com/owner/repo`
+2. **Peer agents** — board Notes, handoff line, cited `AGENT_BRIEF.md` / pack path, implementer/integrator ask
+3. **Board card** — `create-from-template --template research` body Brief table
+4. **Existing** `sources/<slug>/BRIEF.md`
+
+### Normalize source
+
+| Input | Normalized |
+|-------|------------|
+| `https://github.com/owner/repo` | OK for CLI; also record `github:owner/repo` |
+| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` (CLI accepts HTTPS tree URLs) |
+| `github:owner/repo[@ref]` | Canonical |
+| Local path | `path:…` or bare path |
+
+### Defaults (terse chat)
+
+If only a link/path is given:
+
+- **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
+- **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
+- **slug:** repo (or directory) name, lowercase with hyphens
+- **consumers:** implementer, integrator-mas-agent (plus the requesting agent if known)
+- **rounds_max:** 6
+
+Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
+
+### Brief contract (persisted)
+
+Write via `research init` into `BRIEF.md`:
 
 ```text
-source: github:owner/repo@ref | path:/abs/or/rel
-question: <what MAS needs>
+source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
+question: <what MAS / requesting agent needs>
 lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
 rounds_max: 6
-consumers: [implementer, integrator-mas-agent, ...]
-slug: <optional>
+consumers: [implementer, integrator-mas-agent, …]
+slug: <derived or explicit>
 ```
-
-No brief → **refuse** external run.
 
 ## Procedural setup
 
@@ -42,7 +73,7 @@ python3 -m cursor_workflow research init --slug <slug> --source '…' --question
 python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 ```
 
-Fetch pins `SOURCE.md` (path or shallow clone under `_research_results/cache/<slug>/`).
+`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch pins `SOURCE.md` (shallow clone under `_research_results/cache/<slug>/` when remote).
 
 ## Multi-round loop (active)
 
@@ -55,11 +86,11 @@ Work only under `_research_results/sources/<slug>/`. Read foreign trees read-onl
 5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
 6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed`).
 7. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer.
+8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known).
 
 ## Mode: self (optional)
 
-If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only. Prefer external Brief packs for cross-repo learning.
+If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only.
 
 ## Lenses (default)
 

--- a/tests/modules/research/test_research_cli.py
+++ b/tests/modules/research/test_research_cli.py
@@ -132,5 +132,17 @@ def test_parse_source() -> None:
     assert research_cli._parse_source("path:/tmp/x")[0] == "path"
     kind, loc, ref = research_cli._parse_source("github:owner/repo@main")
     assert kind == "github" and loc == "owner/repo" and ref == "main"
+    kind2, loc2, ref2 = research_cli._parse_source(
+        "https://github.com/SavinRazvan/grok-build"
+    )
+    assert kind2 == "github" and loc2 == "SavinRazvan/grok-build" and ref2 is None
+    kind3, loc3, _ref3 = research_cli._parse_source(
+        "https://github.com/SavinRazvan/grok-build.git"
+    )
+    assert kind3 == "github" and loc3 == "SavinRazvan/grok-build"
+    kind4, loc4, ref4 = research_cli._parse_source(
+        "https://github.com/SavinRazvan/grok-build/tree/main/crates"
+    )
+    assert kind4 == "github" and loc4 == "SavinRazvan/grok-build" and ref4 == "main"
     with pytest.raises(ValueError):
         research_cli._parse_source("")


### PR DESCRIPTION
## Summary
- Researcher derives a Research Brief from user chat, peer agent Notes/handoffs, or board cards (terse `/researcher <url>` works with safe defaults).
- `research` CLI accepts `https://github.com/owner/repo` (and `/tree/ref`) in addition to `github:` and `path:`.

## Test plan
- [x] `pytest -q tests/modules/research/`
- [x] doc + integrate validate
- [ ] prepare.py gates

## Board
- `PVTI_lAHOBl46-84A9KZxzgzSrQM`

Made with [Cursor](https://cursor.com)