### PR TITLE
docs: mark researcher shipped/proven + canvas how-it-works

### DIFF
--- a/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/.agents/skills/RESEARCH_WORKFLOW.md
@@ -2,6 +2,8 @@
 
 **Brief-driven multi-round research** for `_research_results/` — not implementation slices (`implementer` + board / `.local/.../current/*`).
 
+**Status (2026-07-19):** Agent is **shipped and proven** (live external pack + verifier PASS). Corpus packs remain **opt-in** — they appear only after `research init` (not an incomplete agent).
+
 Versioned hub (in git). Corpus boundaries: `_research_results/RESEARCH_BOUNDARIES.md` (from `research init`).
 
 ## Order (active)
@@ -11,7 +13,17 @@ Versioned hub (in git). Corpus boundaries: `_research_results/RESEARCH_BOUNDARIE
 3. Normalize source → `research init` → `research fetch` → rounds → `validate`
 4. Pack `BRIEF.md` + `SOURCE.md` under `_research_results/sources/<slug>/`
 
-Agent: **`.cursor/agents/researcher.md`**.
+Agent: **`.cursor/agents/researcher.md`**. Canvas: `canvases/agent-researcher.canvas.tsx`.
+
+## How it works (7 steps)
+
+1. **Intake** — normalize source + question → `BRIEF.md` (defaults for terse `/researcher <url>`)
+2. **Init/fetch** — CLI scaffolds pack + shallow clone to `cache/<slug>/`
+3. **Map/extract** — `MAP.md` + `findings/<lens>.md` with path + ~Lnn evidence
+4. **Deepen** — `rounds/round-N.md` only for open questions (cap ≤6; anti-loop)
+5. **Curate/pack** — `CURATED.md` → `AGENT_BRIEF.md` → `INDEX.json` `status=complete`
+6. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>` PASS
+7. **Exit** — research card Done + Notes with pack paths; handoff to consumer
 
 ## Hard boundary
 
@@ -31,6 +43,7 @@ No product repo edits; no git commits for research packs; writes only `_research
 | D7 | Accept HTTPS GitHub URLs and terse `/researcher <url>` chat; apply skill defaults |
 | D8 | Anti-loop: rounds_max≤6; no re-fetch/re-init without `--force`; exit on complete |
 | D9 | Private GitHub needs consumer `gh`/git auth; public needs network only |
+| D10 | Agent shipped/proven; corpus remains opt-in after first `research init` |
 
 ## Forbidden
 
@@ -57,7 +70,15 @@ No product repo edits; no git commits for research packs; writes only `_research
 
 ## Board
 
