### PR TITLE
chore(ci): Node 24 action runtimes for Kit Quality

### DIFF
--- a/.github/workflows/kit-quality.yml
+++ b/.github/workflows/kit-quality.yml
@@ -13,9 +13,9 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` → `@v6` and `actions/setup-python@v5` → `@v6` in Kit Quality so action entrypoints use Node 24 (clears Node 20 deprecation warnings).
- Python version stays **3.12**.

Closes #42

## Test plan
- [x] CI Kit Quality green on this PR
- [x] Confirm Actions annotation no longer lists checkout@v4 / setup-python@v5 Node 20 deprecation

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: implementer
- Board-Item: PVTI_lAHOBl46-84A9KZxzgzUrm8


Made with [Cursor](https://cursor.com)