### PR TITLE
[EA-RESEARCH-GUARD] Public/private auth + anti-loop + live smoke

### DIFF
--- a/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/.agents/skills/RESEARCH_WORKFLOW.md
@@ -29,6 +29,8 @@ No product repo edits; no git commits for research packs; writes only `_research
 | D5 | CLI owns init/fetch/validate; agent owns rounds 1–6 prose evidence |
 | D6 | Host `mode: self` is optional; default is `external` when a source is present |
 | D7 | Accept HTTPS GitHub URLs and terse `/researcher <url>` chat; apply skill defaults |
+| D8 | Anti-loop: rounds_max≤6; no re-fetch/re-init without `--force`; exit on complete |
+| D9 | Private GitHub needs consumer `gh`/git auth; public needs network only |
 
 ## Forbidden
 
@@ -40,6 +42,8 @@ No product repo edits; no git commits for research packs; writes only `_research
 | Invent evidence without path/~Lnn | Evidence contract |
 | Implement fixes in product tree during research | → implementer |
 | Refuse terse chat that clearly names a GitHub/local source | D7 — adapt + defaults |
+| Endless deepen / re-fetch after complete | D8 — stop rules |
+| Silent private-clone retry without auth | D9 — one attempt, report fail |
 
 ## Pack outputs
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
 **Last updated:** 2026-07-18 (WORKSPACE-CLEAN — DOC-008 canvas roster)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 938
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 942
 
 ## Shipped (confirmed in repo)
 
