### PR TITLE
[DOC-RESEARCH] Align researcher canvas + docs for adaptive intake

### DIFF
--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -53,7 +53,7 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 | `test-runner` | Module tests, coverage; board Exit Status |
 | `verifier` | Evidence checks; board Done / In review |
 | `enterprise-auditor` | Architecture audits; audit card Status + Notes |
-| `researcher` | Brief-driven multi-round packs under `_research_results/`; research card Done + `AGENT_BRIEF` paths |
+| `researcher` | Adaptive Brief multi-round packs under `_research_results/`; chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
 | `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
 | `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
 | `project-board` | Board triage helper (ADR-006); not in default PR pipelines |

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -135,7 +135,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `integrator-mas-agent` | Yes | Yes | `/integrator-mas-agent` |
 | `workflow-drift-guard` | Yes | Yes | `/workflow-drift-guard` |
 | `project-board` | Yes | Yes | `/project-board` |
-| `researcher` | Yes | Yes (optional) | `/researcher` |
+| `researcher` | Yes | Yes (optional packs) | `/researcher` (adaptive Brief + HTTPS) |
 
 **Deprecated agents:** none.
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -230,7 +230,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/verifier` | `.cursor/agents/verifier.md` |
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
-| `/researcher` | `.cursor/agents/researcher.md` — Brief + `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
+| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief (chat/agents/card); HTTPS or `github:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
 | `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |
 | `/mas-infrastructure-integration` | `.cursor/skills/mas-infrastructure-integration/` |

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -49,4 +49,4 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
 | enterprise-auditor | Architecture audits |
-| researcher | Optional research corpus (off by default) |
+| researcher | Brief-driven packs; adaptive chat/agent intake; `research init\|fetch\|validate` |

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -57,7 +57,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | **integrator-mas-agent** | status + claim | →Done; `--agent integrator-mas-agent` |
 | **enterprise-auditor** | status + audit card | →In review/Done; `--agent enterprise-auditor` + artifact paths |
 | **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; `--agent workflow-drift-guard`; remediation via Notes/Ready — no silent tracker edits |
-| **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + `AGENT_BRIEF` / pack paths |
+| **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + `AGENT_BRIEF` / pack paths (adaptive intake from chat/Notes) |
 
 ## Status path
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. After mer
 | Audit orchestration | `.cursor/skills/audit-orchestration/SKILL.md` — parent runs verify-all + Task delegation (no dedicated agent) |
 | Audit module map | `.cursor/skills/audit-module-map/SKILL.md` — optional deep map; invoke via **`enterprise-auditor`** |
 | Maintainer PR | `.agents/skills/pr-workflow/SKILL.md` → `review-pr` → `prepare-pr` → `merge-pr` |
