### PR TITLE
docs: defer EA-019 live Marketplace (prep done)

### DIFF
--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -220,14 +220,19 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 ### Live marketplace (EA-v4-002 / EA-019 — manual when channel ready)
 
-Local pre-publish evidence: run `make gates` + `make smoke-consumer` / `make install-dry-run` on the release tag, then record PASS under `.local/workflow-artifacts/enterprise-architecture-audit/marketplace-dry-run-<date>.md` (prior 2026-06-29 dry-run log is not present in this workspace — recreate rather than cite a missing path).
+Local pre-publish evidence: run `make gates` + `make smoke-consumer` / `make install-dry-run` on the release tag, then record PASS under `.local/workflow-artifacts/enterprise-architecture-audit/marketplace-dry-run-<date>.md`.
+
+**Prep re-verified 2026-07-19 (EA-019):** dry-run PASS — `.local/workflow-artifacts/enterprise-architecture-audit/marketplace-dry-run-2026-07-19.md` (+ `.log`). Listing copy refresh on `main` via PR #72 (1072 tests / kit `0.4.0`).
+
+**Maintainer decision 2026-07-19:** **no public Marketplace submit for now.** Consumers stay on GitHub `/add-plugin`. Live upload remains deferred until explicitly re-scheduled on the board (EA-019 Backlog).
 
 **Not yet exercised:** upload/publish to the live Cursor Marketplace channel. When credentials and channel are available:
 
-1. Complete **Pre-publish** steps above on a release tag
+1. Complete **Pre-publish** steps above on a release tag (or reuse a fresh dry-run)
 2. Follow Cursor Marketplace maintainer docs for your account tier
 3. Record publish URL + version in `.local/workflow-artifacts/enterprise-architecture-audit/` (no secrets in git)
 4. Re-run `enterprise-auditor` focused pass on deployability category
+5. Flip PLUGIN-USER-GUIDE “recommended until Marketplace” once the listing is live
 
 Until live publish, **deployability score remains capped** at local dry-run evidence (see enterprise audit v5 §7 EA-v4-002).
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -107,7 +107,7 @@ Do **not** publish marketplace releases from this repo against upstream `mas-wor
 
 Scheduled only when claimed from the Project (Backlog → Ready).
 
-- **In progress / Ready:** marketplace publish (**EA-019**) — live Cursor Marketplace listing; prep checklist in [marketplace-publish.md](.ai_infra/docs/handoff/marketplace-publish.md).
+- **Deferred (Backlog):** marketplace publish (**EA-019**) — **prep done** (PR #72 + dry-run `marketplace-dry-run-2026-07-19`); **live public Marketplace postponed** (maintainer 2026-07-19). Consumers use `/add-plugin` until listed. Checklist: [marketplace-publish.md](.ai_infra/docs/handoff/marketplace-publish.md).
 - **Closed hygiene (2026-07-19):** EA-020 `gh_project_adapter` thinning (EA-001 + coverage enough); EA-024 ICC module-map tab (ICC deprecated; map at `.local/module-map.md`).
 - **Prose-only (no board card):** always-on GitHub Actions bots; MCP-before-`gh` for board writes.
 
@@ -119,4 +119,4 @@ Mirrored from `mas-workflow-kit` on 2026-07-17 (`1cb6dd7`). Board SSOT, Pattern 
 
 ---
 
-**Last updated:** 2026-07-19 · **Next:** complete EA-019 Marketplace publish (or `project status` → claim Ready)
+**Last updated:** 2026-07-19 · **Next:** `project status` → claim Ready (or schedule deferred Backlog, e.g. EA-019 live Marketplace when ready)


### PR DESCRIPTION
## Summary
- Maintainer: no public Cursor Marketplace listing for now.
- HANDOFF + marketplace-publish: EA-019 prep done (PR #72 + dry-run); live publish Backlog/deferred; `/add-plugin` remains the install path.

## Test plan
- [ ] Docs-only — prepare gates
- Board already: EA-019 → Backlog, Priority p2, Issue #63 retitled deferred


Made with [Cursor](https://cursor.com)