@@ -47,13 +47,13 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 938 collected (937 passed + 1 skipped on full run) | `tests/modules/` |
+| Tests | 942 collected (940 passed + 2 skipped on full run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18
-(COV-100): **5352 statements, 100%** on a full suite pass (**938 collected**;
+(COV-100): **5352 statements, 100%** on a full suite pass (**942 collected**;
 930 passed, 1 skipped). The **Tests** row uses collected count; executed pass/skip
 may differ by marker or import-order skips.
 One import-order `sys.path` bootstrap in `merge.py` is `# pragma: no cover`.

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -230,7 +230,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/verifier` | `.cursor/agents/verifier.md` |
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
-| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief (chat/agents/card); HTTPS or `github:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
+| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate` |
 | `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |
 | `/mas-infrastructure-integration` | `.cursor/skills/mas-infrastructure-integration/` |

--- a/.ai_infra/install/cursor_workflow/research_cli.py
+++ b/.ai_infra/install/cursor_workflow/research_cli.py
@@ -170,6 +170,7 @@ def _write_index_stub(
     commit_sha: str | None = None,
     resolved_path: str | None = None,
     consumers: list[str] | None = None,
+    rounds_max: int = 6,
 ) -> None:
     payload: dict[str, Any] = {
         "schema_version": "1",
@@ -179,6 +180,7 @@ def _write_index_stub(
         "question": question,
         "lenses": lenses,
         "rounds_completed": 0,
+        "rounds_max": rounds_max if rounds_max > 0 else 6,
         "commit_sha": commit_sha,
         "resolved_path": resolved_path,
         "findings": [],
@@ -247,6 +249,12 @@ def structural_validate_index(data: Any) -> list[str]:
     rounds = data.get("rounds_completed")
     if rounds is not None and (not isinstance(rounds, int) or rounds < 0 or rounds > 6):
         errors.append("rounds_completed must be 0..6")
+    rounds_max = data.get("rounds_max")
+    if rounds_max is not None:
+        if not isinstance(rounds_max, int) or rounds_max < 1 or rounds_max > 6:
+            errors.append("rounds_max must be 1..6")
+        elif isinstance(rounds, int) and rounds > rounds_max:
+            errors.append(f"rounds_completed ({rounds}) exceeds rounds_max ({rounds_max})")
     return errors
 
 
@@ -336,8 +344,46 @@ def cmd_research_init(args: argparse.Namespace) -> int:
         lenses=lenses,
         status="init",
         consumers=consumers,
+        rounds_max=int(args.rounds_max or 6),
     )
     return _ok("init", f"pack={pack}")
+
+
+def _clone_github(locator: str, ref: str | None, dest: Path) -> tuple[bool, str]:
+    """Shallow-clone owner/repo into dest. Prefer `gh` (private auth), else git HTTPS.
+
+    Returns (ok, detail). Private repos work when `gh auth` / git credentials can
+    access the repo the same way a local `gh repo clone` / `git clone` would.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    git_flags = ["--depth", "1"]
+    if ref:
+        git_flags.extend(["--branch", ref])
+
+    gh_cmd = ["gh", "repo", "clone", locator, str(dest), "--", *git_flags]
+    try:
+        proc = subprocess.run(gh_cmd, capture_output=True, text=True, timeout=300, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        proc = None
+        gh_err = str(exc)
+    else:
+        if proc.returncode == 0 and dest.is_dir():
+            return True, "gh repo clone"
+        gh_err = (proc.stderr or proc.stdout or "").strip()[:400]
+
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+
+    url = f"https://github.com/{locator}.git"
+    git_cmd = ["git", "clone", *git_flags, url, str(dest)]
+    try:
+        proc2 = subprocess.run(git_cmd, capture_output=True, text=True, timeout=300, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"gh failed ({gh_err}); git clone failed: {exc}"
+    if proc2.returncode != 0:
+        detail = (proc2.stderr or proc2.stdout or "").strip()[:400]
+        return False, f"gh failed ({gh_err}); git clone failed: {detail}"
+    return True, "git clone"
 
 
 def cmd_research_fetch(args: argparse.Namespace) -> int:
@@ -350,6 +396,14 @@ def cmd_research_fetch(args: argparse.Namespace) -> int:
     pack = pack_dir(root, slug)
     if not pack.is_dir():
         return _fail("fetch", EXIT_USAGE, f"pack missing — run research init first: {pack}")
+
+    # Anti-loop: do not re-fetch a pinned pack unless --force
+    if (pack / "SOURCE.md").is_file() and not args.force:
+        return _fail(
+            "fetch",
+            EXIT_USAGE,
+            f"SOURCE.md already exists for {slug} (use --force to re-fetch)",
+        )
 
     try:
         kind, locator, ref = _parse_source(args.source)
@@ -379,22 +433,13 @@ def cmd_research_fetch(args: argparse.Namespace) -> int:
                 shutil.rmtree(cache)
             else:
                 return _fail("fetch", EXIT_USAGE, f"cache exists: {cache} (use --force)")
-        cache.parent.mkdir(parents=True, exist_ok=True)
-        url = f"https://github.com/{locator}.git"
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd.extend(["--branch", ref])
-        cmd.extend([url, str(cache)])
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=300, check=False)
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            return _fail("fetch", EXIT_FAIL, f"git clone failed: {exc}")
-        if proc.returncode != 0:
-            detail = (proc.stderr or proc.stdout or "").strip()[:500]
-            return _fail("fetch", EXIT_FAIL, f"git clone failed: {detail}")
+        ok, how = _clone_github(locator, ref, cache)
+        if not ok:
+            return _fail("fetch", EXIT_FAIL, how)
         resolved = cache
         commit_sha = _git_sha(cache)
         source_label = f"github:{locator}" + (f"@{ref}" if ref else "")
+        print(f"research fetch: clone via {how}", file=sys.stderr)
 
     fetched_at = _utc_now()
     source_md = _render(
@@ -428,6 +473,7 @@ def cmd_research_fetch(args: argparse.Namespace) -> int:
             "question": data.get("question") or "(TBD)",
             "lenses": data.get("lenses") or list(_DEFAULT_LENSES),
             "rounds_completed": data.get("rounds_completed") or 0,
+            "rounds_max": data.get("rounds_max") if isinstance(data.get("rounds_max"), int) else 6,
             "commit_sha": commit_sha,
             "resolved_path": str(resolved),
             "findings": data.get("findings") if isinstance(data.get("findings"), list) else [],
@@ -485,7 +531,10 @@ def cmd_research_validate(args: argparse.Namespace) -> int:
         for e in errors:
             print(f" - {e}", file=sys.stderr)
         return _fail("validate", EXIT_FAIL, f"{len(errors)} error(s)")
-    return _ok("validate", f"slug={slug} status={status}")
+    note = ""
+    if status == "complete":
+        note = " · pack closed (do not deepen further without --force redo)"
+    return _ok("validate", f"slug={slug} status={status}{note}")
 
 
 def register_research_subparser(sub: argparse._SubParsersAction) -> None:

--- a/.ai_infra/templates/research-corpus/INDEX.schema.json
+++ b/.ai_infra/templates/research-corpus/INDEX.schema.json
@@ -37,6 +37,11 @@
       "minimum": 0,
       "maximum": 6
     },
+    "rounds_max": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 6
+    },
     "commit_sha": {
       "type": ["string", "null"]
     },

--- a/.ai_infra/templates/research-corpus/README.md
+++ b/.ai_infra/templates/research-corpus/README.md
@@ -26,6 +26,8 @@ python3 -m cursor_workflow research validate --slug <slug>
 
 Terse chat (`/researcher https://github.com/owner/repo`) is valid: agent derives Brief defaults per skill § Intake.
 
+**Public vs private:** fetch uses `gh repo clone` (preferred) then `git clone`. Private repos require the consumer’s local `gh auth` / git credentials. Anti-loop: max 6 deepen rounds; no re-init/re-fetch without `--force`; stop after `status: complete`.
+
 | File | Role |
 |------|------|
 | `RESEARCH_BOUNDARIES.md` | Hard stop + enable rules (copied to corpus root on first init) |

--- a/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
+++ b/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
@@ -20,6 +20,8 @@ Notes:
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
 4. **External runs need a Brief** — derive from user chat, peer agent handoff/Notes, or board card; persist as `sources/<slug>/BRIEF.md`. Terse `/researcher <url>` is enough (skill defaults apply).
 5. Pin every pack to a **path or commit SHA** in `SOURCE.md`; do not invent evidence.
+6. **Anti-loop:** deepen ≤ `rounds_max` (default 6); after `status: complete` + validate, exit — no endless deepen/re-fetch without explicit `--force` redo.
+7. **GitHub:** public clones work with network; private clones need consumer `gh`/git auth (same as local `gh repo clone`).
 
 ## Modes
 

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -49,6 +49,24 @@ Normalize a **Research Brief** from whatever channel started you — do **not** 
 
 Then write `BRIEF.md` via `research init` and proceed with the skill loop.
 
+## GitHub access (public + private)
+
+| Repo visibility | How fetch works |
+|-----------------|-----------------|
+| **Public** | `research fetch` clones via `gh repo clone` (preferred) or `git clone https://…` |
+| **Private** | Same CLI — requires the **consumer machine** to already authenticate (`gh auth login` and/or git credentials) so a normal local clone of that URL would succeed |
+
+No kit-side GitHub token is stored. If clone fails, report the error and stop (do not retry in a loop).
+
+## Anti-loop (mandatory stop rules)
+
+1. **One pack per slug** — do not `research init` again without user `--force` / explicit redo.
+2. **One fetch** — if `SOURCE.md` exists, do not re-fetch without `--force`.
+3. **Hard cap** — deepen at most `rounds_max` (default **6**). Never invent round-7+.
+4. **Close then exit** — after `INDEX.json` `status: complete` + `research validate` PASS → handoff/Done and **stop**. Do not start another deepen cycle in the same session unless the user explicitly asks to reopen.
+5. **Gaps OK** — if questions remain at cap, write them under gaps / `status: blocked` or complete with “open gaps”; do not keep reading forever.
+6. **No retry storms** — clone/API failures: one attempt, surface stderr, exit (outbox only for board writes).
+
 ## Hard stop (when enabled)
 
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.

--- a/.cursor/skills/research-corpus-execution/SKILL.md
+++ b/.cursor/skills/research-corpus-execution/SKILL.md
@@ -53,6 +53,15 @@ If only a link/path is given:
 
 Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
 
+### GitHub access
+
+| Visibility | Requirement |
+|------------|-------------|
+| Public | Network + `gh` or `git` clone |
+| Private | Same, plus consumer auth (`gh auth login` / git credentials that can clone the URL) |
+
+Clone failures: report once and stop — no retry loop.
+
 ### Brief contract (persisted)
 
 Write via `research init` into `BRIEF.md`:
@@ -73,7 +82,17 @@ python3 -m cursor_workflow research init --slug <slug> --source '…' --question
 python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 ```
 
-`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch pins `SOURCE.md` (shallow clone under `_research_results/cache/<slug>/` when remote).
+`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch prefers `gh repo clone` (private-friendly), else `git clone --depth 1` into `_research_results/cache/<slug>/`. Re-fetch requires `--force`.
+
+## Anti-loop (hard stop)
+
+| Rule | Behavior |
+|------|----------|
+| Cap | Deepen ≤ `rounds_max` (default 6); never round 7+ |
+| Idempotent init/fetch | Existing pack / `SOURCE.md` → refuse unless `--force` |
+| Closed pack | `INDEX.status=complete` + validate PASS → **exit**; do not deepen again unless user reopens |
+| Failures | One clone attempt; surface error; stop |
+| Gaps | Remaining questions → document gaps; set `blocked` or complete with gaps — do not spin |
 
 ## Multi-round loop (active)
 
@@ -82,11 +101,11 @@ Work only under `_research_results/sources/<slug>/`. Read foreign trees read-onl
 1. **Scout** — confirm `SOURCE.md` pin (SHA/path); note languages/size.
 2. **Map** — write `MAP.md` (entrypoints, layout, docs).
 3. **Extract** — for each lens in Brief, fill `findings/<lens>.md` with path + line evidence.
-4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`).
+4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`). **Stop deepening when N == rounds_max.**
 5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
-6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed`).
+6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed` ≤ `rounds_max`).
 7. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known).
+8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known). **Then stop.**
 
 ## Mode: self (optional)
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -49,6 +49,24 @@ Normalize a **Research Brief** from whatever channel started you — do **not** 
 
 Then write `BRIEF.md` via `research init` and proceed with the skill loop.
 
+## GitHub access (public + private)
+
+| Repo visibility | How fetch works |
+|-----------------|-----------------|
+| **Public** | `research fetch` clones via `gh repo clone` (preferred) or `git clone https://…` |
+| **Private** | Same CLI — requires the **consumer machine** to already authenticate (`gh auth login` and/or git credentials) so a normal local clone of that URL would succeed |
+
+No kit-side GitHub token is stored. If clone fails, report the error and stop (do not retry in a loop).
+
+## Anti-loop (mandatory stop rules)
+
+1. **One pack per slug** — do not `research init` again without user `--force` / explicit redo.
+2. **One fetch** — if `SOURCE.md` exists, do not re-fetch without `--force`.
+3. **Hard cap** — deepen at most `rounds_max` (default **6**). Never invent round-7+.
+4. **Close then exit** — after `INDEX.json` `status: complete` + `research validate` PASS → handoff/Done and **stop**. Do not start another deepen cycle in the same session unless the user explicitly asks to reopen.
+5. **Gaps OK** — if questions remain at cap, write them under gaps / `status: blocked` or complete with “open gaps”; do not keep reading forever.
+6. **No retry storms** — clone/API failures: one attempt, surface stderr, exit (outbox only for board writes).
+
 ## Hard stop (when enabled)
 
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -89,7 +89,8 @@ const PATTERNS = [
   ["Hard stop", "Write only _research_results/"],
   ["Adaptive intake", "Chat / peer Notes / board card → Brief (+ defaults)"],
   ["Terse chat", "/researcher https://github.com/owner/repo OK"],
-  ["CLI sources", "HTTPS | github: | path: | bare path"],
+  ["Anti-loop", "≤6 deepen rounds; no re-fetch without --force; exit on complete"],
+  ["GitHub auth", "Public: network; private: consumer gh/git credentials"],
   ["Board lifecycle", "create-from-template research → done + pack paths"],
   ["Consumers", "implementer / integrator read AGENT_BRIEF.md"],
 ];

--- a/payload/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/payload/.agents/skills/RESEARCH_WORKFLOW.md
@@ -29,6 +29,8 @@ No product repo edits; no git commits for research packs; writes only `_research
 | D5 | CLI owns init/fetch/validate; agent owns rounds 1–6 prose evidence |
 | D6 | Host `mode: self` is optional; default is `external` when a source is present |
 | D7 | Accept HTTPS GitHub URLs and terse `/researcher <url>` chat; apply skill defaults |
+| D8 | Anti-loop: rounds_max≤6; no re-fetch/re-init without `--force`; exit on complete |
+| D9 | Private GitHub needs consumer `gh`/git auth; public needs network only |
 
 ## Forbidden
 
@@ -40,6 +42,8 @@ No product repo edits; no git commits for research packs; writes only `_research
 | Invent evidence without path/~Lnn | Evidence contract |
 | Implement fixes in product tree during research | → implementer |
 | Refuse terse chat that clearly names a GitHub/local source | D7 — adapt + defaults |
+| Endless deepen / re-fetch after complete | D8 — stop rules |
+| Silent private-clone retry without auth | D9 — one attempt, report fail |
 
 ## Pack outputs
 

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -230,7 +230,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/verifier` | `.cursor/agents/verifier.md` |
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
-| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief (chat/agents/card); HTTPS or `github:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
+| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate` |
 | `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |
 | `/mas-infrastructure-integration` | `.cursor/skills/mas-infrastructure-integration/` |

--- a/payload/.ai_infra/install/cursor_workflow/research_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/research_cli.py
@@ -170,6 +170,7 @@ def _write_index_stub(
     commit_sha: str | None = None,
     resolved_path: str | None = None,
     consumers: list[str] | None = None,
+    rounds_max: int = 6,
 ) -> None:
     payload: dict[str, Any] = {
         "schema_version": "1",
@@ -179,6 +180,7 @@ def _write_index_stub(
         "question": question,
         "lenses": lenses,
         "rounds_completed": 0,
+        "rounds_max": rounds_max if rounds_max > 0 else 6,
         "commit_sha": commit_sha,
         "resolved_path": resolved_path,
         "findings": [],
@@ -247,6 +249,12 @@ def structural_validate_index(data: Any) -> list[str]:
     rounds = data.get("rounds_completed")
     if rounds is not None and (not isinstance(rounds, int) or rounds < 0 or rounds > 6):
         errors.append("rounds_completed must be 0..6")
+    rounds_max = data.get("rounds_max")
+    if rounds_max is not None:
+        if not isinstance(rounds_max, int) or rounds_max < 1 or rounds_max > 6:
+            errors.append("rounds_max must be 1..6")
+        elif isinstance(rounds, int) and rounds > rounds_max:
+            errors.append(f"rounds_completed ({rounds}) exceeds rounds_max ({rounds_max})")
     return errors
 
 
@@ -336,8 +344,46 @@ def cmd_research_init(args: argparse.Namespace) -> int:
         lenses=lenses,
         status="init",
         consumers=consumers,
+        rounds_max=int(args.rounds_max or 6),
     )
     return _ok("init", f"pack={pack}")
+
+
+def _clone_github(locator: str, ref: str | None, dest: Path) -> tuple[bool, str]:
+    """Shallow-clone owner/repo into dest. Prefer `gh` (private auth), else git HTTPS.
+
+    Returns (ok, detail). Private repos work when `gh auth` / git credentials can
+    access the repo the same way a local `gh repo clone` / `git clone` would.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    git_flags = ["--depth", "1"]
+    if ref:
+        git_flags.extend(["--branch", ref])
+
+    gh_cmd = ["gh", "repo", "clone", locator, str(dest), "--", *git_flags]
+    try:
+        proc = subprocess.run(gh_cmd, capture_output=True, text=True, timeout=300, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        proc = None
+        gh_err = str(exc)
+    else:
+        if proc.returncode == 0 and dest.is_dir():
+            return True, "gh repo clone"
+        gh_err = (proc.stderr or proc.stdout or "").strip()[:400]
+
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+
+    url = f"https://github.com/{locator}.git"
+    git_cmd = ["git", "clone", *git_flags, url, str(dest)]
+    try:
+        proc2 = subprocess.run(git_cmd, capture_output=True, text=True, timeout=300, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"gh failed ({gh_err}); git clone failed: {exc}"
+    if proc2.returncode != 0:
+        detail = (proc2.stderr or proc2.stdout or "").strip()[:400]
+        return False, f"gh failed ({gh_err}); git clone failed: {detail}"
+    return True, "git clone"
 
 
 def cmd_research_fetch(args: argparse.Namespace) -> int:
@@ -350,6 +396,14 @@ def cmd_research_fetch(args: argparse.Namespace) -> int:
     pack = pack_dir(root, slug)
     if not pack.is_dir():
         return _fail("fetch", EXIT_USAGE, f"pack missing — run research init first: {pack}")
+
+    # Anti-loop: do not re-fetch a pinned pack unless --force
+    if (pack / "SOURCE.md").is_file() and not args.force:
+        return _fail(
+            "fetch",
+            EXIT_USAGE,
+            f"SOURCE.md already exists for {slug} (use --force to re-fetch)",
+        )
 
     try:
         kind, locator, ref = _parse_source(args.source)
@@ -379,22 +433,13 @@ def cmd_research_fetch(args: argparse.Namespace) -> int:
                 shutil.rmtree(cache)
             else:
                 return _fail("fetch", EXIT_USAGE, f"cache exists: {cache} (use --force)")
-        cache.parent.mkdir(parents=True, exist_ok=True)
-        url = f"https://github.com/{locator}.git"
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd.extend(["--branch", ref])
-        cmd.extend([url, str(cache)])
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=300, check=False)
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            return _fail("fetch", EXIT_FAIL, f"git clone failed: {exc}")
-        if proc.returncode != 0:
-            detail = (proc.stderr or proc.stdout or "").strip()[:500]
-            return _fail("fetch", EXIT_FAIL, f"git clone failed: {detail}")
+        ok, how = _clone_github(locator, ref, cache)
+        if not ok:
+            return _fail("fetch", EXIT_FAIL, how)
         resolved = cache
         commit_sha = _git_sha(cache)
         source_label = f"github:{locator}" + (f"@{ref}" if ref else "")
+        print(f"research fetch: clone via {how}", file=sys.stderr)
 
     fetched_at = _utc_now()
     source_md = _render(
@@ -428,6 +473,7 @@ def cmd_research_fetch(args: argparse.Namespace) -> int:
             "question": data.get("question") or "(TBD)",
             "lenses": data.get("lenses") or list(_DEFAULT_LENSES),
             "rounds_completed": data.get("rounds_completed") or 0,
+            "rounds_max": data.get("rounds_max") if isinstance(data.get("rounds_max"), int) else 6,
             "commit_sha": commit_sha,
             "resolved_path": str(resolved),
             "findings": data.get("findings") if isinstance(data.get("findings"), list) else [],
@@ -485,7 +531,10 @@ def cmd_research_validate(args: argparse.Namespace) -> int:
         for e in errors:
             print(f" - {e}", file=sys.stderr)
         return _fail("validate", EXIT_FAIL, f"{len(errors)} error(s)")
-    return _ok("validate", f"slug={slug} status={status}")
+    note = ""
+    if status == "complete":
+        note = " · pack closed (do not deepen further without --force redo)"
+    return _ok("validate", f"slug={slug} status={status}{note}")
 
 
 def register_research_subparser(sub: argparse._SubParsersAction) -> None:

--- a/payload/.ai_infra/templates/research-corpus/INDEX.schema.json
+++ b/payload/.ai_infra/templates/research-corpus/INDEX.schema.json
@@ -37,6 +37,11 @@
       "minimum": 0,
       "maximum": 6
     },
+    "rounds_max": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 6
+    },
     "commit_sha": {
       "type": ["string", "null"]
     },

--- a/payload/.ai_infra/templates/research-corpus/README.md
+++ b/payload/.ai_infra/templates/research-corpus/README.md
@@ -26,6 +26,8 @@ python3 -m cursor_workflow research validate --slug <slug>
 
 Terse chat (`/researcher https://github.com/owner/repo`) is valid: agent derives Brief defaults per skill § Intake.
 
+**Public vs private:** fetch uses `gh repo clone` (preferred) then `git clone`. Private repos require the consumer’s local `gh auth` / git credentials. Anti-loop: max 6 deepen rounds; no re-init/re-fetch without `--force`; stop after `status: complete`.
+
 | File | Role |
 |------|------|
 | `RESEARCH_BOUNDARIES.md` | Hard stop + enable rules (copied to corpus root on first init) |

--- a/payload/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
+++ b/payload/.ai_infra/templates/research-corpus/RESEARCH_BOUNDARIES.md
@@ -20,6 +20,8 @@ Notes:
 3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
 4. **External runs need a Brief** — derive from user chat, peer agent handoff/Notes, or board card; persist as `sources/<slug>/BRIEF.md`. Terse `/researcher <url>` is enough (skill defaults apply).
 5. Pin every pack to a **path or commit SHA** in `SOURCE.md`; do not invent evidence.
+6. **Anti-loop:** deepen ≤ `rounds_max` (default 6); after `status: complete` + validate, exit — no endless deepen/re-fetch without explicit `--force` redo.
+7. **GitHub:** public clones work with network; private clones need consumer `gh`/git auth (same as local `gh repo clone`).
 
 ## Modes
 

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -49,6 +49,24 @@ Normalize a **Research Brief** from whatever channel started you — do **not** 
 
 Then write `BRIEF.md` via `research init` and proceed with the skill loop.
 
+## GitHub access (public + private)
+
+| Repo visibility | How fetch works |
+|-----------------|-----------------|
+| **Public** | `research fetch` clones via `gh repo clone` (preferred) or `git clone https://…` |
+| **Private** | Same CLI — requires the **consumer machine** to already authenticate (`gh auth login` and/or git credentials) so a normal local clone of that URL would succeed |
+
+No kit-side GitHub token is stored. If clone fails, report the error and stop (do not retry in a loop).
+
+## Anti-loop (mandatory stop rules)
+
+1. **One pack per slug** — do not `research init` again without user `--force` / explicit redo.
+2. **One fetch** — if `SOURCE.md` exists, do not re-fetch without `--force`.
+3. **Hard cap** — deepen at most `rounds_max` (default **6**). Never invent round-7+.
+4. **Close then exit** — after `INDEX.json` `status: complete` + `research validate` PASS → handoff/Done and **stop**. Do not start another deepen cycle in the same session unless the user explicitly asks to reopen.
+5. **Gaps OK** — if questions remain at cap, write them under gaps / `status: blocked` or complete with “open gaps”; do not keep reading forever.
+6. **No retry storms** — clone/API failures: one attempt, surface stderr, exit (outbox only for board writes).
+
 ## Hard stop (when enabled)
 
 1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.

--- a/payload/.cursor/skills/research-corpus-execution/SKILL.md
+++ b/payload/.cursor/skills/research-corpus-execution/SKILL.md
@@ -53,6 +53,15 @@ If only a link/path is given:
 
 Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
 
+### GitHub access
+
+| Visibility | Requirement |
+|------------|-------------|
+| Public | Network + `gh` or `git` clone |
+| Private | Same, plus consumer auth (`gh auth login` / git credentials that can clone the URL) |
+
+Clone failures: report once and stop — no retry loop.
+
 ### Brief contract (persisted)
 
 Write via `research init` into `BRIEF.md`:
@@ -73,7 +82,17 @@ python3 -m cursor_workflow research init --slug <slug> --source '…' --question
 python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 ```
 
-`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch pins `SOURCE.md` (shallow clone under `_research_results/cache/<slug>/` when remote).
+`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch prefers `gh repo clone` (private-friendly), else `git clone --depth 1` into `_research_results/cache/<slug>/`. Re-fetch requires `--force`.
+
+## Anti-loop (hard stop)
+
+| Rule | Behavior |
+|------|----------|
+| Cap | Deepen ≤ `rounds_max` (default 6); never round 7+ |
+| Idempotent init/fetch | Existing pack / `SOURCE.md` → refuse unless `--force` |
+| Closed pack | `INDEX.status=complete` + validate PASS → **exit**; do not deepen again unless user reopens |
+| Failures | One clone attempt; surface error; stop |
+| Gaps | Remaining questions → document gaps; set `blocked` or complete with gaps — do not spin |
 
 ## Multi-round loop (active)
 
@@ -82,11 +101,11 @@ Work only under `_research_results/sources/<slug>/`. Read foreign trees read-onl
 1. **Scout** — confirm `SOURCE.md` pin (SHA/path); note languages/size.
 2. **Map** — write `MAP.md` (entrypoints, layout, docs).
 3. **Extract** — for each lens in Brief, fill `findings/<lens>.md` with path + line evidence.
-4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`).
+4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`). **Stop deepening when N == rounds_max.**
 5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
-6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed`).
+6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed` ≤ `rounds_max`).
 7. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known).
+8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known). **Then stop.**
 
 ## Mode: self (optional)
 

--- a/skills/research-corpus-execution/SKILL.md
+++ b/skills/research-corpus-execution/SKILL.md
@@ -53,6 +53,15 @@ If only a link/path is given:
 
 Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
 
+### GitHub access
+
+| Visibility | Requirement |
+|------------|-------------|
+| Public | Network + `gh` or `git` clone |
+| Private | Same, plus consumer auth (`gh auth login` / git credentials that can clone the URL) |
+
+Clone failures: report once and stop — no retry loop.
+
 ### Brief contract (persisted)
 
 Write via `research init` into `BRIEF.md`:
@@ -73,7 +82,17 @@ python3 -m cursor_workflow research init --slug <slug> --source '…' --question
 python3 -m cursor_workflow research fetch --slug <slug> --source '…'
 ```
 
-`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch pins `SOURCE.md` (shallow clone under `_research_results/cache/<slug>/` when remote).
+`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch prefers `gh repo clone` (private-friendly), else `git clone --depth 1` into `_research_results/cache/<slug>/`. Re-fetch requires `--force`.
+
+## Anti-loop (hard stop)
+
+| Rule | Behavior |
+|------|----------|
+| Cap | Deepen ≤ `rounds_max` (default 6); never round 7+ |
+| Idempotent init/fetch | Existing pack / `SOURCE.md` → refuse unless `--force` |
+| Closed pack | `INDEX.status=complete` + validate PASS → **exit**; do not deepen again unless user reopens |
+| Failures | One clone attempt; surface error; stop |
+| Gaps | Remaining questions → document gaps; set `blocked` or complete with gaps — do not spin |
 
 ## Multi-round loop (active)
 
@@ -82,11 +101,11 @@ Work only under `_research_results/sources/<slug>/`. Read foreign trees read-onl
 1. **Scout** — confirm `SOURCE.md` pin (SHA/path); note languages/size.
 2. **Map** — write `MAP.md` (entrypoints, layout, docs).
 3. **Extract** — for each lens in Brief, fill `findings/<lens>.md` with path + line evidence.
-4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`).
+4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`). **Stop deepening when N == rounds_max.**
 5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
