### PR TITLE
docs(canvases): sync hubs to docs/codebase + agents-artifacts-board

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -37,7 +37,7 @@ Notes:
 | Board CLI subcommands | **22** leaf commands — full table in ops doc | [project-board-collaboration.md](../operations/project-board-collaboration.md) § Project CLI subcommands |
 | EA-001 residual thin CLI | `project_cli.py` facade (~660 LOC) + parser/handlers split; board CLI modules under `.ai_infra/install/cursor_workflow/`: `project_cli.py`, `project_parser.py`, `project_handlers.py`, `project_atomics.py`, `gh_project_adapter.py`, `project_recipes.py`, `project_outbox.py` | PR #36 |
 | Doc facts validate | DOC-001…008 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
-| Kit canvases | **12** files under `canvases/`; DOC-008 counts **11** `agent-*.canvas.tsx` (excludes concept hub `board-ssot-vs-kit.canvas.tsx`) | `canvases/` · `doc_facts_checks._canvas_paths` |
+| Kit canvases | **13** files under `canvases/`; DOC-008 counts **11** roster/agent canvases (excludes concept hubs `board-ssot-vs-kit.canvas.tsx`, `agents-artifacts-board.canvas.tsx`) | `canvases/` · `doc_facts_checks._canvas_paths` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |
 | Anchoring | session-pointer, change-index | `.local/.../current/` |
 | MCP tools + resources | 20 tools + 6 resources | `.ai_infra/mcp_servers/workflow_mcp/` |

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -372,7 +372,7 @@ export default function AgentRelationsCanvas() {
           label={focus === "all" ? "Handoff edges" : "Outbound"}
         />
         <Stat
-          value={String(focus === "all" ? "4" : inbound)}
+          value={String(focus === "all" ? "5" : inbound)}
           label={focus === "all" ? "Lanes" : "Inbound"}
         />
       </Grid>

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -25,7 +25,7 @@ type SsotMode = "board" | "fallback";
 
 const VERIFIED = "2026-07-19";
 const SOURCES =
-  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · RESEARCH_WORKFLOW.md";
+  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · .agents/skills/RESEARCH_WORKFLOW.md";
 
 const GOALS = [
   "Adaptive Brief from chat, peer agent Notes/handoffs, or board research card",

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -119,6 +119,7 @@ const ARTIFACTS = [
 
 const PEERS = [
   ["Outbound", "next (generic)", "handoff format per card"],
+  ["Inbound", "implementer", "Handoff when tests/coverage needed before merge"],
   ["Inbound", "integrator-mas-agent", "Escalates coverage work to test-runner"],
 ];
 

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -1,0 +1,443 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  CollapsibleSection,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+  Toggle,
+  computeDAGLayout,
+  useCanvasState,
+  useHostTheme,
+} from "cursor/canvas";
+
+/**
+ * Whole-picture hub: agents ↔ GitHub Project board ↔ local artifacts.
+ * Not an agent-* canvas — excluded from DOC-008 roster scan (same as board-ssot-vs-kit).
+ */
+
+const VERIFIED = "2026-07-19";
+const SOURCES =
+  "ADR-008 · project-board-ssot/SKILL.md · project-board-collaboration.md · agent cards · HYGIENE post-COV100";
+
+const NODE_W = 118;
+const NODE_H = 36;
+
+type ViewMode = "loop" | "who-writes";
+
+const LOOP_NODES = [
+  { id: "yaml" },
+  { id: "entry" },
+  { id: "board" },
+  { id: "agent" },
+  { id: "code" },
+  { id: "artifacts" },
+  { id: "exit" },
+  { id: "pr" },
+];
+
+const LOOP_EDGES = [
+  { from: "yaml", to: "entry" },
+  { from: "entry", to: "board" },
+  { from: "board", to: "agent" },
+  { from: "agent", to: "code" },
+  { from: "agent", to: "artifacts" },
+  { from: "code", to: "pr" },
+  { from: "artifacts", to: "exit" },
+  { from: "exit", to: "board" },
+  { from: "pr", to: "board" },
+];
+
+const LOOP_LABELS: Record<string, string> = {
+  yaml: "project_ssot YAML",
+  entry: "Entry: project status",
+  board: "GitHub Project",
+  agent: "Cursor agent",
+  code: "Code + tests",
+  artifacts: ".local artifacts",
+  exit: "Exit: Status + Notes",
+  pr: "PR Pattern A",
+};
+
+const EDGE_HINTS: Record<string, string> = {
+  "yaml→entry": "enabled + board_only",
+  "entry→board": "list / claim",
+  "board→agent": "card body + Notes",
+  "agent→code": "implement / test",
+  "agent→artifacts": "audit · drift · verify",
+  "code→pr": "review → prepare → merge",
+  "artifacts→exit": "paths in Notes",
+  "exit→board": "only writable Status",
+  "pr→board": "mention-pr · merge Done",
+};
+
+const WHO_WRITES: string[][] = [
+  [
+    "project-board",
+    "Board Status / Notes / fields",
+    "(rarely) continuity Notes only",
+    "Triage Ready; handoff next=…",
+  ],
+  [
+    "implementer",
+    "claim · handoff · promote · mention-pr",
+    "session/plan/change-index (offline mirror)",
+    "Ships code; PR path",
+  ],
+  [
+    "test-runner",
+    "Notes on slice card",
+    "test-index · coverage-index · updates-log",
+    "Coverage evidence",
+  ],
+  [
+    "verifier",
+    "Done or In review + failure Notes",
+    "verification-*.md under workflow-artifacts",
+    "Claims vs evidence",
+  ],
+  [
+    "enterprise-auditor",
+    "Audit card Status + artifact paths in Notes",
+    "enterprise-architecture-audit/ · alignment/",
+    "Evidence-only — no product fixes",
+  ],
+  [
+    "workflow-drift-guard",
+    "Drift-pass card Done; remediation via Ready",
+    "drift/drift-audit.md · drift-todos.md",
+    "Never silent dual-write Status",
+  ],
+  [
+    "integrator-mas-agent",
+    "Integration card → Done",
+    "integrate validate evidence in Notes",
+    "Escalate product/coverage/arch",
+  ],
+  [
+    "researcher",
+    "Research card → Done",
+    "_research_results packs (gitignored)",
+    "No product PRs",
+  ],
+];
+
+const ARTIFACT_LANES: string[][] = [
+  [
+    "Board (writable SSOT)",
+    "GitHub Project Status · Notes · Linked PRs",
+    "All agents via cursor_workflow project …",
+    "ADR-008 board_only — only Status writer",
+  ],
+  [
+    "PR Pattern A (local evidence)",
+    ".local/workflow-artifacts/pr/{review,prep,merge}.md",
+    "review-pr · prepare-pr · merge-pr",
+    "Gates in prepare.py — not a second Status",
+  ],
+  [
+    "Audit / alignment",
+    ".local/workflow-artifacts/enterprise-architecture-audit/",
+    "enterprise-auditor",
+    "Actions backlog for implementer",
+  ],
+  [
+    "Drift",
+    ".local/workflow-artifacts/drift/",
+    "workflow-drift-guard",
+    "DRIFT-009 watches dual-write",
+  ],
+  [
+    "Release / smoke",
+    ".local/workflow-artifacts/release/",
+    "maintainer · live-board-smoke",
+    "Opt-in PROJECT_SSOT_LIVE",
+  ],
+  [
+    "Offline fallback trackers",
+    ".local/index-and-planning/current/*",
+    "When board off / unavailable",
+    "Never compete with board Status",
+  ],
+  [
+    "Outbox (rate-limit buffer)",
+    ".local/generated-data/board-outbox.jsonl",
+    "Any agent on EXIT_QUEUED (6)",
+    "Flush later — not a second SSOT",
+  ],
+];
+
+const HAPPY_PATH = [
+  "1. Entry — project status → list Ready / In progress",
+  "2. claim --last --agent <name> (Start date when configured)",
+  "3. Work — code/tests and/or write .local artifacts",
+  "4. Exit — handoff --to in_review|done + Notes (@user/agent · UTC · …)",
+  "5. PR — mention-pr; merge.py can set card Done",
+];
+
+function LoopDag({
+  tokens,
+}: {
+  tokens: ReturnType<typeof useHostTheme>["tokens"];
+}) {
+  const layout = computeDAGLayout({
+    nodes: LOOP_NODES,
+    edges: LOOP_EDGES,
+    direction: "horizontal",
+    nodeWidth: NODE_W,
+    nodeHeight: NODE_H,
+    rankGap: 36,
+    nodeGap: 16,
+  });
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 980 }}
+    >
+      {layout.edges.map((e, i) => {
+        const label = EDGE_HINTS[`${e.from}→${e.to}`] ?? "";
+        const mx = (e.sourceX + e.targetX) / 2;
+        const my = (e.sourceY + e.targetY) / 2 - 8;
+        return (
+          <g key={`e-${e.from}-${e.to}-${i}`}>
+            <path
+              d={`M ${e.sourceX} ${e.sourceY} C ${e.sourceX + 18} ${e.sourceY}, ${e.targetX - 18} ${e.targetY}, ${e.targetX} ${e.targetY}`}
+              fill="none"
+              stroke={
+                e.isBackEdge
+                  ? tokens.stroke.tertiary
+                  : tokens.stroke.secondary
+              }
+              strokeWidth={1.25}
+              strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+            />
+            {label ? (
+              <text
+                x={mx}
+                y={my}
+                textAnchor="middle"
+                fill={tokens.text.secondary}
+                fontSize={9}
+              >
+                {label}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+      {layout.nodes.map((n) => {
+        const accent =
+          n.id === "board" || n.id === "exit" || n.id === "entry";
+        return (
+          <g key={n.id}>
+            <rect
+              x={n.x}
+              y={n.y}
+              width={NODE_W}
+              height={NODE_H}
+              rx={6}
+              fill={
+                accent ? tokens.fill.secondary : tokens.fill.tertiary
+              }
+              stroke={
+                n.id === "board" ? tokens.accent.primary : tokens.stroke.primary
+              }
+              strokeWidth={n.id === "board" ? 1.75 : 1}
+            />
+            <text
+              x={n.x + NODE_W / 2}
+              y={n.y + NODE_H / 2 + 4}
+              textAnchor="middle"
+              fill={tokens.text.primary}
+              fontSize={10}
+              fontWeight={n.id === "board" ? 600 : 400}
+            >
+              {LOOP_LABELS[n.id] ?? n.id}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function ThreePlanes() {
+  const planes: {
+    title: string;
+    tone: string;
+    body: string;
+    highlight: boolean;
+  }[] = [
+    {
+      title: "Board",
+      tone: "SSOT",
+      body: "GitHub Project Status + Notes. Pattern A: claim · handoff · promote · mention-pr.",
+      highlight: true,
+    },
+    {
+      title: "Agents",
+      tone: "Actors",
+      body: "8 Cursor agents. Entry reads board; Exit updates Status. Parent Task-delegates.",
+      highlight: false,
+    },
+    {
+      title: "Artifacts",
+      tone: "Evidence",
+      body: ".local/workflow-artifacts + offline trackers. Never a second Status writer under board_only.",
+      highlight: false,
+    },
+  ];
+  return (
+    <Grid columns={3} gap={12}>
+      {planes.map((p) => (
+        <div key={p.title}>
+          <Card>
+            <CardHeader
+              trailing={
+                <Pill size="sm" tone="neutral" active={p.highlight}>
+                  {p.tone}
+                </Pill>
+              }
+            >
+              {p.title}
+            </CardHeader>
+            <CardBody>
+              <Text size="small" tone="secondary">
+                {p.body}
+              </Text>
+            </CardBody>
+          </Card>
+        </div>
+      ))}
+    </Grid>
+  );
+}
+
+export default function AgentsArtifactsBoardCanvas() {
+  const { tokens } = useHostTheme();
+  const [mode, setMode] = useCanvasState<ViewMode>("viewMode", "loop");
+
+  return (
+    <Stack gap={20} style={{ padding: 20, maxWidth: 1040 }}>
+      <Stack gap={6}>
+        <H1>Agents · artifacts · board</H1>
+        <Text tone="secondary">
+          Whole picture for board_only SSOT — who writes Status, who writes
+          evidence, and how they meet on Exit.
+        </Text>
+        <Row gap={8} style={{ flexWrap: "wrap" }}>
+          <Pill size="sm" tone="neutral" active>
+            ADR-008
+          </Pill>
+          <Pill size="sm" tone="neutral">
+            8 agents
+          </Pill>
+          <Pill size="sm" tone="neutral">
+            Pattern A CLI
+          </Pill>
+          <Text size="small" tone="tertiary">
+            Verified {VERIFIED}
+          </Text>
+        </Row>
+      </Stack>
+
+      <Grid columns={4} gap={12}>
+        <Stat value="Board" label="Only writable Status" />
+        <Stat value=".local" label="Evidence / fallback" />
+        <Stat value="Entry" label="project status" />
+        <Stat value="Exit" label="Status + Notes" />
+      </Grid>
+
+      <Callout tone="info" title="Read order">
+        Open this hub first for orientation. Detail hubs: agent-board-collaboration
+        (recipes), agent-relations (handoff graph), board-ssot-vs-kit (classic vs
+        shipped), per-agent canvases for deep dive.
+      </Callout>
+
+      <ThreePlanes />
+
+      <Divider />
+
+      <Row gap={12} style={{ alignItems: "center", flexWrap: "wrap" }}>
+        <H2>Control loop</H2>
+        <Text size="small" tone="secondary">
+          {mode === "who-writes" ? "Who writes what" : "DAG loop"}
+        </Text>
+        <Toggle
+          checked={mode === "who-writes"}
+          onChange={(on) => setMode(on ? "who-writes" : "loop")}
+        />
+      </Row>
+
+      {mode === "loop" ? (
+        <Stack gap={10}>
+          <Text size="small" tone="secondary">
+            Board is the hub: Entry pulls work, Exit pushes Status. Artifacts and
+            PRs feed Notes — they do not replace Status.
+          </Text>
+          <LoopDag tokens={tokens} />
+          <Stack gap={4}>
+            {HAPPY_PATH.map((line) => (
+              <div key={line}>
+                <Text size="small">{line}</Text>
+              </div>
+            ))}
+          </Stack>
+        </Stack>
+      ) : (
+        <Table
+          headers={["Agent", "Writes on board", "Writes under .local", "Role"]}
+          rows={WHO_WRITES}
+          columnAlign={["left", "left", "left", "left"]}
+        />
+      )}
+
+      <Divider />
+
+      <H2>Artifact lanes</H2>
+      <Text size="small" tone="secondary">
+        Each lane has one job. Mixing Status into trackers under board_only is
+        dual-write (DRIFT-009).
+      </Text>
+      <Spacer height={8} />
+      <Table
+        headers={["Lane", "Path / surface", "Primary writer", "Rule"]}
+        rows={ARTIFACT_LANES}
+        columnAlign={["left", "left", "left", "left"]}
+      />
+
+      <CollapsibleSection title="Side paths (audit / drift)">
+        <Stack gap={8}>
+          <Text size="small">
+            enterprise-auditor → .local audit artifacts → Notes paths →
+            implementer Ready cards. Does not mutate product code during audit.
+          </Text>
+          <Text size="small">
+            implementer makes drift-validate → P0/P1 → workflow-drift-guard writes
+            drift artifacts → remediation via Notes/Ready (never silent tracker
+            Status).
+          </Text>
+          <Text size="small">
+            Rate-limit EXIT_QUEUED (6) → board-outbox.jsonl → project outbox flush
+            when GraphQL budget recovers.
+          </Text>
+        </Stack>
+      </CollapsibleSection>
+
+      <Text size="small" tone="tertiary">
+        Sources: {SOURCES}
+      </Text>
+    </Stack>
+  );
+}

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -26,6 +26,8 @@ import {
 
 type Mode = "classic" | "shipped" | "compare";
 
+const VERIFIED = "2026-07-19";
+
 const CLASSIC_NODES = [
   { id: "agent" },
   { id: "session" },
@@ -141,7 +143,7 @@ const FOLLOWUP_SLICES = [
     items: [
       "Issue body, GraphQL errors, merge Notes warn",
       "set_item_status PVTI-only paths; outbox queue/flush",
-      "1062 tests collected; drift validate green",
+      "1062 tests collected; COV-100 6208 stmts / 100%; drift validate green",
     ],
   },
   {
@@ -327,7 +329,7 @@ export default function BoardSsotVsKitCanvas() {
       <Stack gap={8}>
         <H1>MAS Workflow Kit → Board SSOT (shipped)</H1>
         <Text tone="secondary">
-          Before/after comparison for mas-workflow-kit-project-ssot as of 2026-07-18.
+          Before/after comparison for mas-workflow-kit-project-ssot as of {VERIFIED}.
           PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift residuals, EA-001/004,
           and expanded tests (1062 collected) are shipped on main.
         </Text>
@@ -494,7 +496,7 @@ export default function BoardSsotVsKitCanvas() {
 
       <Divider />
 
-      <H2>project CLI — 21 subcommands (shipped)</H2>
+      <H2>project CLI — 22 leaf subcommands (shipped)</H2>
       <Callout tone="info" title="Module split (EA-001 shipped)">
         Dispatcher: project_cli.py · atomics: project_atomics.py · GraphQL adapter:
         gh_project_adapter.py · Pattern A recipes: project_recipes.py · rate-limit
@@ -612,11 +614,17 @@ export default function BoardSsotVsKitCanvas() {
           <CardBody>
             <Stack gap={4}>
               <Text size="small">project_ssot + board_only in collab YAML</Text>
-              <Text size="small">cursor_workflow project CLI (21 subcommands)</Text>
+              <Text size="small">
+                cursor_workflow project CLI (22 leaf subcommands; outbox status +
+                flush counted separately)
+              </Text>
               <Text size="small">8 agent Anchors + continuation contract</Text>
               <Text size="small">ADR-008 + project-ssot-precedence overlay</Text>
               <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI on main (PR #3)</Text>
-              <Text size="small">1062 tests collected; DRIFT validate P0=0 P1=0 P2=0</Text>
+              <Text size="small">
+                1062 tests collected; COV-100 6208 stmts / 100%; DRIFT validate
+                P0=0 P1=0 P2=0
+              </Text>
               <Text size="small">STANDALONE decided — this repo is the product</Text>
               <Text size="small">
                 BOARD-PROMOTE: Draft→Issue via promote-to-issue / mention-pr auto
@@ -652,7 +660,7 @@ export default function BoardSsotVsKitCanvas() {
 
       <Text size="small" tone="tertiary">
         Source: HANDOFF §1 · ADR-008 · STANDALONE 2026-07-18 · PR #2/#3 merged ·
-        drift validate green · 2026-07-18
+        drift validate green · verified {VERIFIED} · 1062 tests · COV-100 6208 stmts
       </Text>
     </Stack>
   );


### PR DESCRIPTION
## Summary
- Audit all 13 canvases vs IMPLEMENTATION-STATUS / agent cards / board ops docs
- Fix P1: `board-ssot-vs-kit` 21→**22 leaf** subcommands + VERIFIED 2026-07-19 + COV-100 stamp
- Fix P2: relations Lanes 4→5; researcher SOURCES path; test-runner inbound implementer peer
- Ship new whole-picture hub `agents-artifacts-board.canvas.tsx`
- IMPLEMENTATION-STATUS: 13 canvases / DOC-008 still 11

## Test plan
- [x] `python3 -m cursor_workflow doc validate` (DOC-008 PASS, 8/8)
- [x] `python3 -m cursor_workflow drift validate` (P0=0 P1=0)
- [x] verifier 8/8 claims on branch
- [ ] Open `canvases/agents-artifacts-board.canvas.tsx` beside chat


Made with [Cursor](https://cursor.com)