### PR TITLE
chore: live board smoke PASS evidence

### DIFF
--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -138,12 +138,15 @@ Stderr: `project <cmd>: FAIL — CODE=n · reason` or `QUEUED — …`.
 
 Optional end-to-end check against the real Project (skipped in default CI).
 
+**Last PASS:** 2026-07-19 — `make live-board-smoke` (evidence: `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`).
+
 1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes).
 2. Confirm: `python3 -m cursor_workflow project doctor` and `project status`.
-3. Run: `make live-board-smoke`  
-   (sets `PROJECT_SSOT_LIVE=1` and runs `tests/modules/install/test_project_cli_live.py`).
-4. If EXIT_QUEUED / rate-limit: `project outbox status` then `outbox flush` when GraphQL remaining recovers.
-5. Record PASS/FAIL under `.local/workflow-artifacts/release/` (local evidence only).
+3. Clear any other card **In progress** for the same assignee (claim enforces `one_in_progress_per_assignee`).
+4. Run: `make live-board-smoke`  
+   (sets `PROJECT_SSOT_LIVE=1` and runs `tests/modules/install/test_project_cli_live.py`; claim retries briefly for GraphQL eventual consistency).
+5. If EXIT_QUEUED / rate-limit: `project outbox status` then `outbox flush` when GraphQL remaining recovers.
+6. Record PASS/FAIL under `.local/workflow-artifacts/release/` (local evidence only).
 
 Do **not** add this to default PR gates — it mutates the live board.
 

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -138,12 +138,15 @@ Stderr: `project <cmd>: FAIL — CODE=n · reason` or `QUEUED — …`.
 
 Optional end-to-end check against the real Project (skipped in default CI).
 
+**Last PASS:** 2026-07-19 — `make live-board-smoke` (evidence: `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`).
+
 1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes).
 2. Confirm: `python3 -m cursor_workflow project doctor` and `project status`.
-3. Run: `make live-board-smoke`  
-   (sets `PROJECT_SSOT_LIVE=1` and runs `tests/modules/install/test_project_cli_live.py`).
-4. If EXIT_QUEUED / rate-limit: `project outbox status` then `outbox flush` when GraphQL remaining recovers.
-5. Record PASS/FAIL under `.local/workflow-artifacts/release/` (local evidence only).
+3. Clear any other card **In progress** for the same assignee (claim enforces `one_in_progress_per_assignee`).
+4. Run: `make live-board-smoke`  
+   (sets `PROJECT_SSOT_LIVE=1` and runs `tests/modules/install/test_project_cli_live.py`; claim retries briefly for GraphQL eventual consistency).
+5. If EXIT_QUEUED / rate-limit: `project outbox status` then `outbox flush` when GraphQL remaining recovers.
+6. Record PASS/FAIL under `.local/workflow-artifacts/release/` (local evidence only).
 
 Do **not** add this to default PR gates — it mutates the live board.
 

--- a/tests/modules/install/test_project_cli_live.py
+++ b/tests/modules/install/test_project_cli_live.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -69,7 +70,14 @@ def test_live_create_claim_handoff_validate_done() -> None:
             text="live claim",
             limit=100,
         )
-        assert project_cli.cmd_claim(claim) == 0
+        # GraphQL eventual consistency: newly created items may 404 briefly.
+        claim_rc = 1
+        for _ in range(8):
+            claim_rc = project_cli.cmd_claim(claim)
+            if claim_rc == 0:
+                break
+            time.sleep(1.5)
+        assert claim_rc == 0, f"claim failed after retries: exit={claim_rc} id={item_id}"
         handoff = argparse.Namespace(
             directory=REPO_ROOT,
             id=item_id,


### PR DESCRIPTION
## Summary
- `make live-board-smoke` **PASS** (2026-07-19) — EA-015
- Live test retries claim for GraphQL eventual consistency
- Ops doc stamp + one_in_progress_per_assignee note

## Test plan
- [x] `make live-board-smoke` exit 0
- [x] `project doctor` ok
- [x] Evidence under `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`