### PR TITLE
Deprecate HTML Control Center (prefer board SSOT + Canvas)

### DIFF
--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -51,7 +51,7 @@ flowchart LR
 |-------|-------|--------------|---------|
 | **Cursor contract** | `.cursor/`, `.agents/`, `AGENTS.md` | Yes | Agents, skills, rules, MCP config |
 | **Infrastructure** | `.ai_infra/`, `cursor_workflow/` | No | Scripts, docs, templates, optional MCP server |
-| **Runtime** | `.local/`, `.venv` | No | Trackers, dashboards, user settings (gitignored) |
+| **Runtime** | `.local/`, `.venv` | No | Trackers, deprecated HTML dashboards, user settings (gitignored) |
 
 **Important:** Enabling the plugin does **not** replace activate. Open **your app folder** in Cursor, then run **`/workflow-activate`** once (safe to re-run — idempotent).
 
@@ -137,7 +137,7 @@ your-project/
 │   ├── templates/local-workspace|user-settings|agent-integration/
 │   ├── mcp_servers/workflow_mcp/  # with_mcp profile
 │   └── workflows/
-├── .local/                        # trackers, dashboards (gitignored)
+├── .local/                        # trackers, deprecated HTML dashboards (gitignored)
 │   ├── index-and-planning/current/
 │   ├── user_settings/             # YOU edit these
 │   └── agents-control-center/
@@ -157,7 +157,7 @@ your-project/
 | Where | Use for |
 |-------|---------|
 | **Agent chat** (`/` menu) | Plugin install, activate, subagents, skills, PR slash workflow |
-| **Terminal** | `python3 -m cursor_workflow …`, pytest, serving dashboards |
+| **Terminal** | `python3 -m cursor_workflow …`, pytest, serving deprecated dashboards |
 
 ### Agent chat commands
 
@@ -191,11 +191,12 @@ Full list: [consumer-quickstart.md](consumer-quickstart.md) § Terminal commands
 
 ---
 
-## 5. Control Center dashboards
+## 5. Control Center dashboards (deprecated)
 
-Local browser UI for trackers and docs under `.local/agents-control-center/`.
+> **Deprecated (2026-07-19).** Prefer the **GitHub Project board** (`python3 -m cursor_workflow project status`)
+> and **Ctrl+Shift+P → Open Canvas**. HTML under `.local/agents-control-center/` is offline fallback only (ADR-008).
 
-**Do not open HTML via `file://`** — browsers block fetch. From project root:
+Legacy browser UI still ships on activate. **Do not open HTML via `file://`**. From project root:
 
 ```bash
 cd ~/Projects/my-app
@@ -265,7 +266,7 @@ Every session:
 2. Board card Status/Notes — attribution `@user/agent · <ISO-8601-UTC> · …` (CLI stamps); local `history/continuity-index.md` rolls ≥3 days (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
 3. Rate-limit: EXIT_QUEUED → `python3 -m cursor_workflow project outbox flush` after quota recovers (`project_ssot.outbox` in collaboration YAML)
 4. **`/implementer`** (or specialist agent from §6)
-5. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
+5. Optional: [Control Center dashboards (deprecated)](#5-control-center-dashboards-deprecated) — `http.server` + full URL in §5
 
 Token contract: [token-efficiency.md](token-efficiency.md) · Layout: [local-workspace-layout.md](local-workspace-layout.md).
 

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -34,7 +34,7 @@ Install **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) 
 
 **Healthy install?** `python3 -m cursor_workflow health`
 
-> **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards](#control-center-dashboards) · [All CLI commands](#terminal-commands-cheat-sheet)
+> **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards (deprecated)](#control-center-dashboards-deprecated) · [All CLI commands](#terminal-commands-cheat-sheet)
 
 ### Step 1 detail — install plugin from GitHub
 
@@ -157,7 +157,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 2. Claim/update the board card (Status + Notes `@user/agent · <ISO-8601-UTC> · …`); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`; optional `history/continuity-index.md` (≥3-day local rollup)
 3. If board writes hit GraphQL rate-limit (EXIT_QUEUED): `project outbox status` / later `outbox flush` — enable `project_ssot.outbox` defaults after activate
 4. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
-5. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
+5. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
 
 **Add your own agent/skill/MCP:** **`/integrator-mas-agent`** + **`/mas-infrastructure-integration`**
 
@@ -168,7 +168,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 | Where | Use for | Examples |
 |-------|---------|----------|
 | **Agent chat** | Plugin install, subagents, skills, slash workflows | `/add-plugin …`, `/workflow-activate`, `/implementer`, `/review-pr` |
