### PR TITLE
feat: GitHub API safety G1–G5 (precheck, throttle, dedupe)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
 **Last updated:** 2026-07-19 (COV-100 verify — 100% scoped kit coverage)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1072
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1085
 
 ## Shipped (confirmed in repo)
 
@@ -38,7 +38,7 @@ Notes:
 | Board CLI subcommands | **22** leaf commands — full table in ops doc | [project-board-collaboration.md](../operations/project-board-collaboration.md) § Project CLI subcommands |
 | EA-001 residual thin CLI | `project_cli.py` facade (~660 LOC) + parser/handlers split; board CLI modules under `.ai_infra/install/cursor_workflow/`: `project_cli.py`, `project_parser.py`, `project_handlers.py`, `project_atomics.py`, `gh_project_adapter.py`, `project_recipes.py`, `project_outbox.py` | PR #36 |
 | Doc facts validate | DOC-001…008 | `.ai_infra/scripts/architecture/check_doc_facts.py` |
-| Kit canvases | **13** files under `canvases/`; DOC-008 counts **11** roster/agent canvases (excludes concept hubs `board-ssot-vs-kit.canvas.tsx`, `agents-artifacts-board.canvas.tsx`) | `canvases/` · `doc_facts_checks._canvas_paths` |
+| Kit canvases | **14** files under `canvases/`; DOC-008 counts **11** roster/agent canvases (excludes concept hubs `board-ssot-vs-kit.canvas.tsx`, `agents-artifacts-board.canvas.tsx`, `github-api-safety.canvas.tsx`) | `canvases/` · `doc_facts_checks._canvas_paths` |
 | Verify-all matrix | Maintainer preflight | `.ai_infra/scripts/architecture/verify_all.py` |
 | Anchoring | session-pointer, change-index | `.local/.../current/` |
 | MCP tools + resources | 20 tools + 6 resources | `.ai_infra/mcp_servers/workflow_mcp/` |
@@ -52,13 +52,13 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus-execution` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1072 collected (1070 passed + 2 skipped on full run) | `tests/modules/` |
+| Tests | 1085 collected (1083 passed + 2 skipped on full run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-19
-(COV-100 verify): **6208 statements, 100.00%** on a full suite pass (**1072
+(COV-100 verify): **6208 statements, 100.00%** on a full suite pass (**1085
 collected**; 1070 passed, 2 skipped). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -52,7 +52,7 @@ mas-workflow-kit-project-ssot/
 ├── cursor_workflow/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1072; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1085; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1072; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1085; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -113,11 +113,13 @@ All subcommands registered in `.ai_infra/install/cursor_workflow/project_parser.
 
 GitHub GraphQL quota (~5000/hour) can block board writes. When `project_ssot.outbox.enabled`:
 
-1. Live write fails with rate-limit → CLI **enqueues** to `.local/generated-data/board-outbox.jsonl` and returns **EXIT_QUEUED (6)**.
-2. Agent continues local evidence (`change-index`, handoff line) — **do not** hammer `gh` / retry loops.
-3. After quota recovers: `python3 -m cursor_workflow project outbox status` then `outbox flush` (capped by `max_flush_per_run`; refuses if `remaining < min_graphql_remaining`).
-4. Explicit enqueue: `project queue --op append-notes|set-status|handoff|claim|set-assignee|set-field …`
-5. Outbox is a **local buffer**, never a second Status SSOT.
+1. **Precheck (default):** before Pattern A writes, CLI reads cached REST `rate_limit` (TTL `quota_cache_ttl_seconds`, default 45s). If GraphQL `remaining < min_graphql_remaining`, enqueue + **EXIT_QUEUED (6)** without calling Projects GraphQL.
+2. Live write fails with throttle (rate-limit / secondary / 429 / bare Forbidden) → CLI **enqueues** to `.local/generated-data/board-outbox.jsonl` and returns **EXIT_QUEUED (6)**. Permanent scope-miss errors are **not** queued.
+3. **Dedupe:** identical pending `op`+`item_id`+payload fingerprint reuses one outbox row (`dedupe_pending`).
+4. Agent continues local evidence (`change-index`, handoff line) — **do not** hammer `gh` / retry loops (CODE=6 = soft-success).
+5. After quota recovers: `python3 -m cursor_workflow project outbox status` then `outbox flush` (capped by `max_flush_per_run`; refuses if `remaining < min_graphql_remaining`).
+6. Explicit enqueue: `project queue --op append-notes|set-status|handoff|claim|set-assignee|set-field …`
+7. Outbox is a **local buffer**, never a second Status SSOT. Prefer Pattern A CLI over raw `gh api graphql` (raw calls bypass the outbox).
 
 Who flushes: any agent/human after reset; prefer implementer or project-board at slice close. Pending outbox is **not** a DRIFT failure.
 

--- a/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/.ai_infra/install/cursor_workflow/project_cli.py
@@ -110,7 +110,9 @@ from project_recipes import (
     _try_queue_rate_limit,
     append_notes_helper,
     find_items_mentioning_pr,
+    guard_write_or_queue,
     in_progress_conflicts_for_user,
+    note_successful_write,
     resolve_item_id_for_pr,
 )
 
@@ -397,6 +399,17 @@ def cmd_set_status(args: argparse.Namespace) -> int:
             "field_id"
         ):
             queue_payload["start_date"] = utc_today_iso()
+    pre = guard_write_or_queue(
+        root,
+        ssot,
+        cmd="set-status",
+        op="set-status",
+        item_id=item_id,
+        agent=(getattr(args, "agent", None) or "project-cli"),
+        payload=queue_payload,
+    )
+    if pre is not None:
+        return pre
     proc = run_gh(
         [
             "project",
@@ -427,6 +440,7 @@ def cmd_set_status(args: argparse.Namespace) -> int:
             return queued
         return fail("set-status", EXIT_GH, detail)
     print(f"set-status: {item_id} → {args.to} ({option_id})")
+    note_successful_write(root, ssot)
     if _normalize_status(str(args.to)) == "in_progress":
         d_ok, d_detail, d_applied = ensure_start_date_if_starting(ssot, item_id)
         if not d_ok:
@@ -451,6 +465,7 @@ def cmd_set_field(args: argparse.Namespace) -> int:
             EXIT_USAGE,
             "--field must be priority, size, or estimate",
         )
+    agent = getattr(args, "agent", None) or "project-cli"
     if field == "estimate":
         try:
             num = float(str(args.to).strip())
@@ -458,6 +473,17 @@ def cmd_set_field(args: argparse.Namespace) -> int:
             return fail("set-field", EXIT_USAGE, "--to must be a number for estimate")
         if num < 0:
             return fail("set-field", EXIT_USAGE, "estimate must be >= 0")
+        pre = guard_write_or_queue(
+            root,
+            ssot,
+            cmd="set-field",
+            op="set-field",
+            item_id=item_id,
+            agent=agent,
+            payload={"field": "estimate", "to": num},
+        )
+        if pre is not None:
+            return pre
         ok, detail = set_item_number(ssot, item_id, "estimate", num)
         if not ok:
             queued = _try_queue_rate_limit(
@@ -467,18 +493,30 @@ def cmd_set_field(args: argparse.Namespace) -> int:
                 err_detail=detail,
                 op="set-field",
                 item_id=item_id,
-                agent=(getattr(args, "agent", None) or "project-cli"),
+                agent=agent,
                 payload={"field": "estimate", "to": num},
             )
             if queued is not None:
                 return queued
             return fail("set-field", EXIT_GH, detail)
         print(f"set-field: {item_id} estimate → {num}")
+        note_successful_write(root, ssot)
         return EXIT_OK
     try:
         field_id, option_id = resolve_field_option_id(ssot, field, args.to)
     except KeyError as exc:
         return fail("set-field", EXIT_USAGE, str(exc))
+    pre = guard_write_or_queue(
+        root,
+        ssot,
+        cmd="set-field",
+        op="set-field",
+        item_id=item_id,
+        agent=agent,
+        payload={"field": field, "to": args.to},
+    )
+    if pre is not None:
+        return pre
     project_id = str(ssot["project_id"])
     proc = run_gh(
         [
@@ -503,13 +541,14 @@ def cmd_set_field(args: argparse.Namespace) -> int:
             err_detail=detail,
             op="set-field",
             item_id=item_id,
-            agent=(getattr(args, "agent", None) or "project-cli"),
+            agent=agent,
             payload={"field": field, "to": args.to},
         )
         if queued is not None:
             return queued
         return fail("set-field", EXIT_GH, detail)
     print(f"set-field: {item_id} {field} → {args.to} ({option_id})")
+    note_successful_write(root, ssot)
     return EXIT_OK
 def cmd_get(args: argparse.Namespace) -> int:
     root = Path(args.directory).resolve()
@@ -567,6 +606,8 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         limit=args.limit,
     )
     if not ok:
+        if err_code == EXIT_QUEUED:
+            return EXIT_QUEUED
         if err_code == EXIT_GH:
             queued = _try_queue_rate_limit(
                 root,
@@ -606,6 +647,18 @@ def cmd_set_assignee(args: argparse.Namespace) -> int:
             EXIT_USAGE,
             "no login (pass --login or set owner.github_user)",
         )
+    agent = getattr(args, "agent", None) or "project-cli"
+    pre = guard_write_or_queue(
+        root,
+        ssot,
+        cmd="set-assignee",
+        op="set-assignee",
+        item_id=item_id,
+        agent=agent,
+        payload={"login": login},
+    )
+    if pre is not None:
+        return pre
     ok, detail = set_item_assignee(ssot, item_id, login)
     if not ok:
         # DraftIssue / unsupported → validation; gh failures look like network
@@ -625,6 +678,7 @@ def cmd_set_assignee(args: argparse.Namespace) -> int:
             return queued
         return fail("set-assignee", EXIT_GH, detail)
     print(f"set-assignee: {item_id} → @{detail.lstrip('@')}")
+    note_successful_write(root, ssot)
     return EXIT_OK
 def cmd_claim(args: argparse.Namespace) -> int:
     from project_handlers import run_claim

--- a/.ai_infra/install/cursor_workflow/project_handlers.py
+++ b/.ai_infra/install/cursor_workflow/project_handlers.py
@@ -47,6 +47,17 @@ def run_claim(args: argparse.Namespace) -> int:
     start_cfg = fields_block.get('start_date') if isinstance(fields_block, dict) else None
     if conventions.get('set_start_date_on_claim', True) and isinstance(start_cfg, dict) and start_cfg.get('field_id'):
         claim_payload['start_date'] = pc.utc_today_iso()
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='claim',
+        op='claim',
+        item_id=item_id,
+        agent=agent,
+        payload=claim_payload,
+    )
+    if pre is not None:
+        return pre
     items, err = pc.fetch_project_items(ssot, limit=args.limit)
     if err:
         queued = pc._try_queue_rate_limit(root, ssot, cmd='claim', err_detail=err, op='claim', item_id=item_id, agent=agent, payload=claim_payload)
