### PR TITLE
docs: onboarding gh auth + device login (WSL-friendly)

### DIFF
--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -126,10 +126,57 @@ Discover ids manually: `gh project view <N> --owner <login>` (for `project_id`) 
 |------|--------|
 | 1. Install / activate | Agent chat: `/add-plugin …` then **`/workflow-activate`** in **your app repo** — wait for **`VERIFY PASS`**. |
 | 2. Collaboration YAML | Edit `.local/user_settings/github.collaboration.yaml`: set `project_ssot.enabled: true`, `sync_policy: board_only`, and board identity — `name`, `number`, `owner`, `project_id` (from Project URL / `gh project view`). Copy field ids from `gh project field-list <number> --owner <owner>` when wiring `fields.status` / Priority / Size. |
-| 3. GitHub auth | Ensure `gh` can reach Projects: `gh auth refresh -h github.com -s read:project,project` (keep existing **`repo`** scopes). |
+| 3. GitHub auth | See **§ GitHub CLI auth (Projects)** below — grant `repo` + Project scopes; use the device login link if no browser opens. |
 | 4. Doctor + status | `python3 -m cursor_workflow project doctor` (config + templates + `gh` access) then `python3 -m cursor_workflow project status` (shows enabled board). |
 | 5. First card | `python3 -m cursor_workflow project create-from-template --template slice --title "…" --priority p1 --size s --estimate 1 --agent implementer` → `claim --last --agent implementer` (sets Start date). Prefer `project guide`. |
 | 6. Rate-limit buffer | Writes may **precheck** GraphQL quota (cached REST) or queue on throttle / Forbidden / 429. If a write returns **EXIT_QUEUED (6)**, do **not** retry-loop — continue local evidence; after quota recovers run `python3 -m cursor_workflow project outbox status` then `project outbox flush`. Configure `project_ssot.outbox` (`precheck_writes`, `dedupe_pending`, …) in collaboration YAML. Outbox is a local buffer, not a second Status SSOT. |
+
+#### GitHub CLI auth (Projects)
+
+Board SSOT needs the **GitHub CLI** (`gh`) with **repository** access **and** **Projects** read/write. Without Project scopes, `project status` / `claim` / `outbox flush` fail with “missing required scopes”.
+
+| Scope | Why |
+|-------|-----|
+| **`repo`** | Issues, PRs, default repo operations |
+| **`read:project`** | Read Project / fields / items |
+| **`project`** | Write Status, Notes, Tier-1 fields, claim/handoff |
+| **`workflow`** (optional) | GitHub Actions / PR checks if you drive CI from `gh` |
+
+**First login** (new machine):
+
+```bash
+gh auth login -h github.com
+```
+
+Choose HTTPS, authenticate via browser **or** device code, and allow access to the repos you use.
+
+**Add Project permissions** to an existing login:
+
+```bash
+gh auth refresh -h github.com -s read:project,project
+# Keep existing repo (and workflow) scopes — refresh adds Project access.
+```
+
+**If the terminal cannot open a browser** (WSL, headless, remote SSH — `xdg-open: no method available`):
+
+1. Leave the terminal running after `gh auth login` / `gh auth refresh`.
+2. Copy the **one-time code** `gh` prints (e.g. `ABCD-1234`).
+3. Open **[https://github.com/login/device](https://github.com/login/device)** in any browser (Windows host browser is fine from WSL).
+4. Paste the code → sign in → **approve** GitHub + **Project** permissions.
+5. Return to the terminal — you should see `✓ Authentication complete.`
+
+**Verify:**
+
+```bash
+gh auth status
+# Logged in · Token scopes should include: repo, project
+# (read:project may show separately or be covered when project is present)
+
+python3 -m cursor_workflow project doctor
+python3 -m cursor_workflow project status
+```
+
+If `gh` reports **missing required scopes `[read:project]` / `[project]`**, re-run `gh auth refresh -h github.com -s read:project,project` and complete the device link again.
 
 Daily Entry after onboarding: `project status` (board first) — see [project-board-collaboration.md](project-board-collaboration.md).
 

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -5,32 +5,85 @@ Role: Glossary for MAS Workflow Kit workflow terminology.
 Used By:
  - README.md
  - AGENTS.md
+ - HANDOFF.md
 Depends On:
  - .ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
+ - .ai_infra/docs/decisions/README.md
 Notes:
  - Keep definitions short for newcomers.
+ - Numbered catalogs (ADR-NNN, DRIFT-NNN, EA-NNN, INT-NNN, DOC-NNN) live in their index docs — list stems here only.
 -->
 
 # Abbreviations Notepad
 
-Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
+Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs.
 
 ## MAS Workflow Kit flow (plain language)
 
 1. Install kit via `cursor_workflow activate` (plugin) or `cursor_workflow install` (kit clone).
-2. Agents read `.local/` trackers (`session-pointer.md` → `plan.md` → `work-tracker.md`).
-3. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A).
-4. Optional MCP (`workflow-kit`) wraps the same scripts.
+2. When `project_ssot.enabled` + `board_only`: Entry = board (`project status` / claim); Exit = Status + Notes. Local trackers = offline fallback only.
+3. Else: agents read `.local/` trackers (`session-pointer.md` → `plan.md` → `work-tracker.md`).
+4. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A + `prepare.py` GATES).
+5. Optional MCP (`workflow-kit`) wraps the same scripts.
 
 ## Core abbreviations
 
 | Abbreviation | Meaning |
 |---|---|
