### PR TITLE
Post COV-100: align docs to 1121 tests and 100% coverage

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-19 (COV-100 verify — 100% scoped kit coverage)  
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1085
+**Last updated:** 2026-07-19 (post COV-100 doc align — 1121 tests / 6503 stmts / 100%)  
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1121
 
 ## Shipped (confirmed in repo)
 
@@ -52,14 +52,14 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus-execution` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1085 collected (1083 passed + 2 skipped on full run) | `tests/modules/` |
+| Tests | 1121 collected (1119 passed + 2 skipped on full run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-19
-(COV-100 verify): **6208 statements, 100.00%** on a full suite pass (**1085
-collected**; 1070 passed, 2 skipped). One import-order `sys.path` bootstrap in
+(COV-100 verify): **6503 statements, 100.00%** on a full suite pass (**1121
+collected**; 1119 passed, 2 skipped). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,
 `check_debrand.py`, `check_consumer_purity.py`, `check_file_headers.py`) have

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -208,7 +208,9 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-07-19 DOC-CANVAS-ALIGN, archival):** Re-verified against `IMPLEMENTATION-STATUS.md` — **1062** tests collected (1060 passed + 2 skipped), **6208** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts (8 / 11 / 7). Superseded by EA-019 refresh below.
 
-**Listing copy refresh (2026-07-19 EA-019 / PR #70):** Re-verified against `IMPLEMENTATION-STATUS.md` on `main` post Tier-1 Size/Estimate + Start date — **1072** tests collected (1070 passed + 2 skipped), **6208** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts unchanged (**8** / **11** / **7**); kit version **0.4.0**. Prior 1062 line superseded. Ship Marketplace against `0.4.0` (no version bump in this slice).
+**Listing copy refresh (2026-07-19 EA-019 / PR #70, archival):** Re-verified against `IMPLEMENTATION-STATUS.md` on `main` post Tier-1 Size/Estimate + Start date — **1072** tests collected (1070 passed + 2 skipped), **6208** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts unchanged (**8** / **11** / **7**); kit version **0.4.0**. Superseded by COV-100 doc-align refresh below.
+
+**Listing copy refresh (2026-07-19 COV-100 doc-align):** Re-verified against `IMPLEMENTATION-STATUS.md` on `main` post G1–G5 github-api-safety + `test_project_cov100_gaps.py` — **1121** tests collected (1119 passed + 2 skipped), **6503** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow`; agent/skill/rule counts unchanged (**8** / **11** / **7**); kit version **0.4.0**. Prior EA-019 line superseded.
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Local evidence file was not retained in this workspace; recreate with `make smoke-consumer` and write under `.local/workflow-artifacts/release/smoke-consumer-<app>-<date>.md` on the next consumer run.
 
@@ -222,7 +224,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 Local pre-publish evidence: run `make gates` + `make smoke-consumer` / `make install-dry-run` on the release tag, then record PASS under `.local/workflow-artifacts/enterprise-architecture-audit/marketplace-dry-run-<date>.md`.
 
-**Prep re-verified 2026-07-19 (EA-019):** dry-run PASS — `.local/workflow-artifacts/enterprise-architecture-audit/marketplace-dry-run-2026-07-19.md` (+ `.log`). Listing copy refresh on `main` via PR #72 (1072 tests / kit `0.4.0`).
+**Prep re-verified 2026-07-19 (EA-019, archival):** dry-run PASS — `.local/workflow-artifacts/enterprise-architecture-audit/marketplace-dry-run-2026-07-19.md` (+ `.log`). Listing copy refresh on `main` via PR #72 (1072 tests / kit `0.4.0`). Superseded by COV-100 doc-align counts (1121 / 6503 stmts).
 
 **Maintainer decision 2026-07-19:** **no public Marketplace submit for now.** Consumers stay on GitHub `/add-plugin`. Live upload remains deferred until explicitly re-scheduled on the board (EA-019 Backlog).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -52,7 +52,7 @@ mas-workflow-kit-project-ssot/
 ├── cursor_workflow/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1085; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1121; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1085; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1121; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/workflow-complete.md
+++ b/.ai_infra/docs/operations/workflow-complete.md
@@ -55,6 +55,7 @@ Before final `/prepare-pr`:
 2. Follow `.cursor/skills/test-module-coverage/SKILL.md` (local) / test-runner agent profile.
 3. Update `.local/index-and-planning/current/test-plan.md` and `test-index.md`.
 4. Run `python .ai_infra/scripts/pr/check_testing_artifacts.py`.