-`create-from-template --template research` → claim → Done + Notes with pack paths.
+`create-from-template --template research --priority p2` → claim → Done + Notes with pack paths.
+
+## Live proof
+
+| Field | Evidence |
+|-------|----------|
+| Slug | `flexiai-toolsmith` (Issue #74) |
+| Source | `github:SavinRazvan/flexiai-toolsmith` @ `3f8b0c7` |
+| Result | 6 rounds · 18 curated · validate PASS · verifier Claim A+B VERIFIED |
 
 ## Related
 
@@ -67,3 +88,4 @@ No product repo edits; no git commits for research packs; writes only `_research
 | Implementation | `implementer` (reads `AGENT_BRIEF.md`) |
 | Integration | `integrator-mas-agent` |
 | Audit | `enterprise-auditor` |
+| Agent canvas | `canvases/agent-researcher.canvas.tsx` |

--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -53,7 +53,7 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 | `test-runner` | Module tests, coverage; board Exit Status |
 | `verifier` | Evidence checks; board Done / In review |
 | `enterprise-auditor` | Architecture audits; audit card Status + Notes |
-| `researcher` | Adaptive Brief multi-round packs under `_research_results/`; chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
+| `researcher` | **Shipped/proven** adaptive Brief multi-round packs under `_research_results/` (opt-in after init); chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
 | `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
 | `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
 | `project-board` | Board triage helper (ADR-006); not in default PR pipelines |

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -50,6 +50,7 @@ Notes:
 | Three-plane activate | Idempotent plugin consumer setup | `.ai_infra/install/cursor_workflow/activate_cli.py`, `plane_status.py` |
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
+| Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus-execution` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
 | Tests | 1072 collected (1070 passed + 2 skipped on full run) | `tests/modules/` |
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -135,7 +135,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `integrator-mas-agent` | Yes | Yes | `/integrator-mas-agent` |
 | `workflow-drift-guard` | Yes | Yes | `/workflow-drift-guard` |
 | `project-board` | Yes | Yes | `/project-board` |
-| `researcher` | Yes | Yes (optional packs) | `/researcher` (adaptive Brief + HTTPS) |
+| `researcher` | Yes | Yes (opt-in packs after `research init`) | `/researcher` (adaptive Brief + HTTPS; shipped/proven) |
 
 **Deprecated agents:** none.
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -276,7 +276,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/verifier` | `.cursor/agents/verifier.md` |
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
-| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate` |
+| `/researcher` | `.cursor/agents/researcher.md` — **shipped/proven**; adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate`; corpus opt-in after init |
 | `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |
 | `/mas-infrastructure-integration` | `.cursor/skills/mas-infrastructure-integration/` |

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -49,9 +49,9 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
 | enterprise-auditor | Architecture audits |
-| researcher | Brief-driven research packs; adaptive intake from chat/agents/board; CLI `research init\|fetch\|validate` |
+| researcher | Shipped corpus researcher; adaptive Brief; CLI `research init\|fetch\|validate`; packs opt-in after init |
 
-## Research (optional)
+## Research (opt-in corpus)
 
 | Term | Meaning |
 |------|---------|

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -20,7 +20,7 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 **Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.
 
-Build and maintain a **local research corpus** of verified packs. **Off by default** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
+Build and maintain a **local research corpus** of verified packs. **Agent is shipped/proven** (live E2E + verifier PASS 2026-07-19); corpus packs remain **opt-in** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
 
 ## Adaptive intake (mandatory before research)
 

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -4,7 +4,7 @@ model: auto
 description: Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
-# Researcher (optional)
+# Researcher (shipped; opt-in corpus)
 
 ## Anchor (mandatory)
 

--- a/.cursor/skills/research-corpus-execution/SKILL.md
+++ b/.cursor/skills/research-corpus-execution/SKILL.md
@@ -120,3 +120,7 @@ If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID pe
 ```text
 slug · mode · rounds · curated_count · AGENT_BRIEF path · validate PASS/FAIL · next consumer
 ```
+
+## Status
+
+**Agent shipped/proven** (2026-07-19): live external pack (`flexiai-toolsmith`, 18 curated, validate PASS) + verifier Claim A (efficiency) / Claim B (correctness) VERIFIED. Corpus remains **opt-in** after first `research init` — not an incomplete agent. Canvas: `canvases/agent-researcher.canvas.tsx`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. After mer
 | Audit orchestration | `.cursor/skills/audit-orchestration/SKILL.md` — parent runs verify-all + Task delegation (no dedicated agent) |
 | Audit module map | `.cursor/skills/audit-module-map/SKILL.md` — optional deep map; invoke via **`enterprise-auditor`** |
 | Maintainer PR | `.agents/skills/pr-workflow/SKILL.md` → `review-pr` → `prepare-pr` → `merge-pr` |
-| Research corpus (optional) | `.cursor/agents/researcher.md` — adaptive Brief from chat/agents; HTTPS/`github:`/`path:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/` |
+| Research corpus (shipped; opt-in packs) | `.cursor/agents/researcher.md` — adaptive Brief from chat/agents; HTTPS/`github:`/`path:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/`; live E2E proven 2026-07-19 |
 | MCP | `.ai_infra/mcp_servers/workflow_mcp/` — `python -m workflow_mcp`; [`.cursor/mcp.json.kit.example`](.cursor/mcp.json.kit.example) + [connect-external-mcp](.ai_infra/docs/operations/connect-external-mcp.md) |
 
 Scripts:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -97,7 +97,7 @@ If the board is unavailable: `fallback: local_trackers` only, then resume board 
 | `enterprise-auditor` | Alignment / scorecard → `.local/workflow-artifacts/` |
 | `workflow-drift-guard` | DRIFT-009/010; board on Exit |
 | `integrator-mas-agent` | Agents, skills, MCP, kit expansions |
-| `researcher` | Shipped corpus researcher — adaptive Brief; packs under `_research_results/` (opt-in after `research init`); hard-stop on product code |
+| `researcher` | Shipped/proven corpus researcher — adaptive Brief; packs under `_research_results/` (opt-in after `research init`); hard-stop on product code · live E2E Issue #74 |
 
 Do **not** publish marketplace releases from this repo against upstream `mas-workflow-kit`.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -97,7 +97,7 @@ If the board is unavailable: `fallback: local_trackers` only, then resume board 
 | `enterprise-auditor` | Alignment / scorecard → `.local/workflow-artifacts/` |
 | `workflow-drift-guard` | DRIFT-009/010; board on Exit |
 | `integrator-mas-agent` | Agents, skills, MCP, kit expansions |
-| `researcher` | Optional research corpus (off by default) |
+| `researcher` | Shipped corpus researcher — adaptive Brief; packs under `_research_results/` (opt-in after `research init`); hard-stop on product code |
 
 Do **not** publish marketplace releases from this repo against upstream `mas-workflow-kit`.
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -20,7 +20,7 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 **Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.
 
-Build and maintain a **local research corpus** of verified packs. **Off by default** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
+Build and maintain a **local research corpus** of verified packs. **Agent is shipped/proven** (live E2E + verifier PASS 2026-07-19); corpus packs remain **opt-in** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
 
 ## Adaptive intake (mandatory before research)
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -4,7 +4,7 @@ model: auto
 description: Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
-# Researcher (optional)
+# Researcher (shipped; opt-in corpus)
 
 ## Anchor (mandatory)
 

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -76,8 +76,8 @@ const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   },
   {
     id: "researcher",
-    role: "Adaptive Brief research packs (no product PRs)",
-    lane: "Optional",
+    role: "Shipped corpus researcher — packs under _research_results/ (opt-in)",
+    lane: "Research (opt-in corpus)",
   },
 ];
 