+| MAS | Multi-Agent System — this kit’s agent/skill/script workflow product |
+| SSOT | Single Source of Truth — one authoritative place for a given concern |
 | MCP | Model Context Protocol — Cursor tool server integration |
-| PR | Pull request — maintainer merge workflow |
-| ADR | Architecture Decision Record — `.ai_infra/docs/decisions/` |
-| GATES | 2-gate back-compat alias of `resolve_gates()` in `prepare.py` |
-| Pattern A | Script-first workflow; agents invoke one command per action |
+| CLI | Command-line interface — here mainly `python3 -m cursor_workflow …` and `gh` |
+| PR | Pull request — maintainer merge workflow (Pattern A) |
+| ADR | Architecture Decision Record — `.ai_infra/docs/decisions/` (ADR-001…008) |
+| GATES | Hardcoded subprocess list in `.ai_infra/scripts/pr/prepare.py` |
+| Pattern A | Script-first workflow; agents invoke **one** command per maintainer action |
+| YAML | Config format for `github.collaboration.yaml`, registries, manifests |
+| UTC / ISO-8601 | Board Notes timestamps (`YYYY-MM-DDTHH:MM:SSZ`); CLI stamps UTC |
+| CI / CD | Continuous integration / delivery — GitHub Actions + release evidence |
+| RC | Release candidate — needs CI/CD evidence bundles before ship |
+| UI | GitHub Project / settings UI (humans); agents prefer CLI |
+| PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes |
+| GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
+| KISS | Keep It Simple — incremental, reversible slices |
+| DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |
+| AI | Artificial intelligence — optional `Assisted-by:` trailer when AI materially shaped a change |
+| TBD | To Be Determined — placeholder in file headers / relations |
+| DAG | Directed Acyclic Graph — agent **handoff** edges (canvases); no cycles |
+| ACC | Agents Control Center — `.local/agents-control-center/` (folder name) |
+| ICC | Implementation Control Center — HTML dashboard under ACC (**deprecated**; prefer board + canvases) |
+| HTML | Local dashboard pages served via `http.server` (not `file://`) |
+| JSON | Machine artifacts (coverage, board export, registries, MCP config) |
+| IDE | Editor host (Cursor) — canvases open via Open Canvas, not raw `file://` HTML |
+
+## Board / Project SSOT
+
+| Term | Meaning |
+|---|---|
+| `project_ssot` | YAML block in `github.collaboration.yaml` wiring the GitHub Project |
+| `board_only` | `sync_policy` — board is the **only writable** backlog/Status/continuation SSOT |
+| Tier-1 | Mandatory board fields: Status, Priority, Size, Estimate, Start date (on first In progress), Assignee, Linked PR when a PR exists |
+| `PVT_` | GitHub Project v2 **project** node id (in YAML `project_id`) |
+| `PVTI_` | GitHub Project v2 **item** id (card); Draft→Issue keeps the same `PVTI_` |
+| outbox | Local rate-limit buffer (`.local/generated-data/board-outbox.jsonl`); not a second SSOT |
+| EXIT_QUEUED | CLI exit code **6** — write queued to outbox; later `project outbox flush` |
+| dual-write | Forbidden under `board_only`: writing competing Status into local trackers |
+| Entry / Exit | Every agent: read board on Entry; update Status (+ Notes) on Exit |
+| canvas | Cursor Canvas visualization (`canvases/*.canvas.tsx`) — prefer over deprecated ICC HTML |
+
+## Drift, audit, and check ids
+
+| Stem | Meaning | Where to look |
+|---|---|---|
+| DRIFT-NNN | Operational drift check id (plan/tracker/board coherence) | ADR-007; `drift validate` |
+| INT-NNN | Integrate / registry parity check id | `integrate validate` |
+| EA-NNN | Enterprise-architecture finding / backlog id | enterprise-auditor artifacts / HANDOFF |
+| DOC-NNN | Documentation fact / validate check id | `make doc-validate` / doc facts |
+| COV-NNN | Coverage readiness claim / slice label | IMPLEMENTATION-STATUS / coverage evidence |
+| P0 / P1 / P2 / P3 | Priority — board uses `p0\|p1\|p2`; chat P3 → board `p2` + Notes `deferred` | `project-board-ssot` skill |
+| xs…xl | Size options on the board (Tier-1) | Size↔Estimate table in skill |
+
+High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`).
 
 ## Planes
 
@@ -44,16 +97,28 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 
 | Agent | Role |
 |-------|------|
+| project-board | Board triage, Status, Tier-1 fields; hand off to implementer |
 | implementer | Slice implementation |
 | integrator-mas-agent | Extend agents/skills/MCP into kit infrastructure |
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
-| enterprise-auditor | Architecture audits |
-| researcher | Shipped corpus researcher; adaptive Brief; CLI `research init\|fetch\|validate`; packs opt-in after init |
+| enterprise-auditor | Architecture audits (alignment / scorecard artifacts) |
+| workflow-drift-guard | Operational drift audit + board Exit for drift-pass cards |
+| researcher | Brief-driven research packs; CLI `research init\|fetch\|validate` |
 
-## Research (opt-in corpus)
+## Research (optional)
 
 | Term | Meaning |
 |------|---------|
 | Brief | Intake contract for researcher (`BRIEF.md` / chat / board card) — source, question, lenses, consumers |
 | Research pack | Indexed corpus under `_research_results/sources/<slug>/` (`INDEX.json`, `AGENT_BRIEF.md`, …) |
+| AGENT_BRIEF | Consumer-facing brief inside a research pack for implementer/integrator |
+
+## Related indexes (do not duplicate full catalogs here)
+
+| Catalog | Index |
+|---------|--------|
+| ADRs | `.ai_infra/docs/decisions/README.md` |
+| Drift checks | ADR-007 + `.cursor/skills/workflow-drift-audit/SKILL.md` |
+| Board ops | `.ai_infra/docs/operations/project-board-collaboration.md` |
+| Token / log discipline | `.ai_infra/docs/operations/token-efficiency.md` |

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -32,9 +32,10 @@ Install **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) 
 | **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` — or **Cursor → Marketplace** when listed |
 | **2. Activate** | Open **your app folder** → Agent chat: **`/workflow-activate`** → wait for **`VERIFY PASS`** |
 | **3. Your name** | Edit `.local/user_settings/github.collaboration.yaml` → set `display_name` + `github_user` → `python3 -m cursor_workflow contributors validate` |
