### PR TITLE
feat: minimal 2-view board shell overlay (ONBOARD-008)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-07-21 (consumer board onboarding alignment; 1184 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1184
+**Last updated:** 2026-07-21 (consumer board onboarding alignment; 1187 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1187
 
 ## Shipped (confirmed in repo)
 
@@ -53,13 +53,13 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus-execution` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1184 collected (1168 passed + 2 skipped on full green run; intentional live-smoke skips) | `tests/modules/` |
+| Tests | 1187 collected (1168 passed + 2 skipped on full green run; intentional live-smoke skips) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-20
-(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1184
+(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1187
 collected** as of board-shell completeness; intentional live-smoke skips only). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,

--- a/.ai_infra/templates/project-board/views-setup.md
+++ b/.ai_infra/templates/project-board/views-setup.md
@@ -25,7 +25,25 @@ python3 -m cursor_workflow project board-bootstrap --check
 
 GitHub may create a blank Project with names like `View 1`. That is **not** the kit default — rename/create until the board matches the table below.
 
-### Fast path (GitHub UI — do this now)
+### Minimal 2-view overlay (optional)
+
+Use this when you want a **lean board** (Status board + Prioritized backlog only). Agent CLI/API behavior is unchanged — views are human UI only.
+
+1. Copy the exemplar:
+
+```bash
+cp .ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml \
+   .local/user_settings/board-shell.schema.yaml
+```
+
+2. In GitHub UI: create/rename **Status board** (Board, group by Status) and **Prioritized backlog** (Table).
+3. On **both** views: show **Priority**, **Size**, **Estimate**, **Start date** (Tier-1 contract unchanged).
+4. Paste README (`project-readme.md` or `--apply-readme`).
+5. `board-bootstrap --check` until exit **0** — schema path should show `.local/user_settings/board-shell.schema.yaml`.
+
+Kit **default** remains six Playground views ([`board-shell.schema.yaml`](board-shell.schema.yaml)). The overlay only changes what `--check` requires.
+
+### Fast path (GitHub UI — Playground default)
 
 1. Open the Project in the browser.
 2. Click the **View 1** tab → ⋯ / rename → **Status board** → layout **Board** → group by **Status**.

--- a/.ai_infra/templates/user-settings/README.md
+++ b/.ai_infra/templates/user-settings/README.md
@@ -20,6 +20,7 @@ Notes:
 |----------|-----------|--------|
 | `exemplars/github.collaboration.yaml` | `.local/user_settings/github.collaboration.yaml` | Commit trailers, PR bodies, PR phase artifacts |
 | `exemplars/mcp.agents.yaml` | `.local/user_settings/mcp.agents.yaml` | `.cursor/mcp.user.json`, `.cursor/mcp.registry.yaml` |
+| `exemplars/board-shell.schema.minimal.yaml` | `.local/user_settings/board-shell.schema.yaml` | Optional 2-view bootstrap minimum (manual copy; gitignored) |
 
 **Agents:** Read completed files for attribution defaults and MCP intent. Wired integration:
 

--- a/.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml
@@ -1,0 +1,91 @@
+# Minimal 2-view board shell overlay (consumer opt-in)
+#
+# File: board-shell.schema.minimal.yaml
+# Path: .ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml
+# Role: Exemplar for .local/user_settings/board-shell.schema.yaml — two-view minimum.
+# Used By:
+#  - views-setup.md § Minimal 2-view overlay
+#  - board-shell-onboard skill (when user wants simple board)
+# Depends On:
+#  - board-shell.schema.yaml (fields must match kit Tier-1 contract)
+# Notes:
+#  - Copy to .local/user_settings/board-shell.schema.yaml (gitignored).
+#  - Agents use CLI/API only — extra Playground views are optional human UI.
+
+version: 1
+name: minimal-two-view
+
+fields:
+  required:
+    - name: Status
+      data_type: single_select
+      options:
+        - Backlog
+        - Ready
+        - In progress
+        - In review
+        - Done
+    - name: Priority
+      data_type: single_select
+      options:
+        - p0
+        - p1
+        - p2
+    - name: Size
+      data_type: single_select
+      options:
+        - xs
+        - s
+        - m
+        - l
+        - xl
+    - name: Estimate
+      data_type: number
+    - name: Start date
+      data_type: date
+  optional:
+    - name: End date
+      data_type: date
+
+views:
+  visible_columns:
+    - Title
+    - Assignees
+    - Status
+    - Priority
+    - Size
+    - Estimate
+    - Start date
+    - Linked pull requests
+
+  minimum:
+    - name: Status board
+      layout: BOARD_LAYOUT
+      group_by: Status
+      check_columns: true
+    - name: Prioritized backlog
+      layout: TABLE_LAYOUT
+      check_columns: true
+
+  recommended: []
+
+readme:
+  template: project-readme.md
+
+card_create:
+  pattern: create-from-template
+  templates:
+    - slice
+    - bug
+    - research
+  notes: >
+    Tier-1 timing in project-board-ssot skill. Agents never mutate views.
+    Overlay replaces kit default six-view minimum — runtime agent CLI unchanged.
+
+customization:
+  overlay_path: .local/user_settings/board-shell.schema.yaml
+  safe: |
+    Add optional views (Roadmap, Bugs, In review, My items) in GitHub UI anytime.
+    Keep Tier-1 columns on Status board + Prioritized backlog.
+  unsafe: |
+    Removing Tier-1 fields or Priority from either primary view breaks agents.

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -50,13 +50,15 @@ Then print the **automation boundary** (never say “ready for `/implementer`”
 
 | Automated (CLI/API) | Human UI only |
 |---------------------|---------------|
-| YAML ids, field definitions, README (`--apply-readme`) | Six Playground views |
+| YAML ids, field definitions, README (`--apply-readme`) | Views (kit default: six Playground; **minimal overlay: two views**) |
 | `contributors validate`, `project doctor` | Column visibility on Status board + Prioritized backlog |
 | `--ensure-fields` | Filters, layout, rename View 1 |
 
+**Minimal 2-view path:** when the user wants a simple board, offer copy of `board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml` and coach Turn A + Turn B only (see `board-shell-onboard` § Customization).
+
 Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 0.
 
-1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the kit default Playground shell?` — wait for `yes` before any shell work. If `no`, stop.
+1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the board shell?` (Playground default **or** minimal 2-view overlay if user asked) — wait for `yes` before any shell work. If `no`, stop.
 2. Follow `.cursor/skills/board-shell-onboard/SKILL.md` — especially **TURN PROTOCOL** when `board-bootstrap --check` FAILs missing views.
 3. **Do not** dump “follow views-setup.md” and stop. One view/column turn at a time; wait for human `done`; re-run `--check` after each turn.
 4. Optional smoke `create-from-template` then cleanup only after `board-bootstrap --check` exit 0 (no view FAIL, no Tier-1 column FAIL).

--- a/.cursor/skills/board-shell-onboard/SKILL.md
+++ b/.cursor/skills/board-shell-onboard/SKILL.md
@@ -199,6 +199,17 @@ python3 -m cursor_workflow project validate-item --last
 
 ## Customization
 
+### Minimal 2-view overlay
+
+When the user asks for a **simple board** (Status board + Prioritized backlog only):
+
+1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
+2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
+3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F.
+4. Re-run `board-bootstrap --check` after each turn until exit **0**.
+
+### Playground default (six views)
+
 - Edit overlay `.local/user_settings/board-shell.schema.yaml` only if your team intentionally drops a Playground view (expect FAIL→WARN tradeoffs).
 - **Safe:** Insights, Iteration/End date columns, filters.
 - **Unsafe:** remove Status / Priority / Size / Estimate / Start date fields, or hide **Priority** on Prioritized backlog.

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -50,13 +50,15 @@ Then print the **automation boundary** (never say “ready for `/implementer`”
 
 | Automated (CLI/API) | Human UI only |
 |---------------------|---------------|
-| YAML ids, field definitions, README (`--apply-readme`) | Six Playground views |
+| YAML ids, field definitions, README (`--apply-readme`) | Views (kit default: six Playground; **minimal overlay: two views**) |
 | `contributors validate`, `project doctor` | Column visibility on Status board + Prioritized backlog |
 | `--ensure-fields` | Filters, layout, rename View 1 |
 
+**Minimal 2-view path:** when the user wants a simple board, offer copy of `board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml` and coach Turn A + Turn B only (see `board-shell-onboard` § Customization).
+
 Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 0.
 
-1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the kit default Playground shell?` — wait for `yes` before any shell work. If `no`, stop.
+1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the board shell?` (Playground default **or** minimal 2-view overlay if user asked) — wait for `yes` before any shell work. If `no`, stop.
 2. Follow `.cursor/skills/board-shell-onboard/SKILL.md` — especially **TURN PROTOCOL** when `board-bootstrap --check` FAILs missing views.
 3. **Do not** dump “follow views-setup.md” and stop. One view/column turn at a time; wait for human `done`; re-run `--check` after each turn.
 4. Optional smoke `create-from-template` then cleanup only after `board-bootstrap --check` exit 0 (no view FAIL, no Tier-1 column FAIL).

--- a/payload/.ai_infra/templates/project-board/views-setup.md
+++ b/payload/.ai_infra/templates/project-board/views-setup.md
@@ -25,7 +25,25 @@ python3 -m cursor_workflow project board-bootstrap --check
 
 GitHub may create a blank Project with names like `View 1`. That is **not** the kit default — rename/create until the board matches the table below.
 
-### Fast path (GitHub UI — do this now)
+### Minimal 2-view overlay (optional)
+
+Use this when you want a **lean board** (Status board + Prioritized backlog only). Agent CLI/API behavior is unchanged — views are human UI only.
+
+1. Copy the exemplar:
+
+```bash
+cp .ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml \
+   .local/user_settings/board-shell.schema.yaml
+```
+
+2. In GitHub UI: create/rename **Status board** (Board, group by Status) and **Prioritized backlog** (Table).
+3. On **both** views: show **Priority**, **Size**, **Estimate**, **Start date** (Tier-1 contract unchanged).
+4. Paste README (`project-readme.md` or `--apply-readme`).
+5. `board-bootstrap --check` until exit **0** — schema path should show `.local/user_settings/board-shell.schema.yaml`.
+
+Kit **default** remains six Playground views ([`board-shell.schema.yaml`](board-shell.schema.yaml)). The overlay only changes what `--check` requires.
+
+### Fast path (GitHub UI — Playground default)
 
 1. Open the Project in the browser.
 2. Click the **View 1** tab → ⋯ / rename → **Status board** → layout **Board** → group by **Status**.

--- a/payload/.ai_infra/templates/user-settings/README.md
+++ b/payload/.ai_infra/templates/user-settings/README.md
@@ -20,6 +20,7 @@ Notes:
 |----------|-----------|--------|
 | `exemplars/github.collaboration.yaml` | `.local/user_settings/github.collaboration.yaml` | Commit trailers, PR bodies, PR phase artifacts |
 | `exemplars/mcp.agents.yaml` | `.local/user_settings/mcp.agents.yaml` | `.cursor/mcp.user.json`, `.cursor/mcp.registry.yaml` |
+| `exemplars/board-shell.schema.minimal.yaml` | `.local/user_settings/board-shell.schema.yaml` | Optional 2-view bootstrap minimum (manual copy; gitignored) |
 
 **Agents:** Read completed files for attribution defaults and MCP intent. Wired integration:
 

--- a/payload/.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml
@@ -1,0 +1,91 @@
+# Minimal 2-view board shell overlay (consumer opt-in)
+#
+# File: board-shell.schema.minimal.yaml
+# Path: .ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml
+# Role: Exemplar for .local/user_settings/board-shell.schema.yaml — two-view minimum.
+# Used By:
+#  - views-setup.md § Minimal 2-view overlay
+#  - board-shell-onboard skill (when user wants simple board)
+# Depends On:
+#  - board-shell.schema.yaml (fields must match kit Tier-1 contract)
+# Notes:
+#  - Copy to .local/user_settings/board-shell.schema.yaml (gitignored).
+#  - Agents use CLI/API only — extra Playground views are optional human UI.
+
+version: 1
+name: minimal-two-view
+
+fields:
+  required:
+    - name: Status
+      data_type: single_select
+      options:
+        - Backlog
+        - Ready
+        - In progress
+        - In review
+        - Done
+    - name: Priority
+      data_type: single_select
+      options:
+        - p0
+        - p1
+        - p2
+    - name: Size
+      data_type: single_select
+      options:
+        - xs
+        - s
+        - m
+        - l
+        - xl
+    - name: Estimate
+      data_type: number
+    - name: Start date
+      data_type: date
+  optional:
+    - name: End date
+      data_type: date
+
+views:
+  visible_columns:
+    - Title
+    - Assignees
+    - Status
+    - Priority
+    - Size
+    - Estimate
+    - Start date
+    - Linked pull requests
+
+  minimum:
+    - name: Status board
+      layout: BOARD_LAYOUT
+      group_by: Status
+      check_columns: true
+    - name: Prioritized backlog
+      layout: TABLE_LAYOUT
+      check_columns: true
+
+  recommended: []
+
+readme:
+  template: project-readme.md
+
+card_create:
+  pattern: create-from-template
+  templates:
+    - slice
+    - bug
+    - research
+  notes: >
+    Tier-1 timing in project-board-ssot skill. Agents never mutate views.
+    Overlay replaces kit default six-view minimum — runtime agent CLI unchanged.
+
+customization:
+  overlay_path: .local/user_settings/board-shell.schema.yaml
+  safe: |
+    Add optional views (Roadmap, Bugs, In review, My items) in GitHub UI anytime.
+    Keep Tier-1 columns on Status board + Prioritized backlog.
+  unsafe: |
+    Removing Tier-1 fields or Priority from either primary view breaks agents.

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -50,13 +50,15 @@ Then print the **automation boundary** (never say “ready for `/implementer`”
 
 | Automated (CLI/API) | Human UI only |
 |---------------------|---------------|
-| YAML ids, field definitions, README (`--apply-readme`) | Six Playground views |
+| YAML ids, field definitions, README (`--apply-readme`) | Views (kit default: six Playground; **minimal overlay: two views**) |
 | `contributors validate`, `project doctor` | Column visibility on Status board + Prioritized backlog |
 | `--ensure-fields` | Filters, layout, rename View 1 |
 
+**Minimal 2-view path:** when the user wants a simple board, offer copy of `board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml` and coach Turn A + Turn B only (see `board-shell-onboard` § Customization).
+
 Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 0.
 
-1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the kit default Playground shell?` — wait for `yes` before any shell work. If `no`, stop.
+1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the board shell?` (Playground default **or** minimal 2-view overlay if user asked) — wait for `yes` before any shell work. If `no`, stop.
 2. Follow `.cursor/skills/board-shell-onboard/SKILL.md` — especially **TURN PROTOCOL** when `board-bootstrap --check` FAILs missing views.
 3. **Do not** dump “follow views-setup.md” and stop. One view/column turn at a time; wait for human `done`; re-run `--check` after each turn.
 4. Optional smoke `create-from-template` then cleanup only after `board-bootstrap --check` exit 0 (no view FAIL, no Tier-1 column FAIL).

--- a/payload/.cursor/skills/board-shell-onboard/SKILL.md
+++ b/payload/.cursor/skills/board-shell-onboard/SKILL.md
@@ -199,6 +199,17 @@ python3 -m cursor_workflow project validate-item --last
 
 ## Customization
 
+### Minimal 2-view overlay
+
+When the user asks for a **simple board** (Status board + Prioritized backlog only):
+
+1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
+2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
+3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F.
+4. Re-run `board-bootstrap --check` after each turn until exit **0**.
+
+### Playground default (six views)
+
 - Edit overlay `.local/user_settings/board-shell.schema.yaml` only if your team intentionally drops a Playground view (expect FAIL→WARN tradeoffs).
 - **Safe:** Insights, Iteration/End date columns, filters.
 - **Unsafe:** remove Status / Priority / Size / Estimate / Start date fields, or hide **Priority** on Prioritized backlog.

--- a/skills/board-shell-onboard/SKILL.md
+++ b/skills/board-shell-onboard/SKILL.md
@@ -199,6 +199,17 @@ python3 -m cursor_workflow project validate-item --last
 
 ## Customization
 
+### Minimal 2-view overlay
+
+When the user asks for a **simple board** (Status board + Prioritized backlog only):
+
+1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
+2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
+3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F.
+4. Re-run `board-bootstrap --check` after each turn until exit **0**.
+
+### Playground default (six views)
+
 - Edit overlay `.local/user_settings/board-shell.schema.yaml` only if your team intentionally drops a Playground view (expect FAIL→WARN tradeoffs).
 - **Safe:** Insights, Iteration/End date columns, filters.
 - **Unsafe:** remove Status / Priority / Size / Estimate / Start date fields, or hide **Priority** on Prioritized backlog.

--- a/tests/modules/install/test_project_board_bootstrap.py
+++ b/tests/modules/install/test_project_board_bootstrap.py
@@ -481,6 +481,68 @@ def test_compare_views_to_schema_unit() -> None:
     assert any("View 1" in w for w in warnings)
 
 
+def _load_minimal_overlay_schema() -> dict:
+    import yaml
+
+    path = (
+        REPO_ROOT
+        / ".ai_infra"
+        / "templates"
+        / "user-settings"
+        / "exemplars"
+        / "board-shell.schema.minimal.yaml"
+    )
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_minimal_overlay_schema_two_views_pass() -> None:
+    schema = _load_minimal_overlay_schema()
+    tier = _tier1_fields()
+    live = [
+        {"name": "Status board", "layout": "BOARD_LAYOUT", "fields": tier},
+        {"name": "Prioritized backlog", "layout": "TABLE_LAYOUT", "fields": tier},
+    ]
+    problems, warnings = board_shell.compare_views_to_schema(schema, live)
+    assert problems == []
+    assert board_shell.tier1_column_blocking_warnings(warnings) == []
+
+
+def test_minimal_overlay_missing_prioritized_backlog_fails() -> None:
+    schema = _load_minimal_overlay_schema()
+    tier = _tier1_fields()
+    live = [{"name": "Status board", "layout": "BOARD_LAYOUT", "fields": tier}]
+    problems, warnings = board_shell.compare_views_to_schema(schema, live)
+    assert any("Prioritized backlog" in p for p in problems)
+
+
+def test_resolve_board_shell_schema_prefers_overlay(tmp_path: Path) -> None:
+    overlay_dir = tmp_path / ".local" / "user_settings"
+    overlay_dir.mkdir(parents=True)
+    minimal = (
+        REPO_ROOT
+        / ".ai_infra"
+        / "templates"
+        / "user-settings"
+        / "exemplars"
+        / "board-shell.schema.minimal.yaml"
+    )
+    shutil.copy(minimal, overlay_dir / "board-shell.schema.yaml")
+    kit_templates = tmp_path / ".ai_infra" / "templates" / "project-board"
+    kit_templates.mkdir(parents=True)
+    shutil.copy(
+        REPO_ROOT / ".ai_infra" / "templates" / "project-board" / "board-shell.schema.yaml",
+        kit_templates / "board-shell.schema.yaml",
+    )
+    resolved = board_shell.resolve_board_shell_schema_path(tmp_path)
+    assert resolved == overlay_dir / "board-shell.schema.yaml"
+    schema, err = board_shell.load_board_shell_schema(tmp_path)
+    assert err is None and schema is not None
+    assert schema.get("name") == "minimal-two-view"
+    assert len(board_shell.minimum_views(schema)) == 2
+
+
 def test_agents_stub_and_view_pack_text() -> None:
     agents = (REPO_ROOT / ".ai_infra" / "templates" / "AGENTS.stub.md").read_text(encoding="utf-8")
     project_board_readme = (
@@ -503,7 +565,8 @@ def test_agents_stub_and_view_pack_text() -> None:
     assert "Default minimum (required)" in views_setup or "Default views (Playground)" in views_setup
     assert "Priority" in views_setup
     assert "My items" in views_setup
-    assert "Status board" in schema_text
+    assert "Minimal 2-view overlay" in views_setup
+    assert "board-shell.schema.minimal.yaml" in views_setup
     assert "Prioritized backlog" in schema_text
     assert "Roadmap" in schema_text
     assert "recommended: []" in schema_text or "recommended:\n  []" in schema_text


### PR DESCRIPTION
## Summary
- Add board-shell.schema.minimal.yaml exemplar (Status board + Prioritized backlog)
- Document overlay install in views-setup and user-settings README
- Update board-shell-onboard + project-board agent to coach 2-view path
- Add overlay bootstrap unit tests; update test count to 1187

## Test plan
- [x] pytest tests/modules/install/test_project_board_bootstrap.py -q
- [x] pytest -q (1185 passed)
- [x] make doc-validate
- [x] make sync-plugin && make check-plugin