-| Research corpus (optional) | `.cursor/agents/researcher.md` — brief-driven external packs; `research init\|fetch\|validate`; off until `_research_results/` init |
+| Research corpus (optional) | `.cursor/agents/researcher.md` — adaptive Brief from chat/agents; HTTPS/`github:`/`path:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
 | MCP | `.ai_infra/mcp_servers/workflow_mcp/` — `python -m workflow_mcp`; [`.cursor/mcp.json.kit.example`](.cursor/mcp.json.kit.example) + [connect-external-mcp](.ai_infra/docs/operations/connect-external-mcp.md) |
 
 Scripts:

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -102,7 +102,7 @@ const PER_AGENT_ENTRY_EXIT = [
   [
     "researcher",
     "status (+ research card)",
-    "Research card →Done; --agent researcher + corpus paths",
+    "Research card →Done; --agent researcher + AGENT_BRIEF / pack paths",
   ],
 ];
 

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -76,7 +76,7 @@ const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   },
   {
     id: "researcher",
-    role: "Local research corpus only (no product PRs)",
+    role: "Adaptive Brief research packs (no product PRs)",
     lane: "Optional",
   },
 ];

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -25,17 +25,17 @@ type SsotMode = "board" | "fallback";
 
 const VERIFIED = "2026-07-18";
 const SOURCES =
-  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · _research_results/";
+  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · RESEARCH_WORKFLOW.md";
 
 const GOALS = [
-  "Brief-driven multi-round research (GitHub or local path)",
-  "Packs under _research_results/sources/<slug>/ + AGENT_BRIEF for MAS",
+  "Adaptive Brief from chat, peer agent Notes/handoffs, or board research card",
+  "Multi-round packs under _research_results/sources/<slug>/ + AGENT_BRIEF for MAS",
   "Hard-stop: write only _research_results/ — no product git/PR",
 ];
 
 const BOARD_NODES = [
   { id: "status" },
-  { id: "brief" },
+  { id: "intake" },
   { id: "cli" },
   { id: "rounds" },
   { id: "done" },
@@ -43,8 +43,8 @@ const BOARD_NODES = [
 ];
 
 const BOARD_EDGES = [
-  { from: "status", to: "brief" },
-  { from: "brief", to: "cli" },
+  { from: "status", to: "intake" },
+  { from: "intake", to: "cli" },
   { from: "cli", to: "rounds" },
   { from: "rounds", to: "done" },
   { from: "done", to: "notes" },
@@ -52,20 +52,20 @@ const BOARD_EDGES = [
 
 const FALLBACK_NODES = [
   { id: "session" },
-  { id: "brief" },
+  { id: "intake" },
   { id: "rounds" },
   { id: "close" },
 ];
 
 const FALLBACK_EDGES = [
-  { from: "session", to: "brief" },
-  { from: "brief", to: "rounds" },
+  { from: "session", to: "intake" },
+  { from: "intake", to: "rounds" },
   { from: "rounds", to: "close" },
 ];
 
 const BOARD_LABELS: Record<string, string> = {
   status: "project status",
-  brief: "Research Brief",
+  intake: "adaptive Brief",
   cli: "research init/fetch",
   rounds: "rounds 1-6 + validate",
   done: "set-status done",
@@ -74,37 +74,39 @@ const BOARD_LABELS: Record<string, string> = {
 
 const FALLBACK_LABELS: Record<string, string> = {
   session: "session-pointer.md",
-  brief: "Research Brief",
+  intake: "adaptive Brief",
   rounds: "rounds 1-6 + validate",
   close: "local close",
 };
 
 const READ_FIRST = [
-  [".cursor/skills/research-corpus-execution/SKILL.md", "Research canon"],
+  [".cursor/skills/research-corpus-execution/SKILL.md", "Intake + rounds canon"],
   ["_research_results/RESEARCH_BOUNDARIES.md", "Hard-stop boundaries"],
   [".cursor/skills/project-board-ssot/SKILL.md", "When project_ssot.enabled"],
 ];
 
 const PATTERNS = [
   ["Hard stop", "Write only _research_results/"],
-  ["Brief required", "External mode refuses without BRIEF.md"],
-  ["CLI", "research init | fetch | validate"],
+  ["Adaptive intake", "Chat / peer Notes / board card → Brief (+ defaults)"],
+  ["Terse chat", "/researcher https://github.com/owner/repo OK"],
+  ["CLI sources", "HTTPS | github: | path: | bare path"],
   ["Board lifecycle", "create-from-template research → done + pack paths"],
   ["Consumers", "implementer / integrator read AGENT_BRIEF.md"],
-  ["Attribution", "@owner.github_user/researcher via --agent"],
 ];
 
 const ARTIFACTS = [
   ["_research_results/sources/<slug>/", "Pack + AGENT_BRIEF", "implementer / integrator"],
-  ["Board Status + Notes", "Research card done + pack paths", "Next agents"],
+  ["Board Status + Notes", "Research card done + pack paths", "Next / requesting agent"],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
 ];
 
 const PEERS = [
   ["Use instead", "implementer", "Product code changes"],
+  ["Use instead", "integrator-mas-agent", "Kit surface integration"],
   ["Use instead", "pr-workflow", "Git commit/push/PR"],
   ["Use instead", "enterprise-auditor", "Architecture audits"],
   ["Use instead", "verifier", "Claims vs evidence"],
+  ["Consumes from", "any agent", "Notes / handoff / cited pack path"],
 ];
 
 function DagPanel({
@@ -188,13 +190,13 @@ export default function AgentResearcherCanvas() {
           <Pill tone="info" size="sm">
             kit agent
           </Pill>
-          <Pill tone="warning" size="sm">
-            optional / off by default
+          <Pill tone="neutral" size="sm">
+            independent-governed
           </Pill>
         </Row>
         <Text tone="secondary">
-          Optional local research corpus; hard-stop on product code without explicit
-          scope.
+          Brief-driven multi-round research (GitHub HTTPS / github: / local path).
+          Adaptive intake from chat or peer agents; hard-stop on product code.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -203,7 +205,7 @@ export default function AgentResearcherCanvas() {
 
       <Grid columns={3} gap={12}>
         <Stat value="_research_results/" label="Only write target" />
-        <Stat value="hard stop" label="No product code" tone="warning" />
+        <Stat value="adaptive Brief" label="Chat / agents / card" tone="info" />
         <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
       </Grid>
 
@@ -225,10 +227,15 @@ export default function AgentResearcherCanvas() {
             label={mode === "board" ? "board_only SSOT" : "local_trackers fallback"}
           />
         </Row>
+        <Callout tone="info" title="Adaptive intake">
+          Derive Brief from user chat (including /researcher https://github.com/…),
+          peer agent Notes/handoffs, or board research card. Defaults fill missing
+          question/lenses/slug. Refuse only when no source and not mode:self.
+        </Callout>
         <Callout tone="warning" title="Hard stop">
           Write only _research_results/. No src/tests/scripts. No git commit/push/PR.
-          Use implementer, pr-workflow, enterprise-auditor, or verifier instead for
-          those tasks.
+          Use implementer, integrator, pr-workflow, enterprise-auditor, or verifier
+          for those tasks.
         </Callout>
         <DagPanel mode={mode} tokens={tokens} />
       </Stack>
@@ -236,12 +243,18 @@ export default function AgentResearcherCanvas() {
       <CollapsibleSection title="Loop steps (canon)" defaultOpen>
         <Stack gap={6}>
           <Text>
-            1. Entry: project status (+ research card list); else session-pointer.
+            1. Entry: project status (+ research card); else session-pointer.
           </Text>
-          <Text>2. Read _research_results/RESEARCH_BOUNDARIES.md and research-corpus-execution skill.</Text>
-          <Text>3. Produce corpus under _research_results/ only.</Text>
           <Text>
-            4. If research card: set-status done + Notes with corpus paths.
+            2. Adaptive intake → normalize source (HTTPS | github: | path) → Brief.
+          </Text>
+          <Text>
+            3. research init → fetch → rounds 1–6 → validate under
+            _research_results/sources/&lt;slug&gt;/.
+          </Text>
+          <Text>
+            4. If research card: set-status done + Notes with AGENT_BRIEF / INDEX
+            paths; handoff to named consumer.
           </Text>
           <Text>5. Do not touch product code, tests, scripts, or git/PR workflows.</Text>
         </Stack>
@@ -263,7 +276,7 @@ export default function AgentResearcherCanvas() {
             <Table headers={["Path", "When", "Consumed by"]} rows={ARTIFACTS} />
             <Spacer size={8} />
             <Text tone="tertiary" size="small">
-              Research output is read-only input for humans and product agents —
+              Research packs are read-only input for humans and product agents —
               not shipped product code.
             </Text>
           </CardBody>
@@ -274,10 +287,13 @@ export default function AgentResearcherCanvas() {
         <CardHeader>Board interaction</CardHeader>
         <CardBody>
           <Stack gap={6}>
-            <Text>Entry: project status + research card list when board on.</Text>
             <Text>
-              Exit: corpus under _research_results/; research card set-status done +
-              Notes with corpus paths.
+              Create: create-from-template --template research (or claim Ready card).
+            </Text>
+            <Text>Entry: project status + research card when board on.</Text>
+            <Text>
+              Exit: pack under _research_results/sources/&lt;slug&gt;/; research card
+              done + Notes with AGENT_BRIEF paths.
             </Text>
             <Text>
               Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
@@ -292,9 +308,9 @@ export default function AgentResearcherCanvas() {
         <Table headers={["Direction", "Agent", "Evidence"]} rows={PEERS} />
       </Stack>
 
-      <Callout tone="neutral" title="MCP">
-        External research MCP only when listed for this agent in mcp.registry.yaml.
-        Prefer cursor_workflow project for board when research card exists.
+      <Callout tone="neutral" title="MCP + CLI">
+        Prefer python3 -m cursor_workflow research init|fetch|validate. External
+        research MCP only when listed for this agent in mcp.registry.yaml.
       </Callout>
 
       <Text tone="tertiary" size="small">

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -55,7 +55,7 @@ const AGENTS = [
   {
     id: "researcher",
     description:
-      "Optional local research corpus; hard-stop on product code without explicit scope",
+      "Brief-driven multi-round research (chat/agent adaptive intake); packs under _research_results/; hard-stop on product code",
   },
 ];
 
@@ -243,8 +243,9 @@ export default function AgentRosterCanvas() {
             rows={RESEARCHER_REDIRECTS}
           />
           <Callout tone="warning" title="Non-product agent">
-            researcher writes only _research_results/. No src/tests/scripts; no
-            git/PR. Not connected in product handoff DAG.
+            researcher writes only _research_results/ (adaptive Brief from
+            chat/agents). No src/tests/scripts; no git/PR. Not connected in
+            product handoff DAG — consumers read AGENT_BRIEF.md.
           </Callout>
         </CardBody>
       </Card>

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -53,7 +53,7 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 | `test-runner` | Module tests, coverage; board Exit Status |
 | `verifier` | Evidence checks; board Done / In review |
 | `enterprise-auditor` | Architecture audits; audit card Status + Notes |
-| `researcher` | Brief-driven multi-round packs under `_research_results/`; research card Done + `AGENT_BRIEF` paths |
+| `researcher` | Adaptive Brief multi-round packs under `_research_results/`; chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
 | `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
 | `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
 | `project-board` | Board triage helper (ADR-006); not in default PR pipelines |

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -230,7 +230,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/verifier` | `.cursor/agents/verifier.md` |
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
-| `/researcher` | `.cursor/agents/researcher.md` — Brief + `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
+| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief (chat/agents/card); HTTPS or `github:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
 | `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |
 | `/mas-infrastructure-integration` | `.cursor/skills/mas-infrastructure-integration/` |

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -49,4 +49,4 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
 | enterprise-auditor | Architecture audits |
-| researcher | Optional research corpus (off by default) |
+| researcher | Brief-driven packs; adaptive chat/agent intake; `research init\|fetch\|validate` |

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -57,7 +57,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | **integrator-mas-agent** | status + claim | →Done; `--agent integrator-mas-agent` |
 | **enterprise-auditor** | status + audit card | →In review/Done; `--agent enterprise-auditor` + artifact paths |
 | **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; `--agent workflow-drift-guard`; remediation via Notes/Ready — no silent tracker edits |
-| **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + `AGENT_BRIEF` / pack paths |
+| **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + `AGENT_BRIEF` / pack paths (adaptive intake from chat/Notes) |
 
 ## Status path
 

--- a/tests/modules/architecture_scripts/test_check_doc_facts.py
+++ b/tests/modules/architecture_scripts/test_check_doc_facts.py
@@ -78,18 +78,16 @@ def test_unknown_agent_in_canvas_fails_doc008(tmp_path: Path) -> None:
 def test_missing_agent_in_roster_hub_fails_doc008(tmp_path: Path) -> None:
     _copy_minimal_kit(tmp_path)
     relations = tmp_path / "canvases" / "agent-relations.canvas.tsx"
-    relations.write_text(
-        relations.read_text(encoding="utf-8").replace(
-            """  {
-    id: "researcher",
-    role: "Local research corpus only (no product PRs)",
-    lane: "Optional",
-  },
-""",
-            "",
-        ),
-        encoding="utf-8",
+    text = relations.read_text(encoding="utf-8")
+    needle = (
+        '  {\n'
+        '    id: "researcher",\n'
+        '    role: "Adaptive Brief research packs (no product PRs)",\n'
+        '    lane: "Optional",\n'
+        "  },\n"
     )
+    assert needle in text, "fixture must match agent-relations researcher AGENTS row"
+    relations.write_text(text.replace(needle, "", 1), encoding="utf-8")
     results = run_checks(tmp_path)
     doc008 = next(r for r in results if r.check_id == "DOC-008")
     assert not doc008.passed


### PR DESCRIPTION
## Summary
- Refresh `canvases/agent-researcher.canvas.tsx` for adaptive Brief intake (chat/agents/card) and HTTPS CLI sources.
- Align roster/relations/board canvases plus AGENTS, PLUGIN-USER-GUIDE, abbreviations, architecture, repository-map.

## Test plan
- [x] `doc validate` / `integrate validate` / governance consistency
- [ ] prepare.py gates

## Board
- `PVTI_lAHOBl46-84A9KZxzgzSsE0`

Made with [Cursor](https://cursor.com)