+| **3b. GitHub auth** (board SSOT) | `gh auth login` or `gh auth refresh -h github.com -s read:project,project` — grant **repo + Project** permissions. If no browser opens: copy the one-time code → open **https://github.com/login/device** → approve → return to terminal. Details: [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects). |
 | **4. Build** | **`/implementer`** · when `project_ssot.enabled`, Entry = `python3 -m cursor_workflow project status` (board first); else `session-pointer.md` → `plan.md` → `work-tracker.md` |
 
-**Healthy install?** `python3 -m cursor_workflow health`
+**Healthy install?** `python3 -m cursor_workflow health` · with board on: `gh auth status` then `python3 -m cursor_workflow project doctor`
 
 > **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards (deprecated)](#control-center-dashboards-deprecated) · [All CLI commands](#terminal-commands-cheat-sheet)
 

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -142,7 +142,7 @@ Optional end-to-end check against the real Project (skipped in default CI).
 
 **Last PASS:** 2026-07-19 — `make live-board-smoke` (evidence: `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`).
 
-1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes).
+1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes). If `xdg-open` fails, open **https://github.com/login/device**, paste the one-time code, and approve **Project** permissions — see [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
 2. Confirm: `python3 -m cursor_workflow project doctor` and `project status`.
 3. Clear any other card **In progress** for the same assignee (claim enforces `one_in_progress_per_assignee`).
 4. Run: `make live-board-smoke`  

