### PR TITLE
chore: AGENT-PRIORITY protocol + EA-021–023 hygiene

### DIFF
--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -54,7 +54,7 @@ mas-workflow-kit-project-ssot/
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
 ├── tests/                      Kit-dev only — full pytest suite (1062; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
-├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc` in this product repo; consumer kit ships 6 rules via payload)
+├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
 └── AGENTS.md                   Kit-dev router (consumers get AGENTS.stub.md)
 ```
@@ -88,7 +88,7 @@ my-app/
 ├── AGENTS.md                       Stub router (from template)
 ├── .cursor/
 │   ├── agents/                     8 agents (from payload; incl. project-board)
-│   ├── rules/                      6 rules
+│   ├── rules/                      7 rules (6 kit + project-ssot-precedence)
 │   └── skills/                     11 canonical skills only (no repo-root skills/ merge)
 ├── .agents/skills/                 5 maintainer slash folders (+ audit-alignment stub)
 ├── .ai_infra/                      Slim bundle (manifest copy_ai_infra only)
@@ -177,7 +177,7 @@ Merged view for Cursor plugin loading from GitHub. **Not** copied as a single tr
 
 ---
 
-## Rules — consumer `.cursor/rules/` (6 kit) · kit-dev repo (7)
+## Rules — consumer `.cursor/rules/` (7 in this product payload) · kit-dev repo (7)
 
 | Rule | alwaysApply | Kit-dev `.cursor/rules/` |
 |------|:-----------:|:------------------------:|
@@ -187,9 +187,9 @@ Merged view for Cursor plugin loading from GitHub. **Not** copied as a single tr
 | `file-docstring-header-relations.mdc` | Yes | Yes |
 | `local-artifact-protection.mdc` | Yes | Yes |
 | `advisory-audit-alignment-enforcement.mdc` | Yes | Yes |
-| `project-ssot-precedence.mdc` | — | Yes (product repo + overlay at install) |
+| `project-ssot-precedence.mdc` | Yes | Yes (product SSOT; in payload for this kit) |
 
-Product overlays: `overlays/rules/*.mdc` → consumer `.cursor/rules/` at install (`project-ssot-precedence` ships in this product repo).
+Product overlays: `overlays/rules/*.mdc` remains the source for domain overlays; **this product** also ships `project-ssot-precedence` in `payload/.cursor/rules/` (7 total).
 
 ---
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -196,6 +196,16 @@ Full list: [consumer-quickstart.md](consumer-quickstart.md) § Terminal commands
 > **Deprecated (2026-07-19).** Prefer the **GitHub Project board** (`python3 -m cursor_workflow project status`)
 > and **Ctrl+Shift+P → Open Canvas**. HTML under `.local/agents-control-center/` is offline fallback only (ADR-008).
 
+### Kit canvases (Open Canvas)
+
+Versioned under repo `canvases/*.canvas.tsx` (git SSOT). **Rendering** uses Cursor’s managed path:
+
+```text
+~/.cursor/projects/<workspace-id>/canvases/*.canvas.tsx
+```
+
+Clicking a file in the repo explorer opens **source**, not the visualization. To view diagrams: **Ctrl+Shift+P → Open Canvas** (pick e.g. `agents-artifacts-board` or an `agent-*` canvas). See hub canvas `canvases/agents-artifacts-board.canvas.tsx` for the same note.
+
 Legacy browser UI still ships on activate. **Do not open HTML via `file://`**. From project root:
 
 ```bash

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -84,7 +84,7 @@ All subcommands registered in `.ai_infra/install/cursor_workflow/project_parser.
 | `create` | Create a DraftIssue (`--template` = create-from-template) | project-board, implementer, integrator |
 | `create-from-template` | Create DraftIssue from slice/bug body template | project-board, implementer |
 | `set-status` | Set item Status from YAML option ids | Power use (prefer `handoff --to`) |
-| `set-field` | Set Priority, Size, or Estimate | project-board (triage), owning agent |
+| `set-field` | Set Priority, Size, or Estimate | project-board (triage), owning agent — **Priority mandatory** on create/claim (`--to p0\|p1\|p2`; chat P3 → `p2` + Notes `deferred`; see skill § Priority contract) |
 | `get` | Get one project item by id | Any |
 | `append-notes` | Append attributed line under ## Notes | Any (Exit atomic) |
 | `claim` | Pattern A: In progress + Notes (+ Start date when configured) | implementer, integrator, researcher |

--- a/.cursor/agents/enterprise-auditor.md
+++ b/.cursor/agents/enterprise-auditor.md
@@ -14,6 +14,8 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent enterprise-auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When proposing Ready cards, recommend board Priority (`p0`/`p1`/`p2`) alongside Severity.
+
 **Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …"` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
 
 **Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -25,6 +25,8 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card may set Priority/Size/Estimate via `set-field`. Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/.cursor/agents/integrator-mas-agent.md
+++ b/.cursor/agents/integrator-mas-agent.md
@@ -20,6 +20,8 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
 
 **Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -14,6 +14,8 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent project-board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards set Priority/Size/Estimate via `set-field`. Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -14,6 +14,8 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Create research cards with `create-from-template --template research`. If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
 
 **Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -14,6 +14,8 @@ description: Module-focused tests, regressions, coverage.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent test-runner` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 **Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -14,6 +14,8 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent verifier` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When verifying closure, spot-check claimed Priority matches board `set-field`.
+
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 **Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes.

--- a/.cursor/agents/workflow-drift-guard.md
+++ b/.cursor/agents/workflow-drift-guard.md
@@ -14,6 +14,8 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent workflow-drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When seeding Ready remediations, set or recommend board Priority (`p0`/`p1`/`p2`).
+
 **Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
 
 **Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.

--- a/.cursor/skills/implementation-execution-loop/SKILL.md
+++ b/.cursor/skills/implementation-execution-loop/SKILL.md
@@ -21,13 +21,13 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Steps
 
-1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`. Else read plan + tracker; one task `in_progress` locally.
-2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
+1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`, then **`set-field --field priority --to p0|p1|p2`** (mandatory — skill § Priority contract; chat P3 → `p2` + Notes `deferred`). Else read plan + tracker; one task `in_progress` locally; tag tasks `[P0]`…`[P3]` in the plan note.
+2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line (`Priority=p?` + `Tasks: [P…]…`).
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
-6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · next=…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
+6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · Priority=p? · next=…` and `Tasks: [P…]…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
 ## Output
 
-Slice • item_id • Status before→after • modules/files • gates outcome • blockers • next agent
+Slice • item_id • Status before→after • Priority • modules/files • gates outcome • blockers • next agent · Tasks `[P…]`

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -48,12 +48,36 @@ Work is **indexed on the Project**, not in chat alone.
 Handoff line (chat + card Notes):
 
 ```text
-item_id=<from project last or create> · @User/implementer · Status=before→after · next=@User/verifier
+item_id=<from project last or create> · @User/implementer · Status=before→after · Priority=p1 · next=@User/verifier
+Tasks: [P1] …; [P2] …; [P3] …
 ```
 
 Prefer `--last` after create so agents never invent ids.
 
 Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
+
+## Priority contract (all agents — mandatory)
+
+Every task and board card must carry an explicit priority. Do **not** leave Priority empty on a card you create or own.
+
+| Chat / plan label | Board `set-field --field priority --to` | When |
+|-------------------|----------------------------------------|------|
+| **P0** | `p0` | Blocks merge / release / SSOT integrity |
+| **P1** | `p1` | Must do next |
+| **P2** | `p2` | Planned hygiene / polish |
+| **P3** (deferred) | `p2` + Notes line `deferred` | Optional later — **no** `p3` option id in YAML |
+
+```bash
+python3 -m cursor_workflow project set-field --field priority --to p1 --last
+```
+
+Rules:
+
+1. After `create-from-template` / `claim`: set Priority **before** coding.
+2. Exit Notes and chat: list open work as `[P0]…; [P1]…; [P2]…; [P3]…` and include `Priority=p?` in the handoff line.
+3. `enterprise-auditor` / `workflow-drift-guard`: findings keep Severity **and** recommend board Priority when seeding Ready cards.
+4. `verifier`: when verifying closure, spot-check claimed Priority matches board `set-field`.
+
 ## When to use
 
 - Any session where `project_ssot.enabled: true`
@@ -83,6 +107,7 @@ Multi-collaborator: each human’s `owner.github_user` namespaces their agents (
 |----------------|------|-----|-------|
 | **Start date** | Claim | `project claim --last --agent <agent>` | UTC today when `conventions.set_start_date_on_claim: true` and `fields.start_date.field_id` is set; WARN only on failure — claim still succeeds |
 | **Estimate** | Triage / own card | `project set-field --field estimate --to N` | Number field; N ≥ 0 |
+| **Priority** | Create / claim / triage (own card) | `project set-field --field priority --to p0\|p1\|p2` | **Mandatory** — see § Priority contract; chat P3 → `p2` + Notes `deferred` |
 | **Promote Draft→Issue** | Before PR / explicit | `project promote-to-issue --last --agent <name> [--repo owner/repo]` | GraphQL `convertProjectV2DraftIssueItemToIssue`; **same PVTI_** preserved; Assignees + Linked PRs work after promote; Notes line `promoted to Issue #N`; fine-grained PAT caveat (`doctor` / `guide`); **claim does NOT auto-promote** |
 | **Linked PR** | PR open (Issue-backed) | `project mention-pr --pr N --last --agent <agent>` | Auto-promotes Draft when `conventions.promote_to_issue_on_pr` (default true) — **FAIL** if promote fails; **WARN-only** if convention false; Notes with canonical PR URL; GitHub **Linked pull requests** column derived (Issue↔PR) |
 | **Out of scope (agents default)** | — | — | Iteration, Labels, Reviewers, End date — human / UI only |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Abbreviations: [`.ai_infra/docs/operations/abbreviations-notepad.md`](.ai_infra/
 1. If `project_ssot.enabled` → `python -m cursor_workflow project status` → board list/claim (`.cursor/skills/project-board-ssot/SKILL.md` § Continuation contract). Read card Notes for prior handoffs.
 2. Else → `.local/index-and-planning/current/session-pointer.md` → `plan.md` → `work-tracker.md`.
 
-**After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. Notes attribution: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`.
+**After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. **Priority is mandatory** on cards you create/own (`project set-field --field priority --to p0|p1|p2`; chat P3 → `p2` + Notes `deferred`) and in Exit task lists (`[P0]`…`[P3]`). Notes attribution: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
 
 ### Board SSOT (Pattern A + Tier-1)
 

--- a/agents/enterprise-auditor.md
+++ b/agents/enterprise-auditor.md
@@ -14,6 +14,8 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent enterprise-auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When proposing Ready cards, recommend board Priority (`p0`/`p1`/`p2`) alongside Severity.
+
 **Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …"` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
 
 **Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -25,6 +25,8 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card may set Priority/Size/Estimate via `set-field`. Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/agents/integrator-mas-agent.md
+++ b/agents/integrator-mas-agent.md
@@ -20,6 +20,8 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
 
 **Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -14,6 +14,8 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent project-board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards set Priority/Size/Estimate via `set-field`. Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -14,6 +14,8 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Create research cards with `create-from-template --template research`. If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
 
 **Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -14,6 +14,8 @@ description: Module-focused tests, regressions, coverage.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent test-runner` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 **Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -14,6 +14,8 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent verifier` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When verifying closure, spot-check claimed Priority matches board `set-field`.
+
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 **Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes.

--- a/agents/workflow-drift-guard.md
+++ b/agents/workflow-drift-guard.md
@@ -14,6 +14,8 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent workflow-drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When seeding Ready remediations, set or recommend board Priority (`p0`/`p1`/`p2`).
+
 **Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
 
 **Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.

--- a/canvases/agent-enterprise-auditor.canvas.tsx
+++ b/canvases/agent-enterprise-auditor.canvas.tsx
@@ -126,7 +126,7 @@ const ARTIFACTS = [
   [
     ".local/generated-data/project-board-snapshot.json",
     "project export (read-only)",
-    "ICC (EA-010) board panel — read-only",
+    "Deprecated HTML ICC (EA-010) — offline only; prefer board + Open Canvas",
   ],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
 ];

--- a/canvases/agent-workflow-drift-guard.canvas.tsx
+++ b/canvases/agent-workflow-drift-guard.canvas.tsx
@@ -110,7 +110,7 @@ const ARTIFACTS = [
   [
     ".local/generated-data/project-board-snapshot.json",
     "project export",
-    "DRIFT-010 · ICC (EA-010) read-only",
+    "DRIFT-010 · deprecated HTML ICC (EA-010) offline only",
   ],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
 ];

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -365,6 +365,14 @@ export default function AgentsArtifactsBoardCanvas() {
         shipped), per-agent canvases for deep dive.
       </Callout>
 
+      <Callout tone="warning" title="How to render kit canvases">
+        Repo path canvases/*.canvas.tsx opens as source in the explorer. Live
+        visualization: Ctrl+Shift+P → Open Canvas (managed copies under{" "}
+        {`~/.cursor/projects/<workspace-id>/canvases/`}
+        ). HTML Control Center is deprecated — prefer the GitHub Project board +
+        Open Canvas.
+      </Callout>
+
       <ThreePlanes />
 
       <Divider />

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -118,7 +118,7 @@ const ABC_SLICES = [
       "project export → read-only snapshot",
       ".local/generated-data/project-board-snapshot.json",
       "Never writes Status — DRIFT-010 stale PR / board drift",
-      "ICC Project Board tab (EA-010) reads export only",
+      "Deprecated HTML ICC Project Board tab (EA-010) — offline export only; prefer live board + Open Canvas",
     ],
   },
 ];
@@ -600,7 +600,7 @@ export default function BoardSsotVsKitCanvas() {
               ["Audit / PR artifacts under .local/", "Evidence bundles stay in-repo"],
               ["Export snapshot under generated-data/", "Read-only cache — not SSOT"],
               ["Offline fallback trackers", "Only when project_ssot disabled or no gh"],
-              ["ICC board panel", "EA-010 shipped — reads export only"],
+              ["Deprecated HTML ICC board panel", "EA-010 — offline export only; prefer live board + Open Canvas"],
             ]}
           />
         </Stack>
@@ -633,7 +633,7 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">BOARD-TIER1: claim Start date + Estimate set-field + mention-pr</Text>
               <Text size="small">EA-001: project_cli split (atomics/adapter/recipes/outbox)</Text>
               <Text size="small">EA-004: pyright blocking in kit-quality CI</Text>
-              <Text size="small">EA-010: ICC Project Board tab (read-only export snapshot)</Text>
+              <Text size="small">EA-010: deprecated HTML ICC tab (offline export; prefer board + Open Canvas)</Text>
             </Stack>
           </CardBody>
         </Card>

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -9,7 +9,7 @@ Per-project rules and optional docs that **extend** the universal **MAS Workflow
 | `overlays/rules/*.mdc` | Product- or domain-specific Cursor rules (install → target `.cursor/rules/`) |
 | `overlays/docs/` | Optional ops docs merged into project `docs/` at install |
 
-**Kit-dev (this product repo) ships 7 rules** in `.cursor/rules/` — 6 universal kit rules plus `project-ssot-precedence.mdc`. **Consumer activate** copies **6** rules from `payload/.cursor/rules/` (no product-only overlay). **Overlays** add project-specific `.mdc` files at install for *your* app (adapter walls, layer policies, protected paths, etc.).
+**Kit-dev (this product repo) ships 7 rules** in `.cursor/rules/` — 6 universal kit rules plus `project-ssot-precedence.mdc`. **Consumer activate** from this product’s `payload/.cursor/rules/` also copies **7** rules (same set). Additional **Overlays** add app-domain `.mdc` files at install when needed.
 
 ## Install
 

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -196,6 +196,16 @@ Full list: [consumer-quickstart.md](consumer-quickstart.md) § Terminal commands
 > **Deprecated (2026-07-19).** Prefer the **GitHub Project board** (`python3 -m cursor_workflow project status`)
 > and **Ctrl+Shift+P → Open Canvas**. HTML under `.local/agents-control-center/` is offline fallback only (ADR-008).
 
+### Kit canvases (Open Canvas)
+
+Versioned under repo `canvases/*.canvas.tsx` (git SSOT). **Rendering** uses Cursor’s managed path:
+
+```text
+~/.cursor/projects/<workspace-id>/canvases/*.canvas.tsx
+```
+
+Clicking a file in the repo explorer opens **source**, not the visualization. To view diagrams: **Ctrl+Shift+P → Open Canvas** (pick e.g. `agents-artifacts-board` or an `agent-*` canvas). See hub canvas `canvases/agents-artifacts-board.canvas.tsx` for the same note.
+
 Legacy browser UI still ships on activate. **Do not open HTML via `file://`**. From project root:
 
 ```bash

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -84,7 +84,7 @@ All subcommands registered in `.ai_infra/install/cursor_workflow/project_parser.
 | `create` | Create a DraftIssue (`--template` = create-from-template) | project-board, implementer, integrator |
 | `create-from-template` | Create DraftIssue from slice/bug body template | project-board, implementer |
 | `set-status` | Set item Status from YAML option ids | Power use (prefer `handoff --to`) |
-| `set-field` | Set Priority, Size, or Estimate | project-board (triage), owning agent |
+| `set-field` | Set Priority, Size, or Estimate | project-board (triage), owning agent — **Priority mandatory** on create/claim (`--to p0\|p1\|p2`; chat P3 → `p2` + Notes `deferred`; see skill § Priority contract) |
 | `get` | Get one project item by id | Any |
 | `append-notes` | Append attributed line under ## Notes | Any (Exit atomic) |
 | `claim` | Pattern A: In progress + Notes (+ Start date when configured) | implementer, integrator, researcher |

--- a/payload/.cursor/agents/enterprise-auditor.md
+++ b/payload/.cursor/agents/enterprise-auditor.md
@@ -14,6 +14,8 @@ description: Evidence-only enterprise architecture audit; writes workflow artifa
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent enterprise-auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent enterprise-auditor` (→ `@owner.github_user/enterprise-auditor`); atomics `append-notes --agent enterprise-auditor` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When proposing Ready cards, recommend board Priority (`p0`/`p1`/`p2`) alongside Severity.
+
 **Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …"` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
 
 **Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -25,6 +25,8 @@ description: Disciplined implementation slices with trackers and Pattern A gates
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card may set Priority/Size/Estimate via `set-field`. Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/payload/.cursor/agents/integrator-mas-agent.md
+++ b/payload/.cursor/agents/integrator-mas-agent.md
@@ -20,6 +20,8 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
 
 **Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -14,6 +14,8 @@ description: Independent-governed helper — list/create/move GitHub Project SSO
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent project-board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `project claim` / `project handoff --agent project-board` (→ `@owner.github_user/project-board`); atomics `append-notes --agent project-board` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards set Priority/Size/Estimate via `set-field`. Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
 
 **Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -14,6 +14,8 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Board lifecycle (role):** Create research cards with `create-from-template --template research`. If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
 
 **Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -14,6 +14,8 @@ description: Module-focused tests, regressions, coverage.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent test-runner` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract.
+
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 **Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -14,6 +14,8 @@ description: Claims vs evidence; minimal high-signal checks.
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent verifier` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When verifying closure, spot-check claimed Priority matches board `set-field`.
+
 **Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
 
 **Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes.

--- a/payload/.cursor/agents/workflow-drift-guard.md
+++ b/payload/.cursor/agents/workflow-drift-guard.md
@@ -14,6 +14,8 @@ description: Operational workflow drift detection; plan/tracker/session coherenc
 
 **Board rights:** Status + Notes on the card you touch. Tier-1: claim may set Start date (UTC); triage may set Estimate; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent workflow-drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent workflow-drift-guard` (→ `@owner.github_user/workflow-drift-guard`); atomics `append-notes --agent workflow-drift-guard` OK. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
+**Priority (mandatory):** Never leave Priority empty on a card you create or own — `project set-field --field priority --to p0|p1|p2 --last` (YAML options only; chat **P3**/deferred → board `p2` + Notes `deferred`). Exit handoff includes `Priority=p?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/project-board-ssot/SKILL.md` § Priority contract. When seeding Ready remediations, set or recommend board Priority (`p0`/`p1`/`p2`).
+
 **Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
 
 **Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.

--- a/payload/.cursor/skills/implementation-execution-loop/SKILL.md
+++ b/payload/.cursor/skills/implementation-execution-loop/SKILL.md
@@ -21,13 +21,13 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Steps
 
-1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`. Else read plan + tracker; one task `in_progress` locally.
-2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
+1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`, then **`set-field --field priority --to p0|p1|p2`** (mandatory — skill § Priority contract; chat P3 → `p2` + Notes `deferred`). Else read plan + tracker; one task `in_progress` locally; tag tasks `[P0]`…`[P3]` in the plan note.
+2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line (`Priority=p?` + `Tasks: [P…]…`).
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
-6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · next=…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
+6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · Priority=p? · next=…` and `Tasks: [P…]…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
 ## Output
 
-Slice • item_id • Status before→after • modules/files • gates outcome • blockers • next agent
+Slice • item_id • Status before→after • Priority • modules/files • gates outcome • blockers • next agent · Tasks `[P…]`

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -48,12 +48,36 @@ Work is **indexed on the Project**, not in chat alone.
 Handoff line (chat + card Notes):
 
 ```text
-item_id=<from project last or create> · @User/implementer · Status=before→after · next=@User/verifier
+item_id=<from project last or create> · @User/implementer · Status=before→after · Priority=p1 · next=@User/verifier
+Tasks: [P1] …; [P2] …; [P3] …
 ```
 
 Prefer `--last` after create so agents never invent ids.
 
 Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
+
+## Priority contract (all agents — mandatory)
+
+Every task and board card must carry an explicit priority. Do **not** leave Priority empty on a card you create or own.
+
+| Chat / plan label | Board `set-field --field priority --to` | When |
+|-------------------|----------------------------------------|------|
+| **P0** | `p0` | Blocks merge / release / SSOT integrity |
+| **P1** | `p1` | Must do next |
+| **P2** | `p2` | Planned hygiene / polish |
+| **P3** (deferred) | `p2` + Notes line `deferred` | Optional later — **no** `p3` option id in YAML |
+
+```bash
+python3 -m cursor_workflow project set-field --field priority --to p1 --last
+```
+
+Rules:
+
+1. After `create-from-template` / `claim`: set Priority **before** coding.
+2. Exit Notes and chat: list open work as `[P0]…; [P1]…; [P2]…; [P3]…` and include `Priority=p?` in the handoff line.
+3. `enterprise-auditor` / `workflow-drift-guard`: findings keep Severity **and** recommend board Priority when seeding Ready cards.
+4. `verifier`: when verifying closure, spot-check claimed Priority matches board `set-field`.
+
 ## When to use
 
 - Any session where `project_ssot.enabled: true`
@@ -83,6 +107,7 @@ Multi-collaborator: each human’s `owner.github_user` namespaces their agents (
 |----------------|------|-----|-------|
 | **Start date** | Claim | `project claim --last --agent <agent>` | UTC today when `conventions.set_start_date_on_claim: true` and `fields.start_date.field_id` is set; WARN only on failure — claim still succeeds |
 | **Estimate** | Triage / own card | `project set-field --field estimate --to N` | Number field; N ≥ 0 |
+| **Priority** | Create / claim / triage (own card) | `project set-field --field priority --to p0\|p1\|p2` | **Mandatory** — see § Priority contract; chat P3 → `p2` + Notes `deferred` |
 | **Promote Draft→Issue** | Before PR / explicit | `project promote-to-issue --last --agent <name> [--repo owner/repo]` | GraphQL `convertProjectV2DraftIssueItemToIssue`; **same PVTI_** preserved; Assignees + Linked PRs work after promote; Notes line `promoted to Issue #N`; fine-grained PAT caveat (`doctor` / `guide`); **claim does NOT auto-promote** |
 | **Linked PR** | PR open (Issue-backed) | `project mention-pr --pr N --last --agent <agent>` | Auto-promotes Draft when `conventions.promote_to_issue_on_pr` (default true) — **FAIL** if promote fails; **WARN-only** if convention false; Notes with canonical PR URL; GitHub **Linked pull requests** column derived (Issue↔PR) |
 | **Out of scope (agents default)** | — | — | Iteration, Labels, Reviewers, End date — human / UI only |

--- a/skills/implementation-execution-loop/SKILL.md
+++ b/skills/implementation-execution-loop/SKILL.md
@@ -21,13 +21,13 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 
 ## Steps
 
-1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`. Else read plan + tracker; one task `in_progress` locally.
-2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line.
+1. **SSOT select:** `python -m cursor_workflow project status`. If operational → list/claim board card (`claim --last` after create, or claim Ready). When creating: see `.ai_infra/templates/project-board/README.md` — `create-from-template --template slice` (feature/`chore/`) or `--template bug` (defect/`fix/`), then `claim --last --agent implementer`, then **`set-field --field priority --to p0|p1|p2`** (mandatory — skill § Priority contract; chat P3 → `p2` + Notes `deferred`). Else read plan + tracker; one task `in_progress` locally; tag tasks `[P0]`…`[P3]` in the plan note.
+2. Document acceptance + rollback on **card body** (or `plan.md` if fallback). Mid-slice handoffs go in card **Notes** + handoff line (`Priority=p?` + `Tasks: [P…]…`).
 3. Implement: contracts → code → tests. **New Python/sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 4. **Gates:** run commands in `.ai_infra/scripts/pr/prepare.py` `GATES` (plus `check_governance_consistency.py` when governance changes). Prefer scoped `pytest` with a short reason.
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
-6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · next=…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
+6. **Close (board-indexed):** `set-status --to in_review|done`; print `item_id=… · Status=… · Priority=p? · next=…` and `Tasks: [P…]…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`workflow-drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
 ## Output
 
-Slice • item_id • Status before→after • modules/files • gates outcome • blockers • next agent
+Slice • item_id • Status before→after • Priority • modules/files • gates outcome • blockers • next agent · Tasks `[P…]`

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -48,12 +48,36 @@ Work is **indexed on the Project**, not in chat alone.
 Handoff line (chat + card Notes):
 
 ```text
-item_id=<from project last or create> · @User/implementer · Status=before→after · next=@User/verifier
+item_id=<from project last or create> · @User/implementer · Status=before→after · Priority=p1 · next=@User/verifier
+Tasks: [P1] …; [P2] …; [P3] …
 ```
 
 Prefer `--last` after create so agents never invent ids.
 
 Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
+
+## Priority contract (all agents — mandatory)
+
+Every task and board card must carry an explicit priority. Do **not** leave Priority empty on a card you create or own.
+
+| Chat / plan label | Board `set-field --field priority --to` | When |
+|-------------------|----------------------------------------|------|
+| **P0** | `p0` | Blocks merge / release / SSOT integrity |
+| **P1** | `p1` | Must do next |
+| **P2** | `p2` | Planned hygiene / polish |
+| **P3** (deferred) | `p2` + Notes line `deferred` | Optional later — **no** `p3` option id in YAML |
+
+```bash
+python3 -m cursor_workflow project set-field --field priority --to p1 --last
+```
+
+Rules:
+
+1. After `create-from-template` / `claim`: set Priority **before** coding.
+2. Exit Notes and chat: list open work as `[P0]…; [P1]…; [P2]…; [P3]…` and include `Priority=p?` in the handoff line.
+3. `enterprise-auditor` / `workflow-drift-guard`: findings keep Severity **and** recommend board Priority when seeding Ready cards.
+4. `verifier`: when verifying closure, spot-check claimed Priority matches board `set-field`.
+
 ## When to use
 
 - Any session where `project_ssot.enabled: true`
@@ -83,6 +107,7 @@ Multi-collaborator: each human’s `owner.github_user` namespaces their agents (
 |----------------|------|-----|-------|
 | **Start date** | Claim | `project claim --last --agent <agent>` | UTC today when `conventions.set_start_date_on_claim: true` and `fields.start_date.field_id` is set; WARN only on failure — claim still succeeds |
 | **Estimate** | Triage / own card | `project set-field --field estimate --to N` | Number field; N ≥ 0 |
+| **Priority** | Create / claim / triage (own card) | `project set-field --field priority --to p0\|p1\|p2` | **Mandatory** — see § Priority contract; chat P3 → `p2` + Notes `deferred` |
 | **Promote Draft→Issue** | Before PR / explicit | `project promote-to-issue --last --agent <name> [--repo owner/repo]` | GraphQL `convertProjectV2DraftIssueItemToIssue`; **same PVTI_** preserved; Assignees + Linked PRs work after promote; Notes line `promoted to Issue #N`; fine-grained PAT caveat (`doctor` / `guide`); **claim does NOT auto-promote** |
 | **Linked PR** | PR open (Issue-backed) | `project mention-pr --pr N --last --agent <agent>` | Auto-promotes Draft when `conventions.promote_to_issue_on_pr` (default true) — **FAIL** if promote fails; **WARN-only** if convention false; Notes with canonical PR URL; GitHub **Linked pull requests** column derived (Issue↔PR) |
 | **Out of scope (agents default)** | — | — | Iteration, Labels, Reviewers, End date — human / UI only |


### PR DESCRIPTION
## Summary
- **P1 AGENT-PRIORITY:** Mandatory Priority contract on all 8 agents + `project-board-ssot` / `implementation-execution-loop` skills + AGENTS.md + ops docs (`set-field --to p0|p1|p2`; chat P3 → board `p2` + Notes `deferred`).
- **P2 EA-021:** Canvas ICC refs steered to deprecated HTML / Open Canvas + board.
- **P2 EA-022:** `repository-map` + `overlays/README` — consumer payload ships **7** rules.
- **P2 EA-023:** Open Canvas managed-path note on `agents-artifacts-board` + PLUGIN-USER-GUIDE.
- Board cards seeded with Priority (PROC p1; DOC p2; deferred EA-019/020/024 p2 + deferred Notes).

## Test plan
- [x] `python3 -m cursor_workflow doc validate` (DOC-001…008 PASS)
- [ ] `make gates` / prepare.py via PR workflow
- [x] Grep: Priority (mandatory) on 8 agents


Made with [Cursor](https://cursor.com)