+5. **Post scoped coverage 100%:** full doc reality sync per `.cursor/skills/test-module-coverage/SKILL.md` step 6 — `IMPLEMENTATION-STATUS.md`, `make coverage-index`, `make doc-validate`, README/HANDOFF/repository-map claims, `make sync-plugin` when payload copies change.
 
 ## D) Doc / plan sync (when scope shifts)
 

--- a/.cursor/skills/test-module-coverage/SKILL.md
+++ b/.cursor/skills/test-module-coverage/SKILL.md
@@ -16,7 +16,8 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 3. Update `.local/index-and-planning/current/test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
 4. Run: `pytest` scoped to module → broader as needed. Before merge path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (see `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
 5. For coverage evidence, install `dev` extras (`pip install -e ".[dev]"`) then run `pytest --cov=.ai_infra --cov=cursor_workflow --cov-report=term-missing -q`; record gaps in board card Notes when `project_ssot.enabled` + `board_only`, else `work-tracker.md`; always one line in `updates-log.md` per `implementation-workflow-governance.mdc`. **Scope:** this metric tracks the installable kit import surface (`.ai_infra/**` modules imported during tests + `cursor_workflow/**`); subprocess-only scanners (`check_governance_consistency.py`, `check_debrand.py`, etc.) are validated via their own module tests but excluded from `--cov` by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