--- a/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -9,7 +9,8 @@
 #
 # Kit default: AI uses Assisted-by (not Co-authored-by: cursoragent@...).
 # Opt-in legacy mode below if your org requires Git co-author trailers for tools.
-# Project SSOT: set enabled: true and fill board ids; requires gh scopes read:project + project.
+# Project SSOT: set enabled: true and fill board ids; requires gh scopes read:project + project (+ repo).
+# Onboarding: gh auth login|refresh -s read:project,project — if no browser, https://github.com/login/device (see PLUGIN-USER-GUIDE § GitHub CLI auth).
 
 version: 1
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -68,7 +68,9 @@ python3 -m cursor_workflow project list --status ready
 # claim / create-from-template — see: python3 -m cursor_workflow project guide
 ```
 
-Auth (board write): `gh auth refresh -h github.com -s read:project,project` (keep `repo`).
+Auth (board write): `gh auth refresh -h github.com -s read:project,project` (keep `repo`).  
+No browser (WSL)? Copy the one-time code → **https://github.com/login/device** → approve Project permissions → `gh auth status`.  
+Full walkthrough: [PLUGIN-USER-GUIDE § GitHub CLI auth](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
 
 If the board is unavailable: `fallback: local_trackers` only, then resume board sync. Never invent a second Status SSOT.
 

--- a/README.md
+++ b/README.md
@@ -93,14 +93,27 @@ python3 -m cursor_workflow health
 
 **With Project SSOT on** (kit-shaped board: Status · Priority · Size · Estimate **points** · Start date):
 
+Agents and `cursor_workflow project …` call **`gh`**. You must authorize GitHub **and** grant **Projects** access (read + write).
+
 ```bash
