### PR TITLE
docs: EA-019 marketplace pre-publish listing + HANDOFF hygiene

### DIFF
--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -208,6 +208,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-07-19 DOC-CANVAS-ALIGN):** Re-verified against `IMPLEMENTATION-STATUS.md` — **1062** tests collected (1060 passed + 2 skipped), **6208** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts (8 / 11 / 7). Prior 931/5352 line superseded.
 
+**Listing copy refresh (2026-07-19 EA-019 / PR #70):** Re-verified against `IMPLEMENTATION-STATUS.md` on `main` post Tier-1 Size/Estimate + Start date — **1072** tests collected (1070 passed + 2 skipped), **6208** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts unchanged (**8** / **11** / **7**); kit version **0.4.0**. Prior 1062 line superseded. Ship Marketplace against `0.4.0` (no version bump in this slice).
+
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Local evidence file was not retained in this workspace; recreate with `make smoke-consumer` and write under `.local/workflow-artifacts/release/smoke-consumer-<app>-<date>.md` on the next consumer run.
 
 ## Publish

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -105,7 +105,11 @@ Do **not** publish marketplace releases from this repo against upstream `mas-wor
 
 ## Deferred product backlog (board)
 
-Scheduled only when claimed from the Project (Backlog → Ready). Examples: marketplace publish (EA-019), adapter thinning (EA-020), ICC `pages.json` module-map (EA-024). Always-on GitHub Actions bots and MCP-before-`gh` remain explicitly deferred.
+Scheduled only when claimed from the Project (Backlog → Ready).
+
+- **In progress / Ready:** marketplace publish (**EA-019**) — live Cursor Marketplace listing; prep checklist in [marketplace-publish.md](.ai_infra/docs/handoff/marketplace-publish.md).
+- **Closed hygiene (2026-07-19):** EA-020 `gh_project_adapter` thinning (EA-001 + coverage enough); EA-024 ICC module-map tab (ICC deprecated; map at `.local/module-map.md`).
+- **Prose-only (no board card):** always-on GitHub Actions bots; MCP-before-`gh` for board writes.
 
 ---
 
@@ -115,4 +119,4 @@ Mirrored from `mas-workflow-kit` on 2026-07-17 (`1cb6dd7`). Board SSOT, Pattern 
 
 ---
 
-**Last updated:** 2026-07-19 · **Next:** `project status` → claim Ready (or schedule deferred Backlog)
+**Last updated:** 2026-07-19 · **Next:** complete EA-019 Marketplace publish (or `project status` → claim Ready)


### PR DESCRIPTION
## Summary
- Refresh marketplace-publish listing copy to **1072** tests / kit `0.4.0` (post PR #70).
- Update HANDOFF deferred backlog: EA-019 active; EA-020/024 closed hygiene; GHA/MCP-before-gh prose-only.

## Test plan
- [x] `make gates` / install-dry-run / smoke-consumer / sync-plugin / check-plugin / debrand (see local dry-run artifact)
- [ ] Pattern A prepare on this PR

Board: `PVTI_lAHOBl46-84A9KZxzgzVZGM` · Issue #63


Made with [Cursor](https://cursor.com)