### PR TITLE
fix(EA-013): smoke generated-data skip + DRIFT-004b backticks

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
 **Last updated:** 2026-07-18 (WORKSPACE-CLEAN — DOC-008 canvas roster)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 942
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 943
 
 ## Shipped (confirmed in repo)
 
@@ -47,14 +47,14 @@ Notes:
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 942 collected (940 passed + 2 skipped on full run) | `tests/modules/` |
+| Tests | 943 collected (941 passed + 2 skipped on full run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-18
-(COV-100): **5352 statements, 100%** on a full suite pass (**942 collected**;
-930 passed, 1 skipped). The **Tests** row uses collected count; executed pass/skip
+(COV-100): **5352 statements, 100%** on a full suite pass (**943 collected**;
+941 passed, 2 skipped). The **Tests** row uses collected count; executed pass/skip
 may differ by marker or import-order skips.
 One import-order `sys.path` bootstrap in `merge.py` is `# pragma: no cover`.
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,

--- a/.ai_infra/scripts/install/smoke_marketplace.sh
+++ b/.ai_infra/scripts/install/smoke_marketplace.sh
@@ -55,8 +55,9 @@ config = smoke / ".local/agents-control-center/config"
 pages = json.loads((config / "pages.json").read_text(encoding="utf-8"))
 for page in pages["pages"]:
     rel = page["file"]
-    if rel.startswith("../../workflow-artifacts/"):
-        print(f"SKIP {page['id']} (Tier 2)")
+    # Tier 2 / runtime: stubs refreshed later, or machine output (board export).
+    if rel.startswith("../../workflow-artifacts/") or "/generated-data/" in rel:
+        print(f"SKIP {page['id']} (runtime)")
         continue
     ok = (config / rel).resolve().is_file()
     if not ok:

--- a/.ai_infra/scripts/workflow/drift_checks.py
+++ b/.ai_infra/scripts/workflow/drift_checks.py
@@ -257,7 +257,8 @@ def _parse_session_board_field(board_cell: str) -> tuple[str | None, str]:
     if not m:
         return None, ""
     item_id = m.group(1)
-    rest = (cell[: m.start()] + cell[m.end() :]).strip(" -–—|,;")
+    # Strip markdown backticks left when cell is like `PVTI_…` Done
+    rest = (cell[: m.start()] + cell[m.end() :]).strip(" -–—|,;`")
     return item_id, rest
 
 

--- a/payload/.ai_infra/scripts/install/smoke_marketplace.sh
+++ b/payload/.ai_infra/scripts/install/smoke_marketplace.sh
@@ -55,8 +55,9 @@ config = smoke / ".local/agents-control-center/config"
 pages = json.loads((config / "pages.json").read_text(encoding="utf-8"))
 for page in pages["pages"]:
     rel = page["file"]
-    if rel.startswith("../../workflow-artifacts/"):
-        print(f"SKIP {page['id']} (Tier 2)")
+    # Tier 2 / runtime: stubs refreshed later, or machine output (board export).
+    if rel.startswith("../../workflow-artifacts/") or "/generated-data/" in rel:
+        print(f"SKIP {page['id']} (runtime)")
         continue
     ok = (config / rel).resolve().is_file()
     if not ok:

--- a/payload/.ai_infra/scripts/workflow/drift_checks.py
+++ b/payload/.ai_infra/scripts/workflow/drift_checks.py
@@ -257,7 +257,8 @@ def _parse_session_board_field(board_cell: str) -> tuple[str | None, str]:
     if not m:
         return None, ""
     item_id = m.group(1)
-    rest = (cell[: m.start()] + cell[m.end() :]).strip(" -–—|,;")
+    # Strip markdown backticks left when cell is like `PVTI_…` Done
+    rest = (cell[: m.start()] + cell[m.end() :]).strip(" -–—|,;`")
     return item_id, rest
 
 

--- a/tests/modules/workflow_drift/test_drift004b_session_board.py
+++ b/tests/modules/workflow_drift/test_drift004b_session_board.py
@@ -81,6 +81,14 @@ def test_parse_session_board_field() -> None:
     assert "progress" in st.lower()
 
 
+def test_parse_session_board_field_strips_markdown_backticks() -> None:
+    iid, st = _parse_session_board_field(
+        "`PVTI_lAHOBl46-84A9KZxzgzSsE0` Done"
+    )
+    assert iid == "PVTI_lAHOBl46-84A9KZxzgzSsE0"
+    assert st.lower() == "done"
+
+
 def test_drift004b_skips_without_snapshot(tmp_path: Path) -> None:
     root = _scaffold(
         tmp_path,


### PR DESCRIPTION
Skip runtime generated-data pages in smoke_marketplace (align with scaffold), strip markdown backticks from session-pointer Board status claims, and bump IMPLEMENTATION-STATUS test count to 943.

Author: Savin Ionuț Răzvan
GitHub-User: @SavinRazvan
Assisted-by: Cursor
Co-authored-by: Cursor <cursoragent@cursor.com>
