### PR TITLE
fix: merge board sync fetch PVTI directly (AA-board-012)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-21 (consumer board onboarding alignment; 1180 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1180
+**Last updated:** 2026-07-21 (consumer board onboarding alignment; 1184 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1184
 
 ## Shipped (confirmed in repo)
 
@@ -53,13 +53,13 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus-execution` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1180 collected (1168 passed + 2 skipped on full green run; intentional live-smoke skips) | `tests/modules/` |
+| Tests | 1184 collected (1168 passed + 2 skipped on full green run; intentional live-smoke skips) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-20
-(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1180
+(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1184
 collected** as of board-shell completeness; intentional live-smoke skips only). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,

--- a/.ai_infra/install/cursor_workflow/gh_project_adapter.py
+++ b/.ai_infra/install/cursor_workflow/gh_project_adapter.py
@@ -411,6 +411,101 @@ def find_item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any]
         if str(item.get("id") or "") == item_id:
             return item
     return None
+
+def fetch_project_item_by_id(
+    ssot: dict[str, Any], item_id: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    """
+    Fetch a single ProjectV2Item by its PVTI_… id.
+
+    Normalizes a small subset of fields to match the `gh project item-list` item
+    shape expected by downstream validators (status, priority, size, estimate,
+    start date, and content.body).
+    """
+    iid = (item_id or "").strip()
+    if not iid:
+        return None, "empty item id"
+
+    query = (
+        "query($id:ID!){node(id:$id){...on ProjectV2Item{id content{"
+        "__typename "
+        "...on DraftIssue{id title body} "
+        "...on Issue{id number title body repository{nameWithOwner}}"
+        "}"
+        "fieldValues(first:50){nodes{__typename "
+        "...on ProjectV2ItemFieldSingleSelectValue{name field{name}} "
+        "...on ProjectV2ItemFieldTextValue{text field{name}} "
+        "...on ProjectV2ItemFieldDateValue{date field{name}} "
+        "}}}}}"
+    )
+    proc = _cli().run_gh(
+        ["api", "graphql", "-f", f"query={query}", "-f", f"id={iid}"]
+    )
+    if proc.returncode != 0:
+        return None, (proc.stderr or proc.stdout or "gh graphql node query failed").strip()
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return None, f"invalid graphql JSON: {exc}"
+
+    errors = data.get("errors")
+    if errors:
+        msg = errors[0].get("message") if isinstance(errors[0], dict) else errors
+        return None, str(msg)
+
+    node = (data.get("data") or {}).get("node")
+    if not isinstance(node, dict):
+        return None, f"project item not found: {iid}"
+
+    content = node.get("content")
+    body = ""
+    if isinstance(content, dict):
+        maybe_body = content.get("body")
+        if isinstance(maybe_body, str):
+            body = maybe_body
+
+    out: dict[str, Any] = {
+        "id": str(node.get("id") or iid),
+        "content": {"body": body},
+    }
+
+    field_values = node.get("fieldValues") or {}
+    if isinstance(field_values, dict):
+        nodes = field_values.get("nodes") or []
+        if isinstance(nodes, list):
+            for v in nodes:
+                if not isinstance(v, dict):
+                    continue
+                field = v.get("field")
+                field_name = ""
+                if isinstance(field, dict):
+                    field_name = str(field.get("name") or "").strip()
+                if not field_name:
+                    continue
+                normalized = field_name.strip().lower().replace(" ", "_").replace("-", "_")
+
+                if normalized in ("status",):
+                    val = v.get("name")
+                    if isinstance(val, str):
+                        out["status"] = val
+                elif normalized in ("priority",):
+                    val = v.get("name")
+                    if isinstance(val, str):
+                        out["priority"] = val
+                elif normalized in ("size",):
+                    val = v.get("name")
+                    if isinstance(val, str):
+                        out["size"] = val
+                elif normalized in ("estimate",):
+                    val = v.get("text") if "text" in v else v.get("name")
+                    if val is not None:
+                        out["estimate"] = str(val).strip()
+                elif normalized in ("start_date", "startdate", "start_date_utc", "startdateutc", "start_date_time", "start_date_time_utc", "start_date_datetime"):
+                    val = v.get("date")
+                    if val is not None:
+                        out["start date"] = str(val).strip()
+
+    return out, None
 def resolve_item_content(
     ssot: dict[str, Any], item_id: str
 ) -> tuple[str | None, str | None, dict[str, Any] | None, str | None]:

--- a/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/.ai_infra/install/cursor_workflow/project_cli.py
@@ -36,6 +36,7 @@ from gh_project_adapter import (
     create_issue_item,
     edit_item_body,
     fetch_project_items,
+    fetch_project_item_by_id,
     find_item_by_id,
     promote_draft_item_to_issue,
     resolve_draft_content,

--- a/.ai_infra/scripts/pr/merge.py
+++ b/.ai_infra/scripts/pr/merge.py
@@ -135,11 +135,13 @@ def sync_board_after_merge(
 
     conventions = ssot.get("conventions") or {}
     done_logical = str(conventions.get("done_status") or "done")
-    items, list_err = project_cli.fetch_project_items(ssot, limit=100)
-    if list_err:
-        print(f"[WARN] board sync list failed: {list_err}", file=sys.stderr)
-        return f"board sync: warn — list failed ({list_err})"
-    item = project_cli.find_item_by_id(items, resolved)
+    item, item_err = project_cli.fetch_project_item_by_id(ssot, resolved)
+    if item_err:
+        print(
+            f"[WARN] board sync fetch failed: {item_err} (item={resolved})",
+            file=sys.stderr,
+        )
+        return f"board sync: warn — fetch failed ({item_err})"
     if item is None:
         print(f"[WARN] board sync: item not found: {resolved}", file=sys.stderr)
         return f"board sync: warn — item not found ({resolved})"

--- a/payload/.ai_infra/install/cursor_workflow/gh_project_adapter.py
+++ b/payload/.ai_infra/install/cursor_workflow/gh_project_adapter.py
@@ -411,6 +411,101 @@ def find_item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any]
         if str(item.get("id") or "") == item_id:
             return item
     return None
+
+def fetch_project_item_by_id(
+    ssot: dict[str, Any], item_id: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    """
+    Fetch a single ProjectV2Item by its PVTI_… id.
+
+    Normalizes a small subset of fields to match the `gh project item-list` item
+    shape expected by downstream validators (status, priority, size, estimate,
+    start date, and content.body).
+    """
+    iid = (item_id or "").strip()
+    if not iid:
+        return None, "empty item id"
+
+    query = (
+        "query($id:ID!){node(id:$id){...on ProjectV2Item{id content{"
+        "__typename "
+        "...on DraftIssue{id title body} "
+        "...on Issue{id number title body repository{nameWithOwner}}"
+        "}"
+        "fieldValues(first:50){nodes{__typename "
+        "...on ProjectV2ItemFieldSingleSelectValue{name field{name}} "
+        "...on ProjectV2ItemFieldTextValue{text field{name}} "
+        "...on ProjectV2ItemFieldDateValue{date field{name}} "
+        "}}}}}"
+    )
+    proc = _cli().run_gh(
+        ["api", "graphql", "-f", f"query={query}", "-f", f"id={iid}"]
+    )
+    if proc.returncode != 0:
+        return None, (proc.stderr or proc.stdout or "gh graphql node query failed").strip()
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return None, f"invalid graphql JSON: {exc}"
+
+    errors = data.get("errors")
+    if errors:
+        msg = errors[0].get("message") if isinstance(errors[0], dict) else errors
+        return None, str(msg)
+
+    node = (data.get("data") or {}).get("node")
+    if not isinstance(node, dict):
+        return None, f"project item not found: {iid}"
+
+    content = node.get("content")
+    body = ""
+    if isinstance(content, dict):
+        maybe_body = content.get("body")
+        if isinstance(maybe_body, str):
+            body = maybe_body
+
+    out: dict[str, Any] = {
+        "id": str(node.get("id") or iid),
+        "content": {"body": body},
+    }
+
+    field_values = node.get("fieldValues") or {}
+    if isinstance(field_values, dict):
+        nodes = field_values.get("nodes") or []
+        if isinstance(nodes, list):
+            for v in nodes:
+                if not isinstance(v, dict):
+                    continue
+                field = v.get("field")
+                field_name = ""
+                if isinstance(field, dict):
+                    field_name = str(field.get("name") or "").strip()
+                if not field_name:
+                    continue
+                normalized = field_name.strip().lower().replace(" ", "_").replace("-", "_")
+
+                if normalized in ("status",):
+                    val = v.get("name")
+                    if isinstance(val, str):
+                        out["status"] = val
+                elif normalized in ("priority",):
+                    val = v.get("name")
+                    if isinstance(val, str):
+                        out["priority"] = val
+                elif normalized in ("size",):
+                    val = v.get("name")
+                    if isinstance(val, str):
+                        out["size"] = val
+                elif normalized in ("estimate",):
+                    val = v.get("text") if "text" in v else v.get("name")
+                    if val is not None:
+                        out["estimate"] = str(val).strip()
+                elif normalized in ("start_date", "startdate", "start_date_utc", "startdateutc", "start_date_time", "start_date_time_utc", "start_date_datetime"):
+                    val = v.get("date")
+                    if val is not None:
+                        out["start date"] = str(val).strip()
+
+    return out, None
 def resolve_item_content(
     ssot: dict[str, Any], item_id: str
 ) -> tuple[str | None, str | None, dict[str, Any] | None, str | None]:

--- a/payload/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_cli.py
@@ -36,6 +36,7 @@ from gh_project_adapter import (
     create_issue_item,
     edit_item_body,
     fetch_project_items,
+    fetch_project_item_by_id,
     find_item_by_id,
     promote_draft_item_to_issue,
     resolve_draft_content,

--- a/payload/.ai_infra/scripts/pr/merge.py
+++ b/payload/.ai_infra/scripts/pr/merge.py
@@ -135,11 +135,13 @@ def sync_board_after_merge(
 
     conventions = ssot.get("conventions") or {}
     done_logical = str(conventions.get("done_status") or "done")
-    items, list_err = project_cli.fetch_project_items(ssot, limit=100)
-    if list_err:
-        print(f"[WARN] board sync list failed: {list_err}", file=sys.stderr)
-        return f"board sync: warn — list failed ({list_err})"
-    item = project_cli.find_item_by_id(items, resolved)
+    item, item_err = project_cli.fetch_project_item_by_id(ssot, resolved)
+    if item_err:
+        print(
+            f"[WARN] board sync fetch failed: {item_err} (item={resolved})",
+            file=sys.stderr,
+        )
+        return f"board sync: warn — fetch failed ({item_err})"
     if item is None:
         print(f"[WARN] board sync: item not found: {resolved}", file=sys.stderr)
         return f"board sync: warn — item not found ({resolved})"

--- a/tests/modules/install/test_gh_project_adapter_coverage.py
+++ b/tests/modules/install/test_gh_project_adapter_coverage.py
@@ -402,6 +402,84 @@ def test_fetch_project_items_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "invalid JSON" in (err or "")
 
 
+def test_fetch_project_item_by_id_ok_maps_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps(
+        {
+            "data": {
+                "node": {
+                    "id": VALID_PVTI,
+                    "content": {
+                        "__typename": "Issue",
+                        "body": "## Acceptance\n\nok\n",
+                    },
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "in_review",
+                                "field": {"name": "Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "p1",
+                                "field": {"name": "Priority"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "s",
+                                "field": {"name": "Size"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldTextValue",
+                                "text": "1",
+                                "field": {"name": "Estimate"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldDateValue",
+                                "date": "2026-07-20",
+                                "field": {"name": "Start date"},
+                            },
+                        ]
+                    },
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok(payload))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert err is None
+    assert item is not None
+    assert item["id"] == VALID_PVTI
+    assert item["status"] == "in_review"
+    assert item["priority"] == "p1"
+    assert item["size"] == "s"
+    assert item["estimate"] == "1"
+    assert item["start date"] == "2026-07-20"
+    assert item["content"]["body"].startswith("## Acceptance")
+
+
+def test_fetch_project_item_by_id_gh_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_fail("node query failed"))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is None
+    assert "node query failed" in (err or "")
+
+
+def test_fetch_project_item_by_id_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok("not-json"))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is None
+    assert "invalid graphql JSON" in (err or "")
+
+
+def test_fetch_project_item_by_id_node_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps({"data": {"node": None}})
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok(payload))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is None
+    assert "not found" in (err or "")
+
+
 def test_resolve_item_content_di_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         project_cli,

--- a/tests/modules/pr_workflow/test_merge_board_sync.py
+++ b/tests/modules/pr_workflow/test_merge_board_sync.py
@@ -99,8 +99,8 @@ def test_sync_board_happy_with_item_id(
     monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "98236657"))
     monkeypatch.setattr(
         project_cli,
-        "fetch_project_items",
-        lambda *a, **k: ([_ready_item()], None),
+        "fetch_project_item_by_id",
+        lambda *a, **k: (_ready_item(), None),
     )
     monkeypatch.setattr(project_cli, "edit_item_body", lambda *a, **k: (True, "ok"))
     monkeypatch.setattr(
@@ -138,8 +138,8 @@ def test_sync_board_warn_edit_item_body_fails_after_set_status(
     monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "98236657"))
     monkeypatch.setattr(
         project_cli,
-        "fetch_project_items",
-        lambda *a, **k: ([_ready_item()], None),
+        "fetch_project_item_by_id",
+        lambda *a, **k: (_ready_item(), None),
     )
     monkeypatch.setattr(
         project_cli,
@@ -170,8 +170,8 @@ def test_sync_board_notes_via_edit_item_body(
     monkeypatch.setattr(project_cli, "set_item_status", lambda *a, **k: (True, "98236657"))
     monkeypatch.setattr(
         project_cli,
-        "fetch_project_items",
-        lambda *a, **k: ([_ready_item()], None),
+        "fetch_project_item_by_id",
+        lambda *a, **k: (_ready_item(), None),
     )
     monkeypatch.setattr(project_cli, "edit_item_body", capture_edit)
     monkeypatch.setattr(
@@ -261,8 +261,8 @@ def test_sync_board_set_status_failure(
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
     monkeypatch.setattr(
         project_cli,
-        "fetch_project_items",
-        lambda *a, **k: ([_ready_item()], None),
+        "fetch_project_item_by_id",
+        lambda *a, **k: (_ready_item(), None),
     )
     monkeypatch.setattr(
         project_cli, "set_item_status", lambda *a, **k: (False, "rate limited")
@@ -280,14 +280,16 @@ def test_sync_board_list_failure_before_status(
 ) -> None:
     monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (SAMPLE_SSOT, []))
     monkeypatch.setattr(
-        project_cli, "fetch_project_items", lambda *a, **k: ([], "list boom")
+        project_cli,
+        "fetch_project_item_by_id",
+        lambda *a, **k: (None, "list boom"),
     )
     line = merge_mod.sync_board_after_merge(
         root=tmp_path, pr="1", merge_sha="abc", item_id="PVTI_x"
     )
-    assert "list failed" in line
+    assert "fetch failed" in line
     assert "list boom" in line
-    assert "[WARN] board sync list failed" in capsys.readouterr().err
+    assert "[WARN] board sync fetch failed" in capsys.readouterr().err
 
 
 def test_sync_board_body_gate_blocks_tbd(
@@ -309,8 +311,8 @@ def test_sync_board_body_gate_blocks_tbd(
     }
     monkeypatch.setattr(
         project_cli,
-        "fetch_project_items",
-        lambda *a, **k: ([tbd_item], None),
+        "fetch_project_item_by_id",
+        lambda *a, **k: (tbd_item, None),
     )
     called = {"status": False}
 


### PR DESCRIPTION
Fix post-merge board sync to fetch the target Project item directly by PVTI id (no limit=100 scan), avoiding missing Done updates on large boards.

Changes:
- gh_project_adapter: add fetch_project_item_by_id (GraphQL node fetch)
- project_cli: re-export
- merge.py: use direct fetch
- tests: update merge sync tests + add adapter coverage

Validation: targeted pytest and full pytest -q.