### PR TITLE
docs: post-COV100 plan sync + project CLI doc inventory

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -34,7 +34,8 @@ Notes:
 | Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_recipes.py` / `project_cli.py` + skill § Notes |
 | Local continuity-index | Rolling ≥3-day UTC rows; board Notes = full card lifetime | `history/continuity-index.md` (+ exemplar) |
 | Board outbox (rate-limit) | `project queue` / `outbox status|flush`; EXIT_QUEUED=6; **58 mocked unit tests** | `project_outbox.py` + `project_atomics.py` / `project_cli.py` + `tests/modules/install/test_project_outbox.py` |
-| EA-001 residual thin CLI | `project_cli.py` facade (~660 LOC) + `project_parser.py` + `project_handlers.py` | PR close-remaining-ea-gaps |
+| Board CLI subcommands | **22** leaf commands — full table in ops doc | [project-board-collaboration.md](../operations/project-board-collaboration.md) § Project CLI subcommands |
+| EA-001 residual thin CLI | `project_cli.py` facade (~660 LOC) + parser/handlers split; board CLI modules under `.ai_infra/install/cursor_workflow/`: `project_cli.py`, `project_parser.py`, `project_handlers.py`, `project_atomics.py`, `gh_project_adapter.py`, `project_recipes.py`, `project_outbox.py` | PR #36 |
 | Doc facts validate | DOC-001…008 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | Kit canvases | **12** files under `canvases/`; DOC-008 counts **11** `agent-*.canvas.tsx` (excludes concept hub `board-ssot-vs-kit.canvas.tsx`) | `canvases/` · `doc_facts_checks._canvas_paths` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -54,7 +54,7 @@ mas-workflow-kit-project-ssot/
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
 ├── tests/                      Kit-dev only — full pytest suite (1062; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
-├── overlays/                   Optional product rules source (empty in core kit)
+├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc` in this product repo; consumer kit ships 6 rules via payload)
 ├── project-rules/              Deprecated alias → use overlays/rules/
 └── AGENTS.md                   Kit-dev router (consumers get AGENTS.stub.md)
 ```

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -71,6 +71,35 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 
 **Attribution:** Notes use `@owner.github_user/<agent> · <ISO-8601-UTC> · …` from each collaborator’s `github.collaboration.yaml` (CLI stamps UTC; do not hand-forge timestamps). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 
+## Project CLI subcommands (Pattern A)
+
+All subcommands registered in `.ai_infra/install/cursor_workflow/project_parser.py`. Prefer recipes (`claim`, `handoff`, `guide`) over atomics.
+
+| Subcommand | Purpose | Typical agent |
+|------------|---------|---------------|
+| `status` | Show `project_ssot` config from user_settings | Any (Entry) |
+| `list` | List project items (optional `--status` filter) | Any (Entry) |
+| `create` | Create a DraftIssue (`--template` = create-from-template) | project-board, implementer, integrator |
+| `create-from-template` | Create DraftIssue from slice/bug body template | project-board, implementer |
+| `set-status` | Set item Status from YAML option ids | Power use (prefer `handoff --to`) |
+| `set-field` | Set Priority, Size, or Estimate | project-board (triage), owning agent |
+| `get` | Get one project item by id | Any |
+| `append-notes` | Append attributed line under ## Notes | Any (Exit atomic) |
+| `claim` | Pattern A: In progress + Notes (+ Start date when configured) | implementer, integrator, researcher |
+| `mention-pr` | Notes with PR URL; auto-promote Draft when configured | implementer |
+| `promote-to-issue` | Convert DraftIssue → Issue (same `PVTI_`) | implementer (before shippable PR) |
+| `handoff` | Pattern A: Notes `next=@user/agent` + optional set-status | Any (Exit) |
+| `validate-item` | Check body sections / attribution / status (exit 5 on fail) | verifier, project-board |
+| `last` | Print last saved item_id (after create/claim) | Any (with `--last` recipes) |
+| `guide` | Print safe recipes using `--last` (no placeholder ids) | Any (Entry) |
+| `doctor` | Validate project_ssot config, templates, and gh project access | Maintainer / human |
+| `set-assignee` | Assign GitHub human user (Issue-backed items) | project-board, implementer |
+| `find-by-pr` | Resolve project item id from PR number or URL | verifier, merge.py |
+| `export` | Read-only board snapshot (never mutates Status) | workflow-drift-guard, ICC |
+| `queue` | Enqueue a board op to local outbox (EXIT_QUEUED=6) | Any (rate-limit fallback) |
+| `outbox status` | Outbox counts + GraphQL remaining | Any |
+| `outbox flush` | Apply pending outbox ops when quota allows | implementer, project-board |
+
 ## workflow-drift-guard specifically
 
 1. **Read board first** (`project status`, `list --status in_progress`) so dual-write checks compare board Status vs trackers.

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -23,7 +23,7 @@ Also customize `.ai_infra/scripts/pr/prepare.py` `GATES` once — document extra
 
 ## This directory in the kit repo
 
-- `overlays/rules/` — **empty** in core (placeholder for your project's overlay source)
+- `overlays/rules/` — ships **`project-ssot-precedence.mdc`** in **mas-workflow-kit-project-ssot** (product-only; copy at consumer install). Add more `*.mdc` for your app domain.
 - [`project-rules/`](../project-rules/) — same overlay concept (alias README for installs that prefer that name)
 
 ## Anti-patterns

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -71,6 +71,35 @@ Handoff: `item_id=<from create or --last> · @User/implementer · Status=a→b �
 
 **Attribution:** Notes use `@owner.github_user/<agent> · <ISO-8601-UTC> · …` from each collaborator’s `github.collaboration.yaml` (CLI stamps UTC; do not hand-forge timestamps). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
 