-gh auth refresh -h github.com -s read:project,project   # keep repo
+# First time on this machine (interactive):
+gh auth login -h github.com
+# Or add/refresh Project scopes on an existing login:
+gh auth refresh -h github.com -s read:project,project   # keep existing repo (+ workflow if you use Actions)
+
+# If the terminal cannot open a browser (common on WSL):
+# 1) Copy the one-time code gh prints
+# 2) Open https://github.com/login/device in any browser
+# 3) Paste the code → approve GitHub + Project permissions
+# 4) Return to the terminal (✓ Authentication complete)
+
+gh auth status   # expect scopes including: repo, project (read:project may appear too)
 python3 -m cursor_workflow project doctor
 python3 -m cursor_workflow project status
 python3 -m cursor_workflow project guide                # safe recipes
 ```
 
-Wire field ids with `gh project view` / `gh project field-list` — full checklist: [PLUGIN-USER-GUIDE § Product promise](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#product-promise).
+Wire field ids with `gh project view` / `gh project field-list` — full checklist: [PLUGIN-USER-GUIDE § Consumer project_ssot onboarding](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#consumer-project_ssot-onboarding-checklist) (step 3 = GitHub auth).
 
 ### 4. Start building
 

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -126,10 +126,57 @@ Discover ids manually: `gh project view <N> --owner <login>` (for `project_id`) 
 |------|--------|
 | 1. Install / activate | Agent chat: `/add-plugin …` then **`/workflow-activate`** in **your app repo** — wait for **`VERIFY PASS`**. |
 | 2. Collaboration YAML | Edit `.local/user_settings/github.collaboration.yaml`: set `project_ssot.enabled: true`, `sync_policy: board_only`, and board identity — `name`, `number`, `owner`, `project_id` (from Project URL / `gh project view`). Copy field ids from `gh project field-list <number> --owner <owner>` when wiring `fields.status` / Priority / Size. |
-| 3. GitHub auth | Ensure `gh` can reach Projects: `gh auth refresh -h github.com -s read:project,project` (keep existing **`repo`** scopes). |
+| 3. GitHub auth | See **§ GitHub CLI auth (Projects)** below — grant `repo` + Project scopes; use the device login link if no browser opens. |
 | 4. Doctor + status | `python3 -m cursor_workflow project doctor` (config + templates + `gh` access) then `python3 -m cursor_workflow project status` (shows enabled board). |
 | 5. First card | `python3 -m cursor_workflow project create-from-template --template slice --title "…" --priority p1 --size s --estimate 1 --agent implementer` → `claim --last --agent implementer` (sets Start date). Prefer `project guide`. |
 | 6. Rate-limit buffer | Writes may **precheck** GraphQL quota (cached REST) or queue on throttle / Forbidden / 429. If a write returns **EXIT_QUEUED (6)**, do **not** retry-loop — continue local evidence; after quota recovers run `python3 -m cursor_workflow project outbox status` then `project outbox flush`. Configure `project_ssot.outbox` (`precheck_writes`, `dedupe_pending`, …) in collaboration YAML. Outbox is a local buffer, not a second Status SSOT. |
+
+#### GitHub CLI auth (Projects)
+
+Board SSOT needs the **GitHub CLI** (`gh`) with **repository** access **and** **Projects** read/write. Without Project scopes, `project status` / `claim` / `outbox flush` fail with “missing required scopes”.
+
+| Scope | Why |
+|-------|-----|
+| **`repo`** | Issues, PRs, default repo operations |
+| **`read:project`** | Read Project / fields / items |
+| **`project`** | Write Status, Notes, Tier-1 fields, claim/handoff |
+| **`workflow`** (optional) | GitHub Actions / PR checks if you drive CI from `gh` |
+
+**First login** (new machine):
+
+```bash
+gh auth login -h github.com
+```
+
+Choose HTTPS, authenticate via browser **or** device code, and allow access to the repos you use.
+
+**Add Project permissions** to an existing login:
+
+```bash
+gh auth refresh -h github.com -s read:project,project
+# Keep existing repo (and workflow) scopes — refresh adds Project access.
+```
+
+**If the terminal cannot open a browser** (WSL, headless, remote SSH — `xdg-open: no method available`):
+
+1. Leave the terminal running after `gh auth login` / `gh auth refresh`.
+2. Copy the **one-time code** `gh` prints (e.g. `ABCD-1234`).
+3. Open **[https://github.com/login/device](https://github.com/login/device)** in any browser (Windows host browser is fine from WSL).
+4. Paste the code → sign in → **approve** GitHub + **Project** permissions.
+5. Return to the terminal — you should see `✓ Authentication complete.`
+
+**Verify:**
+
+```bash
+gh auth status
+# Logged in · Token scopes should include: repo, project
+# (read:project may show separately or be covered when project is present)
+
+python3 -m cursor_workflow project doctor
+python3 -m cursor_workflow project status
+```
+
+If `gh` reports **missing required scopes `[read:project]` / `[project]`**, re-run `gh auth refresh -h github.com -s read:project,project` and complete the device link again.
 
 Daily Entry after onboarding: `project status` (board first) — see [project-board-collaboration.md](project-board-collaboration.md).
 

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -5,32 +5,85 @@ Role: Glossary for MAS Workflow Kit workflow terminology.
 Used By:
  - README.md
  - AGENTS.md
+ - HANDOFF.md
 Depends On:
  - .ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
+ - .ai_infra/docs/decisions/README.md
 Notes:
  - Keep definitions short for newcomers.
+ - Numbered catalogs (ADR-NNN, DRIFT-NNN, EA-NNN, INT-NNN, DOC-NNN) live in their index docs — list stems here only.
 -->
 
 # Abbreviations Notepad
 
-Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
+Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs.
 
 ## MAS Workflow Kit flow (plain language)
 
 1. Install kit via `cursor_workflow activate` (plugin) or `cursor_workflow install` (kit clone).
-2. Agents read `.local/` trackers (`session-pointer.md` → `plan.md` → `work-tracker.md`).
-3. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A).
-4. Optional MCP (`workflow-kit`) wraps the same scripts.
+2. When `project_ssot.enabled` + `board_only`: Entry = board (`project status` / claim); Exit = Status + Notes. Local trackers = offline fallback only.
+3. Else: agents read `.local/` trackers (`session-pointer.md` → `plan.md` → `work-tracker.md`).
+4. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A + `prepare.py` GATES).
+5. Optional MCP (`workflow-kit`) wraps the same scripts.
 
 ## Core abbreviations
 
 | Abbreviation | Meaning |
 |---|---|
+| MAS | Multi-Agent System — this kit’s agent/skill/script workflow product |
+| SSOT | Single Source of Truth — one authoritative place for a given concern |
 | MCP | Model Context Protocol — Cursor tool server integration |
-| PR | Pull request — maintainer merge workflow |
-| ADR | Architecture Decision Record — `.ai_infra/docs/decisions/` |
-| GATES | 2-gate back-compat alias of `resolve_gates()` in `prepare.py` |
-| Pattern A | Script-first workflow; agents invoke one command per action |
+| CLI | Command-line interface — here mainly `python3 -m cursor_workflow …` and `gh` |
+| PR | Pull request — maintainer merge workflow (Pattern A) |
+| ADR | Architecture Decision Record — `.ai_infra/docs/decisions/` (ADR-001…008) |
+| GATES | Hardcoded subprocess list in `.ai_infra/scripts/pr/prepare.py` |
+| Pattern A | Script-first workflow; agents invoke **one** command per maintainer action |
+| YAML | Config format for `github.collaboration.yaml`, registries, manifests |
+| UTC / ISO-8601 | Board Notes timestamps (`YYYY-MM-DDTHH:MM:SSZ`); CLI stamps UTC |
+| CI / CD | Continuous integration / delivery — GitHub Actions + release evidence |
+| RC | Release candidate — needs CI/CD evidence bundles before ship |
+| UI | GitHub Project / settings UI (humans); agents prefer CLI |
+| PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes |
+| GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
+| KISS | Keep It Simple — incremental, reversible slices |
+| DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |
+| AI | Artificial intelligence — optional `Assisted-by:` trailer when AI materially shaped a change |
+| TBD | To Be Determined — placeholder in file headers / relations |
+| DAG | Directed Acyclic Graph — agent **handoff** edges (canvases); no cycles |
+| ACC | Agents Control Center — `.local/agents-control-center/` (folder name) |
+| ICC | Implementation Control Center — HTML dashboard under ACC (**deprecated**; prefer board + canvases) |
+| HTML | Local dashboard pages served via `http.server` (not `file://`) |
+| JSON | Machine artifacts (coverage, board export, registries, MCP config) |
+| IDE | Editor host (Cursor) — canvases open via Open Canvas, not raw `file://` HTML |
+
+## Board / Project SSOT
+
+| Term | Meaning |
+|---|---|
+| `project_ssot` | YAML block in `github.collaboration.yaml` wiring the GitHub Project |
+| `board_only` | `sync_policy` — board is the **only writable** backlog/Status/continuation SSOT |
+| Tier-1 | Mandatory board fields: Status, Priority, Size, Estimate, Start date (on first In progress), Assignee, Linked PR when a PR exists |
+| `PVT_` | GitHub Project v2 **project** node id (in YAML `project_id`) |
+| `PVTI_` | GitHub Project v2 **item** id (card); Draft→Issue keeps the same `PVTI_` |
+| outbox | Local rate-limit buffer (`.local/generated-data/board-outbox.jsonl`); not a second SSOT |
+| EXIT_QUEUED | CLI exit code **6** — write queued to outbox; later `project outbox flush` |
+| dual-write | Forbidden under `board_only`: writing competing Status into local trackers |
+| Entry / Exit | Every agent: read board on Entry; update Status (+ Notes) on Exit |
+| canvas | Cursor Canvas visualization (`canvases/*.canvas.tsx`) — prefer over deprecated ICC HTML |
+
+## Drift, audit, and check ids
+
+| Stem | Meaning | Where to look |
+|---|---|---|
+| DRIFT-NNN | Operational drift check id (plan/tracker/board coherence) | ADR-007; `drift validate` |
+| INT-NNN | Integrate / registry parity check id | `integrate validate` |
+| EA-NNN | Enterprise-architecture finding / backlog id | enterprise-auditor artifacts / HANDOFF |
+| DOC-NNN | Documentation fact / validate check id | `make doc-validate` / doc facts |
+| COV-NNN | Coverage readiness claim / slice label | IMPLEMENTATION-STATUS / coverage evidence |
+| P0 / P1 / P2 / P3 | Priority — board uses `p0\|p1\|p2`; chat P3 → board `p2` + Notes `deferred` | `project-board-ssot` skill |
+| xs…xl | Size options on the board (Tier-1) | Size↔Estimate table in skill |
+
+High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`).
 
 ## Planes
 
@@ -44,16 +97,28 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 
 | Agent | Role |
 |-------|------|
+| project-board | Board triage, Status, Tier-1 fields; hand off to implementer |
 | implementer | Slice implementation |
 | integrator-mas-agent | Extend agents/skills/MCP into kit infrastructure |
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
-| enterprise-auditor | Architecture audits |
-| researcher | Shipped corpus researcher; adaptive Brief; CLI `research init\|fetch\|validate`; packs opt-in after init |
+| enterprise-auditor | Architecture audits (alignment / scorecard artifacts) |
+| workflow-drift-guard | Operational drift audit + board Exit for drift-pass cards |
+| researcher | Brief-driven research packs; CLI `research init\|fetch\|validate` |
 
-## Research (opt-in corpus)
+## Research (optional)
 
 | Term | Meaning |
 |------|---------|
 | Brief | Intake contract for researcher (`BRIEF.md` / chat / board card) — source, question, lenses, consumers |
 | Research pack | Indexed corpus under `_research_results/sources/<slug>/` (`INDEX.json`, `AGENT_BRIEF.md`, …) |
+| AGENT_BRIEF | Consumer-facing brief inside a research pack for implementer/integrator |
+
+## Related indexes (do not duplicate full catalogs here)
+
+| Catalog | Index |
+|---------|--------|
+| ADRs | `.ai_infra/docs/decisions/README.md` |
+| Drift checks | ADR-007 + `.cursor/skills/workflow-drift-audit/SKILL.md` |
+| Board ops | `.ai_infra/docs/operations/project-board-collaboration.md` |
+| Token / log discipline | `.ai_infra/docs/operations/token-efficiency.md` |

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -32,9 +32,10 @@ Install **MAS Workflow Kit — Project SSOT** (`mas-workflow-kit-project-ssot`) 
 | **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/mas-workflow-kit-project-ssot` — or **Cursor → Marketplace** when listed |
 | **2. Activate** | Open **your app folder** → Agent chat: **`/workflow-activate`** → wait for **`VERIFY PASS`** |
 | **3. Your name** | Edit `.local/user_settings/github.collaboration.yaml` → set `display_name` + `github_user` → `python3 -m cursor_workflow contributors validate` |