-6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed`).
+6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed` ≤ `rounds_max`).
 7. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known).
+8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known). **Then stop.**
 
 ## Mode: self (optional)
 

--- a/tests/modules/research/test_research_cli.py
+++ b/tests/modules/research/test_research_cli.py
@@ -146,3 +146,120 @@ def test_parse_source() -> None:
     assert kind4 == "github" and loc4 == "SavinRazvan/grok-build" and ref4 == "main"
     with pytest.raises(ValueError):
         research_cli._parse_source("")
+
+
+def test_fetch_refuses_without_force_when_source_exists(tmp_path: Path) -> None:
+    _seed_templates(tmp_path)
+    fixture = tmp_path / "fixture-repo"
+    fixture.mkdir()
+    (fixture / "README.md").write_text("# x\n", encoding="utf-8")
+
+    class NS:
+        pass
+
+    init = NS()
+    init.directory = tmp_path
+    init.slug = "once"
+    init.source = f"path:{fixture}"
+    init.question = "q"
+    init.lenses = "architecture"
+    init.consumers = "implementer"
+    init.mode = "external"
+    init.rounds_max = 6
+    init.notes = ""
+    init.brief = None
+    init.force = False
+    assert research_cli.cmd_research_init(init) == 0
+
+    fetch = NS()
+    fetch.directory = tmp_path
+    fetch.slug = "once"
+    fetch.source = f"path:{fixture}"
+    fetch.force = False
+    assert research_cli.cmd_research_fetch(fetch) == 0
+    assert research_cli.cmd_research_fetch(fetch) == research_cli.EXIT_USAGE
+
+
+def test_rounds_completed_cannot_exceed_rounds_max() -> None:
+    errs = research_cli.structural_validate_index(
+        {
+            "schema_version": "1",
+            "slug": "x",
+            "mode": "external",
+            "source": "path:.",
+            "question": "q",
+            "lenses": ["architecture"],
+            "findings": [],
+            "curated_count": 0,
+            "status": "in_progress",
+            "rounds_completed": 7,
+            "rounds_max": 6,
+        }
+    )
+    assert any("rounds_completed" in e for e in errs)
+
+
+def test_clone_github_prefers_gh(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):  # noqa: ANN001
+        calls.append(list(cmd))
+
+        class P:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        dest = Path(cmd[4]) if cmd[0] == "gh" else Path(cmd[-1])
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / ".git").mkdir(exist_ok=True)
+        return P()
+
+    monkeypatch.setattr(research_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(research_cli, "_git_sha", lambda _p: "abc123")
+    dest = tmp_path / "cache"
+    ok, how = research_cli._clone_github("octocat/Hello-World", None, dest)
+    assert ok and how == "gh repo clone"
+    assert calls and calls[0][0] == "gh"
+
+
+@pytest.mark.live
+def test_live_public_github_fetch_smoke(tmp_path: Path) -> None:
+    """Optional: RESEARCH_LIVE=1 pytest -m live … — tiny public clone."""
+    import os
+
+    if os.environ.get("RESEARCH_LIVE") != "1":
+        pytest.skip("Set RESEARCH_LIVE=1 for live GitHub fetch smoke")
+    _seed_templates(tmp_path)
+
+    class NS:
+        pass
+
+    init = NS()
+    init.directory = tmp_path
+    init.slug = "hello-world"
+    init.source = "https://github.com/octocat/Hello-World"
+    init.question = "smoke"
+    init.lenses = "architecture"
+    init.consumers = "implementer"
+    init.mode = "external"
+    init.rounds_max = 1
+    init.notes = ""
+    init.brief = None
+    init.force = False
+    assert research_cli.cmd_research_init(init) == 0
+
+    fetch = NS()
+    fetch.directory = tmp_path
+    fetch.slug = "hello-world"
+    fetch.source = "https://github.com/octocat/Hello-World"
+    fetch.force = False
+    assert research_cli.cmd_research_fetch(fetch) == 0
+
+    pack = tmp_path / "_research_results" / "sources" / "hello-world"
+    assert (pack / "SOURCE.md").is_file()
+
+    validate = NS()
+    validate.directory = tmp_path
+    validate.slug = "hello-world"
+    assert research_cli.cmd_research_validate(validate) == 0


### PR DESCRIPTION
## Summary
- Public GitHub: fetch works with network (`gh` preferred, else `git clone`).
- Private GitHub: same CLI when consumer has `gh auth` / git credentials.
- Anti-loop: ≤6 deepen rounds; no re-init/re-fetch without `--force`; stop after `status: complete`.
- Tests: unit guards + optional `RESEARCH_LIVE=1` smoke (octocat/Hello-World) — verified locally.

## Test plan
- [x] `pytest tests/modules/research/`
- [x] `RESEARCH_LIVE=1 pytest -m live …Hello-World`
- [ ] prepare.py gates

## Board
- `PVTI_lAHOBl46-84A9KZxzgzStjk`

Made with [Cursor](https://cursor.com)