### PR TITLE
Add Browser assist map for board shell turns

### DIFF
--- a/.ai_infra/templates/project-board/views-setup.md
+++ b/.ai_infra/templates/project-board/views-setup.md
@@ -1,6 +1,6 @@
 # Project board views setup
 
-Human-only paste guide for GitHub Project settings UI (ADR-008). Agents never mutate views, workflows, Insights, or README via undocumented APIs.
+Human paste guide for GitHub Project settings UI (ADR-008). There is **no official API** to create/rename views or set column visibility. Agents **coach** by default; **browser MCP** only when the human explicitly asks (see **Browser assist map**). Opt-in CLI: `--ensure-fields` / `--apply-readme` only.
 
 **CLI asymmetry:** `board-bootstrap --check` **reads** view/column metadata via GraphQL and **detects** gaps; it **cannot fix** views or column visibility — only `--ensure-fields` / `--apply-readme` mutate field defs / README.
 
@@ -67,7 +67,29 @@ Kit **default** remains six Playground views ([`board-shell.schema.yaml`](board-
 5. README: `--apply-readme` or paste `project-readme.md`.
 6. `python3 -m cursor_workflow project board-bootstrap --check` until green.
 
-Agents coach this as **TURN PROTOCOL** in `board-shell-onboard` (one view per chat turn). They cannot click for you.
+Agents coach this as **TURN PROTOCOL** in `board-shell-onboard` (one view per chat turn). **Default:** human clicks. **If the user asks** for browser help, agents may use browser MCP and follow **Browser assist map** below.
+
+---
+
+## Browser assist map (opt-in — universal sections)
+
+No consumer-specific URLs. Open the Project from `project status`. Use when the human asks the agent to drive the browser (or as a click cheat-sheet).
+
+| Goal | UI section | Target |
+|------|------------|--------|
+| Active view | Top **view tabs** | Exact kit name (`Status board`, `Prioritized backlog`, …) |
+| Rename | Tab **⋯** / View menu → **Rename** | Kit view name |
+| New view | **+ New view** | Layout + name from turn |
+| Layout | View menu → **Layout** | Board / Table / Roadmap |
+| Group by | View menu / toolbar **Group by** | **Status** on Status board; optional **Priority** on Prioritized backlog (polish only) |
+| Tier-1 columns | **+** / **Fields** / View settings → Fields | Priority, Size, Estimate, Start date |
+| Undo bad Slice | View menu → **Slice by** → clear | Groups without slice chips |
+| Persist | **Save** on view if shown | Survives reload |
+| README | Settings → README **or** `--apply-readme` | Non-empty README |
+
+**Minimal fast path:** Status board (Board + Group by Status + Tier-1) → Prioritized backlog (Table + Tier-1) → README → re-check. **Group by Priority** on the backlog is optional and **not** required for `--check` exit 0.
+
+Verify after each change: `python3 -m cursor_workflow project board-bootstrap --check`.
 
 ---
 
@@ -142,6 +164,6 @@ Then: `python3 -m cursor_workflow project status`.
 
 ---
 
-## 5. Keep the board human-owned
+## 5. Keep views API-free (browser opt-in)
 
-Agents write card fields and Notes via `cursor_workflow project` only. They do not configure views, workflows, Insights, or README (except opt-in `--apply-readme` / `--ensure-fields`).
+Agents write card fields and Notes via `cursor_workflow project`. They do not use undocumented GraphQL for views. Default shell setup is human UI + coach; **if asked**, browser MCP follows the **Browser assist map**. Opt-in CLI: `--apply-readme` / `--ensure-fields`.

--- a/.cursor/agents/project-board.md
+++ b/.cursor/agents/project-board.md
@@ -81,7 +81,7 @@ Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 
 | Hand off code slices to implementer | Mutate upstream `mas-workflow-kit` |
 | Fall back to local trackers when disabled | Invent MCP tools |
 | One TURN PROTOCOL turn → wait `done` → re-check | Bulk-dump all views from `views-setup.md` in one message |
-| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn | Open browser MCP for views unprompted |
+| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn; follow **Browser assist map** in `board-shell-onboard` / `views-setup.md` | Open browser MCP for views unprompted; invent GraphQL view mutations |
 | | Say “ready for `/implementer`” after wire-only (API slice) |
 
 ## Handoff format

--- a/.cursor/skills/board-shell-onboard/SKILL.md
+++ b/.cursor/skills/board-shell-onboard/SKILL.md
@@ -118,9 +118,32 @@ You **must** run this conversation loop. **Forbidden:** “follow views-setup.md
 
 **Default:** human performs clicks in GitHub UI; you coach one turn at a time.
 
-**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers.
+**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers. Follow **Browser assist map** below (same targets as `views-setup.md`).
 
 **Open:** Project URL from `project status` (e.g. `https://github.com/users/…/projects/N`).
+
+### Browser assist map (universal click targets — opt-in only)
+
+Use this when driving **cursor-ide-browser** (or when coaching clicks). Prefer **minimal 2-view** path unless the user asked for six-view Playground. After each turn: `board-bootstrap --check`.
+
+| Goal | Where to go (GitHub Project UI) | Done when |
+|------|----------------------------------|-----------|
+| Open project | Navigate to Project URL from `project status` | Project header + view tabs visible |
+| Select a view | Click the **view tab** by exact name (`Status board`, `Prioritized backlog`, …) | That view is active |
+| Rename view | Active tab → **⋯** (or right-click / View menu) → **Rename** → type kit name → confirm | Tab label matches schema |
+| New view | **+ New view** (or **New view**) → pick layout → name it | New tab exists with correct name |
+| Layout | View menu / **⋯** → **Layout** → **Board** / **Table** / **Roadmap** | Layout matches turn |
+| Group by (required) | View menu / toolbar **Group by** → **Status** (Status board) | Board columns are Status groups |
+| Show Tier-1 columns | Active view → **+** / field picker / **Fields** / **View settings → Fields** → enable **Priority**, **Size**, **Estimate**, **Start date** | `--check` no longer FAILs those columns on that view |
+| Clear Slice by (if set by mistake) | View menu → **Slice by** → **No slicing** (or clear) | No slice chips; groups only if Group by set |
+| Save view | If UI shows unsaved / **Save** on the view | Changes persist after reload |
+| README | Prefer CLI `--apply-readme` after consent; else Project **⋯** / Settings → **README** | README non-empty; `--check` OK |
+
+**Fast minimal path (browser):** Turn A (Status board rename/layout/Group by Status + Tier-1 fields) → Turn B (Prioritized backlog Table + Tier-1 fields) → Turn G (README) → Turn H only if `--check` still FAILs columns → exit when `--check` **0**.
+
+**Optional polish (not a bootstrap gate):** on **Prioritized backlog** → **Group by** → **Priority** (P0/P1/P2 sections). Empty boards may hide empty group headers until cards have Priority set. Do **not** block “ready for agents” on this.
+
+**Browser stop conditions:** login / 2FA / permission / CAPTCHA / “can’t find control after 2 tries” → hand back to human with the same turn table row; do not invent GraphQL view mutations.
 
 **Turn A — kill `View 1` → Status board**
 
@@ -209,7 +232,7 @@ When the user asks for a **simple board** (Status board + Prioritized backlog on
 
 1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
 2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
-3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F.
+3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F. Optional: **Group by Priority** on Prioritized backlog (polish; not a `--check` gate).
 4. Re-run `board-bootstrap --check` after each turn until exit **0**.
 
 ### Playground default (six views)
@@ -231,5 +254,6 @@ Only say **ready for agents** when `board-bootstrap --check` exits **0** (no vie
 ## Canon
 
 - Schema: `.ai_infra/templates/project-board/board-shell.schema.yaml`
+- Click map: `.ai_infra/templates/project-board/views-setup.md` § Browser assist map
 - Day-to-day cards: `.cursor/skills/project-board-ssot/SKILL.md`
 - ADR-008: no view API; coach + check by default; browser MCP only when user asks

--- a/agents/project-board.md
+++ b/agents/project-board.md
@@ -81,7 +81,7 @@ Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 
 | Hand off code slices to implementer | Mutate upstream `mas-workflow-kit` |
 | Fall back to local trackers when disabled | Invent MCP tools |
 | One TURN PROTOCOL turn → wait `done` → re-check | Bulk-dump all views from `views-setup.md` in one message |
-| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn | Open browser MCP for views unprompted |
+| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn; follow **Browser assist map** in `board-shell-onboard` / `views-setup.md` | Open browser MCP for views unprompted; invent GraphQL view mutations |
 | | Say “ready for `/implementer`” after wire-only (API slice) |
 
 ## Handoff format

--- a/payload/.ai_infra/templates/project-board/views-setup.md
+++ b/payload/.ai_infra/templates/project-board/views-setup.md
@@ -1,6 +1,6 @@
 # Project board views setup
 
-Human-only paste guide for GitHub Project settings UI (ADR-008). Agents never mutate views, workflows, Insights, or README via undocumented APIs.
+Human paste guide for GitHub Project settings UI (ADR-008). There is **no official API** to create/rename views or set column visibility. Agents **coach** by default; **browser MCP** only when the human explicitly asks (see **Browser assist map**). Opt-in CLI: `--ensure-fields` / `--apply-readme` only.
 
 **CLI asymmetry:** `board-bootstrap --check` **reads** view/column metadata via GraphQL and **detects** gaps; it **cannot fix** views or column visibility — only `--ensure-fields` / `--apply-readme` mutate field defs / README.
 
@@ -67,7 +67,29 @@ Kit **default** remains six Playground views ([`board-shell.schema.yaml`](board-
 5. README: `--apply-readme` or paste `project-readme.md`.
 6. `python3 -m cursor_workflow project board-bootstrap --check` until green.
 
-Agents coach this as **TURN PROTOCOL** in `board-shell-onboard` (one view per chat turn). They cannot click for you.
+Agents coach this as **TURN PROTOCOL** in `board-shell-onboard` (one view per chat turn). **Default:** human clicks. **If the user asks** for browser help, agents may use browser MCP and follow **Browser assist map** below.
+
+---
+
+## Browser assist map (opt-in — universal sections)
+
+No consumer-specific URLs. Open the Project from `project status`. Use when the human asks the agent to drive the browser (or as a click cheat-sheet).
+
+| Goal | UI section | Target |
+|------|------------|--------|
+| Active view | Top **view tabs** | Exact kit name (`Status board`, `Prioritized backlog`, …) |
+| Rename | Tab **⋯** / View menu → **Rename** | Kit view name |
+| New view | **+ New view** | Layout + name from turn |
+| Layout | View menu → **Layout** | Board / Table / Roadmap |
+| Group by | View menu / toolbar **Group by** | **Status** on Status board; optional **Priority** on Prioritized backlog (polish only) |
+| Tier-1 columns | **+** / **Fields** / View settings → Fields | Priority, Size, Estimate, Start date |
+| Undo bad Slice | View menu → **Slice by** → clear | Groups without slice chips |
+| Persist | **Save** on view if shown | Survives reload |
+| README | Settings → README **or** `--apply-readme` | Non-empty README |
+
+**Minimal fast path:** Status board (Board + Group by Status + Tier-1) → Prioritized backlog (Table + Tier-1) → README → re-check. **Group by Priority** on the backlog is optional and **not** required for `--check` exit 0.
+
+Verify after each change: `python3 -m cursor_workflow project board-bootstrap --check`.
 
 ---
 
@@ -142,6 +164,6 @@ Then: `python3 -m cursor_workflow project status`.
 
 ---
 
-## 5. Keep the board human-owned
+## 5. Keep views API-free (browser opt-in)
 
-Agents write card fields and Notes via `cursor_workflow project` only. They do not configure views, workflows, Insights, or README (except opt-in `--apply-readme` / `--ensure-fields`).
+Agents write card fields and Notes via `cursor_workflow project`. They do not use undocumented GraphQL for views. Default shell setup is human UI + coach; **if asked**, browser MCP follows the **Browser assist map**. Opt-in CLI: `--apply-readme` / `--ensure-fields`.

--- a/payload/.cursor/agents/project-board.md
+++ b/payload/.cursor/agents/project-board.md
@@ -81,7 +81,7 @@ Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 
 | Hand off code slices to implementer | Mutate upstream `mas-workflow-kit` |
 | Fall back to local trackers when disabled | Invent MCP tools |
 | One TURN PROTOCOL turn → wait `done` → re-check | Bulk-dump all views from `views-setup.md` in one message |
-| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn | Open browser MCP for views unprompted |
+| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn; follow **Browser assist map** in `board-shell-onboard` / `views-setup.md` | Open browser MCP for views unprompted; invent GraphQL view mutations |
 | | Say “ready for `/implementer`” after wire-only (API slice) |
 
 ## Handoff format

--- a/payload/.cursor/skills/board-shell-onboard/SKILL.md
+++ b/payload/.cursor/skills/board-shell-onboard/SKILL.md
@@ -118,9 +118,32 @@ You **must** run this conversation loop. **Forbidden:** “follow views-setup.md
 
 **Default:** human performs clicks in GitHub UI; you coach one turn at a time.
 
-**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers.
+**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers. Follow **Browser assist map** below (same targets as `views-setup.md`).
 
 **Open:** Project URL from `project status` (e.g. `https://github.com/users/…/projects/N`).
+
+### Browser assist map (universal click targets — opt-in only)
+
+Use this when driving **cursor-ide-browser** (or when coaching clicks). Prefer **minimal 2-view** path unless the user asked for six-view Playground. After each turn: `board-bootstrap --check`.
+
+| Goal | Where to go (GitHub Project UI) | Done when |
+|------|----------------------------------|-----------|
+| Open project | Navigate to Project URL from `project status` | Project header + view tabs visible |
+| Select a view | Click the **view tab** by exact name (`Status board`, `Prioritized backlog`, …) | That view is active |
+| Rename view | Active tab → **⋯** (or right-click / View menu) → **Rename** → type kit name → confirm | Tab label matches schema |
+| New view | **+ New view** (or **New view**) → pick layout → name it | New tab exists with correct name |
+| Layout | View menu / **⋯** → **Layout** → **Board** / **Table** / **Roadmap** | Layout matches turn |
+| Group by (required) | View menu / toolbar **Group by** → **Status** (Status board) | Board columns are Status groups |
+| Show Tier-1 columns | Active view → **+** / field picker / **Fields** / **View settings → Fields** → enable **Priority**, **Size**, **Estimate**, **Start date** | `--check` no longer FAILs those columns on that view |
+| Clear Slice by (if set by mistake) | View menu → **Slice by** → **No slicing** (or clear) | No slice chips; groups only if Group by set |
+| Save view | If UI shows unsaved / **Save** on the view | Changes persist after reload |
+| README | Prefer CLI `--apply-readme` after consent; else Project **⋯** / Settings → **README** | README non-empty; `--check` OK |
+
+**Fast minimal path (browser):** Turn A (Status board rename/layout/Group by Status + Tier-1 fields) → Turn B (Prioritized backlog Table + Tier-1 fields) → Turn G (README) → Turn H only if `--check` still FAILs columns → exit when `--check` **0**.
+
+**Optional polish (not a bootstrap gate):** on **Prioritized backlog** → **Group by** → **Priority** (P0/P1/P2 sections). Empty boards may hide empty group headers until cards have Priority set. Do **not** block “ready for agents” on this.
+
+**Browser stop conditions:** login / 2FA / permission / CAPTCHA / “can’t find control after 2 tries” → hand back to human with the same turn table row; do not invent GraphQL view mutations.
 
 **Turn A — kill `View 1` → Status board**
 
@@ -209,7 +232,7 @@ When the user asks for a **simple board** (Status board + Prioritized backlog on
 
 1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
 2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
-3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F.
+3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F. Optional: **Group by Priority** on Prioritized backlog (polish; not a `--check` gate).
 4. Re-run `board-bootstrap --check` after each turn until exit **0**.
 
 ### Playground default (six views)
@@ -231,5 +254,6 @@ Only say **ready for agents** when `board-bootstrap --check` exits **0** (no vie
 ## Canon
 
 - Schema: `.ai_infra/templates/project-board/board-shell.schema.yaml`
+- Click map: `.ai_infra/templates/project-board/views-setup.md` § Browser assist map
 - Day-to-day cards: `.cursor/skills/project-board-ssot/SKILL.md`
 - ADR-008: no view API; coach + check by default; browser MCP only when user asks

--- a/skills/board-shell-onboard/SKILL.md
+++ b/skills/board-shell-onboard/SKILL.md
@@ -118,9 +118,32 @@ You **must** run this conversation loop. **Forbidden:** “follow views-setup.md
 
 **Default:** human performs clicks in GitHub UI; you coach one turn at a time.
 
-**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers.
+**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers. Follow **Browser assist map** below (same targets as `views-setup.md`).
 
 **Open:** Project URL from `project status` (e.g. `https://github.com/users/…/projects/N`).
+
+### Browser assist map (universal click targets — opt-in only)
+
+Use this when driving **cursor-ide-browser** (or when coaching clicks). Prefer **minimal 2-view** path unless the user asked for six-view Playground. After each turn: `board-bootstrap --check`.
+
+| Goal | Where to go (GitHub Project UI) | Done when |
+|------|----------------------------------|-----------|
+| Open project | Navigate to Project URL from `project status` | Project header + view tabs visible |
+| Select a view | Click the **view tab** by exact name (`Status board`, `Prioritized backlog`, …) | That view is active |
+| Rename view | Active tab → **⋯** (or right-click / View menu) → **Rename** → type kit name → confirm | Tab label matches schema |
+| New view | **+ New view** (or **New view**) → pick layout → name it | New tab exists with correct name |
+| Layout | View menu / **⋯** → **Layout** → **Board** / **Table** / **Roadmap** | Layout matches turn |
+| Group by (required) | View menu / toolbar **Group by** → **Status** (Status board) | Board columns are Status groups |
+| Show Tier-1 columns | Active view → **+** / field picker / **Fields** / **View settings → Fields** → enable **Priority**, **Size**, **Estimate**, **Start date** | `--check` no longer FAILs those columns on that view |
+| Clear Slice by (if set by mistake) | View menu → **Slice by** → **No slicing** (or clear) | No slice chips; groups only if Group by set |
+| Save view | If UI shows unsaved / **Save** on the view | Changes persist after reload |
+| README | Prefer CLI `--apply-readme` after consent; else Project **⋯** / Settings → **README** | README non-empty; `--check` OK |
+
+**Fast minimal path (browser):** Turn A (Status board rename/layout/Group by Status + Tier-1 fields) → Turn B (Prioritized backlog Table + Tier-1 fields) → Turn G (README) → Turn H only if `--check` still FAILs columns → exit when `--check` **0**.
+
+**Optional polish (not a bootstrap gate):** on **Prioritized backlog** → **Group by** → **Priority** (P0/P1/P2 sections). Empty boards may hide empty group headers until cards have Priority set. Do **not** block “ready for agents” on this.
+
+**Browser stop conditions:** login / 2FA / permission / CAPTCHA / “can’t find control after 2 tries” → hand back to human with the same turn table row; do not invent GraphQL view mutations.
 
 **Turn A — kill `View 1` → Status board**
 
@@ -209,7 +232,7 @@ When the user asks for a **simple board** (Status board + Prioritized backlog on
 
 1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
 2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
-3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F.
+3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F. Optional: **Group by Priority** on Prioritized backlog (polish; not a `--check` gate).
 4. Re-run `board-bootstrap --check` after each turn until exit **0**.
 
 ### Playground default (six views)
@@ -231,5 +254,6 @@ Only say **ready for agents** when `board-bootstrap --check` exits **0** (no vie
 ## Canon
 
 - Schema: `.ai_infra/templates/project-board/board-shell.schema.yaml`
+- Click map: `.ai_infra/templates/project-board/views-setup.md` § Browser assist map
 - Day-to-day cards: `.cursor/skills/project-board-ssot/SKILL.md`
 - ADR-008: no view API; coach + check by default; browser MCP only when user asks

--- a/tests/modules/install/test_project_board_bootstrap.py
+++ b/tests/modules/install/test_project_board_bootstrap.py
@@ -568,6 +568,8 @@ def test_agents_stub_and_view_pack_text() -> None:
     assert "My items" in views_setup
     assert "Minimal 2-view overlay" in views_setup
     assert "board-shell.schema.minimal.yaml" in views_setup
+    assert "Browser assist map" in views_setup
+    assert "Group by" in views_setup
     assert "Prioritized backlog" in schema_text
     assert "Roadmap" in schema_text
     assert "recommended: []" in schema_text or "recommended:\n  []" in schema_text
@@ -581,11 +583,14 @@ def test_agents_stub_and_view_pack_text() -> None:
         REPO_ROOT / ".cursor" / "skills" / "board-shell-onboard" / "SKILL.md"
     ).read_text(encoding="utf-8")
     assert "board-bootstrap --check" in skill
+    assert "Browser assist map" in skill
+    assert "Optional polish" in skill or "optional polish" in skill.lower()
     assert "Do not" in skill or "do not" in skill.lower()
     project_board_agent = (
         REPO_ROOT / ".cursor" / "agents" / "project-board.md"
     ).read_text(encoding="utf-8")
     assert "browser MCP" in project_board_agent
+    assert "Browser assist map" in project_board_agent
     assert "asks" in project_board_agent.lower() or "explicit" in project_board_agent.lower()
     assert "api=complete" in project_board_agent
 


### PR DESCRIPTION
## Summary
- Add a universal **Browser assist map** (view tabs, ⋯/View menu, Fields, Group by, Slice clear, Save) so `/project-board` can set the board quickly when the user asks for browser help.
- Document minimal fast path + optional Group-by-Priority polish (not a bootstrap gate).
- Update `views-setup.md`, `board-shell-onboard`, `project-board` agent; sync plugin payload; extend pack text tests.

## Test plan
- [x] `pytest tests/modules/install/test_project_board_bootstrap.py::test_agents_stub_and_view_pack_text`
- [x] `make check-plugin`
- [x] governance consistency
- [ ] prepare.py / CI quality

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: Auto | review-pr | prepare-pr | merge-pr
- Board-Item: PVTI_lAHOBl46-84A9KZxzgznBw8