@@ -194,7 +194,7 @@ const LANES: [string, string][] = [
   ["Delivery", "implementer · test-runner · verifier"],
   ["Infrastructure", "integrator-mas-agent"],
   ["Quality", "enterprise-auditor · workflow-drift-guard"],
-  ["Optional", "researcher"],
+  ["Research (opt-in corpus)", "researcher"],
 ];
 
 const DAG_NODES = AGENTS.filter((a) => a.id !== "researcher").map((a) => ({
@@ -385,13 +385,13 @@ export default function AgentRelationsCanvas() {
             </Pill>
           }
         >
-          Collaboration graph (researcher omitted — redirects only)
+          Collaboration graph (researcher omitted — non-product redirects)
         </CardHeader>
         <CardBody>
           <RelationDag focus={focus} tokens={tokens} />
           <Text tone="tertiary" size="small">
             Accent edges = selected agent’s handoffs. Dashed = back-edge (cycle).
-            researcher has no product edges — see redirects below.
+            researcher is shipped/proven but has no product edges — see redirects.
           </Text>
         </CardBody>
       </Card>
@@ -441,8 +441,9 @@ export default function AgentRelationsCanvas() {
             />
             <Spacer />
             <Text size="small" tone="tertiary">
-              Hard stop: write only under _research_results/; no product
-              commit/push/PR.
+              Shipped/proven (live E2E + verifier 2026-07-19). Hard stop: write
+              only under _research_results/; no product commit/push/PR. Corpus
+              opt-in after research init — see agent-researcher canvas.
             </Text>
           </CardBody>
         </Card>

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -25,12 +25,13 @@ type SsotMode = "board" | "fallback";
 
 const VERIFIED = "2026-07-19";
 const SOURCES =
-  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · .agents/skills/RESEARCH_WORKFLOW.md";
+  ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · .agents/skills/RESEARCH_WORKFLOW.md · live pack flexiai-toolsmith + verifier";
 
 const GOALS = [
   "Adaptive Brief from chat, peer agent Notes/handoffs, or board research card",
   "Multi-round packs under _research_results/sources/<slug>/ + AGENT_BRIEF for MAS",
   "Hard-stop: write only _research_results/ — no product git/PR",
+  "Anti-loop efficient: ≤6 rounds, one init/fetch, exit on validate PASS",
 ];
 
 const BOARD_NODES = [
@@ -79,6 +80,26 @@ const FALLBACK_LABELS: Record<string, string> = {
   close: "local close",
 };
 
+const HOW_IT_WORKS = [
+  ["1 Intake", "Normalize source (HTTPS | github: | path) + question → BRIEF.md"],
+  ["2 Init/fetch", "research init → research fetch (shallow clone → cache/<slug>/)"],
+  ["3 Map/extract", "MAP.md + findings/<lens>.md with path + ~Lnn evidence"],
+  ["4 Deepen", "rounds/round-N.md only for open questions (cap ≤6)"],
+  ["5 Curate/pack", "CURATED.md → AGENT_BRIEF.md → INDEX.json status=complete"],
+  ["6 Validate", "research validate --slug <slug> must PASS"],
+  ["7 Exit", "Research card Done + Notes with pack paths; handoff to consumer"],
+];
+
+const LIVE_PROOF = [
+  ["Slug", "flexiai-toolsmith"],
+  ["Source", "github:SavinRazvan/flexiai-toolsmith @ 3f8b0c7"],
+  ["Rounds", "6/6 (justified; anti-loop exit)"],
+  ["Curated", "18 verified rows"],
+  ["Validate", "PASS"],
+  ["Verifier", "Claim A+B VERIFIED (2026-07-19)"],
+  ["Board", "Issue #74 Done · pack paths in Notes"],
+];
+
 const READ_FIRST = [
   [".cursor/skills/research-corpus-execution/SKILL.md", "Intake + rounds canon"],
   ["_research_results/RESEARCH_BOUNDARIES.md", "Hard-stop boundaries"],
@@ -86,13 +107,15 @@ const READ_FIRST = [
 ];
 
 const PATTERNS = [
+  ["Shipped agent", "Fully functional — live E2E + verifier PASS"],
+  ["Opt-in corpus", "Packs appear only after research init (not incomplete)"],
   ["Hard stop", "Write only _research_results/"],
   ["Adaptive intake", "Chat / peer Notes / board card → Brief (+ defaults)"],
   ["Terse chat", "/researcher https://github.com/owner/repo OK"],
   ["Anti-loop", "≤6 deepen rounds; no re-fetch without --force; exit on complete"],
   ["GitHub auth", "Public: network; private: consumer gh/git credentials"],
   ["Board lifecycle", "create-from-template research → done + pack paths"],
-  ["Consumers", "implementer / integrator read AGENT_BRIEF.md"],
+  ["Consumers", "implementer / integrator / chat-user read AGENT_BRIEF.md"],
 ];
 
 const ARTIFACTS = [
@@ -108,6 +131,7 @@ const PEERS = [
   ["Use instead", "enterprise-auditor", "Architecture audits"],
   ["Use instead", "verifier", "Claims vs evidence"],
   ["Consumes from", "any agent", "Notes / handoff / cited pack path"],
+  ["Proven with", "verifier", "Post-pack Claim A/B check (optional)"],
 ];
 
 function DagPanel({
@@ -188,6 +212,9 @@ export default function AgentResearcherCanvas() {
       <Stack gap={8}>
         <Row gap={10} style={{ alignItems: "center" }}>
           <H1 style={{ margin: 0 }}>researcher</H1>
+          <Pill tone="success" size="sm">
+            shipped / proven
+          </Pill>
           <Pill tone="info" size="sm">
             kit agent
           </Pill>
@@ -198,17 +225,26 @@ export default function AgentResearcherCanvas() {
         <Text tone="secondary">
           Brief-driven multi-round research (GitHub HTTPS / github: / local path).
           Adaptive intake from chat or peer agents; hard-stop on product code.
+          Agent is fully functional; corpus packs are opt-in after research init.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
         </Text>
       </Stack>
 
-      <Grid columns={3} gap={12}>
+      <Grid columns={4} gap={12}>
+        <Stat value="proven" label="Live E2E + verifier" tone="success" />
         <Stat value="_research_results/" label="Only write target" />
-        <Stat value="adaptive Brief" label="Chat / agents / card" tone="info" />
+        <Stat value="≤6 rounds" label="Anti-loop cap" tone="info" />
         <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
       </Grid>
+
+      <Callout tone="success" title="Status (2026-07-19)">
+        Researcher is shipped and efficient. Live proof: flexiai-toolsmith pack
+        (18 curated, validate PASS) + verifier Claim A (efficiency) and Claim B
+        (correctness) VERIFIED. “Optional” means opt-in corpus — not an incomplete
+        agent.
+      </Callout>
 
       <Stack gap={8}>
         <H2>Goals</H2>
@@ -218,6 +254,27 @@ export default function AgentResearcherCanvas() {
       </Stack>
 
       <Divider />
+
+      <Stack gap={10}>
+        <H2 style={{ margin: 0 }}>How it works</H2>
+        <Table headers={["Step", "Action"]} rows={HOW_IT_WORKS} />
+        <Callout tone="info" title="CLI owns scaffold; agent owns evidence">
+          python3 -m cursor_workflow research init|fetch|validate. Agent fills
+          rounds 1–6 prose under sources/&lt;slug&gt;/ then exits on complete.
+        </Callout>
+      </Stack>
+
+      <Card>
+        <CardHeader>Live proof (flexiai-toolsmith)</CardHeader>
+        <CardBody>
+          <Table headers={["Field", "Evidence"]} rows={LIVE_PROOF} />
+          <Spacer size={8} />
+          <Text tone="tertiary" size="small">
+            Pack: _research_results/sources/flexiai-toolsmith/AGENT_BRIEF.md ·
+            Board Issue #74
+          </Text>
+        </CardBody>
+      </Card>
 
       <Stack gap={10}>
         <Row gap={12} style={{ alignItems: "center" }}>
@@ -289,7 +346,8 @@ export default function AgentResearcherCanvas() {
         <CardBody>
           <Stack gap={6}>
             <Text>
-              Create: create-from-template --template research (or claim Ready card).
+              Create: create-from-template --template research --priority p2
+              --size m --estimate 3 --agent researcher (or claim Ready card).
             </Text>
             <Text>Entry: project status + research card when board on.</Text>
             <Text>

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -55,7 +55,7 @@ const AGENTS = [
   {
     id: "researcher",
     description:
-      "Brief-driven multi-round research (chat/agent adaptive intake); packs under _research_results/; hard-stop on product code",
+      "Shipped/proven corpus researcher — adaptive Brief; packs under _research_results/ (opt-in after init); hard-stop on product code",
   },
 ];
 
@@ -194,8 +194,8 @@ export default function AgentRosterCanvas() {
         </Row>
         <Text tone="secondary">
           Explicit handoff edges from agent cards (skill chain test-runner→verifier
-          when tests gate PR). researcher is non-product — redirects to product
-          agents.
+          when tests gate PR). researcher is shipped/proven and non-product —
+          corpus opt-in; redirects to product agents for code/PR.
         </Text>
         <Callout tone="info" title="Board lifecycle (all 8)">
           Tier-1: Start date on claim or first In progress; Size↔Estimate points
@@ -242,10 +242,11 @@ export default function AgentRosterCanvas() {
             headers={["Agent", "When"]}
             rows={RESEARCHER_REDIRECTS}
           />
-          <Callout tone="warning" title="Non-product agent">
-            researcher writes only _research_results/ (adaptive Brief from
-            chat/agents). No src/tests/scripts; no git/PR. Not connected in
-            product handoff DAG — consumers read AGENT_BRIEF.md.
+          <Callout tone="info" title="Shipped non-product agent">
+            researcher is fully functional (live E2E + verifier PASS 2026-07-19).
+            Writes only _research_results/ after research init (opt-in corpus).
+            No src/tests/scripts; no git/PR. Not in product handoff DAG —
+            consumers read AGENT_BRIEF.md. See agent-researcher canvas.
           </Callout>
         </CardBody>
       </Card>

--- a/payload/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/payload/.agents/skills/RESEARCH_WORKFLOW.md
@@ -2,6 +2,8 @@
 
 **Brief-driven multi-round research** for `_research_results/` — not implementation slices (`implementer` + board / `.local/.../current/*`).
 
+**Status (2026-07-19):** Agent is **shipped and proven** (live external pack + verifier PASS). Corpus packs remain **opt-in** — they appear only after `research init` (not an incomplete agent).
+
 Versioned hub (in git). Corpus boundaries: `_research_results/RESEARCH_BOUNDARIES.md` (from `research init`).
 
 ## Order (active)
@@ -11,7 +13,17 @@ Versioned hub (in git). Corpus boundaries: `_research_results/RESEARCH_BOUNDARIE
 3. Normalize source → `research init` → `research fetch` → rounds → `validate`
 4. Pack `BRIEF.md` + `SOURCE.md` under `_research_results/sources/<slug>/`
 
-Agent: **`.cursor/agents/researcher.md`**.
+Agent: **`.cursor/agents/researcher.md`**. Canvas: `canvases/agent-researcher.canvas.tsx`.
+
+## How it works (7 steps)
+
+1. **Intake** — normalize source + question → `BRIEF.md` (defaults for terse `/researcher <url>`)
+2. **Init/fetch** — CLI scaffolds pack + shallow clone to `cache/<slug>/`
+3. **Map/extract** — `MAP.md` + `findings/<lens>.md` with path + ~Lnn evidence
+4. **Deepen** — `rounds/round-N.md` only for open questions (cap ≤6; anti-loop)
+5. **Curate/pack** — `CURATED.md` → `AGENT_BRIEF.md` → `INDEX.json` `status=complete`
+6. **Validate** — `python3 -m cursor_workflow research validate --slug <slug>` PASS
+7. **Exit** — research card Done + Notes with pack paths; handoff to consumer
 
 ## Hard boundary
 
@@ -31,6 +43,7 @@ No product repo edits; no git commits for research packs; writes only `_research
 | D7 | Accept HTTPS GitHub URLs and terse `/researcher <url>` chat; apply skill defaults |
 | D8 | Anti-loop: rounds_max≤6; no re-fetch/re-init without `--force`; exit on complete |
 | D9 | Private GitHub needs consumer `gh`/git auth; public needs network only |
+| D10 | Agent shipped/proven; corpus remains opt-in after first `research init` |
 
 ## Forbidden
 
@@ -57,7 +70,15 @@ No product repo edits; no git commits for research packs; writes only `_research
 
 ## Board
 
-`create-from-template --template research` → claim → Done + Notes with pack paths.
+`create-from-template --template research --priority p2` → claim → Done + Notes with pack paths.
+
+## Live proof
+
+| Field | Evidence |
+|-------|----------|
+| Slug | `flexiai-toolsmith` (Issue #74) |
+| Source | `github:SavinRazvan/flexiai-toolsmith` @ `3f8b0c7` |
+| Result | 6 rounds · 18 curated · validate PASS · verifier Claim A+B VERIFIED |
 
 ## Related
 
@@ -67,3 +88,4 @@ No product repo edits; no git commits for research packs; writes only `_research
 | Implementation | `implementer` (reads `AGENT_BRIEF.md`) |
 | Integration | `integrator-mas-agent` |
 | Audit | `enterprise-auditor` |
+| Agent canvas | `canvases/agent-researcher.canvas.tsx` |

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -53,7 +53,7 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 | `test-runner` | Module tests, coverage; board Exit Status |
 | `verifier` | Evidence checks; board Done / In review |
 | `enterprise-auditor` | Architecture audits; audit card Status + Notes |
-| `researcher` | Adaptive Brief multi-round packs under `_research_results/`; chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
+| `researcher` | **Shipped/proven** adaptive Brief multi-round packs under `_research_results/` (opt-in after init); chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
 | `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
 | `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
 | `project-board` | Board triage helper (ADR-006); not in default PR pipelines |

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -276,7 +276,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/verifier` | `.cursor/agents/verifier.md` |
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
-| `/researcher` | `.cursor/agents/researcher.md` — adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate` |
+| `/researcher` | `.cursor/agents/researcher.md` — **shipped/proven**; adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate`; corpus opt-in after init |
 | `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |
 | `/mas-infrastructure-integration` | `.cursor/skills/mas-infrastructure-integration/` |

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -49,9 +49,9 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
 | enterprise-auditor | Architecture audits |
-| researcher | Brief-driven research packs; adaptive intake from chat/agents/board; CLI `research init\|fetch\|validate` |
+| researcher | Shipped corpus researcher; adaptive Brief; CLI `research init\|fetch\|validate`; packs opt-in after init |
 
-## Research (optional)
+## Research (opt-in corpus)
 
 | Term | Meaning |
 |------|---------|

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -20,7 +20,7 @@ description: Brief-driven multi-round research (GitHub/local) into _research_res
 
 **Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.
 
-Build and maintain a **local research corpus** of verified packs. **Off by default** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
+Build and maintain a **local research corpus** of verified packs. **Agent is shipped/proven** (live E2E + verifier PASS 2026-07-19); corpus packs remain **opt-in** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
 
 ## Adaptive intake (mandatory before research)
 

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -4,7 +4,7 @@ model: auto
 description: Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
-# Researcher (optional)
+# Researcher (shipped; opt-in corpus)
 
 ## Anchor (mandatory)
 

--- a/payload/.cursor/skills/research-corpus-execution/SKILL.md
+++ b/payload/.cursor/skills/research-corpus-execution/SKILL.md
@@ -120,3 +120,7 @@ If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID pe
 ```text
 slug · mode · rounds · curated_count · AGENT_BRIEF path · validate PASS/FAIL · next consumer
 ```
+
+## Status
+
+**Agent shipped/proven** (2026-07-19): live external pack (`flexiai-toolsmith`, 18 curated, validate PASS) + verifier Claim A (efficiency) / Claim B (correctness) VERIFIED. Corpus remains **opt-in** after first `research init` — not an incomplete agent. Canvas: `canvases/agent-researcher.canvas.tsx`.

--- a/skills/research-corpus-execution/SKILL.md
+++ b/skills/research-corpus-execution/SKILL.md
@@ -120,3 +120,7 @@ If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID pe
 ```text
 slug · mode · rounds · curated_count · AGENT_BRIEF path · validate PASS/FAIL · next consumer
 ```
+
+## Status
+
+**Agent shipped/proven** (2026-07-19): live external pack (`flexiai-toolsmith`, 18 curated, validate PASS) + verifier Claim A (efficiency) / Claim B (correctness) VERIFIED. Corpus remains **opt-in** after first `research init` — not an incomplete agent. Canvas: `canvases/agent-researcher.canvas.tsx`.

--- a/tests/modules/architecture_scripts/test_check_doc_facts.py
+++ b/tests/modules/architecture_scripts/test_check_doc_facts.py
@@ -82,8 +82,8 @@ def test_missing_agent_in_roster_hub_fails_doc008(tmp_path: Path) -> None:
     needle = (
         '  {\n'
         '    id: "researcher",\n'
-        '    role: "Adaptive Brief research packs (no product PRs)",\n'
-        '    lane: "Optional",\n'
+        '    role: "Shipped corpus researcher — packs under _research_results/ (opt-in)",\n'
+        '    lane: "Research (opt-in corpus)",\n'
         "  },\n"
     )
     assert needle in text, "fixture must match agent-relations researcher AGENTS row"


### PR DESCRIPTION
## Summary
- Mark **researcher** as shipped/proven (live flexiai-toolsmith pack + verifier Claim A/B PASS); clarify “optional” as **opt-in corpus** after `research init`, not an incomplete agent.
- Expand `agent-researcher` canvas with how-it-works (7 steps) and live-proof table; update roster/relations canvases accordingly.
- Sync HANDOFF, AGENTS, IMPLEMENTATION-STATUS, RESEARCH_WORKFLOW, skill, PLUGIN-USER-GUIDE, abbreviations, architecture + plugin mirrors.

## Test plan
- [x] `make sync-plugin` / `make check-plugin` PASS
- [x] `python3 .ai_infra/scripts/architecture/check_doc_facts.py` PASS
- [ ] Open `agent-researcher` canvas in IDE and confirm shipped/proven + how-it-works sections render
- [ ] Skim `HANDOFF.md` agent roster row for researcher

Board: Issue #75 · `PVTI_lAHOBl46-84A9KZxzgzWDvQ` (Done)

Made with [Cursor](https://cursor.com)