### PR TITLE
Align docs and canvases to 1062-test canon (DOC-CANVAS-ALIGN)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -36,6 +36,7 @@ Notes:
 | Board outbox (rate-limit) | `project queue` / `outbox status|flush`; EXIT_QUEUED=6; **58 mocked unit tests** | `project_outbox.py` + `project_atomics.py` / `project_cli.py` + `tests/modules/install/test_project_outbox.py` |
 | EA-001 residual thin CLI | `project_cli.py` facade (~660 LOC) + `project_parser.py` + `project_handlers.py` | PR close-remaining-ea-gaps |
 | Doc facts validate | DOC-001…008 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
+| Kit canvases | **12** files under `canvases/`; DOC-008 counts **11** `agent-*.canvas.tsx` (excludes concept hub `board-ssot-vs-kit.canvas.tsx`) | `canvases/` · `doc_facts_checks._canvas_paths` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |
 | Anchoring | session-pointer, change-index | `.local/.../current/` |
 | MCP tools + resources | 20 tools + 6 resources | `.ai_infra/mcp_servers/workflow_mcp/` |

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -202,7 +202,9 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07):** Verified `plugin.json` `description`, the Description row above, and README consumer sections (`What you get`, agent/skill/rule counts) against `IMPLEMENTATION-STATUS.md` on `main` — 633 tests (post DRIFT-005 slice), DOC-006 PASS, coverage scope 3588 stmts / 100% on `--cov=.ai_infra --cov=cursor_workflow`. No stale test or coverage numbers in marketplace-facing copy; feature counts (8 agents, 11 skills, 5 PR skills, 7 rules) match shipped inventory.
 
-**Listing copy refresh (2026-07-18 WORKSPACE-CLEAN):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633/692 lines above are archival only.
+**Listing copy refresh (2026-07-18 WORKSPACE-CLEAN):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md` at that date; agent/skill/rule counts unchanged (8 / 11 / 7). Historical 633/692 lines above are archival only.
+
+**Listing copy refresh (2026-07-19 DOC-CANVAS-ALIGN):** Re-verified against `IMPLEMENTATION-STATUS.md` — **1062** tests collected (1060 passed + 2 skipped), **6208** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts (8 / 11 / 7). Prior 931/5352 line superseded.
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Record: `.local/workflow-artifacts/release/smoke-consumer-smart-notes-2026-07-08.md`.
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -52,7 +52,7 @@ mas-workflow-kit-project-ssot/
 ├── cursor_workflow/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (GATES live in prepare.py)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (929)
+├── tests/                      Kit-dev only — full pytest suite (1062; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (empty in core kit)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -89,7 +89,7 @@ my-app/
 ├── .cursor/
 │   ├── agents/                     8 agents (from payload; incl. project-board)
 │   ├── rules/                      6 rules
-│   └── skills/                     10 canonical skills only (no repo-root skills/ merge)
+│   └── skills/                     11 canonical skills only (no repo-root skills/ merge)
 ├── .agents/skills/                 5 maintainer slash folders (+ audit-alignment stub)
 ├── .ai_infra/                      Slim bundle (manifest copy_ai_infra only)
 │   ├── scripts/pr|architecture|integration|workflow|install/
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (929), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `scripts/ci/`, `scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1062; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `scripts/ci/`, `scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type FlowMode = "slice" | "side";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   "project-board-collaboration.md · project-board-ssot/SKILL.md · .cursor/agents/*.md · agent-roster edges";
 

--- a/canvases/agent-enterprise-auditor.canvas.tsx
+++ b/canvases/agent-enterprise-auditor.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/enterprise-auditor.md · enterprise-architecture-audit/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/implementer.md · implementation-execution-loop/SKILL.md · project-board-ssot/SKILL.md § Continuation";
 

--- a/canvases/agent-integrator-mas-agent.canvas.tsx
+++ b/canvases/agent-integrator-mas-agent.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/integrator-mas-agent.md · mas-infrastructure-integration/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/agent-project-board.canvas.tsx
+++ b/canvases/agent-project-board.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/project-board.md · project-board-ssot/SKILL.md · ADR-006";
 

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -20,7 +20,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/*.md PEERS · audit-orchestration Phase 3 · project-board-ssot § Continuation · agent-roster edges";
 

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · RESEARCH_WORKFLOW.md";
 

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -16,7 +16,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES = "Aggregated from .cursor/agents/*.md";
 
 const AGENTS = [

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/test-runner.md · test-module-coverage/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES = ".cursor/agents/verifier.md · project-board-ssot/SKILL.md § Continuation";
 
 const GOALS = [

--- a/canvases/agent-workflow-drift-guard.canvas.tsx
+++ b/canvases/agent-workflow-drift-guard.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-18";
+const VERIFIED = "2026-07-19";
 const SOURCES =
   ".cursor/agents/workflow-drift-guard.md · workflow-drift-audit/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -141,7 +141,7 @@ const FOLLOWUP_SLICES = [
     items: [
       "Issue body, GraphQL errors, merge Notes warn",
       "set_item_status PVTI-only paths; outbox queue/flush",
-      "929 tests collected; drift validate green",
+      "1062 tests collected; drift validate green",
     ],
   },
   {
@@ -329,7 +329,7 @@ export default function BoardSsotVsKitCanvas() {
         <Text tone="secondary">
           Before/after comparison for mas-workflow-kit-project-ssot as of 2026-07-18.
           PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift residuals, EA-001/004,
-          and expanded tests (929 collected) are shipped on main.
+          and expanded tests (1062 collected) are shipped on main.
         </Text>
       </Stack>
 
@@ -616,7 +616,7 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">8 agent Anchors + continuation contract</Text>
               <Text size="small">ADR-008 + project-ssot-precedence overlay</Text>
               <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI on main (PR #3)</Text>
-              <Text size="small">929 tests collected; DRIFT validate P0=0 P1=0 P2=0</Text>
+              <Text size="small">1062 tests collected; DRIFT validate P0=0 P1=0 P2=0</Text>
               <Text size="small">STANDALONE decided — this repo is the product</Text>
               <Text size="small">
                 BOARD-PROMOTE: Draft→Issue via promote-to-issue / mention-pr auto


### PR DESCRIPTION
## Summary
- EA-001…004: repository-map **1062** + skills **11**; marketplace stamp **1062/6208**; board-ssot-vs-kit **1062**
- Agent canvases: `VERIFIED` → 2026-07-19; IMPLEMENTATION-STATUS notes DOC-008 (11) vs 12 files
- Evidence: `.local/workflow-artifacts/alignment/canvas-doc-matrix.md` (gitignored)

Board: `PVTI_lAHOBl46-84A9KZxzgzUfws`

## Test plan
- [x] `make doc-validate` (DOC-006=1062, DOC-008 PASS)
- [x] `drift validate` P0=0
- [ ] prepare.py gates on PR


Made with [Cursor](https://cursor.com)