### PR TITLE
chore: align canvases to CLI/docs baseline (DOC-CANVAS-ALIGN)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,7 +15,7 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-20 (DOC-ALIGN secondary surfaces + cov100_closure six-view mocks; Playground default + template-first; 1168 tests / 7089 stmts / 100%)
+**Last updated:** 2026-07-20 (DOC-CANVAS-ALIGN: canvases CLI+board-shell+test-runner sync; 1168 tests / 7089 stmts / 100%)
 **Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1168
 
 ## Shipped (confirmed in repo)

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -216,6 +216,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-07-20 board-shell completeness):** Re-verified — **1168** tests collected (Playground-default schema + template-first agent voice); agent/skill/rule counts (**8** / **12** / **7**); kit version **0.4.0**. Prior DOC-ONBOARD line superseded.
 
+**Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1168** / **7089** / **100%**; **8** / **12** / **7**).
+
 **Listing copy refresh (2026-07-20 DOC-ALIGN secondary + marketplace description):** Description row + `plugin.json` now mention Project SSOT / Playground board shell / **8 / 12 / 7**; archival stamps above remain historical.
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Local evidence file was not retained in this workspace; recreate with `make smoke-consumer` and write under `.local/workflow-artifacts/release/smoke-consumer-<app>-<date>.md` on the next consumer run.

--- a/canvases/agent-enterprise-auditor.canvas.tsx
+++ b/canvases/agent-enterprise-auditor.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   ".cursor/agents/enterprise-auditor.md · enterprise-architecture-audit/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/agent-integrator-mas-agent.canvas.tsx
+++ b/canvases/agent-integrator-mas-agent.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   ".cursor/agents/integrator-mas-agent.md · mas-infrastructure-integration/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -20,7 +20,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   ".cursor/agents/*.md PEERS · audit-orchestration Phase 3 · project-board-ssot § Continuation · agent-roster edges";
 

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   ".cursor/agents/researcher.md · research-corpus-execution/SKILL.md · research_cli.py · .agents/skills/RESEARCH_WORKFLOW.md · live pack flexiai-toolsmith + verifier";
 

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -16,7 +16,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES = "Aggregated from .cursor/agents/*.md";
 
 const AGENTS = [

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   ".cursor/agents/test-runner.md · test-module-coverage/SKILL.md · project-board-ssot/SKILL.md";
 
@@ -31,6 +31,7 @@ const GOALS = [
   "Module-focused tests, regressions, coverage",
   "Run targeted module tests before full suite",
   "Update test-index and test-plan when tests change",
+  "After scoped 100%: doc reality sync (IMPLEMENTATION-STATUS + make coverage-index + make doc-validate)",
 ];
 
 const BOARD_NODES = [
@@ -76,7 +77,7 @@ const BOARD_LABELS: Record<string, string> = {
   claim: "claim card",
   index: "test-index.md",
   tests: "tests/modules/",
-  coverage: "pytest --cov",
+  coverage: "coverage.json",
   artifacts: "test-plan + change-index",
   handoff: "handoff",
   next: "next agent",
@@ -86,7 +87,7 @@ const FALLBACK_LABELS: Record<string, string> = {
   session: "session-pointer.md",
   index: "test-index.md",
   tests: "tests/modules/",
-  coverage: "pytest --cov",
+  coverage: "coverage.json",
   artifacts: "test-plan + change-index",
   handoff: "handoff / close",
 };
@@ -104,12 +105,18 @@ const PATTERNS = [
   ["Board lifecycle", "Exit in_review if tests gate PR else done"],
   ["Tier-1", "Shared Board rights; promote only if opening a shippable PR"],
   ["Module layout", "tests/modules/<module>/ matching source boundaries"],
+  ["Coverage evidence", "pytest --cov writes coverage.json only — do not invent alternate names"],
+  ["Shell filters", "Prefer grep/python over rg (often absent from PATH)"],
+  ["Post-100% sync", "IMPLEMENTATION-STATUS + make coverage-index + make doc-validate"],
   ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/test-runner via --agent test-runner"],
 ];
 
 const ARTIFACTS = [
   ["tests/modules/<module>/", "Implementation / regression", "CI / prepare.py"],
+  ["coverage.json", "Coverage evidence run", "test-runner / DOC-006"],
+  ["coverage-index.md", "After meaningful coverage / 100% closure", "test-runner / implementer"],
+  ["IMPLEMENTATION-STATUS.md", "After scoped 100% / count change", "DOC-006 / maintainers"],
   ["test-index.md", "When tests change", "test-runner / implementer"],
   ["test-plan.md", "When tests change", "test-runner / implementer"],
   ["change-index.md", "Exit", "Next agents / humans"],
@@ -256,9 +263,17 @@ export default function AgentTestRunnerCanvas() {
           <Text>1. Claim card (board) or read session-pointer (fallback).</Text>
           <Text>2. Read test-index / test-plan when tests or ownership change.</Text>
           <Text>3. Run module-focused tests; regressions; coverage when required.</Text>
-          <Text>4. check_testing_artifacts.py before PR path.</Text>
           <Text>
-            5. Exit: Status in_review if tests gate PR else done; update
+            4. Coverage evidence: pytest --cov writes coverage.json only; prefer
+            grep/python over rg.
+          </Text>
+          <Text>5. check_testing_artifacts.py before PR path.</Text>
+          <Text>
+            6. After scoped 100%: sync IMPLEMENTATION-STATUS, make coverage-index,
+            make doc-validate.
+          </Text>
+          <Text>
+            7. Exit: Status in_review if tests gate PR else done; update
             change-index + test-index/test-plan.
           </Text>
         </Stack>

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES = ".cursor/agents/verifier.md · project-board-ssot/SKILL.md § Continuation";
 
 const GOALS = [

--- a/canvases/agent-workflow-drift-guard.canvas.tsx
+++ b/canvases/agent-workflow-drift-guard.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   ".cursor/agents/workflow-drift-guard.md · workflow-drift-audit/SKILL.md · project-board-ssot/SKILL.md";
 

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -26,7 +26,7 @@ import {
  * Not an agent-* canvas — excluded from DOC-008 roster scan (same as board-ssot-vs-kit).
  */
 