@@ -89,8 +100,12 @@ def run_claim(args: argparse.Namespace) -> int:
         # already had a date
         pass
     note = getattr(args, 'text', None) or 'claimed'
-    n_ok, n_detail, n_code = pc.append_notes_helper(root, ssot, item_id, agent=agent, text=note, limit=args.limit)
+    n_ok, n_detail, n_code = pc.append_notes_helper(
+        root, ssot, item_id, agent=agent, text=note, limit=args.limit, skip_precheck=True
+    )
     if not n_ok:
+        if n_code == pc.EXIT_QUEUED:
+            return n_code
         if n_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='claim', err_detail=n_detail, op='append-notes', item_id=item_id, agent=agent, payload={'text': note})
             if queued is not None:
@@ -125,9 +140,23 @@ def run_handoff(args: argparse.Namespace) -> int:
         self_attr = pc.format_agent_attribution(root, agent)
     except ValueError as exc:
         return pc.fail('handoff', pc.EXIT_USAGE, str(exc))
+    extra = (getattr(args, 'text', None) or '').strip()
+    status_to = (getattr(args, 'to', None) or '').strip()
+    handoff_payload = {'next': next_agent, 'to': status_to, 'note': extra}
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='handoff',
+        op='handoff',
+        item_id=item_id,
+        agent=agent,
+        payload=handoff_payload,
+    )
+    if pre is not None:
+        return pre
     items, err = pc.fetch_project_items(ssot, limit=args.limit)
     if err:
-        queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=err, op='handoff', item_id=item_id, agent=agent, payload={'next': next_agent, 'to': (getattr(args, 'to', None) or '').strip(), 'note': (getattr(args, 'text', None) or '').strip()})
+        queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=err, op='handoff', item_id=item_id, agent=agent, payload=handoff_payload)
         if queued is not None:
             return queued
         return pc.fail('handoff', pc.EXIT_GH, err)
@@ -135,17 +164,15 @@ def run_handoff(args: argparse.Namespace) -> int:
     if item is None:
         return pc.fail('handoff', pc.EXIT_NOT_FOUND, f'item not found: {item_id}')
     before = pc._normalize_status(str(item.get('status') or ''))
-    extra = (getattr(args, 'text', None) or '').strip()
     note_core = f'next={next_attr}'
     if extra:
         note_core = f'{extra} · {note_core}'
-    status_to = (getattr(args, 'to', None) or '').strip()
     if status_to:
         ok, detail = pc.set_item_status(ssot, item_id, status_to)
         if not ok:
             if 'unknown' in detail.lower():
                 return pc.fail('handoff', pc.EXIT_USAGE, detail)
-            queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=detail, op='handoff', item_id=item_id, agent=agent, payload={'next': next_agent, 'to': status_to, 'note': extra})
+            queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=detail, op='handoff', item_id=item_id, agent=agent, payload=handoff_payload)
             if queued is not None:
                 return queued
             return pc.fail('handoff', pc.EXIT_GH, detail)
@@ -157,8 +184,12 @@ def run_handoff(args: argparse.Namespace) -> int:
                 print(f'handoff: start_date={d_detail}')
             elif 'field_id missing' in d_detail:
                 print(f'handoff: WARN — start_date skipped: {d_detail}', file=sys.stderr)
-    n_ok, n_detail, n_code = pc.append_notes_helper(root, ssot, item_id, agent=agent, text=note_core, limit=args.limit)
+    n_ok, n_detail, n_code = pc.append_notes_helper(
+        root, ssot, item_id, agent=agent, text=note_core, limit=args.limit, skip_precheck=True
+    )
     if not n_ok:
+        if n_code == pc.EXIT_QUEUED:
+            return n_code
         if n_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=n_detail, op='handoff', item_id=item_id, agent=agent, payload={'next': next_agent, 'to': status_to, 'note': extra})
             if queued is not None:
@@ -205,6 +236,17 @@ def run_mention_pr(args: argparse.Namespace) -> int:
     pr_num = pdata.get('number')
     if not pr_url:
         return pc.fail('mention-pr', pc.EXIT_GH, 'pr view missing url')
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='mention-pr',
+        op='append-notes',
+        item_id=item_id,
+        agent=agent,
+        payload={'text': f'PR {pr_num}: {pr_url}'},
+    )
+    if pre is not None:
+        return pre
     kind, _cid, _meta, kerr = pc.resolve_item_content(ssot, item_id)
     conventions = ssot.get('conventions') or {}
     promote_on = conventions.get('promote_to_issue_on_pr', True)
@@ -220,8 +262,12 @@ def run_mention_pr(args: argparse.Namespace) -> int:
         else:
             print(f'mention-pr: WARN — card looks DraftIssue; GitHub Linked pull requests fills for Issue-backed items. Run: project promote-to-issue --last (promote_to_issue_on_pr={promote_on}).', file=sys.stderr)
     note = f'PR {pr_num}: {pr_url}'
-    ok, detail, err_code = pc.append_notes_helper(root, ssot, item_id, agent=agent, text=note, limit=args.limit)
+    ok, detail, err_code = pc.append_notes_helper(
+        root, ssot, item_id, agent=agent, text=note, limit=args.limit, skip_precheck=True
+    )
     if not ok:
+        if err_code == pc.EXIT_QUEUED:
+            return err_code
         if err_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='mention-pr', err_detail=detail, op='append-notes', item_id=item_id, agent=agent, payload={'text': note})
             if queued is not None:
@@ -251,6 +297,17 @@ def run_promote_to_issue(args: argparse.Namespace) -> int:
     if not agent:
         return pc.fail('promote-to-issue', pc.EXIT_USAGE, '--agent required')
     repo = (getattr(args, 'repo', None) or '').strip() or str(ssot.get('default_repo') or '').strip()
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='promote-to-issue',
+        op='promote-to-issue',
+        item_id=item_id,
+        agent=agent,
+        payload={'repo': repo},
+    )
+    if pre is not None:
+        return pre
     ok, detail, meta = pc.promote_draft_item_to_issue(ssot, item_id, repo=repo)
     if not ok:
         queued = pc._try_queue_rate_limit(root, ssot, cmd='promote-to-issue', err_detail=detail, op='promote-to-issue', item_id=item_id, agent=agent, payload={'repo': repo})
@@ -275,8 +332,12 @@ def run_promote_to_issue(args: argparse.Namespace) -> int:
         else:
             print(f'promote-to-issue: assignee=@{a_detail.lstrip('@')}')
     note = f'promoted to Issue #{issue_n}: {url}' if url else f'promoted to Issue #{issue_n}'
-    n_ok, n_detail, n_code = pc.append_notes_helper(root, ssot, out_id, agent=agent, text=note, limit=args.limit)
+    n_ok, n_detail, n_code = pc.append_notes_helper(
+        root, ssot, out_id, agent=agent, text=note, limit=args.limit, skip_precheck=True
+    )
     if not n_ok:
+        if n_code == pc.EXIT_QUEUED:
+            return n_code
         if n_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='promote-to-issue', err_detail=n_detail, op='append-notes', item_id=out_id, agent=agent, payload={'text': note})
             if queued is not None:

--- a/.ai_infra/install/cursor_workflow/project_outbox.py
+++ b/.ai_infra/install/cursor_workflow/project_outbox.py
@@ -9,6 +9,7 @@ Depends On:
 Notes:
  - Outbox is a local buffer, never a second Status SSOT (ADR-008).
  - Flush is pull-based; refuses when GraphQL remaining < min_graphql_remaining.
+ - Cached REST rate_limit precheck (TTL) before Pattern A writes; pending-op dedupe.
 """
 
 from __future__ import annotations
@@ -42,10 +43,26 @@ _OUTBOX_OPS = frozenset(
     }
 )
 _DEFAULT_PATH = ".local/generated-data/board-outbox.jsonl"
+_DEFAULT_QUOTA_CACHE = ".local/generated-data/graphql-quota-cache.json"
 _RATE_LIMIT_RE = re.compile(
-    r"rate\s*limit|API rate limit exceeded|secondary rate limit",
+    r"rate\s*limit|API rate limit exceeded|secondary rate limit|"
+    r"\b429\b|retry\s*later|wait a few minutes|too many requests",
     re.IGNORECASE,
 )
+_FORBIDDEN_RE = re.compile(r"\b403\b|\bForbidden\b", re.IGNORECASE)
+_SCOPE_MISS_RE = re.compile(
+    r"missing required scopes|required scopes|authentication token is missing",
+    re.IGNORECASE,
+)
+_DEDUPE_PAYLOAD_KEYS: dict[str, tuple[str, ...]] = {
+    "append-notes": ("text",),
+    "set-status": ("to",),
+    "claim": ("to", "text", "start_date"),
+    "handoff": ("next", "to", "note", "text"),
+    "set-assignee": ("login",),
+    "set-field": ("field", "to", "name", "value"),
+    "promote-to-issue": ("repo",),
+}
 
 
 def load_outbox_config(ssot: dict[str, Any]) -> dict[str, Any]:
@@ -57,6 +74,11 @@ def load_outbox_config(ssot: dict[str, Any]) -> dict[str, Any]:
         "min_graphql_remaining": int(raw.get("min_graphql_remaining") or 200),
         "max_flush_per_run": int(raw.get("max_flush_per_run") or 10),
         "retry_backoff_seconds": int(raw.get("retry_backoff_seconds") or 30),
+        "precheck_writes": bool(raw.get("precheck_writes", True)),
+        "quota_cache_ttl_seconds": int(raw.get("quota_cache_ttl_seconds") or 45),
+        "quota_cache_path": str(raw.get("quota_cache_path") or _DEFAULT_QUOTA_CACHE).strip()
+        or _DEFAULT_QUOTA_CACHE,
+        "dedupe_pending": bool(raw.get("dedupe_pending", True)),
     }
 
 
@@ -65,9 +87,29 @@ def outbox_path(root: Path, cfg: dict[str, Any]) -> Path:
     return (root / rel).resolve() if not rel.is_absolute() else rel
 
 
-def is_rate_limit_error(text: str) -> bool:
-    return bool(_RATE_LIMIT_RE.search(text or ""))
+def quota_cache_path(root: Path, cfg: dict[str, Any]) -> Path:
+    rel = Path(str(cfg.get("quota_cache_path") or _DEFAULT_QUOTA_CACHE))
+    return (root / rel).resolve() if not rel.is_absolute() else rel
 
+
+def is_queueable_gh_throttle(text: str) -> bool:
+    """
+    True when stderr suggests transient GitHub throttle (queue to outbox).
+    Excludes permanent auth/scope failures.
+    """
+    blob = text or ""
+    if _SCOPE_MISS_RE.search(blob):
+        return False
+    if _RATE_LIMIT_RE.search(blob):
+        return True
+    if _FORBIDDEN_RE.search(blob):
+        return True
+    return False
+
+
+def is_rate_limit_error(text: str) -> bool:
+    """Alias for is_queueable_gh_throttle (back-compat)."""
+    return is_queueable_gh_throttle(text)
 
 def graphql_rate_limit() -> dict[str, Any]:
     """