-| **Terminal** | Validation, health, gates, serving dashboards | `python3 -m cursor_workflow health`, `http.server` → [dashboard URL](#control-center-dashboards) |
+| **Terminal** | Validation, health, gates, serving deprecated dashboards | `python3 -m cursor_workflow health`, `http.server` → [dashboard URL](#control-center-dashboards-deprecated) |
 
 **Rule:** `/add-plugin` and `/workflow-activate` are **chat commands** — do not paste them into bash.
 
@@ -216,9 +216,14 @@ Commit trailer preview: `python3 -m cursor_workflow contributors commit-trailers
 
 ---
 
-## Control Center dashboards
+## Control Center dashboards (deprecated)
 
-Local HTML dashboards browse your trackers and kit docs in the browser. They ship under `.local/agents-control-center/` on activate.
+> **Deprecated (2026-07-19).** Prefer the **GitHub Project board** when `project_ssot.enabled`
+> (`python3 -m cursor_workflow project status`) and **Ctrl+Shift+P → Open Canvas** for kit
+> visualizations. Local HTML under `.local/agents-control-center/` remains an **offline**
+> markdown/tracker browser only; it is not the backlog or status SSOT (ADR-008).
+
+Local HTML pages still ship on activate for legacy/offline use.
 
 **Do not** open HTML via `file://` — browsers block `fetch()`.
 
@@ -233,23 +238,18 @@ python3 -m http.server 8000
 
 *(Port busy? Use `8001` — swap the port in every URL below.)*
 
-Leave the terminal open while browsing. More pages:
-
 | Page | URL |
 |------|-----|
 | **Home** | http://localhost:8000/.local/agents-control-center/dashboards/index.html |
 | **Implementation Control Center** | http://localhost:8000/.local/agents-control-center/dashboards/implementation-control-center.html |
 | **Module audit** | http://localhost:8000/.local/agents-control-center/audits/module-audit.html |
 
-Use the top **navigator** to switch between Home, Control Center, and Module audit.
+### What still works (offline only)
 
-### What you can do there
+- **Control Center** — sidebar tabs over local markdown (`session-pointer`, `plan`, …) and read-only board export snapshot
+- **Module audit** — workflow module map HTML when exported
 
-- **Control Center** — pick a page from the sidebar (`session-pointer`, `plan`, `work-tracker`, workflow docs, …); markdown renders with tables and lists
-- **Home** — links to trackers and quick paths
-- **Module audit** — workflow module map (when exported)
-
-### Refresh dashboards after a kit update
+### Refresh after a kit update
 
 Re-run activate (chat or terminal):
 

--- a/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/.ai_infra/docs/operations/local-workspace-layout.md
@@ -46,7 +46,7 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | `index-and-planning/current/` | Live trackers: `plan.md`, `work-tracker.md`, `session-pointer.md`, `change-index.md`, tests, `architecture.md` |
 | `index-and-planning/history/` | `updates-log.md` (UTC-prefixed lines), `continuity-index.md` (rolling ≥3-day board↔artifact index) |
 | `index-and-planning/audits/` | Local governance audit snapshots |
-| `agents-control-center/` | Dashboard config (`config/pages.json`) and optional HTML |
+| `agents-control-center/` | **Deprecated** HTML dashboards + `config/pages.json` (offline tracker browser; prefer board SSOT) |
 | `workflow-artifacts/pr/` | `review.md`, `prep.md`, `merge.md` |
 | `workflow-artifacts/alignment/` | `alignment-audit.md`, `alignment-todos.md` |
 | `workflow-artifacts/enterprise-architecture-audit/` | Full audit report + actions |
@@ -74,14 +74,14 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 |--------|----------|
 | `.ai_infra/scripts/pr/check_testing_artifacts.py` | Default `--planning-dir`: `.local/index-and-planning/current` |
 | `.ai_infra/scripts/pr/review.py`, `prepare.py`, `merge.py` | Artifacts via `local_workflow_paths.py` |
-| `.ai_infra/scripts/install/scaffold.py` | Tier 1: exemplar trackers (if missing), artifact buckets, README stubs, `AGENTS.md` (if missing); kit-managed dashboards + `pages.json` **always refreshed** on scaffold/activate |
+| `.ai_infra/scripts/install/scaffold.py` | Tier 1: exemplar trackers (if missing), artifact buckets, README stubs, `AGENTS.md` (if missing); kit-managed **deprecated** dashboards + `pages.json` **always refreshed** on scaffold/activate |
 | `.ai_infra/scripts/ci/seed_kit_workspace.py` | CI fixture seed; same bucket set as scaffold |
 
 ## Templates (versioned in git)
 
 Copy from **`.ai_infra/templates/local-workspace/`** into `.local/` at scaffold (`exemplars/`, `artifact-stubs/`). Dashboard HTML, assets, `module-audit.html`, and `pages.json` refresh from templates on every scaffold/activate (idempotent re-activate included).
 
-**Implementation Control Center:** manifest tab **Project Board** (`format: project-board-snapshot`) renders `.local/generated-data/project-board-snapshot.json` via `local-board-snapshot.js`. Refresh snapshot with `python3 -m cursor_workflow project export`. The panel is **read-only** — it never writes GitHub Project Status.
+**Implementation Control Center (deprecated HTML):** manifest tab **Project Board** (`format: project-board-snapshot`) renders `.local/generated-data/project-board-snapshot.json` via `local-board-snapshot.js`. Refresh snapshot with `python3 -m cursor_workflow project export`. The panel is **read-only** — it never writes GitHub Project Status. Prefer the live Project board when `project_ssot.enabled`.
 
 **User settings:** copy from **`.ai_infra/templates/user-settings/exemplars/`** into **`.local/user_settings/`** (`github.collaboration.yaml`, `mcp.agents.yaml`). See [RENDERED-EXAMPLES.md](../../templates/user-settings/RENDERED-EXAMPLES.md).
 

--- a/.ai_infra/docs/operations/workflow-complete.md
+++ b/.ai_infra/docs/operations/workflow-complete.md
@@ -89,7 +89,7 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 2. **`.local/index-and-planning/current/work-tracker.md`** — resolve task status; keep one primary `in_progress`.
 3. **`test-plan.md` / `test-index.md`** — update when tests or ownership changed.
 4. **`coverage-index.md`** — regenerate after any coverage run that matters.
-5. **`implementation-control-center.html`** — under `.local/agents-control-center/dashboards/`; if you add a tracker, update **`../config/pages.json`**.
+5. **`implementation-control-center.html` (deprecated)** — under `.local/agents-control-center/dashboards/`; offline tracker browser only. Prefer board SSOT when enabled. If you still add a tracker tab, update **`../config/pages.json`**.
 6. **`module-audit.html`** — touch only when deliberately refreshing a deep module audit export.
 7. **`make drift-validate`** — hand off to **`workflow-drift-guard`** on P0/P1.
 

--- a/.ai_infra/scripts/install/scaffold.py
+++ b/.ai_infra/scripts/install/scaffold.py
@@ -68,6 +68,8 @@ AUDIT_EXEMPLARS = (
     "agent-governance-todos.md",
 )
 DASHBOARD_HTML = ("index.html", "implementation-control-center.html")
+# Deprecated HTML ICC (2026-07-19): still refreshed on activate for offline fallback;
+# prefer GitHub Project board (ADR-008) + Cursor Open Canvas.
 DASHBOARD_ASSETS = (
     "site-nav.js",
     "local-shell.css",

--- a/.ai_infra/templates/local-workspace/README.md
+++ b/.ai_infra/templates/local-workspace/README.md
@@ -16,6 +16,10 @@ Notes:
 
 Scaffold copies exemplars into `.local/index-and-planning/current/`, `pages.json` into `.local/agents-control-center/config/`, README stubs into `workflow-artifacts/*`, and optional dashboards.
 
+> **Deprecated (2026-07-19):** HTML dashboards under `agents-control-center/dashboards/` are **maintenance-only**.
+> Prefer the **GitHub Project board** (`project_ssot` / ADR-008) for backlog and status, and **Cursor → Open Canvas**
+> for kit visualizations. Templates still refresh on activate so existing offline browsers keep working.
+
 | Template | Target |
 |----------|--------|
 | `exemplars/*.md` | `.local/index-and-planning/current/` |

--- a/.ai_infra/templates/local-workspace/implementation-control-center.html
+++ b/.ai_infra/templates/local-workspace/implementation-control-center.html
@@ -9,6 +9,7 @@ Depends On:
  - ../config/pages.json (after copy: `.local/agents-control-center/config/pages.json`)
  - Paths declared inside pages.json (`.local/...` and `docs/...`)
 Notes:
+ - Deprecated 2026-07-19: prefer GitHub Project board (ADR-008) + Cursor Open Canvas.
  - Page list is manifest-driven; edit `pages.json` instead of hardcoding PAGES here.
  - Default manifest includes **Strategy index** tab (`.ai_infra/docs/roadmap/README.md`); product plan tabs belong in consumer overlays.
 -->
@@ -17,11 +18,17 @@ Notes:
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Implementation Control Center</title>
+  <title>Implementation Control Center (deprecated)</title>
   <link rel="stylesheet" href="local-shell.css" />
 </head>
 <body>
   <div class="local-content">
+    <aside class="local-deprecation" role="status">
+      <strong>Deprecated.</strong>
+      When <code>project_ssot.enabled</code>, the GitHub Project is the writable SSOT — not this HTML UI.
+      Use <code>python3 -m cursor_workflow project status</code> / board recipes; open kit canvases via
+      <strong>Ctrl+Shift+P → Open Canvas</strong>. This page is an offline markdown browser only.
+    </aside>
     <section class="local-surface local-page-head">
       <h1>Implementation Control Center</h1>
       <p class="local-sub">Markdown-backed workspace: pick a tab below. Paths come from <code>../config/pages.json</code> (relative to this file).</p>

--- a/.ai_infra/templates/local-workspace/index.html
+++ b/.ai_infra/templates/local-workspace/index.html
@@ -1,13 +1,14 @@
 <!--
 File: index.html
-Path: docs/templates/local-workspace/index.html
-Role: Landing page for local HTML tools — copy to `.local/agents-control-center/dashboards/index.html`.
+Path: .ai_infra/templates/local-workspace/index.html
+Role: DEPRECATED landing page for local HTML tools — copy to `.local/agents-control-center/dashboards/index.html`.
 Used By:
- - Browser entry when serving repo root or `.local/` over HTTP
+ - Browser entry when serving repo root or `.local/` over HTTP (legacy / offline fallback)
 Depends On:
  - local-shell.css, site-nav.js
  - ./implementation-control-center.html, ../audits/module-audit.html (relative targets after copy)
 Notes:
+ - Deprecated 2026-07-19: prefer GitHub Project board (ADR-008) + Cursor Open Canvas.
  - Keep links relative to `dashboards/` so they work on any static server.
 -->
 <!DOCTYPE html>
@@ -15,11 +16,18 @@ Notes:
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Local control center</title>
+  <title>Local control center (deprecated)</title>
   <link rel="stylesheet" href="local-shell.css" />
 </head>
 <body>
   <div class="local-content local-content--narrow">
+    <aside class="local-deprecation" role="status">
+      <strong>Deprecated.</strong>
+      Prefer the <strong>GitHub Project board</strong>
+      (<code>python3 -m cursor_workflow project status</code>) for backlog/status,
+      and <strong>Ctrl+Shift+P → Open Canvas</strong> for kit visualizations.
+      These HTML pages remain as an offline tracker browser only.
+    </aside>
     <section class="local-surface local-page-head">
       <h1>Local control center</h1>
       <p class="local-sub">Gitignored workspace under <code>.local/agents-control-center/</code> — use the <strong>Navigator</strong> above to switch pages, or open a tool below.</p>

--- a/.ai_infra/templates/local-workspace/local-shell.css
+++ b/.ai_infra/templates/local-workspace/local-shell.css
@@ -169,6 +169,25 @@ a.local-card .local-card-desc {
   line-height: 1.5;
 }
 
+/* Deprecation banner (ICC HTML — prefer board SSOT + Cursor Open Canvas) */
+.local-deprecation {
+  margin: 0 0 18px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid #8a6a1a;
+  background: #2a2208;
+  color: #f0e2b0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.local-deprecation strong {
+  color: #ffd666;
+}
+.local-deprecation code {
+  background: #1a1505;
+  color: #ffe9a0;
+}
+
 /* Inline / panel code */
 code,
 .local-panel code {

--- a/.ai_infra/templates/local-workspace/site-nav.js
+++ b/.ai_infra/templates/local-workspace/site-nav.js
@@ -8,6 +8,7 @@
  * Depends On:
  *  - <html data-local-site="dashboards|audits" data-local-active="home|control|audit">
  * Notes:
+ *  - Deprecated 2026-07-19 with the HTML dashboards (prefer board SSOT + Open Canvas).
  *  - Add new pages here + update data-local-active values on each HTML shell.
  */
 (function () {
@@ -112,11 +113,11 @@
 
   const title = document.createElement("span");
   title.className = "local-site-nav-title";
-  title.textContent = "Navigator";
+  title.textContent = "Navigator (deprecated)";
 
   const count = document.createElement("span");
   count.className = "local-site-nav-count";
-  count.textContent = "3 HTML pages";
+  count.textContent = "3 HTML pages · offline fallback";
 
   inner.appendChild(title);
   inner.appendChild(count);

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -51,7 +51,7 @@ flowchart LR
 |-------|-------|--------------|---------|
 | **Cursor contract** | `.cursor/`, `.agents/`, `AGENTS.md` | Yes | Agents, skills, rules, MCP config |
 | **Infrastructure** | `.ai_infra/`, `cursor_workflow/` | No | Scripts, docs, templates, optional MCP server |
-| **Runtime** | `.local/`, `.venv` | No | Trackers, dashboards, user settings (gitignored) |
+| **Runtime** | `.local/`, `.venv` | No | Trackers, deprecated HTML dashboards, user settings (gitignored) |
 
 **Important:** Enabling the plugin does **not** replace activate. Open **your app folder** in Cursor, then run **`/workflow-activate`** once (safe to re-run — idempotent).
 
@@ -137,7 +137,7 @@ your-project/
 │   ├── templates/local-workspace|user-settings|agent-integration/
 │   ├── mcp_servers/workflow_mcp/  # with_mcp profile
 │   └── workflows/
-├── .local/                        # trackers, dashboards (gitignored)
+├── .local/                        # trackers, deprecated HTML dashboards (gitignored)
 │   ├── index-and-planning/current/
 │   ├── user_settings/             # YOU edit these
 │   └── agents-control-center/
@@ -157,7 +157,7 @@ your-project/
 | Where | Use for |
 |-------|---------|
 | **Agent chat** (`/` menu) | Plugin install, activate, subagents, skills, PR slash workflow |
-| **Terminal** | `python3 -m cursor_workflow …`, pytest, serving dashboards |
+| **Terminal** | `python3 -m cursor_workflow …`, pytest, serving deprecated dashboards |
 
 ### Agent chat commands
 
@@ -191,11 +191,12 @@ Full list: [consumer-quickstart.md](consumer-quickstart.md) § Terminal commands
 
 ---
 
-## 5. Control Center dashboards
+## 5. Control Center dashboards (deprecated)
 
-Local browser UI for trackers and docs under `.local/agents-control-center/`.
+> **Deprecated (2026-07-19).** Prefer the **GitHub Project board** (`python3 -m cursor_workflow project status`)
+> and **Ctrl+Shift+P → Open Canvas**. HTML under `.local/agents-control-center/` is offline fallback only (ADR-008).
 
-**Do not open HTML via `file://`** — browsers block fetch. From project root:
+Legacy browser UI still ships on activate. **Do not open HTML via `file://`**. From project root:
 
 ```bash
 cd ~/Projects/my-app
@@ -265,7 +266,7 @@ Every session:
 2. Board card Status/Notes — attribution `@user/agent · <ISO-8601-UTC> · …` (CLI stamps); local `history/continuity-index.md` rolls ≥3 days (local `plan.md` / `work-tracker.md` = offline fallback under `board_only`)
 3. Rate-limit: EXIT_QUEUED → `python3 -m cursor_workflow project outbox flush` after quota recovers (`project_ssot.outbox` in collaboration YAML)
 4. **`/implementer`** (or specialist agent from §6)
-5. Optional: [Control Center dashboards](#5-control-center-dashboards) — `http.server` + full URL in §5
+5. Optional: [Control Center dashboards (deprecated)](#5-control-center-dashboards-deprecated) — `http.server` + full URL in §5
 
 Token contract: [token-efficiency.md](token-efficiency.md) · Layout: [local-workspace-layout.md](local-workspace-layout.md).
 

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -34,7 +34,7 @@ Install **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) 
 
 **Healthy install?** `python3 -m cursor_workflow health`
 
-> **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards](#control-center-dashboards) · [All CLI commands](#terminal-commands-cheat-sheet)
+> **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards (deprecated)](#control-center-dashboards-deprecated) · [All CLI commands](#terminal-commands-cheat-sheet)
 
 ### Step 1 detail — install plugin from GitHub
 
@@ -157,7 +157,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 2. Claim/update the board card (Status + Notes `@user/agent · <ISO-8601-UTC> · …`); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`; optional `history/continuity-index.md` (≥3-day local rollup)
 3. If board writes hit GraphQL rate-limit (EXIT_QUEUED): `project outbox status` / later `outbox flush` — enable `project_ssot.outbox` defaults after activate
 4. **`/implementer`** (or `/test-runner`, `/verifier`, `/enterprise-auditor`)
-5. Dashboard (optional): see [Control Center dashboards](#control-center-dashboards) below
+5. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
 
 **Add your own agent/skill/MCP:** **`/integrator-mas-agent`** + **`/mas-infrastructure-integration`**
 
@@ -168,7 +168,7 @@ Optional: `.local/user_settings/mcp.agents.yaml` · external MCP → **`/connect
 | Where | Use for | Examples |
 |-------|---------|----------|
 | **Agent chat** | Plugin install, subagents, skills, slash workflows | `/add-plugin …`, `/workflow-activate`, `/implementer`, `/review-pr` |
-| **Terminal** | Validation, health, gates, serving dashboards | `python3 -m cursor_workflow health`, `http.server` → [dashboard URL](#control-center-dashboards) |
+| **Terminal** | Validation, health, gates, serving deprecated dashboards | `python3 -m cursor_workflow health`, `http.server` → [dashboard URL](#control-center-dashboards-deprecated) |
 
 **Rule:** `/add-plugin` and `/workflow-activate` are **chat commands** — do not paste them into bash.
 
@@ -216,9 +216,14 @@ Commit trailer preview: `python3 -m cursor_workflow contributors commit-trailers
 
 ---
 
-## Control Center dashboards
+## Control Center dashboards (deprecated)
 
-Local HTML dashboards browse your trackers and kit docs in the browser. They ship under `.local/agents-control-center/` on activate.
+> **Deprecated (2026-07-19).** Prefer the **GitHub Project board** when `project_ssot.enabled`
+> (`python3 -m cursor_workflow project status`) and **Ctrl+Shift+P → Open Canvas** for kit
+> visualizations. Local HTML under `.local/agents-control-center/` remains an **offline**
+> markdown/tracker browser only; it is not the backlog or status SSOT (ADR-008).
+
+Local HTML pages still ship on activate for legacy/offline use.
 
 **Do not** open HTML via `file://` — browsers block `fetch()`.
 
@@ -233,23 +238,18 @@ python3 -m http.server 8000
 
 *(Port busy? Use `8001` — swap the port in every URL below.)*
 
-Leave the terminal open while browsing. More pages:
-
 | Page | URL |
 |------|-----|
 | **Home** | http://localhost:8000/.local/agents-control-center/dashboards/index.html |
 | **Implementation Control Center** | http://localhost:8000/.local/agents-control-center/dashboards/implementation-control-center.html |
 | **Module audit** | http://localhost:8000/.local/agents-control-center/audits/module-audit.html |
 
-Use the top **navigator** to switch between Home, Control Center, and Module audit.
+### What still works (offline only)
 
-### What you can do there
+- **Control Center** — sidebar tabs over local markdown (`session-pointer`, `plan`, …) and read-only board export snapshot
+- **Module audit** — workflow module map HTML when exported
 
-- **Control Center** — pick a page from the sidebar (`session-pointer`, `plan`, `work-tracker`, workflow docs, …); markdown renders with tables and lists
-- **Home** — links to trackers and quick paths
-- **Module audit** — workflow module map (when exported)
-
-### Refresh dashboards after a kit update
+### Refresh after a kit update
 
 Re-run activate (chat or terminal):
 

--- a/payload/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/payload/.ai_infra/docs/operations/local-workspace-layout.md
@@ -46,7 +46,7 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | `index-and-planning/current/` | Live trackers: `plan.md`, `work-tracker.md`, `session-pointer.md`, `change-index.md`, tests, `architecture.md` |
 | `index-and-planning/history/` | `updates-log.md` (UTC-prefixed lines), `continuity-index.md` (rolling ≥3-day board↔artifact index) |
 | `index-and-planning/audits/` | Local governance audit snapshots |
-| `agents-control-center/` | Dashboard config (`config/pages.json`) and optional HTML |
+| `agents-control-center/` | **Deprecated** HTML dashboards + `config/pages.json` (offline tracker browser; prefer board SSOT) |
 | `workflow-artifacts/pr/` | `review.md`, `prep.md`, `merge.md` |
 | `workflow-artifacts/alignment/` | `alignment-audit.md`, `alignment-todos.md` |
 | `workflow-artifacts/enterprise-architecture-audit/` | Full audit report + actions |
@@ -74,14 +74,14 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 |--------|----------|
 | `.ai_infra/scripts/pr/check_testing_artifacts.py` | Default `--planning-dir`: `.local/index-and-planning/current` |
 | `.ai_infra/scripts/pr/review.py`, `prepare.py`, `merge.py` | Artifacts via `local_workflow_paths.py` |
-| `.ai_infra/scripts/install/scaffold.py` | Tier 1: exemplar trackers (if missing), artifact buckets, README stubs, `AGENTS.md` (if missing); kit-managed dashboards + `pages.json` **always refreshed** on scaffold/activate |
+| `.ai_infra/scripts/install/scaffold.py` | Tier 1: exemplar trackers (if missing), artifact buckets, README stubs, `AGENTS.md` (if missing); kit-managed **deprecated** dashboards + `pages.json` **always refreshed** on scaffold/activate |
 | `.ai_infra/scripts/ci/seed_kit_workspace.py` | CI fixture seed; same bucket set as scaffold |
 
 ## Templates (versioned in git)
 
 Copy from **`.ai_infra/templates/local-workspace/`** into `.local/` at scaffold (`exemplars/`, `artifact-stubs/`). Dashboard HTML, assets, `module-audit.html`, and `pages.json` refresh from templates on every scaffold/activate (idempotent re-activate included).
 
-**Implementation Control Center:** manifest tab **Project Board** (`format: project-board-snapshot`) renders `.local/generated-data/project-board-snapshot.json` via `local-board-snapshot.js`. Refresh snapshot with `python3 -m cursor_workflow project export`. The panel is **read-only** — it never writes GitHub Project Status.
+**Implementation Control Center (deprecated HTML):** manifest tab **Project Board** (`format: project-board-snapshot`) renders `.local/generated-data/project-board-snapshot.json` via `local-board-snapshot.js`. Refresh snapshot with `python3 -m cursor_workflow project export`. The panel is **read-only** — it never writes GitHub Project Status. Prefer the live Project board when `project_ssot.enabled`.
 
 **User settings:** copy from **`.ai_infra/templates/user-settings/exemplars/`** into **`.local/user_settings/`** (`github.collaboration.yaml`, `mcp.agents.yaml`). See [RENDERED-EXAMPLES.md](../../templates/user-settings/RENDERED-EXAMPLES.md).
 

--- a/payload/.ai_infra/docs/operations/workflow-complete.md
+++ b/payload/.ai_infra/docs/operations/workflow-complete.md
@@ -89,7 +89,7 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 2. **`.local/index-and-planning/current/work-tracker.md`** — resolve task status; keep one primary `in_progress`.
 3. **`test-plan.md` / `test-index.md`** — update when tests or ownership changed.
 4. **`coverage-index.md`** — regenerate after any coverage run that matters.
-5. **`implementation-control-center.html`** — under `.local/agents-control-center/dashboards/`; if you add a tracker, update **`../config/pages.json`**.
+5. **`implementation-control-center.html` (deprecated)** — under `.local/agents-control-center/dashboards/`; offline tracker browser only. Prefer board SSOT when enabled. If you still add a tracker tab, update **`../config/pages.json`**.
 6. **`module-audit.html`** — touch only when deliberately refreshing a deep module audit export.
 7. **`make drift-validate`** — hand off to **`workflow-drift-guard`** on P0/P1.
 

--- a/payload/.ai_infra/scripts/install/scaffold.py
+++ b/payload/.ai_infra/scripts/install/scaffold.py
@@ -68,6 +68,8 @@ AUDIT_EXEMPLARS = (
     "agent-governance-todos.md",
 )
 DASHBOARD_HTML = ("index.html", "implementation-control-center.html")
+# Deprecated HTML ICC (2026-07-19): still refreshed on activate for offline fallback;
+# prefer GitHub Project board (ADR-008) + Cursor Open Canvas.
 DASHBOARD_ASSETS = (
     "site-nav.js",
     "local-shell.css",

--- a/payload/.ai_infra/templates/local-workspace/README.md
+++ b/payload/.ai_infra/templates/local-workspace/README.md
@@ -16,6 +16,10 @@ Notes:
 
 Scaffold copies exemplars into `.local/index-and-planning/current/`, `pages.json` into `.local/agents-control-center/config/`, README stubs into `workflow-artifacts/*`, and optional dashboards.
 
+> **Deprecated (2026-07-19):** HTML dashboards under `agents-control-center/dashboards/` are **maintenance-only**.
+> Prefer the **GitHub Project board** (`project_ssot` / ADR-008) for backlog and status, and **Cursor → Open Canvas**
+> for kit visualizations. Templates still refresh on activate so existing offline browsers keep working.
+
 | Template | Target |
 |----------|--------|
 | `exemplars/*.md` | `.local/index-and-planning/current/` |

--- a/payload/.ai_infra/templates/local-workspace/implementation-control-center.html
+++ b/payload/.ai_infra/templates/local-workspace/implementation-control-center.html
@@ -9,6 +9,7 @@ Depends On:
  - ../config/pages.json (after copy: `.local/agents-control-center/config/pages.json`)
  - Paths declared inside pages.json (`.local/...` and `docs/...`)
 Notes:
+ - Deprecated 2026-07-19: prefer GitHub Project board (ADR-008) + Cursor Open Canvas.
  - Page list is manifest-driven; edit `pages.json` instead of hardcoding PAGES here.
  - Default manifest includes **Strategy index** tab (`.ai_infra/docs/roadmap/README.md`); product plan tabs belong in consumer overlays.
 -->
@@ -17,11 +18,17 @@ Notes:
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Implementation Control Center</title>
+  <title>Implementation Control Center (deprecated)</title>
   <link rel="stylesheet" href="local-shell.css" />
 </head>
 <body>
   <div class="local-content">
+    <aside class="local-deprecation" role="status">
+      <strong>Deprecated.</strong>
+      When <code>project_ssot.enabled</code>, the GitHub Project is the writable SSOT — not this HTML UI.
+      Use <code>python3 -m cursor_workflow project status</code> / board recipes; open kit canvases via
+      <strong>Ctrl+Shift+P → Open Canvas</strong>. This page is an offline markdown browser only.
+    </aside>
     <section class="local-surface local-page-head">
       <h1>Implementation Control Center</h1>
       <p class="local-sub">Markdown-backed workspace: pick a tab below. Paths come from <code>../config/pages.json</code> (relative to this file).</p>

--- a/payload/.ai_infra/templates/local-workspace/index.html
+++ b/payload/.ai_infra/templates/local-workspace/index.html
@@ -1,13 +1,14 @@
 <!--
 File: index.html
-Path: docs/templates/local-workspace/index.html
-Role: Landing page for local HTML tools — copy to `.local/agents-control-center/dashboards/index.html`.
+Path: .ai_infra/templates/local-workspace/index.html
+Role: DEPRECATED landing page for local HTML tools — copy to `.local/agents-control-center/dashboards/index.html`.
 Used By:
- - Browser entry when serving repo root or `.local/` over HTTP
+ - Browser entry when serving repo root or `.local/` over HTTP (legacy / offline fallback)
 Depends On:
  - local-shell.css, site-nav.js
  - ./implementation-control-center.html, ../audits/module-audit.html (relative targets after copy)
 Notes:
+ - Deprecated 2026-07-19: prefer GitHub Project board (ADR-008) + Cursor Open Canvas.
  - Keep links relative to `dashboards/` so they work on any static server.
 -->
 <!DOCTYPE html>
@@ -15,11 +16,18 @@ Notes:
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Local control center</title>
+  <title>Local control center (deprecated)</title>
   <link rel="stylesheet" href="local-shell.css" />
 </head>
 <body>
   <div class="local-content local-content--narrow">
+    <aside class="local-deprecation" role="status">
+      <strong>Deprecated.</strong>
+      Prefer the <strong>GitHub Project board</strong>
+      (<code>python3 -m cursor_workflow project status</code>) for backlog/status,
+      and <strong>Ctrl+Shift+P → Open Canvas</strong> for kit visualizations.
+      These HTML pages remain as an offline tracker browser only.
+    </aside>
     <section class="local-surface local-page-head">
       <h1>Local control center</h1>
       <p class="local-sub">Gitignored workspace under <code>.local/agents-control-center/</code> — use the <strong>Navigator</strong> above to switch pages, or open a tool below.</p>

--- a/payload/.ai_infra/templates/local-workspace/local-shell.css
+++ b/payload/.ai_infra/templates/local-workspace/local-shell.css
@@ -169,6 +169,25 @@ a.local-card .local-card-desc {
   line-height: 1.5;
 }
 
+/* Deprecation banner (ICC HTML — prefer board SSOT + Cursor Open Canvas) */
+.local-deprecation {
+  margin: 0 0 18px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid #8a6a1a;
+  background: #2a2208;
+  color: #f0e2b0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.local-deprecation strong {
+  color: #ffd666;
+}
+.local-deprecation code {
+  background: #1a1505;
+  color: #ffe9a0;
+}
+
 /* Inline / panel code */
 code,
 .local-panel code {

--- a/payload/.ai_infra/templates/local-workspace/site-nav.js
+++ b/payload/.ai_infra/templates/local-workspace/site-nav.js
@@ -8,6 +8,7 @@
  * Depends On:
  *  - <html data-local-site="dashboards|audits" data-local-active="home|control|audit">
  * Notes:
+ *  - Deprecated 2026-07-19 with the HTML dashboards (prefer board SSOT + Open Canvas).
  *  - Add new pages here + update data-local-active values on each HTML shell.
  */
 (function () {
@@ -112,11 +113,11 @@
 
   const title = document.createElement("span");
   title.className = "local-site-nav-title";
-  title.textContent = "Navigator";
+  title.textContent = "Navigator (deprecated)";
 
   const count = document.createElement("span");
   count.className = "local-site-nav-count";
-  count.textContent = "3 HTML pages";
+  count.textContent = "3 HTML pages · offline fallback";
 
   inner.appendChild(title);
   inner.appendChild(count);


### PR DESCRIPTION
## Summary
- Mark local HTML Control Center / ICC as **deprecated** offline fallback; prefer GitHub Project board (ADR-008) and Cursor Open Canvas.
- Add deprecation banners + CSS in dashboard templates; note in scaffold and ops docs.
- Keep payload mirrors in sync with `.ai_infra/`.

## Test plan
- [x] Docs/templates only (+ scaffold comment); no CLI behavior change expected
- [ ] `prepare.py` gates green
- [ ] CI `quality` green


Made with [Cursor](https://cursor.com)