+| **3b. GitHub auth** (board SSOT) | `gh auth login` or `gh auth refresh -h github.com -s read:project,project` — grant **repo + Project** permissions. If no browser opens: copy the one-time code → open **https://github.com/login/device** → approve → return to terminal. Details: [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects). |
 | **4. Build** | **`/implementer`** · when `project_ssot.enabled`, Entry = `python3 -m cursor_workflow project status` (board first); else `session-pointer.md` → `plan.md` → `work-tracker.md` |
 
-**Healthy install?** `python3 -m cursor_workflow health`
+**Healthy install?** `python3 -m cursor_workflow health` · with board on: `gh auth status` then `python3 -m cursor_workflow project doctor`
 
 > **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards (deprecated)](#control-center-dashboards-deprecated) · [All CLI commands](#terminal-commands-cheat-sheet)
 

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -142,7 +142,7 @@ Optional end-to-end check against the real Project (skipped in default CI).
 
 **Last PASS:** 2026-07-19 — `make live-board-smoke` (evidence: `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`).
 
-1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes).
+1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes). If `xdg-open` fails, open **https://github.com/login/device**, paste the one-time code, and approve **Project** permissions — see [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
 2. Confirm: `python3 -m cursor_workflow project doctor` and `project status`.
 3. Clear any other card **In progress** for the same assignee (claim enforces `one_in_progress_per_assignee`).
 4. Run: `make live-board-smoke`  