+## Project CLI subcommands (Pattern A)
+
+All subcommands registered in `.ai_infra/install/cursor_workflow/project_parser.py`. Prefer recipes (`claim`, `handoff`, `guide`) over atomics.
+
+| Subcommand | Purpose | Typical agent |
+|------------|---------|---------------|
+| `status` | Show `project_ssot` config from user_settings | Any (Entry) |
+| `list` | List project items (optional `--status` filter) | Any (Entry) |
+| `create` | Create a DraftIssue (`--template` = create-from-template) | project-board, implementer, integrator |
+| `create-from-template` | Create DraftIssue from slice/bug body template | project-board, implementer |
+| `set-status` | Set item Status from YAML option ids | Power use (prefer `handoff --to`) |
+| `set-field` | Set Priority, Size, or Estimate | project-board (triage), owning agent |
+| `get` | Get one project item by id | Any |
+| `append-notes` | Append attributed line under ## Notes | Any (Exit atomic) |
+| `claim` | Pattern A: In progress + Notes (+ Start date when configured) | implementer, integrator, researcher |
+| `mention-pr` | Notes with PR URL; auto-promote Draft when configured | implementer |
+| `promote-to-issue` | Convert DraftIssue → Issue (same `PVTI_`) | implementer (before shippable PR) |
+| `handoff` | Pattern A: Notes `next=@user/agent` + optional set-status | Any (Exit) |
+| `validate-item` | Check body sections / attribution / status (exit 5 on fail) | verifier, project-board |
+| `last` | Print last saved item_id (after create/claim) | Any (with `--last` recipes) |
+| `guide` | Print safe recipes using `--last` (no placeholder ids) | Any (Entry) |
+| `doctor` | Validate project_ssot config, templates, and gh project access | Maintainer / human |
+| `set-assignee` | Assign GitHub human user (Issue-backed items) | project-board, implementer |
+| `find-by-pr` | Resolve project item id from PR number or URL | verifier, merge.py |
+| `export` | Read-only board snapshot (never mutates Status) | workflow-drift-guard, ICC |
+| `queue` | Enqueue a board op to local outbox (EXIT_QUEUED=6) | Any (rate-limit fallback) |
+| `outbox status` | Outbox counts + GraphQL remaining | Any |
+| `outbox flush` | Apply pending outbox ops when quota allows | implementer, project-board |
+
 ## workflow-drift-guard specifically
 
 1. **Read board first** (`project status`, `list --status in_progress`) so dual-write checks compare board Status vs trackers.


### PR DESCRIPTION
## Summary
- Reconcile plan.md with closed EA-001-residual / AA-RES-001 / Live-smoke (EA-014)
- Add Pattern A project subcommand catalogue (EA-016)
- List all seven board CLI modules in IMPLEMENTATION-STATUS (EA-017)
- Fix overlays/repository-map wording for product SSOT precedence

## Test plan
- [x] doc validate 8/8 PASS
- [x] drift validate 11/11 PASS
- [x] Verifier Slice A 5/5