-6. Report: modules • edges added • gaps • tracker edits.
+6. **After scoped coverage reaches 100%** (or any coverage-closure slice): mandatory doc reality sync — update `IMPLEMENTATION-STATUS.md` **Tests:** + coverage scope numbers, regenerate `.local/index-and-planning/current/coverage-index.md` via `make coverage-index`, run `make doc-validate`, sync related README/HANDOFF/repository-map claims, then `make sync-plugin` when skills/docs payload copies change.
+7. Report: modules • edges added • gaps • tracker edits.
 
 ## Themes (when relevant)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1085 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1121 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -143,7 +143,7 @@ const FOLLOWUP_SLICES = [
     items: [
       "Issue body, GraphQL errors, merge Notes warn",
       "set_item_status PVTI-only paths; outbox queue/flush",
-      "1062 tests collected; COV-100 6208 stmts / 100%; drift validate green",
+      "1121 tests collected; COV-100 6503 stmts / 100%; drift validate green",
     ],
   },
   {
@@ -331,7 +331,7 @@ export default function BoardSsotVsKitCanvas() {
         <Text tone="secondary">
           Before/after comparison for mas-workflow-kit-project-ssot as of {VERIFIED}.
           PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift residuals, EA-001/004,
-          and expanded tests (1062 collected) are shipped on main.
+          and expanded tests (1121 collected) are shipped on main.
         </Text>
       </Stack>
 
@@ -622,7 +622,7 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">ADR-008 + project-ssot-precedence overlay</Text>
               <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI on main (PR #3)</Text>
               <Text size="small">
-                1062 tests collected; COV-100 6208 stmts / 100%; DRIFT validate
+                1121 tests collected; COV-100 6503 stmts / 100%; DRIFT validate
                 P0=0 P1=0 P2=0
               </Text>
               <Text size="small">STANDALONE decided — this repo is the product</Text>
@@ -660,7 +660,7 @@ export default function BoardSsotVsKitCanvas() {
 
       <Text size="small" tone="tertiary">
         Source: HANDOFF §1 · ADR-008 · STANDALONE 2026-07-18 · PR #2/#3 merged ·
-        drift validate green · verified {VERIFIED} · 1062 tests · COV-100 6208 stmts
+        drift validate green · verified {VERIFIED} · 1121 tests · COV-100 6503 stmts
       </Text>
     </Stack>
   );

--- a/payload/.ai_infra/docs/operations/workflow-complete.md
+++ b/payload/.ai_infra/docs/operations/workflow-complete.md
@@ -55,6 +55,7 @@ Before final `/prepare-pr`:
 2. Follow `.cursor/skills/test-module-coverage/SKILL.md` (local) / test-runner agent profile.
 3. Update `.local/index-and-planning/current/test-plan.md` and `test-index.md`.
 4. Run `python .ai_infra/scripts/pr/check_testing_artifacts.py`.
+5. **Post scoped coverage 100%:** full doc reality sync per `.cursor/skills/test-module-coverage/SKILL.md` step 6 — `IMPLEMENTATION-STATUS.md`, `make coverage-index`, `make doc-validate`, README/HANDOFF/repository-map claims, `make sync-plugin` when payload copies change.
 
 ## D) Doc / plan sync (when scope shifts)
 

--- a/payload/.cursor/skills/test-module-coverage/SKILL.md
+++ b/payload/.cursor/skills/test-module-coverage/SKILL.md
@@ -16,7 +16,8 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 3. Update `.local/index-and-planning/current/test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
 4. Run: `pytest` scoped to module → broader as needed. Before merge path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (see `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
 5. For coverage evidence, install `dev` extras (`pip install -e ".[dev]"`) then run `pytest --cov=.ai_infra --cov=cursor_workflow --cov-report=term-missing -q`; record gaps in board card Notes when `project_ssot.enabled` + `board_only`, else `work-tracker.md`; always one line in `updates-log.md` per `implementation-workflow-governance.mdc`. **Scope:** this metric tracks the installable kit import surface (`.ai_infra/**` modules imported during tests + `cursor_workflow/**`); subprocess-only scanners (`check_governance_consistency.py`, `check_debrand.py`, etc.) are validated via their own module tests but excluded from `--cov` by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
-6. Report: modules • edges added • gaps • tracker edits.
+6. **After scoped coverage reaches 100%** (or any coverage-closure slice): mandatory doc reality sync — update `IMPLEMENTATION-STATUS.md` **Tests:** + coverage scope numbers, regenerate `.local/index-and-planning/current/coverage-index.md` via `make coverage-index`, run `make doc-validate`, sync related README/HANDOFF/repository-map claims, then `make sync-plugin` when skills/docs payload copies change.
+7. Report: modules • edges added • gaps • tracker edits.
 
 ## Themes (when relevant)
 

--- a/skills/test-module-coverage/SKILL.md
+++ b/skills/test-module-coverage/SKILL.md
@@ -16,7 +16,8 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 3. Update `.local/index-and-planning/current/test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
 4. Run: `pytest` scoped to module → broader as needed. Before merge path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (see `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
 5. For coverage evidence, install `dev` extras (`pip install -e ".[dev]"`) then run `pytest --cov=.ai_infra --cov=cursor_workflow --cov-report=term-missing -q`; record gaps in board card Notes when `project_ssot.enabled` + `board_only`, else `work-tracker.md`; always one line in `updates-log.md` per `implementation-workflow-governance.mdc`. **Scope:** this metric tracks the installable kit import surface (`.ai_infra/**` modules imported during tests + `cursor_workflow/**`); subprocess-only scanners (`check_governance_consistency.py`, `check_debrand.py`, etc.) are validated via their own module tests but excluded from `--cov` by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
-6. Report: modules • edges added • gaps • tracker edits.
+6. **After scoped coverage reaches 100%** (or any coverage-closure slice): mandatory doc reality sync — update `IMPLEMENTATION-STATUS.md` **Tests:** + coverage scope numbers, regenerate `.local/index-and-planning/current/coverage-index.md` via `make coverage-index`, run `make doc-validate`, sync related README/HANDOFF/repository-map claims, then `make sync-plugin` when skills/docs payload copies change.
+7. Report: modules • edges added • gaps • tracker edits.
 
 ## Themes (when relevant)
 

--- a/tests/modules/install/test_project_cov100_gaps.py
+++ b/tests/modules/install/test_project_cov100_gaps.py
@@ -1,0 +1,944 @@
+"""
+File: test_project_cov100_gaps.py
+Path: tests/modules/install/test_project_cov100_gaps.py
+Role: Targeted tests for remaining scoped kit coverage gaps (project_* + gh adapter).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/project_cli.py
+ - .ai_infra/install/cursor_workflow/project_handlers.py
+ - .ai_infra/install/cursor_workflow/project_outbox.py
+ - .ai_infra/install/cursor_workflow/project_recipes.py
+ - .ai_infra/install/cursor_workflow/project_atomics.py
+ - .ai_infra/install/cursor_workflow/gh_project_adapter.py
+Notes:
+ - Monkeypatches gh/GraphQL; no live network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PKG_DIR = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+if str(_PKG_DIR) not in sys.path:
+    sys.path.insert(0, str(_PKG_DIR))
+
+import gh_project_adapter as gha  # noqa: E402
+import project_atomics  # noqa: E402
+import project_cli  # noqa: E402
+import project_handlers  # noqa: E402
+import project_outbox  # noqa: E402
+import project_recipes  # noqa: E402
+from test_project_cli import SAMPLE_SSOT, VALID_PVTI, _write_collab  # noqa: E402
+
+
+def _ensure_pr_scripts(tmp_path: Path) -> None:
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr"
+    dst = tmp_path / ".ai_infra" / "scripts" / "pr"
+    dst.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "user_settings.py",
+        "user_settings_load.py",
+        "user_settings_resolve.py",
+        "user_settings_render.py",
+        "local_workflow_paths.py",
+    ):
+        file_src = src / name
+        if file_src.is_file():
+            (dst / name).write_text(file_src.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _ssot(**overrides: object) -> dict:
+    data = json.loads(json.dumps(SAMPLE_SSOT))
+    data["default_repo"] = data.get("default_repo") or "SavinRazvan/mas-workflow-kit-project-ssot"
+    data["fields"] = {
+        **data.get("fields", {}),
+        "estimate": {"field_id": "PVTF_estimate"},
+        "start_date": {"field_id": "PVTF_start"},
+    }
+    data["conventions"] = {
+        **data.get("conventions", {}),
+        "body_sections": ["Acceptance", "Rollback", "Notes"],
+        "require_attribution_on_exit": True,
+        "one_in_progress_per_assignee": True,
+        "claim": "set_assignee",
+        "set_start_date_on_claim": True,
+    }
+    data.update(overrides)
+    if "conventions" in overrides:
+        data["conventions"] = {**data["conventions"], **overrides["conventions"]}  # type: ignore[arg-type]
+    if "fields" in overrides:
+        data["fields"] = {**data["fields"], **overrides["fields"]}  # type: ignore[arg-type]
+    return data
+
+
+def _outbox_ssot(tmp_path: Path, **outbox_overrides: object) -> dict:
+    rel = "outbox/cov100-outbox.jsonl"
+    outbox = {
+        "enabled": True,
+        "path": rel,
+        "min_graphql_remaining": 200,
+        "max_flush_per_run": 10,
+        "retry_backoff_seconds": 0,
+        **outbox_overrides,
+    }
+    return {**_ssot(), "outbox": outbox}
+
+
+def _mock_graphql(monkeypatch: pytest.MonkeyPatch, *, remaining: int = 5000, error: str | None = None) -> None:
+    if error:
+
+        def _fail() -> dict:
+            return {"remaining": None, "limit": None, "reset_epoch": None, "error": error}
+
+        monkeypatch.setattr(project_outbox, "graphql_rate_limit", _fail)
+    else:
+
+        def _ok() -> dict:
+            return {
+                "remaining": remaining,
+                "limit": 5000,
+                "reset_epoch": 1700000000,
+                "error": None,
+            }
+
+        monkeypatch.setattr(project_outbox, "graphql_rate_limit", _ok)
+
+
+def _board_item(*, start_date: str = "", item_id: str = VALID_PVTI, status: str = "Ready") -> dict:
+    item: dict = {
+        "id": item_id,
+        "title": "Slice",
+        "status": status,
+        "content": {
+            "body": "## Acceptance\n\nx\n\n## Rollback\n\ny\n\n## Notes\n\n",
+        },
+    }
+    if start_date:
+        item["start date"] = start_date
+    return item
+
+
+def _create_template_args(**overrides: object) -> argparse.Namespace:
+    base = {
+        "directory": REPO_ROOT,
+        "title": "[T] slice",
+        "template": "slice",
+        "acceptance": "do X",
+        "rollback": "revert",
+        "notes": "",
+        "status": "",
+        "priority": "p1",
+        "size": None,
+        "estimate": None,
+        "agent": "",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _fake_create_gh(item_id: str = "PVTI_lAHOBl46-84A9KZxnew001"):
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        if args[:2] == ["issue", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="https://github.com/SavinRazvan/mas-workflow-kit-project-ssot/issues/99\n",
+                stderr="",
+            )
+        if args[:2] == ["project", "item-add"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"id": item_id}),
+                stderr="",
+            )
+        if args[:2] == ["project", "item-edit"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="unexpected")
+
+    return fake_gh
+
+
+# --- project_cli create-from-template gaps ---
+
+
+@pytest.mark.parametrize(
+    "estimate,expected",
+    [
+        ("not-a-number", "must be a number"),
+        ("-1", ">= 0"),
+    ],
+)
+def test_create_from_template_bad_estimate(
+    monkeypatch: pytest.MonkeyPatch, estimate: str, expected: str
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "create_board_item",
+        lambda *a, **k: ("PVTI_x", "", None),
+    )
+    args = _create_template_args(estimate=estimate)
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_USAGE
+
+
+def test_create_from_template_priority_keyerror_after_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "create_board_item",
+        lambda *a, **k: ("PVTI_x", "", None),
+    )
+
+    def raise_priority(ssot, field, value):
+        if field == "priority":
+            raise KeyError("priority field missing")
+        return "fid", "oid"
+
+    monkeypatch.setattr(project_cli, "resolve_field_option_id", raise_priority)
+    args = _create_template_args()
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_USAGE
+
+
+def test_create_from_template_priority_gh_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "create_board_item",
+        lambda *a, **k: ("PVTI_x", "", None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="priority edit failed"),
+    )
+    args = _create_template_args()
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_GH
+
+
+def test_create_from_template_size_and_estimate_warn_paths(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "create_board_item",
+        lambda *a, **k: ("PVTI_x", "", None),
+    )
+    calls = {"n": 0}
+
+    def fake_gh(args: list[str], *, timeout_s: float = 60.0):
+        if args[:2] == ["project", "item-edit"]:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="size edit failed")
+        return SimpleNamespace(returncode=1, stdout="", stderr="unexpected")
+
+    monkeypatch.setattr(project_cli, "run_gh", fake_gh)
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_field_option_id",
+        lambda ssot, field, value: ("fid", "oid"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "set_item_number",
+        lambda *a, **k: (False, "estimate edit failed"),
+    )
+    args = _create_template_args(size="m", estimate="2")
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_OK
+    err = capsys.readouterr().err
+    assert "size skipped" in err
+    assert "estimate skipped" in err
+
+
+def test_create_from_template_size_keyerror_warn(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "create_board_item",
+        lambda *a, **k: ("PVTI_x", "", None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    def resolve(ssot, field, value):
+        if field == "size":
+            raise KeyError("size field missing")
+        return "fid", "oid"
+
+    monkeypatch.setattr(project_cli, "resolve_field_option_id", resolve)
+    monkeypatch.setattr(project_cli, "set_item_number", lambda *a, **k: (True, "ok"))
+    args = _create_template_args(size="m", estimate="2")
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_OK
+    assert "size skipped" in capsys.readouterr().err
+
+
+def test_create_from_template_guessed_notes_with_agent(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(project_cli, "run_gh", _fake_create_gh())
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    args = _create_template_args(agent="implementer")
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "notes: Size/Estimate guessed" in out
+
+
+def test_create_from_template_guessed_notes_fail_with_agent(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(project_cli, "run_gh", _fake_create_gh("PVTI_lAHOBl46-84A9KZxnew003"))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "notes failed", project_cli.EXIT_GH),
+    )
+    args = _create_template_args(agent="implementer")
+    assert project_cli.cmd_create_from_template(args) == project_cli.EXIT_OK
+    assert "guessed Notes failed" in capsys.readouterr().err
+
+
+# --- project_cli guard precheck + set-status start_date warn ---
+
+
+def test_cmd_set_status_precheck_queues_before_gh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_PVTI,
+        last=False,
+        to="ready",
+        agent="implementer",
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_set_status_start_date_warn_on_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "ensure_start_date_if_starting",
+        lambda *a, **k: (False, "date write failed", False),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_PVTI,
+        last=False,
+        to="in_progress",
+        agent="implementer",
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_OK
+    assert "start_date skipped" in capsys.readouterr().err
+
+
+def test_cmd_set_field_estimate_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_PVTI,
+        last=False,
+        field="estimate",
+        to="2",
+        agent="implementer",
+    )
+    assert project_cli.cmd_set_field(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_set_field_priority_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_PVTI,
+        last=False,
+        field="priority",
+        to="p1",
+        agent="implementer",
+    )
+    assert project_cli.cmd_set_field(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_append_notes_returns_queued_from_helper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (_ssot(), []))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "queued", project_cli.EXIT_QUEUED),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_PVTI,
+        last=False,
+        text="x",
+        agent="implementer",
+        limit=50,
+    )
+    assert project_cli.cmd_append_notes(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_set_assignee_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID_PVTI,
+        last=False,
+        login="alice",
+        agent="implementer",
+    )
+    assert project_cli.cmd_set_assignee(args) == project_cli.EXIT_QUEUED
+
+
+# --- project_handlers gaps ---
+
+
+def _claim_args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    base = {
+        "directory": tmp_path,
+        "id": VALID_PVTI,
+        "last": False,
+        "agent": "implementer",
+        "text": "claimed",
+        "limit": 100,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _handoff_args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    base = {
+        "directory": tmp_path,
+        "id": VALID_PVTI,
+        "last": False,
+        "agent": "implementer",
+        "next": "verifier",
+        "to": "in_review",
+        "text": "done",
+        "limit": 100,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_run_claim_precheck_queues_before_fetch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    assert project_handlers.run_claim(_claim_args(tmp_path)) == project_cli.EXIT_QUEUED
+
+
+def test_run_claim_skips_start_date_when_already_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot, limit=100: ([_board_item(start_date="2026-07-01")], None),
+    )
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(project_cli, "set_item_assignee", lambda *a, **k: (True, "test"))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    assert project_handlers.run_claim(_claim_args(tmp_path)) == project_cli.EXIT_OK
+
+
+def test_run_claim_notes_exit_queued_direct(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot, limit=100: ([_board_item()], None),
+    )
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(project_cli, "set_item_assignee", lambda *a, **k: (True, "test"))
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "queued", project_cli.EXIT_QUEUED),
+    )
+    assert project_handlers.run_claim(_claim_args(tmp_path)) == project_cli.EXIT_QUEUED
+
+
+def test_run_handoff_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    assert project_handlers.run_handoff(_handoff_args(tmp_path)) == project_cli.EXIT_QUEUED
+
+
+def test_run_handoff_start_date_warn_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot, limit=100: ([_board_item()], None),
+    )
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "oid"))
+    monkeypatch.setattr(
+        project_cli,
+        "ensure_start_date_if_starting",
+        lambda *a, **k: (False, "date write failed", False),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    assert project_handlers.run_handoff(_handoff_args(tmp_path, to="in_progress")) == project_cli.EXIT_OK
+    assert "start_date skipped" in capsys.readouterr().err
+
+    monkeypatch.setattr(
+        project_cli,
+        "ensure_start_date_if_starting",
+        lambda *a, **k: (True, "skipped: fields.start_date.field_id missing", False),
+    )
+    assert project_handlers.run_handoff(_handoff_args(tmp_path, to="in_progress")) == project_cli.EXIT_OK
+    assert "field_id missing" in capsys.readouterr().err
+
+
+def test_run_handoff_notes_exit_queued_direct(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot, limit=100: ([_board_item(status="In Progress")], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "queued", project_cli.EXIT_QUEUED),
+    )
+    assert project_handlers.run_handoff(_handoff_args(tmp_path, to="")) == project_cli.EXIT_QUEUED
+
+
+def test_run_mention_pr_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_arg",
+        lambda root, args, cmd: (VALID_PVTI, project_cli.EXIT_OK),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"number": 1, "url": "https://github.com/o/r/pull/1"}),
+            stderr="",
+        ),
+    )
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(directory=tmp_path, id=VALID_PVTI, pr="1", agent="implementer", limit=100)
+    assert project_handlers.run_mention_pr(args) == project_cli.EXIT_QUEUED
+
+
+def test_run_promote_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_arg",
+        lambda root, args, cmd: (VALID_PVTI, project_cli.EXIT_OK),
+    )
+    _mock_graphql(monkeypatch, remaining=50)
+    args = argparse.Namespace(directory=tmp_path, id=VALID_PVTI, agent="implementer", repo="", limit=100)
+    assert project_handlers.run_promote_to_issue(args) == project_cli.EXIT_QUEUED
+
+
+def test_run_promote_notes_exit_queued_direct(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_arg",
+        lambda root, args, cmd: (VALID_PVTI, project_cli.EXIT_OK),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "promote_draft_item_to_issue",
+        lambda *a, **k: (
+            True,
+            "Issue #1",
+            {"item_id": VALID_PVTI, "issue_number": "1", "url": "u", "noop": False},
+        ),
+    )
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "")
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "queued", project_cli.EXIT_QUEUED),
+    )
+    args = argparse.Namespace(directory=tmp_path, id=VALID_PVTI, agent="implementer", repo="", limit=100)
+    assert project_handlers.run_promote_to_issue(args) == project_cli.EXIT_QUEUED
+
+
+# --- project_outbox gaps ---
+
+
+def test_read_quota_cache_bad_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not-json", encoding="utf-8")
+    assert project_outbox.read_quota_cache(path) is None
+
+
+def test_get_cached_invalid_fetched_at_refreshes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    cfg = project_outbox.load_outbox_config(ssot)
+    path = project_outbox.quota_cache_path(tmp_path, cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"fetched_at": "not-a-float", "remaining": 999}), encoding="utf-8")
+    calls = {"n": 0}
+
+    def _rl() -> dict:
+        calls["n"] += 1
+        return {"remaining": 4000, "limit": 5000, "reset_epoch": 0, "error": None}
+
+    monkeypatch.setattr(project_outbox, "graphql_rate_limit", _rl)
+    info = project_outbox.get_cached_graphql_remaining(tmp_path, ssot)
+    assert info["remaining"] == 4000
+    assert info["from_cache"] is False
+    assert calls["n"] == 1
+
+
+def test_remaining_below_min_on_error_and_bad_remaining(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_outbox,
+        "get_cached_graphql_remaining",
+        lambda *a, **k: {"error": "gh down", "remaining": 0},
+    )
+    below, info = project_outbox.remaining_below_min(tmp_path, ssot)
+    assert below is False
+    assert info["error"] == "gh down"
+
+    monkeypatch.setattr(
+        project_outbox,
+        "get_cached_graphql_remaining",
+        lambda *a, **k: {"remaining": "many", "error": None},
+    )
+    below2, _ = project_outbox.remaining_below_min(tmp_path, ssot)
+    assert below2 is False
+
+
+def test_find_duplicate_pending_skips_wrong_status_op_and_item_id() -> None:
+    entries = [
+        _valid_outbox_entry(status="done", op="append-notes"),
+        _valid_outbox_entry(status="pending", op="set-status"),
+        _valid_outbox_entry(status="pending", op="append-notes", item_id="PVTI_other"),
+    ]
+    assert (
+        project_outbox.find_duplicate_pending(
+            entries,
+            op="append-notes",
+            item_id=VALID_PVTI,
+            payload={"text": "queued note"},
+        )
+        is None
+    )
+
+
+def test_run_mention_pr_notes_exit_queued_direct(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_arg",
+        lambda root, args, cmd: (VALID_PVTI, project_cli.EXIT_OK),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"number": 1, "url": "https://github.com/o/r/pull/1"}),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("issue", "9", {"repo": "o/r"}, None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "queued", project_cli.EXIT_QUEUED),
+    )
+    args = argparse.Namespace(directory=tmp_path, id=VALID_PVTI, pr="1", agent="implementer", limit=100)
+    assert project_handlers.run_mention_pr(args) == project_cli.EXIT_QUEUED
+
+
+def _valid_outbox_entry(**overrides: object) -> dict:
+    base = {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "ts": "2026-07-18T10:00:00Z",
+        "agent": "implementer",
+        "github_user": "@test",
+        "op": "append-notes",
+        "item_id": VALID_PVTI,
+        "payload": {"text": "queued note"},
+        "status": "pending",
+        "attempts": 0,
+        "last_error": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_maybe_enqueue_precheck_disabled_returns_none(tmp_path: Path) -> None:
+    ssot = _outbox_ssot(tmp_path, precheck_writes=False)
+    assert (
+        project_outbox.maybe_enqueue_on_low_quota(
+            tmp_path,
+            ssot,
+            cmd="set-status",
+            op="set-status",
+            item_id=VALID_PVTI,
+            agent="implementer",
+            payload={"to": "ready"},
+        )
+        is None
+    )
+
+
+def test_maybe_enqueue_low_quota_enqueue_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _mock_graphql(monkeypatch, remaining=50)
+    monkeypatch.setattr(project_outbox, "enqueue_op", lambda *a, **k: (None, "disk full"))
+    code = project_outbox.maybe_enqueue_on_low_quota(
+        tmp_path,
+        ssot,
+        cmd="set-status",
+        op="set-status",
+        item_id=VALID_PVTI,
+        agent="implementer",
+        payload={"to": "ready"},
+    )
+    assert code == project_cli.EXIT_GH
+    assert "low-quota enqueue failed" in capsys.readouterr().err
+
+
+def test_note_successful_write_noop_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path, enabled=False)
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        project_outbox,
+        "get_cached_graphql_remaining",
+        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1) or {},
+    )
+    project_outbox.note_successful_write(tmp_path, ssot)
+    assert calls["n"] == 0
+
+
+def test_apply_outbox_set_status_fail_and_start_date_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    ssot["fields"] = {**ssot["fields"], "start_date": {"field_id": "PVTF_start"}}
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (False, "status failed"))
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_outbox_entry(op="set-status", payload={"to": "in_progress"}),
+    )
+    assert not ok and detail == "status failed"
+
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(project_cli, "set_item_date", lambda *a, **k: (False, "date failed"))
+    ok2, detail2 = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_outbox_entry(
+            op="set-status",
+            payload={"to": "in_progress", "start_date": "2026-07-18"},
+        ),
+    )
+    assert not ok2 and "start_date failed" in detail2
+
+    monkeypatch.setattr(
+        project_cli,
+        "ensure_start_date_if_starting",
+        lambda *a, **k: (False, "ensure failed", False),
+    )
+    ok3, detail3 = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_outbox_entry(op="set-status", payload={"to": "in_progress"}),
+    )
+    assert not ok3 and "start_date failed" in detail3
+
+
+def test_apply_outbox_handoff_in_progress_start_date_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(
+        project_cli,
+        "ensure_start_date_if_starting",
+        lambda *a, **k: (False, "handoff date failed", False),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_outbox_entry(
+            op="handoff",
+            payload={"next": "verifier", "to": "in_progress", "note": "x"},
+        ),
+    )
+    assert not ok and "start_date failed" in detail
+
+
+# --- gh_project_adapter + atomics + recipes ---
+
+
+def test_create_board_item_routes_to_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+    ssot = _ssot(conventions={"item_kind_default": "draft"})
+    called: list[str] = []
+
+    def fake_draft(ssot, title, body):
+        called.append("draft")
+        return "DI_x", "raw", None
+
+    monkeypatch.setattr(project_cli, "create_draft_item", fake_draft)
+    item_id, raw, err = gha.create_board_item(ssot, "T", "B")
+    assert called == ["draft"]
+    assert item_id == "DI_x" and err is None
+
+
+def test_item_start_date_value_non_dict() -> None:
+    assert project_atomics.item_start_date_value(None) == ""
+    assert project_atomics.item_start_date_value("not-a-dict") == ""  # type: ignore[arg-type]
+
+
+def test_append_notes_helper_precheck_queues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ssot = _outbox_ssot(tmp_path)
+    _ensure_pr_scripts(tmp_path)
+    _write_collab(tmp_path, ssot)
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    _mock_graphql(monkeypatch, remaining=50)
+    ok, detail, code = project_recipes.append_notes_helper(
+        tmp_path,
+        ssot,
+        VALID_PVTI,
+        agent="implementer",
+        text="queued via precheck",
+        limit=50,
+        skip_precheck=False,
+    )
+    assert not ok
+    assert "queued to outbox" in detail
+    assert code == project_cli.EXIT_QUEUED


### PR DESCRIPTION
## Summary
- Land `test_project_cov100_gaps.py` and confirm scoped kit coverage **100.00%** (6503 statements).
- Align IMPLEMENTATION-STATUS, README, repository-map, marketplace note, and board-ssot canvas to **1121** collected tests.
- Codify standing order: after scoped coverage hits 100%, sync docs (`test-module-coverage` step 6 + `workflow-complete.md` §C).

## Test plan
- [x] `pytest -q` — 1119 passed, 2 skipped
- [x] `make coverage-index` — 100.00%
- [x] `make doc-validate` / `make drift-validate` — green (DOC-006/DRIFT-005 = 1121)
- [ ] CI green on PR

Closes #88

Made with [Cursor](https://cursor.com)