@@ -130,6 +172,117 @@ def format_reset_iso(reset_epoch: Any) -> str:
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_now_epoch() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def read_quota_cache(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_quota_cache(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def refresh_graphql_quota(root: Path, ssot: dict[str, Any]) -> dict[str, Any]:
+    """Fetch GraphQL remaining via REST and write TTL cache."""
+    cfg = load_outbox_config(ssot)
+    rl = graphql_rate_limit()
+    payload = {
+        "remaining": rl.get("remaining"),
+        "limit": rl.get("limit"),
+        "reset_epoch": rl.get("reset_epoch"),
+        "error": rl.get("error"),
+        "fetched_at": _utc_now_epoch(),
+        "fetched_at_iso": _utc_now(),
+    }
+    write_quota_cache(quota_cache_path(root, cfg), payload)
+    return payload
+
+
+def get_cached_graphql_remaining(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    force_refresh: bool = False,
+) -> dict[str, Any]:
+    """
+    Return quota dict with remaining/limit/reset_epoch/error/from_cache.
+    Uses TTL cache; refreshes via REST when stale or force_refresh.
+    """
+    cfg = load_outbox_config(ssot)
+    path = quota_cache_path(root, cfg)
+    ttl = int(cfg["quota_cache_ttl_seconds"])
+    if not force_refresh:
+        cached = read_quota_cache(path)
+        if cached is not None:
+            try:
+                fetched = float(cached.get("fetched_at") or 0)
+            except (TypeError, ValueError):
+                fetched = 0.0
+            if fetched and (_utc_now_epoch() - fetched) <= ttl and cached.get("error") is None:
+                out = dict(cached)
+                out["from_cache"] = True
+                return out
+    fresh = refresh_graphql_quota(root, ssot)
+    fresh["from_cache"] = False
+    return fresh
+
+
+def remaining_below_min(root: Path, ssot: dict[str, Any], *, force_refresh: bool = False) -> tuple[bool, dict[str, Any]]:
+    """Return (below_min, quota_info). On read error, treat as not below (fail open to live write)."""
+    cfg = load_outbox_config(ssot)
+    info = get_cached_graphql_remaining(root, ssot, force_refresh=force_refresh)
+    if info.get("error"):
+        return False, info
+    try:
+        rem = int(info["remaining"]) if info.get("remaining") is not None else -1
+    except (TypeError, ValueError):
+        return False, info
+    min_rem = int(cfg["min_graphql_remaining"])
+    return rem >= 0 and rem < min_rem, info
+
+
+def _payload_fingerprint(op: str, payload: dict[str, Any]) -> tuple[Any, ...]:
+    keys = _DEDUPE_PAYLOAD_KEYS.get(op, tuple(sorted(payload.keys())))
+    parts: list[Any] = []
+    for key in keys:
+        val = payload.get(key)
+        if isinstance(val, str):
+            parts.append(val.strip())
+        else:
+            parts.append(val)
+    return tuple(parts)
+
+
+def find_duplicate_pending(
+    entries: list[dict[str, Any]],
+    *,
+    op: str,
+    item_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    want = _payload_fingerprint(op, payload)
+    for entry in entries:
+        if str(entry.get("status") or "") != "pending":
+            continue
+        if str(entry.get("op") or "") != op:
+            continue
+        if str(entry.get("item_id") or "") != item_id:
+            continue
+        existing_payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+        if _payload_fingerprint(op, existing_payload) == want:
+            return entry
+    return None
 
 
 def validate_outbox_entry(entry: dict[str, Any]) -> list[str]:
@@ -248,15 +401,22 @@ def enqueue_op(
         return None, "; ".join(errs)
     path = outbox_path(root, cfg)
     entries = read_outbox_entries(path)
+    if cfg.get("dedupe_pending", True):
+        dup = find_duplicate_pending(
+            entries, op=op_key, item_id=item_id.strip(), payload=dict(payload or {})
+        )
+        if dup is not None:
+            return dup, ""
     entries.append(entry)
     write_outbox_entries(path, entries)
     return entry, ""
 
 
-def queued_message(cmd: str, entry: dict[str, Any]) -> str:
+def queued_message(cmd: str, entry: dict[str, Any], *, reason: str = "throttle") -> str:
     return (
-        f"project {cmd}: QUEUED — id={entry.get('id')} op={entry.get('op')} "
-        f"item={entry.get('item_id')} · run: python3 -m cursor_workflow project outbox flush"
+        f"project {cmd}: QUEUED — CODE=6 · reason={reason} · id={entry.get('id')} "
+        f"op={entry.get('op')} item={entry.get('item_id')} · "
+        f"do not retry; later: python3 -m cursor_workflow project outbox flush"
     )
 
 
@@ -272,13 +432,13 @@ def maybe_enqueue_on_gh_fail(
     payload: dict[str, Any],
 ) -> int | None:
     """
-    If outbox enabled and error looks like rate-limit, enqueue and return EXIT_QUEUED.
+    If outbox enabled and error is queueable throttle, enqueue and return EXIT_QUEUED.
     Otherwise return None (caller should fail as before).
     """
     cfg = load_outbox_config(ssot)
     if not cfg["enabled"]:
         return None
-    if not is_rate_limit_error(err_detail):
+    if not is_queueable_gh_throttle(err_detail):
         return None
     entry, err = enqueue_op(
         root,
@@ -290,12 +450,89 @@ def maybe_enqueue_on_gh_fail(
     )
     if entry is None:
         print(
-            f"project {cmd}: FAIL — CODE={EXIT_GH} · rate-limit and enqueue failed: {err}",
+            f"project {cmd}: FAIL — CODE={EXIT_GH} · throttle and enqueue failed: {err}",
             file=sys.stderr,
         )
         return EXIT_GH
-    print(queued_message(cmd, entry), file=sys.stderr)
+    print(queued_message(cmd, entry, reason="throttle"), file=sys.stderr)
     return EXIT_QUEUED
+
+
+def maybe_enqueue_on_low_quota(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """
+    If precheck enabled and cached GraphQL remaining < min, enqueue and EXIT_QUEUED.
+    Returns None when write may proceed (or precheck disabled / quota unreadable).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"] or not cfg.get("precheck_writes", True):
+        return None
+    below, info = remaining_below_min(root, ssot)
+    if not below:
+        return None
+    entry, err = enqueue_op(
+        root,
+        ssot,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+    if entry is None:
+        print(
+            f"project {cmd}: FAIL — CODE={EXIT_GH} · low-quota enqueue failed: {err}",
+            file=sys.stderr,
+        )
+        return EXIT_GH
+    rem = info.get("remaining")
+    min_rem = cfg["min_graphql_remaining"]
+    print(
+        queued_message(cmd, entry, reason=f"precheck remaining={rem}<{min_rem}"),
+        file=sys.stderr,
+    )
+    return EXIT_QUEUED
+
+
+def guard_write_or_queue(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """
+    Call before Pattern A GraphQL writes.
+    Returns EXIT_QUEUED to skip the live write; None to proceed.
+    """
+    return maybe_enqueue_on_low_quota(
+        root,
+        ssot,
+        cmd=cmd,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+
+
+def note_successful_write(root: Path, ssot: dict[str, Any]) -> None:
+    """Refresh quota cache after a successful live write (respects TTL)."""
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return
+    # Soft refresh only when cache missing/stale — avoids REST spam
+    get_cached_graphql_remaining(root, ssot, force_refresh=False)
 
 
 def count_outbox(path: Path) -> dict[str, int]:
@@ -346,6 +583,7 @@ def apply_outbox_entry(
             agent=agent,
             text=str(payload.get("text") or ""),
             limit=limit,
+            skip_precheck=True,
         )
         return ok, detail
 
@@ -487,7 +725,8 @@ def flush_outbox(
     if not cfg["enabled"]:
         return EXIT_USAGE, "outbox.enabled is false"
     path = outbox_path(root, cfg)
-    rl = graphql_rate_limit()
+    # Prefer TTL cache; force refresh at flush start for accurate gate
+    rl = get_cached_graphql_remaining(root, ssot, force_refresh=True)
     remaining = rl.get("remaining")
     min_rem = int(cfg["min_graphql_remaining"])
     if rl.get("error"):
@@ -516,8 +755,8 @@ def flush_outbox(
     for idx in pending_idxs:
         if applied >= cap:
             break
-        # Re-check remaining mid-batch
-        rl2 = graphql_rate_limit()
+        # Mid-batch: re-read REST quota (flush is rare + capped; prefer accuracy)
+        rl2 = get_cached_graphql_remaining(root, ssot, force_refresh=True)
         try:
             rem2 = int(rl2.get("remaining")) if rl2.get("remaining") is not None else rem_i
         except (TypeError, ValueError):
@@ -533,15 +772,23 @@ def flush_outbox(
             entry["status"] = "done"
             entry["last_error"] = None
             done_n += 1
+            # Drop local remaining by 1 without REST when cache present
+            cached = read_quota_cache(quota_cache_path(root, cfg))
+            if cached and cached.get("remaining") is not None:
+                try:
+                    cached["remaining"] = max(0, int(cached["remaining"]) - 1)
+                    write_quota_cache(quota_cache_path(root, cfg), cached)
+                except (TypeError, ValueError):
+                    pass
         else:
             entry["last_error"] = detail
-            if is_rate_limit_error(detail):
+            if is_queueable_gh_throttle(detail):
                 entry["status"] = "pending"
                 stopped_early = True
                 write_outbox_entries(path, entries)
                 return (
                     EXIT_GH,
-                    f"flush stopped on rate-limit after done={done_n}; detail={detail}",
+                    f"flush stopped on rate-limit/throttle after done={done_n}; detail={detail}",
                 )
             entry["status"] = "failed"
             fail_n += 1

--- a/.ai_infra/install/cursor_workflow/project_recipes.py
+++ b/.ai_infra/install/cursor_workflow/project_recipes.py
@@ -93,6 +93,7 @@ def append_notes_helper(
     agent: str,
     text: str,
     limit: int = 100,
+    skip_precheck: bool = False,
 ) -> tuple[bool, str, int]:
     """
     Append attributed Notes. Returns (ok, detail, exit_code_on_fail).
@@ -106,6 +107,18 @@ def append_notes_helper(
             note_text = _cli().format_note_line(root, str(agent), text)
         except ValueError as exc:
             return False, str(exc), EXIT_USAGE
+    if not skip_precheck:
+        queued = guard_write_or_queue(
+            root,
+            ssot,
+            cmd="append-notes",
+            op="append-notes",
+            item_id=item_id,
+            agent=str(agent).strip() or "project-cli",
+            payload={"text": text},
+        )
+        if queued is not None:
+            return False, "queued to outbox (low GraphQL quota precheck)", queued
     items, err = _cli().fetch_project_items(ssot, limit=limit)
     if err:
         return False, err, EXIT_GH
@@ -119,6 +132,7 @@ def append_notes_helper(
     ok, detail = _cli().edit_item_body(ssot, item_id, new_body)
     if not ok:
         return False, detail, EXIT_GH
+    note_successful_write(root, ssot)
     return True, "updated", EXIT_OK
 def _try_queue_rate_limit(
     root: Path,
@@ -144,6 +158,36 @@ def _try_queue_rate_limit(
         agent=agent,
         payload=payload,
     )
+
+
+def guard_write_or_queue(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """Precheck GraphQL quota; EXIT_QUEUED when remaining below min."""
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    return _outbox.guard_write_or_queue(
+        root,
+        ssot,
+        cmd=cmd,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+
+
+def note_successful_write(root: Path, ssot: dict[str, Any]) -> None:
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    _outbox.note_successful_write(root, ssot)
 def find_items_mentioning_pr(
     items: list[dict[str, Any]],
     *,

--- a/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -50,9 +50,13 @@ project_ssot:
   outbox:
     enabled: true
     path: .local/generated-data/board-outbox.jsonl
-    min_graphql_remaining: 200
+    min_graphql_remaining: 200          # refuse flush / precheck-queue when GraphQL remaining below this
     max_flush_per_run: 10
     retry_backoff_seconds: 30
+    precheck_writes: true               # cached REST rate_limit before Pattern A writes
+    quota_cache_ttl_seconds: 45         # avoid REST spam; protects GraphQL
+    quota_cache_path: .local/generated-data/graphql-quota-cache.json
+    dedupe_pending: true                # same op+item+payload → one pending outbox row
 
   # Project V2 single-select fields (replace ids from field-list)
   fields:

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -12,7 +12,7 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
 - Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.

--- a/.cursor/skills/project-board-ssot/SKILL.md
+++ b/.cursor/skills/project-board-ssot/SKILL.md
@@ -42,7 +42,7 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit / Forbidden throttle / precheck low quota: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
 | **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
 Handoff line (chat + card Notes):

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1072 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1085 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 
@@ -139,7 +139,7 @@ python3 -m cursor_workflow project list --status ready
 # create / claim — see: python3 -m cursor_workflow project guide
 ```
 
-Maintainer gates: `make gates` · `make drift-validate` · `make doc-validate` · shipped matrix: [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md). Kit canvases: **13** files under `canvases/` (**11** agent/roster hubs + 2 concept hubs — see IMPLEMENTATION-STATUS § Kit canvases).
+Maintainer gates: `make gates` · `make drift-validate` · `make doc-validate` · shipped matrix: [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md). Kit canvases: **14** files under `canvases/` (**11** agent/roster hubs + 3 concept hubs — see IMPLEMENTATION-STATUS § Kit canvases).
 
 ---
 

--- a/canvases/github-api-safety.canvas.tsx
+++ b/canvases/github-api-safety.canvas.tsx
@@ -1,0 +1,256 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Grid,
+  H1,
+  H2,
+  Pill,
+  Row,
+  Spacer,
+  Stack,
+  Stat,
+  Table,
+  Text,
+} from "cursor/canvas";
+
+/**
+ * Inventory of GitHub API hammering / safety protections in MAS Workflow Kit.
+ * Source: project_outbox.py, project_atomics, agent Board-rights blocks, ADR-008.
+ * Verified: 2026-07-19
+ */
+
+const HARD = [
+  {
+    layer: "Outbox enqueue",
+    what: "On rate-limit stderr → JSONL queue; EXIT_QUEUED (6)",
+    where: "project_outbox.maybe_enqueue_on_gh_fail",
+    enforces: "Code",
+  },
+  {
+    layer: "Flush quota gate",
+    what: "Refuse flush if GraphQL remaining < min (default 200)",
+    where: "flush_outbox + outbox status",
+    enforces: "Code",
+  },
+  {
+    layer: "Flush batch cap",
+    what: "max_flush_per_run (default 10) + mid-batch re-check",
+    where: "flush_outbox loop",
+    enforces: "Code",
+  },
+  {
+    layer: "Flush backoff",
+    what: "sleep(retry_backoff_seconds) after non-RL failure (default 30s)",
+    where: "flush_outbox",
+    enforces: "Code",
+  },
+  {
+    layer: "RL detector",
+    what: "Regex: rate limit / secondary rate limit",
+    where: "is_rate_limit_error",
+    enforces: "Code",
+  },
+  {
+    layer: "Placeholder IDs",
+    what: "Reject short/ellipsis PVTI_ stubs (CODE=2)",
+    where: "is_placeholder_item_id / resolve_item_id_arg",
+    enforces: "Code",
+  },
+  {
+    layer: "Doctor skip-live",
+    what: "Skip item-list when remaining < min_graphql_remaining",
+    where: "run_doctor",
+    enforces: "Code",
+  },
+  {
+    layer: "Pattern A recipes",
+    what: "claim/handoff/create wrap atomics; --last preferred",
+    where: "project_handlers + project guide",
+    enforces: "Code + docs",
+  },
+] as const;
+
+const SOFT = [
+  {
+    layer: "Agent Board rights",
+    what: "EXIT_QUEUED → do not hammer; outbox status/flush",
+    where: "All 8 agent cards",
+  },
+  {
+    layer: "Skill checklist",
+    what: "Exit: no retry loop; confirm outbox status",
+    where: "project-board-ssot/SKILL.md",
+  },
+  {
+    layer: "Always-apply rule",
+    what: "EXIT_QUEUED → outbox; no GraphQL hammer; no dual-write",
+    where: "project-ssot-precedence.mdc",
+  },
+  {
+    layer: "Researcher anti-loop",
+    what: "rounds ≤6; one clone attempt; no re-init without --force",
+    where: "researcher + research-corpus-execution",
+  },
+  {
+    layer: "Read-only export",
+    what: "project export never mutates Status",
+    where: "ADR-008 / project-board-collaboration",
+  },
+] as const;
+
+const GAPS = [
+  {
+    gap: "Raw gh / GraphQL outside CLI",
+    risk: "Bypasses outbox entirely",
+    note: "Policy-only — Pattern A CLI required; cannot sandbox Cursor shell",
+  },
+  {
+    gap: "EXIT_QUEUED obedience is soft",
+    risk: "Agent can ignore code 6 and re-run claim",
+    note: "Stronger CODE=6 messaging; LLM compliance still soft",
+  },
+] as const;
+
+const FIXED = [
+  {
+    id: "G1",
+    what: "Cached REST rate_limit precheck (TTL 45s) before Pattern A writes",
+  },
+  {
+    id: "G2",
+    what: "Queue Forbidden/429 throttle; exclude missing-scopes",
+  },
+  {
+    id: "G5",
+    what: "Pending outbox dedupe by op+item+payload",
+  },
+] as const;
+
+const CONFIG = [
+  ["outbox.enabled", "true", "Master switch"],
+  ["min_graphql_remaining", "200", "Flush / precheck gate"],
+  ["precheck_writes", "true", "Cached REST before writes"],
+  ["quota_cache_ttl_seconds", "45", "REST cache TTL"],
+  ["dedupe_pending", "true", "One pending row per fingerprint"],
+  ["max_flush_per_run", "10", "Ops per flush"],
+  ["retry_backoff_seconds", "30", "Sleep after failed apply"],
+] as const;
+
+export default function GithubApiSafetyCanvas() {
+  return (
+    <Stack gap={20} style={{ padding: 24, maxWidth: 960 }}>
+      <Stack gap={6}>
+        <Row gap={8} align="center">
+          <H1>GitHub API safety</H1>
+          <Pill tone="neutral">2026-07-19</Pill>
+        </Row>
+        <Text tone="secondary">
+          How MAS Workflow Kit limits API hammering and unsafe Project writes —
+          hard (code), soft (policy), and real gaps.
+        </Text>
+      </Stack>
+
+      <Grid columns={3} gap={12}>
+        <Stat value="3" label="Gaps fixed (G1/G2/G5)" />
+        <Stat value="2" label="Residual soft gaps" />
+        <Stat value="CODE=6" label="Do not retry" />
+      </Grid>
+
+      <Callout tone="info">
+        Verdict: cached precheck + Forbidden/429 queue + pending dedupe for
+        Pattern A writes. Safe if agents use{" "}
+        <Text weight="semibold">cursor_workflow project …</Text> and stop on
+        EXIT_QUEUED (6).
+      </Callout>
+
+      <H2>Fixed in this slice</H2>
+      <Table
+        headers={["ID", "Fix"]}
+        rows={FIXED.map((r) => [r.id, r.what])}
+      />
+
+      <H2>Hard protections (enforced in code)</H2>
+      <Table
+        headers={["Layer", "Behavior", "Where", "Kind"]}
+        rows={HARD.map((r) => [r.layer, r.what, r.where, r.enforces])}
+      />
+
+      <H2>Config defaults</H2>
+      <Text tone="secondary" size="small">
+        github.collaboration.yaml → project_ssot.outbox
+      </Text>
+      <Table
+        headers={["Key", "Default", "Role"]}
+        rows={CONFIG.map(([k, d, role]) => [k, d, role])}
+      />
+
+      <H2>Soft protections (agents / rules)</H2>
+      <Table
+        headers={["Layer", "Instruction", "Where"]}
+        rows={SOFT.map((r) => [r.layer, r.what, r.where])}
+      />
+
+      <H2>Exit codes that matter</H2>
+      <Grid columns={2} gap={12}>
+        <Card>
+          <CardHeader>EXIT_QUEUED = 6</CardHeader>
+          <CardBody>
+            <Text>
+              Soft-success: op landed in outbox. Agent must continue local work
+              — not retry gh in a loop.
+            </Text>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>Flush refuse</CardHeader>
+          <CardBody>
+            <Text>
+              remaining &lt; min_graphql_remaining → EXIT_GH, wait for reset.
+              Mid-batch re-checks quota.
+            </Text>
+          </CardBody>
+        </Card>
+      </Grid>
+
+      <H2>Flow</H2>
+      <Card>
+        <CardBody>
+          <Stack gap={4}>
+            <Text size="small">1. Write fails with rate-limit stderr</Text>
+            <Text size="small">2. maybe_enqueue_on_gh_fail → board-outbox.jsonl</Text>
+            <Text size="small">3. EXIT_QUEUED (6) — soft success</Text>
+            <Text size="small">4. Agent continues local evidence (no retry loop)</Text>
+            <Text size="small">
+              5. Later: outbox status → outbox flush (cap 10 · remaining≥200 ·
+              backoff 30s)
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Divider />
+
+      <H2>Residual gaps (accepted)</H2>
+      <Table
+        headers={["Gap", "Risk", "Note"]}
+        rows={GAPS.map((g) => [g.gap, g.risk, g.note])}
+      />
+
+      <Callout tone="warning">
+        Forbidden/403 and raw <Text weight="semibold">gh api graphql</Text>{" "}
+        bypass the outbox. Parallel agents can still pile pending ops on one
+        card (hygiene, not a hard lock).
+      </Callout>
+
+      <Spacer height={8} />
+      <Text tone="secondary" size="small">
+        Canon: ADR-008 · project_outbox.py · project-board-ssot skill ·
+        project-ssot-precedence.mdc · project-board-collaboration.md § Rate
+        limits
+      </Text>
+    </Stack>
+  );
+}

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -12,7 +12,7 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
 - Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -113,11 +113,13 @@ All subcommands registered in `.ai_infra/install/cursor_workflow/project_parser.
 
 GitHub GraphQL quota (~5000/hour) can block board writes. When `project_ssot.outbox.enabled`:
 
-1. Live write fails with rate-limit → CLI **enqueues** to `.local/generated-data/board-outbox.jsonl` and returns **EXIT_QUEUED (6)**.
-2. Agent continues local evidence (`change-index`, handoff line) — **do not** hammer `gh` / retry loops.
-3. After quota recovers: `python3 -m cursor_workflow project outbox status` then `outbox flush` (capped by `max_flush_per_run`; refuses if `remaining < min_graphql_remaining`).
-4. Explicit enqueue: `project queue --op append-notes|set-status|handoff|claim|set-assignee|set-field …`
-5. Outbox is a **local buffer**, never a second Status SSOT.
+1. **Precheck (default):** before Pattern A writes, CLI reads cached REST `rate_limit` (TTL `quota_cache_ttl_seconds`, default 45s). If GraphQL `remaining < min_graphql_remaining`, enqueue + **EXIT_QUEUED (6)** without calling Projects GraphQL.
+2. Live write fails with throttle (rate-limit / secondary / 429 / bare Forbidden) → CLI **enqueues** to `.local/generated-data/board-outbox.jsonl` and returns **EXIT_QUEUED (6)**. Permanent scope-miss errors are **not** queued.
+3. **Dedupe:** identical pending `op`+`item_id`+payload fingerprint reuses one outbox row (`dedupe_pending`).
+4. Agent continues local evidence (`change-index`, handoff line) — **do not** hammer `gh` / retry loops (CODE=6 = soft-success).
+5. After quota recovers: `python3 -m cursor_workflow project outbox status` then `outbox flush` (capped by `max_flush_per_run`; refuses if `remaining < min_graphql_remaining`).
+6. Explicit enqueue: `project queue --op append-notes|set-status|handoff|claim|set-assignee|set-field …`
+7. Outbox is a **local buffer**, never a second Status SSOT. Prefer Pattern A CLI over raw `gh api graphql` (raw calls bypass the outbox).
 
 Who flushes: any agent/human after reset; prefer implementer or project-board at slice close. Pending outbox is **not** a DRIFT failure.
 

--- a/payload/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_cli.py
@@ -110,7 +110,9 @@ from project_recipes import (
     _try_queue_rate_limit,
     append_notes_helper,
     find_items_mentioning_pr,
+    guard_write_or_queue,
     in_progress_conflicts_for_user,
+    note_successful_write,
     resolve_item_id_for_pr,
 )
 
@@ -397,6 +399,17 @@ def cmd_set_status(args: argparse.Namespace) -> int:
             "field_id"
         ):
             queue_payload["start_date"] = utc_today_iso()
+    pre = guard_write_or_queue(
+        root,
+        ssot,
+        cmd="set-status",
+        op="set-status",
+        item_id=item_id,
+        agent=(getattr(args, "agent", None) or "project-cli"),
+        payload=queue_payload,
+    )
+    if pre is not None:
+        return pre
     proc = run_gh(
         [
             "project",
@@ -427,6 +440,7 @@ def cmd_set_status(args: argparse.Namespace) -> int:
             return queued
         return fail("set-status", EXIT_GH, detail)
     print(f"set-status: {item_id} → {args.to} ({option_id})")
+    note_successful_write(root, ssot)
     if _normalize_status(str(args.to)) == "in_progress":
         d_ok, d_detail, d_applied = ensure_start_date_if_starting(ssot, item_id)
         if not d_ok:
@@ -451,6 +465,7 @@ def cmd_set_field(args: argparse.Namespace) -> int:
             EXIT_USAGE,
             "--field must be priority, size, or estimate",
         )
+    agent = getattr(args, "agent", None) or "project-cli"
     if field == "estimate":
         try:
             num = float(str(args.to).strip())
@@ -458,6 +473,17 @@ def cmd_set_field(args: argparse.Namespace) -> int:
             return fail("set-field", EXIT_USAGE, "--to must be a number for estimate")
         if num < 0:
             return fail("set-field", EXIT_USAGE, "estimate must be >= 0")
+        pre = guard_write_or_queue(
+            root,
+            ssot,
+            cmd="set-field",
+            op="set-field",
+            item_id=item_id,
+            agent=agent,
+            payload={"field": "estimate", "to": num},
+        )
+        if pre is not None:
+            return pre
         ok, detail = set_item_number(ssot, item_id, "estimate", num)
         if not ok:
             queued = _try_queue_rate_limit(
@@ -467,18 +493,30 @@ def cmd_set_field(args: argparse.Namespace) -> int:
                 err_detail=detail,
                 op="set-field",
                 item_id=item_id,
-                agent=(getattr(args, "agent", None) or "project-cli"),
+                agent=agent,
                 payload={"field": "estimate", "to": num},
             )
             if queued is not None:
                 return queued
             return fail("set-field", EXIT_GH, detail)
         print(f"set-field: {item_id} estimate → {num}")
+        note_successful_write(root, ssot)
         return EXIT_OK
     try:
         field_id, option_id = resolve_field_option_id(ssot, field, args.to)
     except KeyError as exc:
         return fail("set-field", EXIT_USAGE, str(exc))
+    pre = guard_write_or_queue(
+        root,
+        ssot,
+        cmd="set-field",
+        op="set-field",
+        item_id=item_id,
+        agent=agent,
+        payload={"field": field, "to": args.to},
+    )
+    if pre is not None:
+        return pre
     project_id = str(ssot["project_id"])
     proc = run_gh(
         [
@@ -503,13 +541,14 @@ def cmd_set_field(args: argparse.Namespace) -> int:
             err_detail=detail,
             op="set-field",
             item_id=item_id,
-            agent=(getattr(args, "agent", None) or "project-cli"),
+            agent=agent,
             payload={"field": field, "to": args.to},
         )
         if queued is not None:
             return queued
         return fail("set-field", EXIT_GH, detail)
     print(f"set-field: {item_id} {field} → {args.to} ({option_id})")
+    note_successful_write(root, ssot)
     return EXIT_OK
 def cmd_get(args: argparse.Namespace) -> int:
     root = Path(args.directory).resolve()
@@ -567,6 +606,8 @@ def cmd_append_notes(args: argparse.Namespace) -> int:
         limit=args.limit,
     )
     if not ok:
+        if err_code == EXIT_QUEUED:
+            return EXIT_QUEUED
         if err_code == EXIT_GH:
             queued = _try_queue_rate_limit(
                 root,
@@ -606,6 +647,18 @@ def cmd_set_assignee(args: argparse.Namespace) -> int:
             EXIT_USAGE,
             "no login (pass --login or set owner.github_user)",
         )
+    agent = getattr(args, "agent", None) or "project-cli"
+    pre = guard_write_or_queue(
+        root,
+        ssot,
+        cmd="set-assignee",
+        op="set-assignee",
+        item_id=item_id,
+        agent=agent,
+        payload={"login": login},
+    )
+    if pre is not None:
+        return pre
     ok, detail = set_item_assignee(ssot, item_id, login)
     if not ok:
         # DraftIssue / unsupported → validation; gh failures look like network
@@ -625,6 +678,7 @@ def cmd_set_assignee(args: argparse.Namespace) -> int:
             return queued
         return fail("set-assignee", EXIT_GH, detail)
     print(f"set-assignee: {item_id} → @{detail.lstrip('@')}")
+    note_successful_write(root, ssot)
     return EXIT_OK
 def cmd_claim(args: argparse.Namespace) -> int:
     from project_handlers import run_claim

--- a/payload/.ai_infra/install/cursor_workflow/project_handlers.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_handlers.py
@@ -47,6 +47,17 @@ def run_claim(args: argparse.Namespace) -> int:
     start_cfg = fields_block.get('start_date') if isinstance(fields_block, dict) else None
     if conventions.get('set_start_date_on_claim', True) and isinstance(start_cfg, dict) and start_cfg.get('field_id'):
         claim_payload['start_date'] = pc.utc_today_iso()
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='claim',
+        op='claim',
+        item_id=item_id,
+        agent=agent,
+        payload=claim_payload,
+    )
+    if pre is not None:
+        return pre
     items, err = pc.fetch_project_items(ssot, limit=args.limit)
     if err:
         queued = pc._try_queue_rate_limit(root, ssot, cmd='claim', err_detail=err, op='claim', item_id=item_id, agent=agent, payload=claim_payload)
@@ -89,8 +100,12 @@ def run_claim(args: argparse.Namespace) -> int:
         # already had a date
         pass
     note = getattr(args, 'text', None) or 'claimed'
-    n_ok, n_detail, n_code = pc.append_notes_helper(root, ssot, item_id, agent=agent, text=note, limit=args.limit)
+    n_ok, n_detail, n_code = pc.append_notes_helper(
+        root, ssot, item_id, agent=agent, text=note, limit=args.limit, skip_precheck=True
+    )
     if not n_ok:
+        if n_code == pc.EXIT_QUEUED:
+            return n_code
         if n_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='claim', err_detail=n_detail, op='append-notes', item_id=item_id, agent=agent, payload={'text': note})
             if queued is not None:
@@ -125,9 +140,23 @@ def run_handoff(args: argparse.Namespace) -> int:
         self_attr = pc.format_agent_attribution(root, agent)
     except ValueError as exc:
         return pc.fail('handoff', pc.EXIT_USAGE, str(exc))
+    extra = (getattr(args, 'text', None) or '').strip()
+    status_to = (getattr(args, 'to', None) or '').strip()
+    handoff_payload = {'next': next_agent, 'to': status_to, 'note': extra}
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='handoff',
+        op='handoff',
+        item_id=item_id,
+        agent=agent,
+        payload=handoff_payload,
+    )
+    if pre is not None:
+        return pre
     items, err = pc.fetch_project_items(ssot, limit=args.limit)
     if err:
-        queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=err, op='handoff', item_id=item_id, agent=agent, payload={'next': next_agent, 'to': (getattr(args, 'to', None) or '').strip(), 'note': (getattr(args, 'text', None) or '').strip()})
+        queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=err, op='handoff', item_id=item_id, agent=agent, payload=handoff_payload)
         if queued is not None:
             return queued
         return pc.fail('handoff', pc.EXIT_GH, err)
@@ -135,17 +164,15 @@ def run_handoff(args: argparse.Namespace) -> int:
     if item is None:
         return pc.fail('handoff', pc.EXIT_NOT_FOUND, f'item not found: {item_id}')
     before = pc._normalize_status(str(item.get('status') or ''))
-    extra = (getattr(args, 'text', None) or '').strip()
     note_core = f'next={next_attr}'
     if extra:
         note_core = f'{extra} · {note_core}'
-    status_to = (getattr(args, 'to', None) or '').strip()
     if status_to:
         ok, detail = pc.set_item_status(ssot, item_id, status_to)
         if not ok:
             if 'unknown' in detail.lower():
                 return pc.fail('handoff', pc.EXIT_USAGE, detail)
-            queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=detail, op='handoff', item_id=item_id, agent=agent, payload={'next': next_agent, 'to': status_to, 'note': extra})
+            queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=detail, op='handoff', item_id=item_id, agent=agent, payload=handoff_payload)
             if queued is not None:
                 return queued
             return pc.fail('handoff', pc.EXIT_GH, detail)
@@ -157,8 +184,12 @@ def run_handoff(args: argparse.Namespace) -> int:
                 print(f'handoff: start_date={d_detail}')
             elif 'field_id missing' in d_detail:
                 print(f'handoff: WARN — start_date skipped: {d_detail}', file=sys.stderr)
-    n_ok, n_detail, n_code = pc.append_notes_helper(root, ssot, item_id, agent=agent, text=note_core, limit=args.limit)
+    n_ok, n_detail, n_code = pc.append_notes_helper(
+        root, ssot, item_id, agent=agent, text=note_core, limit=args.limit, skip_precheck=True
+    )
     if not n_ok:
+        if n_code == pc.EXIT_QUEUED:
+            return n_code
         if n_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='handoff', err_detail=n_detail, op='handoff', item_id=item_id, agent=agent, payload={'next': next_agent, 'to': status_to, 'note': extra})
             if queued is not None:
@@ -205,6 +236,17 @@ def run_mention_pr(args: argparse.Namespace) -> int:
     pr_num = pdata.get('number')
     if not pr_url:
         return pc.fail('mention-pr', pc.EXIT_GH, 'pr view missing url')
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='mention-pr',
+        op='append-notes',
+        item_id=item_id,
+        agent=agent,
+        payload={'text': f'PR {pr_num}: {pr_url}'},
+    )
+    if pre is not None:
+        return pre
     kind, _cid, _meta, kerr = pc.resolve_item_content(ssot, item_id)
     conventions = ssot.get('conventions') or {}
     promote_on = conventions.get('promote_to_issue_on_pr', True)
@@ -220,8 +262,12 @@ def run_mention_pr(args: argparse.Namespace) -> int:
         else:
             print(f'mention-pr: WARN — card looks DraftIssue; GitHub Linked pull requests fills for Issue-backed items. Run: project promote-to-issue --last (promote_to_issue_on_pr={promote_on}).', file=sys.stderr)
     note = f'PR {pr_num}: {pr_url}'
-    ok, detail, err_code = pc.append_notes_helper(root, ssot, item_id, agent=agent, text=note, limit=args.limit)
+    ok, detail, err_code = pc.append_notes_helper(
+        root, ssot, item_id, agent=agent, text=note, limit=args.limit, skip_precheck=True
+    )
     if not ok:
+        if err_code == pc.EXIT_QUEUED:
+            return err_code
         if err_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='mention-pr', err_detail=detail, op='append-notes', item_id=item_id, agent=agent, payload={'text': note})
             if queued is not None:
@@ -251,6 +297,17 @@ def run_promote_to_issue(args: argparse.Namespace) -> int:
     if not agent:
         return pc.fail('promote-to-issue', pc.EXIT_USAGE, '--agent required')
     repo = (getattr(args, 'repo', None) or '').strip() or str(ssot.get('default_repo') or '').strip()
+    pre = pc.guard_write_or_queue(
+        root,
+        ssot,
+        cmd='promote-to-issue',
+        op='promote-to-issue',
+        item_id=item_id,
+        agent=agent,
+        payload={'repo': repo},
+    )
+    if pre is not None:
+        return pre
     ok, detail, meta = pc.promote_draft_item_to_issue(ssot, item_id, repo=repo)
     if not ok:
         queued = pc._try_queue_rate_limit(root, ssot, cmd='promote-to-issue', err_detail=detail, op='promote-to-issue', item_id=item_id, agent=agent, payload={'repo': repo})
@@ -275,8 +332,12 @@ def run_promote_to_issue(args: argparse.Namespace) -> int:
         else:
             print(f'promote-to-issue: assignee=@{a_detail.lstrip('@')}')
     note = f'promoted to Issue #{issue_n}: {url}' if url else f'promoted to Issue #{issue_n}'
-    n_ok, n_detail, n_code = pc.append_notes_helper(root, ssot, out_id, agent=agent, text=note, limit=args.limit)
+    n_ok, n_detail, n_code = pc.append_notes_helper(
+        root, ssot, out_id, agent=agent, text=note, limit=args.limit, skip_precheck=True
+    )
     if not n_ok:
+        if n_code == pc.EXIT_QUEUED:
+            return n_code
         if n_code == pc.EXIT_GH:
             queued = pc._try_queue_rate_limit(root, ssot, cmd='promote-to-issue', err_detail=n_detail, op='append-notes', item_id=out_id, agent=agent, payload={'text': note})
             if queued is not None:

--- a/payload/.ai_infra/install/cursor_workflow/project_outbox.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_outbox.py
@@ -9,6 +9,7 @@ Depends On:
 Notes:
  - Outbox is a local buffer, never a second Status SSOT (ADR-008).
  - Flush is pull-based; refuses when GraphQL remaining < min_graphql_remaining.
+ - Cached REST rate_limit precheck (TTL) before Pattern A writes; pending-op dedupe.
 """
 
 from __future__ import annotations
@@ -42,10 +43,26 @@ _OUTBOX_OPS = frozenset(
     }
 )
 _DEFAULT_PATH = ".local/generated-data/board-outbox.jsonl"
+_DEFAULT_QUOTA_CACHE = ".local/generated-data/graphql-quota-cache.json"
 _RATE_LIMIT_RE = re.compile(
-    r"rate\s*limit|API rate limit exceeded|secondary rate limit",
+    r"rate\s*limit|API rate limit exceeded|secondary rate limit|"
+    r"\b429\b|retry\s*later|wait a few minutes|too many requests",
     re.IGNORECASE,
 )
+_FORBIDDEN_RE = re.compile(r"\b403\b|\bForbidden\b", re.IGNORECASE)
+_SCOPE_MISS_RE = re.compile(
+    r"missing required scopes|required scopes|authentication token is missing",
+    re.IGNORECASE,
+)
+_DEDUPE_PAYLOAD_KEYS: dict[str, tuple[str, ...]] = {
+    "append-notes": ("text",),
+    "set-status": ("to",),
+    "claim": ("to", "text", "start_date"),
+    "handoff": ("next", "to", "note", "text"),
+    "set-assignee": ("login",),
+    "set-field": ("field", "to", "name", "value"),
+    "promote-to-issue": ("repo",),
+}
 
 
 def load_outbox_config(ssot: dict[str, Any]) -> dict[str, Any]:
@@ -57,6 +74,11 @@ def load_outbox_config(ssot: dict[str, Any]) -> dict[str, Any]:
         "min_graphql_remaining": int(raw.get("min_graphql_remaining") or 200),
         "max_flush_per_run": int(raw.get("max_flush_per_run") or 10),
         "retry_backoff_seconds": int(raw.get("retry_backoff_seconds") or 30),
+        "precheck_writes": bool(raw.get("precheck_writes", True)),
+        "quota_cache_ttl_seconds": int(raw.get("quota_cache_ttl_seconds") or 45),
+        "quota_cache_path": str(raw.get("quota_cache_path") or _DEFAULT_QUOTA_CACHE).strip()
+        or _DEFAULT_QUOTA_CACHE,
+        "dedupe_pending": bool(raw.get("dedupe_pending", True)),
     }
 
 
@@ -65,9 +87,29 @@ def outbox_path(root: Path, cfg: dict[str, Any]) -> Path:
     return (root / rel).resolve() if not rel.is_absolute() else rel
 
 
-def is_rate_limit_error(text: str) -> bool:
-    return bool(_RATE_LIMIT_RE.search(text or ""))
+def quota_cache_path(root: Path, cfg: dict[str, Any]) -> Path:
+    rel = Path(str(cfg.get("quota_cache_path") or _DEFAULT_QUOTA_CACHE))
+    return (root / rel).resolve() if not rel.is_absolute() else rel
 
+
+def is_queueable_gh_throttle(text: str) -> bool:
+    """
+    True when stderr suggests transient GitHub throttle (queue to outbox).
+    Excludes permanent auth/scope failures.
+    """
+    blob = text or ""
+    if _SCOPE_MISS_RE.search(blob):
+        return False
+    if _RATE_LIMIT_RE.search(blob):
+        return True
+    if _FORBIDDEN_RE.search(blob):
+        return True
+    return False
+
+
+def is_rate_limit_error(text: str) -> bool:
+    """Alias for is_queueable_gh_throttle (back-compat)."""
+    return is_queueable_gh_throttle(text)
 
 def graphql_rate_limit() -> dict[str, Any]:
     """
@@ -130,6 +172,117 @@ def format_reset_iso(reset_epoch: Any) -> str:
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_now_epoch() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def read_quota_cache(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_quota_cache(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def refresh_graphql_quota(root: Path, ssot: dict[str, Any]) -> dict[str, Any]:
+    """Fetch GraphQL remaining via REST and write TTL cache."""
+    cfg = load_outbox_config(ssot)
+    rl = graphql_rate_limit()
+    payload = {
+        "remaining": rl.get("remaining"),
+        "limit": rl.get("limit"),
+        "reset_epoch": rl.get("reset_epoch"),
+        "error": rl.get("error"),
+        "fetched_at": _utc_now_epoch(),
+        "fetched_at_iso": _utc_now(),
+    }
+    write_quota_cache(quota_cache_path(root, cfg), payload)
+    return payload
+
+
+def get_cached_graphql_remaining(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    force_refresh: bool = False,
+) -> dict[str, Any]:
+    """
+    Return quota dict with remaining/limit/reset_epoch/error/from_cache.
+    Uses TTL cache; refreshes via REST when stale or force_refresh.
+    """
+    cfg = load_outbox_config(ssot)
+    path = quota_cache_path(root, cfg)
+    ttl = int(cfg["quota_cache_ttl_seconds"])
+    if not force_refresh:
+        cached = read_quota_cache(path)
+        if cached is not None:
+            try:
+                fetched = float(cached.get("fetched_at") or 0)
+            except (TypeError, ValueError):
+                fetched = 0.0
+            if fetched and (_utc_now_epoch() - fetched) <= ttl and cached.get("error") is None:
+                out = dict(cached)
+                out["from_cache"] = True
+                return out
+    fresh = refresh_graphql_quota(root, ssot)
+    fresh["from_cache"] = False
+    return fresh
+
+
+def remaining_below_min(root: Path, ssot: dict[str, Any], *, force_refresh: bool = False) -> tuple[bool, dict[str, Any]]:
+    """Return (below_min, quota_info). On read error, treat as not below (fail open to live write)."""
+    cfg = load_outbox_config(ssot)
+    info = get_cached_graphql_remaining(root, ssot, force_refresh=force_refresh)
+    if info.get("error"):
+        return False, info
+    try:
+        rem = int(info["remaining"]) if info.get("remaining") is not None else -1
+    except (TypeError, ValueError):
+        return False, info
+    min_rem = int(cfg["min_graphql_remaining"])
+    return rem >= 0 and rem < min_rem, info
+
+
+def _payload_fingerprint(op: str, payload: dict[str, Any]) -> tuple[Any, ...]:
+    keys = _DEDUPE_PAYLOAD_KEYS.get(op, tuple(sorted(payload.keys())))
+    parts: list[Any] = []
+    for key in keys:
+        val = payload.get(key)
+        if isinstance(val, str):
+            parts.append(val.strip())
+        else:
+            parts.append(val)
+    return tuple(parts)
+
+
+def find_duplicate_pending(
+    entries: list[dict[str, Any]],
+    *,
+    op: str,
+    item_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    want = _payload_fingerprint(op, payload)
+    for entry in entries:
+        if str(entry.get("status") or "") != "pending":
+            continue
+        if str(entry.get("op") or "") != op:
+            continue
+        if str(entry.get("item_id") or "") != item_id:
+            continue
+        existing_payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+        if _payload_fingerprint(op, existing_payload) == want:
+            return entry
+    return None
 
 
 def validate_outbox_entry(entry: dict[str, Any]) -> list[str]:
@@ -248,15 +401,22 @@ def enqueue_op(
         return None, "; ".join(errs)
     path = outbox_path(root, cfg)
     entries = read_outbox_entries(path)
+    if cfg.get("dedupe_pending", True):
+        dup = find_duplicate_pending(
+            entries, op=op_key, item_id=item_id.strip(), payload=dict(payload or {})
+        )
+        if dup is not None:
+            return dup, ""
     entries.append(entry)
     write_outbox_entries(path, entries)
     return entry, ""
 
 
-def queued_message(cmd: str, entry: dict[str, Any]) -> str:
+def queued_message(cmd: str, entry: dict[str, Any], *, reason: str = "throttle") -> str:
     return (
-        f"project {cmd}: QUEUED — id={entry.get('id')} op={entry.get('op')} "
-        f"item={entry.get('item_id')} · run: python3 -m cursor_workflow project outbox flush"
+        f"project {cmd}: QUEUED — CODE=6 · reason={reason} · id={entry.get('id')} "
+        f"op={entry.get('op')} item={entry.get('item_id')} · "
+        f"do not retry; later: python3 -m cursor_workflow project outbox flush"
     )
 
 
@@ -272,13 +432,13 @@ def maybe_enqueue_on_gh_fail(
     payload: dict[str, Any],
 ) -> int | None:
     """
-    If outbox enabled and error looks like rate-limit, enqueue and return EXIT_QUEUED.
+    If outbox enabled and error is queueable throttle, enqueue and return EXIT_QUEUED.
     Otherwise return None (caller should fail as before).
     """
     cfg = load_outbox_config(ssot)
     if not cfg["enabled"]:
         return None
-    if not is_rate_limit_error(err_detail):
+    if not is_queueable_gh_throttle(err_detail):
         return None
     entry, err = enqueue_op(
         root,
@@ -290,12 +450,89 @@ def maybe_enqueue_on_gh_fail(
     )
     if entry is None:
         print(
-            f"project {cmd}: FAIL — CODE={EXIT_GH} · rate-limit and enqueue failed: {err}",
+            f"project {cmd}: FAIL — CODE={EXIT_GH} · throttle and enqueue failed: {err}",
             file=sys.stderr,
         )
         return EXIT_GH
-    print(queued_message(cmd, entry), file=sys.stderr)
+    print(queued_message(cmd, entry, reason="throttle"), file=sys.stderr)
     return EXIT_QUEUED
+
+
+def maybe_enqueue_on_low_quota(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """
+    If precheck enabled and cached GraphQL remaining < min, enqueue and EXIT_QUEUED.
+    Returns None when write may proceed (or precheck disabled / quota unreadable).
+    """
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"] or not cfg.get("precheck_writes", True):
+        return None
+    below, info = remaining_below_min(root, ssot)
+    if not below:
+        return None
+    entry, err = enqueue_op(
+        root,
+        ssot,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+    if entry is None:
+        print(
+            f"project {cmd}: FAIL — CODE={EXIT_GH} · low-quota enqueue failed: {err}",
+            file=sys.stderr,
+        )
+        return EXIT_GH
+    rem = info.get("remaining")
+    min_rem = cfg["min_graphql_remaining"]
+    print(
+        queued_message(cmd, entry, reason=f"precheck remaining={rem}<{min_rem}"),
+        file=sys.stderr,
+    )
+    return EXIT_QUEUED
+
+
+def guard_write_or_queue(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """
+    Call before Pattern A GraphQL writes.
+    Returns EXIT_QUEUED to skip the live write; None to proceed.
+    """
+    return maybe_enqueue_on_low_quota(
+        root,
+        ssot,
+        cmd=cmd,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+
+
+def note_successful_write(root: Path, ssot: dict[str, Any]) -> None:
+    """Refresh quota cache after a successful live write (respects TTL)."""
+    cfg = load_outbox_config(ssot)
+    if not cfg["enabled"]:
+        return
+    # Soft refresh only when cache missing/stale — avoids REST spam
+    get_cached_graphql_remaining(root, ssot, force_refresh=False)
 
 
 def count_outbox(path: Path) -> dict[str, int]:
@@ -346,6 +583,7 @@ def apply_outbox_entry(
             agent=agent,
             text=str(payload.get("text") or ""),
             limit=limit,
+            skip_precheck=True,
         )
         return ok, detail
 
@@ -487,7 +725,8 @@ def flush_outbox(
     if not cfg["enabled"]:
         return EXIT_USAGE, "outbox.enabled is false"
     path = outbox_path(root, cfg)
-    rl = graphql_rate_limit()
+    # Prefer TTL cache; force refresh at flush start for accurate gate
+    rl = get_cached_graphql_remaining(root, ssot, force_refresh=True)
     remaining = rl.get("remaining")
     min_rem = int(cfg["min_graphql_remaining"])
     if rl.get("error"):
@@ -516,8 +755,8 @@ def flush_outbox(
     for idx in pending_idxs:
         if applied >= cap:
             break
-        # Re-check remaining mid-batch
-        rl2 = graphql_rate_limit()
+        # Mid-batch: re-read REST quota (flush is rare + capped; prefer accuracy)
+        rl2 = get_cached_graphql_remaining(root, ssot, force_refresh=True)
         try:
             rem2 = int(rl2.get("remaining")) if rl2.get("remaining") is not None else rem_i
         except (TypeError, ValueError):
@@ -533,15 +772,23 @@ def flush_outbox(
             entry["status"] = "done"
             entry["last_error"] = None
             done_n += 1
+            # Drop local remaining by 1 without REST when cache present
+            cached = read_quota_cache(quota_cache_path(root, cfg))
+            if cached and cached.get("remaining") is not None:
+                try:
+                    cached["remaining"] = max(0, int(cached["remaining"]) - 1)
+                    write_quota_cache(quota_cache_path(root, cfg), cached)
+                except (TypeError, ValueError):
+                    pass
         else:
             entry["last_error"] = detail
-            if is_rate_limit_error(detail):
+            if is_queueable_gh_throttle(detail):
                 entry["status"] = "pending"
                 stopped_early = True
                 write_outbox_entries(path, entries)
                 return (
                     EXIT_GH,
-                    f"flush stopped on rate-limit after done={done_n}; detail={detail}",
+                    f"flush stopped on rate-limit/throttle after done={done_n}; detail={detail}",
                 )
             entry["status"] = "failed"
             fail_n += 1

--- a/payload/.ai_infra/install/cursor_workflow/project_recipes.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_recipes.py
@@ -93,6 +93,7 @@ def append_notes_helper(
     agent: str,
     text: str,
     limit: int = 100,
+    skip_precheck: bool = False,
 ) -> tuple[bool, str, int]:
     """
     Append attributed Notes. Returns (ok, detail, exit_code_on_fail).
@@ -106,6 +107,18 @@ def append_notes_helper(
             note_text = _cli().format_note_line(root, str(agent), text)
         except ValueError as exc:
             return False, str(exc), EXIT_USAGE
+    if not skip_precheck:
+        queued = guard_write_or_queue(
+            root,
+            ssot,
+            cmd="append-notes",
+            op="append-notes",
+            item_id=item_id,
+            agent=str(agent).strip() or "project-cli",
+            payload={"text": text},
+        )
+        if queued is not None:
+            return False, "queued to outbox (low GraphQL quota precheck)", queued
     items, err = _cli().fetch_project_items(ssot, limit=limit)
     if err:
         return False, err, EXIT_GH
@@ -119,6 +132,7 @@ def append_notes_helper(
     ok, detail = _cli().edit_item_body(ssot, item_id, new_body)
     if not ok:
         return False, detail, EXIT_GH
+    note_successful_write(root, ssot)
     return True, "updated", EXIT_OK
 def _try_queue_rate_limit(
     root: Path,
@@ -144,6 +158,36 @@ def _try_queue_rate_limit(
         agent=agent,
         payload=payload,
     )
+
+
+def guard_write_or_queue(
+    root: Path,
+    ssot: dict[str, Any],
+    *,
+    cmd: str,
+    op: str,
+    item_id: str,
+    agent: str,
+    payload: dict[str, Any],
+) -> int | None:
+    """Precheck GraphQL quota; EXIT_QUEUED when remaining below min."""
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    return _outbox.guard_write_or_queue(
+        root,
+        ssot,
+        cmd=cmd,
+        op=op,
+        item_id=item_id,
+        agent=agent,
+        payload=payload,
+    )
+
+
+def note_successful_write(root: Path, ssot: dict[str, Any]) -> None:
+    import project_outbox as _outbox  # noqa: PLC0415
+
+    _outbox.note_successful_write(root, ssot)
 def find_items_mentioning_pr(
     items: list[dict[str, Any]],
     *,

--- a/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -50,9 +50,13 @@ project_ssot:
   outbox:
     enabled: true
     path: .local/generated-data/board-outbox.jsonl
-    min_graphql_remaining: 200
+    min_graphql_remaining: 200          # refuse flush / precheck-queue when GraphQL remaining below this
     max_flush_per_run: 10
     retry_backoff_seconds: 30
+    precheck_writes: true               # cached REST rate_limit before Pattern A writes
+    quota_cache_ttl_seconds: 45         # avoid REST spam; protects GraphQL
+    quota_cache_path: .local/generated-data/graphql-quota-cache.json
+    dedupe_pending: true                # same op+item+payload → one pending outbox row
 
   # Project V2 single-select fields (replace ids from field-list)
   fields:

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -12,7 +12,7 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
 - Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.

--- a/payload/.cursor/skills/project-board-ssot/SKILL.md
+++ b/payload/.cursor/skills/project-board-ssot/SKILL.md
@@ -42,7 +42,7 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit / Forbidden throttle / precheck low quota: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
 | **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
 Handoff line (chat + card Notes):

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -12,7 +12,7 @@ alwaysApply: true
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
 - Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers.
+- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
 - Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
 - PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
 - Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.

--- a/skills/project-board-ssot/SKILL.md
+++ b/skills/project-board-ssot/SKILL.md
@@ -42,7 +42,7 @@ Work is **indexed on the Project**, not in chat alone.
 |-------|----------|
 | **Entry** | `project status` → find/claim related card (`list --status ready` or your In progress). Read Acceptance / Rollback / Notes on the card body. |
 | **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
+| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit / Forbidden throttle / precheck low quota: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
 | **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
 
 Handoff line (chat + card Notes):

--- a/tests/modules/install/test_project_outbox.py
+++ b/tests/modules/install/test_project_outbox.py
@@ -119,6 +119,10 @@ def test_load_outbox_config_defaults() -> None:
     assert cfg["min_graphql_remaining"] == 200
     assert cfg["max_flush_per_run"] == 10
     assert cfg["retry_backoff_seconds"] == 30
+    assert cfg["precheck_writes"] is True
+    assert cfg["quota_cache_ttl_seconds"] == 45
+    assert cfg["dedupe_pending"] is True
+    assert "graphql-quota-cache.json" in cfg["quota_cache_path"]
 
 
 def test_load_outbox_config_custom_and_disabled() -> None:
@@ -154,13 +158,20 @@ def test_load_outbox_config_missing_outbox_key() -> None:
         ("API rate limit exceeded", True),
         ("secondary rate limit hit", True),
         ("Rate Limit: too many requests", True),
+        ("HTTP 429", True),
+        ("Please retry later", True),
+        ("Post https://api.github.com/graphql: Forbidden", True),
+        ("error: 403 Forbidden", True),
         ("network timeout", False),
         ("", False),
         ("item not found", False),
+        ("authentication token is missing required scopes [project]", False),
+        ("error: your authentication token is missing required scopes", False),
     ],
 )
 def test_is_rate_limit_error(text: str, expected: bool) -> None:
     assert project_outbox.is_rate_limit_error(text) is expected
+    assert project_outbox.is_queueable_gh_throttle(text) is expected
 
 
 # --- graphql_rate_limit ---
@@ -502,6 +513,8 @@ def test_maybe_enqueue_rate_limit_returns_queued(
     assert code == project_outbox.EXIT_QUEUED
     err = capsys.readouterr().err
     assert "QUEUED" in err
+    assert "CODE=6" in err
+    assert "do not retry" in err
 
 
 def test_maybe_enqueue_non_rate_limit_returns_none() -> None:
@@ -1408,3 +1421,155 @@ def test_apply_outbox_set_field_priority_gh_fail(
     )
     assert not ok
     assert "edit failed" in detail
+
+
+# --- G1 cached precheck / G5 dedupe ---
+
+
+def test_enqueue_dedupe_pending(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    e1, err1 = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="claim",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"to": "in_progress", "text": "claimed"},
+    )
+    e2, err2 = project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="claim",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"to": "in_progress", "text": "claimed"},
+    )
+    assert err1 == "" and err2 == ""
+    assert e1 is not None and e2 is not None
+    assert e1["id"] == e2["id"]
+    path = _outbox_file(tmp_path, ssot)
+    assert project_outbox.count_outbox(path)["pending"] == 1
+
+
+def test_enqueue_no_dedupe_different_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "one"},
+    )
+    project_outbox.enqueue_op(
+        tmp_path,
+        ssot,
+        op="append-notes",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"text": "two"},
+    )
+    path = _outbox_file(tmp_path, ssot)
+    assert project_outbox.count_outbox(path)["pending"] == 2
+
+
+def test_guard_write_or_queue_low_quota(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path, min_graphql_remaining=200)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    code = project_outbox.guard_write_or_queue(
+        tmp_path,
+        ssot,
+        cmd="set-status",
+        op="set-status",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"to": "in_progress"},
+    )
+    assert code == project_outbox.EXIT_QUEUED
+    err = capsys.readouterr().err
+    assert "precheck" in err
+    assert "CODE=6" in err
+    path = _outbox_file(tmp_path, ssot)
+    assert project_outbox.count_outbox(path)["pending"] == 1
+
+
+def test_guard_write_or_queue_ok_when_remaining_high(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _mock_graphql(monkeypatch, remaining=4000)
+    code = project_outbox.guard_write_or_queue(
+        tmp_path,
+        ssot,
+        cmd="set-status",
+        op="set-status",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"to": "done"},
+    )
+    assert code is None
+
+
+def test_quota_cache_ttl_hit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path, quota_cache_ttl_seconds=60)
+    calls = {"n": 0}
+
+    def _rl() -> dict:
+        calls["n"] += 1
+        return {
+            "remaining": 3000,
+            "limit": 5000,
+            "reset_epoch": 1700000000,
+            "error": None,
+        }
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _rl)
+    a = project_outbox.get_cached_graphql_remaining(tmp_path, ssot)
+    b = project_outbox.get_cached_graphql_remaining(tmp_path, ssot)
+    assert a["remaining"] == 3000
+    assert b["from_cache"] is True
+    assert calls["n"] == 1
+
+
+def test_maybe_enqueue_forbidden_queued(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    code = project_outbox.maybe_enqueue_on_gh_fail(
+        tmp_path,
+        ssot,
+        cmd="claim",
+        err_detail='Post "https://api.github.com/graphql": Forbidden',
+        op="claim",
+        item_id=VALID_ITEM_ID,
+        agent="implementer",
+        payload={"to": "in_progress"},
+    )
+    assert code == project_outbox.EXIT_QUEUED
+
+
+def test_maybe_enqueue_scope_miss_not_queued(tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    assert (
+        project_outbox.maybe_enqueue_on_gh_fail(
+            tmp_path,
+            ssot,
+            cmd="claim",
+            err_detail="authentication token is missing required scopes [project]",
+            op="claim",
+            item_id=VALID_ITEM_ID,
+            agent="implementer",
+            payload={"to": "in_progress"},
+        )
+        is None
+    )

--- a/tests/modules/install/test_project_tier1.py
+++ b/tests/modules/install/test_project_tier1.py
@@ -260,7 +260,7 @@ def test_cmd_mention_pr_appends_notes(
         lambda *a, **k: ("issue", "I_x", {"title": "T"}, None),
     )
 
-    def fake_notes(root, ssot, item_id, *, agent, text, limit=100):
+    def fake_notes(root, ssot, item_id, *, agent, text, limit=100, skip_precheck=False):
         notes.append(text)
         return True, "updated", project_cli.EXIT_OK
 


### PR DESCRIPTION
## Summary
- Cached REST `rate_limit` precheck (TTL) before Pattern A board writes → EXIT_QUEUED when GraphQL remaining is low
- Queue Forbidden/429 throttle errors; do not queue missing-scopes failures
- Pending outbox dedupe by op+item+payload; stronger CODE=6 messaging
- Docs/skill/exemplar/canvas + test count 1085

## Test plan
- [x] `pytest tests/modules/install/test_project_outbox.py -q` (88 passed)
- [x] `make sync-plugin` / `make check-plugin`
- [x] `check_doc_facts.py` / governance consistency
- [ ] `prepare.py` gates on PR

## Board
- Issue #82 · `PVTI_lAHOBl46-84A9KZxzgzWtGA`
- Board-Item: PVTI_lAHOBl46-84A9KZxzgzWtGA


Made with [Cursor](https://cursor.com)