-const VERIFIED = "2026-07-19";
+const VERIFIED = "2026-07-20";
 const SOURCES =
   "ADR-008 · project-board-ssot/SKILL.md · project-board-collaboration.md · agent cards · HYGIENE post-COV100";
 
@@ -138,6 +138,12 @@ const ARTIFACT_LANES: string[][] = [
     "GitHub Project Status · Notes · Linked PRs",
     "All agents via cursor_workflow project …",
     "ADR-008 board_only — only Status writer",
+  ],
+  [
+    "Day-0 board shell",
+    "board-bootstrap --check · views-setup.md · board-shell-onboard",
+    "project-board / human (before claim)",
+    "Does not write Status — Playground six-view gate",
   ],
   [
     "PR Pattern A (local evidence)",

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -183,6 +183,7 @@ const CLI_ATOMIC_ROWS = [
   ["find-by-pr", "Resolve card from PR number"],
   ["export", "Read-only snapshot → project-board-snapshot.json"],
   ["doctor", "Config / PAT / field-id diagnostics"],
+  ["board-bootstrap", "Schema-aware shell check; opt-in --ensure-fields / --apply-readme"],
   ["queue", "Enqueue deferred board write"],
   ["outbox", "status | flush — EXIT_QUEUED (6) buffer"],
 ];
@@ -511,8 +512,8 @@ export default function BoardSsotVsKitCanvas() {
       <Text tone="tertiary" size="small">
         Full list: status · list · create · create-from-template · set-status ·
         set-field · get · append-notes · claim · mention-pr · promote-to-issue ·
-        handoff · validate-item · last · guide · doctor · set-assignee · find-by-pr ·
-        export · queue · outbox
+        handoff · validate-item · last · guide · doctor · board-bootstrap ·
+        set-assignee · find-by-pr · export · queue · outbox
       </Text>
 
       <Grid columns={2} gap={12}>
@@ -567,6 +568,11 @@ export default function BoardSsotVsKitCanvas() {
           ["Stale PR detection", "N/A", "DRIFT-010 + export snapshot"],
           ["PR merge gates", "prepare.py Pattern A", "Unchanged (local_only)"],
           ["Offline / no gh", "N/A (always local)", "fallback: local_trackers"],
+          [
+            "Day-0 board shell",
+            "N/A",
+            "board-bootstrap --check vs board-shell.schema.yaml (Playground six-view); board-shell-onboard coach",
+          ],
         ]}
         striped
       />
@@ -634,6 +640,10 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">EA-001: project_cli split (atomics/adapter/recipes/outbox)</Text>
               <Text size="small">EA-004: pyright blocking in kit-quality CI</Text>
               <Text size="small">EA-010: deprecated HTML ICC tab (offline export; prefer board + Open Canvas)</Text>
+              <Text size="small">
+                Day-0: board-shell-onboard + board-bootstrap --check (Playground
+                six-view default; schema board-shell.schema.yaml)
+              </Text>
             </Stack>
           </CardBody>
         </Card>

--- a/canvases/github-api-safety.canvas.tsx
+++ b/canvases/github-api-safety.canvas.tsx
@@ -19,7 +19,7 @@ import {
 /**
  * Inventory of GitHub API hammering / safety protections in MAS Workflow Kit.
  * Source: project_outbox.py, project_cli/handlers, agent Board-rights, ADR-008.
- * Verified: 2026-07-19 — post PR #83 (G1–G5) + #85 (soft-align docs/schema)
+ * Verified: 2026-07-20 — post PR #83 (G1–G5) + #85 (soft-align docs/schema)
  */
 
 const FIXED = [


### PR DESCRIPTION
## Summary
- Fix P0: `board-ssot-vs-kit` CLI table now lists all **22** leaf commands including `board-bootstrap`, plus day-0 board-shell story.
- Bump canvas `VERIFIED` to **2026-07-20**; align `agent-test-runner` to coverage.json + post-100% doc sync; add day-0 shell lane on `agents-artifacts-board`.
- Marketplace listing refresh + IMPLEMENTATION-STATUS stamp; DOC-006/008 green.

## Test plan
- [x] CLI row count == 22 and includes `board-bootstrap`
- [x] `check_doc_facts.py` PASS (DOC-006/008)
- [x] Spot-check `coverage.json` / day-0 lane present
- [ ] prepare.py gates via `/prepare-pr`

Board: PVTI_lAHOBl46-84A9KZxzgzc-5E · Issue #119

Made with [Cursor](https://cursor.com)