--- a/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -9,7 +9,8 @@
 #
 # Kit default: AI uses Assisted-by (not Co-authored-by: cursoragent@...).
 # Opt-in legacy mode below if your org requires Git co-author trailers for tools.
-# Project SSOT: set enabled: true and fill board ids; requires gh scopes read:project + project.
+# Project SSOT: set enabled: true and fill board ids; requires gh scopes read:project + project (+ repo).
+# Onboarding: gh auth login|refresh -s read:project,project — if no browser, https://github.com/login/device (see PLUGIN-USER-GUIDE § GitHub CLI auth).
 
 version: 1
 


### PR DESCRIPTION
## Summary
- Document `gh auth login` / `refresh` with required scopes (`repo`, `read:project`, `project`) for Project SSOT onboarding.
- Add WSL / no-browser path: one-time code → https://github.com/login/device → approve Project permissions.
- Expand abbreviations notepad (ICC, DAG, SSOT, outbox, …) and sync payload mirrors.

## Test plan
- [ ] Skim README § Configure and PLUGIN-USER-GUIDE § GitHub CLI auth
- [ ] Confirm device URL is https://github.com/login/device
- [ ] `make check-plugin` / prepare gates green

Board: Issue #90 · PVTI_lAHOBl46-84A9KZxzgzY2bc

Made with [Cursor](https://cursor.com)