### PR TITLE
feat: rename agent integrator-mas-agent → integrator

### DIFF
--- a/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/.agents/skills/RESEARCH_WORKFLOW.md
@@ -86,6 +86,6 @@ No product repo edits; no git commits for research packs; writes only `_research
 |----------|------|
 | PR merge | `pr-workflow/SKILL.md` |
 | Implementation | `implementer` (reads `AGENT_BRIEF.md`) |
-| Integration | `integrator-mas-agent` |
+| Integration | `integrator` |
 | Audit | `enterprise-auditor` |
 | Agent canvas | `canvases/agent-researcher.canvas.tsx` |

--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -54,7 +54,7 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 | `verifier` | Evidence checks; board Done / In review |
 | `enterprise-auditor` | Architecture audits; audit card Status + Notes |
 | `researcher` | **Shipped/proven** adaptive Brief multi-round packs under `_research_results/` (opt-in after init); chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
-| `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
+| `integrator` | Add agents/skills/MCP; integration card Status |
 | `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
 | `project-board` | Board triage + **first-run shell coach** (`board-shell`; ADR-006); not in default PR pipelines |
 

--- a/.ai_infra/docs/decisions/ADR-006-agent-integration-model.md
+++ b/.ai_infra/docs/decisions/ADR-006-agent-integration-model.md
@@ -7,7 +7,7 @@
 
 Consumers extend the MAS Workflow Kit by adding agents, skills, MCP servers, and scripts. Without a clear integration contract, new capability drifts from gates, PR pipelines, registry parity, and procedural discipline.
 
-The **integrator-mas-agent** and **integrator-protocol** skill proceduralize extension; this ADR records the architectural decision.
+The **integrator** and **integrator-protocol** skill proceduralize extension; this ADR records the architectural decision.
 
 ## Decision
 
@@ -46,7 +46,7 @@ Standalone agent for a narrow domain; not in default PR pipelines unless explici
 | Work updates trackers, gates, or manifest | Work is read-only or single-shot |
 | Agent id should appear in PR `Agent/s` | Agent should not appear in PR attribution |
 | Multiple agents coordinate on same slice | Single-purpose tool with no PR coupling,
-| Examples: implementer, integrator-mas-agent, enterprise-auditor | Examples: one-off research, external-only automation |
+| Examples: implementer, integrator, enterprise-auditor | Examples: one-off research, external-only automation |
 
 ## Consequences
 
@@ -57,6 +57,6 @@ Standalone agent for a narrow domain; not in default PR pipelines unless explici
 
 ## References
 
-- `.cursor/agents/integrator-mas-agent.md`
+- `.cursor/agents/integrator.md`
 - `.cursor/skills/integrator-protocol/SKILL.md`
 - `.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md`

--- a/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
+++ b/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
@@ -13,11 +13,11 @@
 
 **Product:** installable **multi-agent workflow infrastructure** for any Cursor project (not a PyPI package, not an MCP-first product).
 
-**User journey:** plugin unpacks the full **consumer infrastructure** → user completes `.local/user_settings/` (GitHub + MCP worksheets) → **`/integrator-mas-agent`** extends agents/skills/MCP while preserving Pattern A, gates, and three-plane layout.
+**User journey:** plugin unpacks the full **consumer infrastructure** → user completes `.local/user_settings/` (GitHub + MCP worksheets) → **`/integrator`** extends agents/skills/MCP while preserving Pattern A, gates, and three-plane layout.
 
 **Optional add-on:** MCP server under `.ai_infra/mcp_servers/` — wraps the same scripts; agents do not require it.
 
-**Expansion path:** after install, use **`/integrator-mas-agent`** to add agents/skills/MCP. Machine checks: `python -m cursor_workflow integrate validate` (P0: agent sections, registry parity, pipeline names, user_settings schema). ADR-006 defines MAS-integrated vs independent-governed modes.
+**Expansion path:** after install, use **`/integrator`** to add agents/skills/MCP. Machine checks: `python -m cursor_workflow integrate validate` (P0: agent sections, registry parity, pipeline names, user_settings schema). ADR-006 defines MAS-integrated vs independent-governed modes.
 
 ---
 
@@ -54,11 +54,11 @@ flowchart LR
 | 2. Activate planes | Agent or human | `python -m cursor_workflow activate --directory .` |
 | 3. Personalize | Human | `.local/user_settings/github.collaboration.yaml` |
 | 4. Validate | Agent or human | `contributors validate` + `integrate validate` |
-| 5. Extend infra | Agent or human | **`/integrator-mas-agent`** in Agent chat (not shell) |
+| 5. Extend infra | Agent or human | **`/integrator`** in Agent chat (not shell) |
 
 **Source for activate:** plugin `payload/` directory. Set `WORKFLOW_KIT_PAYLOAD=/path/to/payload` when auto-detect fails.
 
-**Agents are not CLI commands.** Names like `integrator-mas-agent` are Cursor subagents — invoke with **`/integrator-mas-agent`** in Agent chat or via parent Agent Task delegation ([Subagents](https://cursor.com/docs/subagents)).
+**Agents are not CLI commands.** Names like `integrator` are Cursor subagents — invoke with **`/integrator`** in Agent chat or via parent Agent Task delegation ([Subagents](https://cursor.com/docs/subagents)).
 
 ---
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -132,7 +132,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `test-runner` | Yes | Yes | `/test-runner` |
 | `verifier` | Yes | Yes | `/verifier` |
 | `enterprise-auditor` | Yes | Yes | `/enterprise-auditor` |
-| `integrator-mas-agent` | Yes | Yes | `/integrator-mas-agent` |
+| `integrator` | Yes | Yes | `/integrator` |
 | `workflow-drift-guard` | Yes | Yes | `/workflow-drift-guard` |
 | `project-board` | Yes | Yes | `/project-board` |
 | `researcher` | Yes | Yes (opt-in packs after `research init`) | `/researcher` (adaptive Brief + HTTPS; shipped/proven) |
@@ -153,7 +153,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `drift-audit` | `workflow-drift-guard` |
 | `implementer-loop` | `implementer` |
 | `test-coverage` | `test-runner` |
-| `integrator-protocol` | `integrator-mas-agent` |
+| `integrator-protocol` | `integrator` |
 | `board-ssot` | `project-board` (board Entry/Exit; ADR-008) |
 | `board-shell` | `project-board` (first-run shell coach) |
 | `workflow-activate` | Install / re-activate |

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -258,7 +258,7 @@ your-project/
 | Implement | `/implementer` |
 | Tests | `/test-runner` |
 | PR lifecycle | `/review-pr` → `/prepare-pr` → `/merge-pr` |
-| Extend kit | `/integrator-mas-agent` |
+| Extend kit | `/integrator` |
 
 ### Terminal commands (project root)
 
@@ -331,7 +331,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **Architecture audit** *(not day-0)* | `/enterprise-auditor` | — (subagent only; no dedicated MCP tool) | [agent-workflow-procedures.md](agent-workflow-procedures.md) §1 — after board shell |
 | **Operational drift** (plan ↔ tracker) | `/workflow-drift-guard` (optional) | `python3 -m cursor_workflow drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
-| **Add agents / skills / MCP** | `/integrator-mas-agent` + `/integrator-protocol` | `integrate validate` | [mas-infrastructure-integration.md](mas-infrastructure-integration.md) |
+| **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [mas-infrastructure-integration.md](mas-infrastructure-integration.md) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
 | **Upgrade / refresh dashboards** | `/workflow-activate` | `python3 -m cursor_workflow activate --directory .` | [upgrade-kit.md](upgrade-kit.md) |
 | **Check install health** | — | `python3 -m cursor_workflow health` | [gate-matrix.md](gate-matrix.md) |
@@ -348,7 +348,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
 | `/researcher` | `.cursor/agents/researcher.md` — **shipped/proven**; adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate`; corpus opt-in after init |
-| `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
+| `/integrator` | `.cursor/agents/integrator.md` |
 | `/project-board` | `.cursor/agents/project-board.md` + `board-ssot` + first-run `board-shell` |
 | `/board-shell` | `.cursor/skills/board-shell/` — first-run coach (also via `/project-board`) |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -99,7 +99,7 @@ High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `i
 |-------|------|
 | project-board | Board triage, Status, Tier-1 fields; hand off to implementer |
 | implementer | Slice implementation |
-| integrator-mas-agent | Extend agents/skills/MCP into kit infrastructure |
+| integrator | Extend agents/skills/MCP into kit infrastructure |
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
 | enterprise-auditor | Architecture audits (alignment / scorecard artifacts) |

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -75,7 +75,7 @@ Cursor lists **subagents**, **skills**, and **commands** in the same **`/`** men
 | Implement a slice | **`/implementer`** | `.cursor/agents/implementer.md` |
 | Run tests | **`/test-runner`** | `.cursor/agents/test-runner.md` |
 | PR review / prepare / merge | **`/review-pr`**, `/prepare-pr`, `/merge-pr` | `.agents/skills/` (loaded as skills) |
-| Extend agents/skills/MCP | **`/integrator-mas-agent`** + `/integrator-protocol` | agent + skill |
+| Extend agents/skills/MCP | **`/integrator`** + `/integrator-protocol` | agent + skill |
 | Attach a file or doc | **`@`** + pick context | — ([Prompting](https://cursor.com/docs/agent/prompting)) |
 
 Agent may also **auto-delegate** subagents or **auto-apply** skills when the task matches their `description` — explicit **`/name`** is the reliable manual path.
@@ -262,7 +262,7 @@ python3 -m cursor_workflow project status
 4. **`/implementer`** (or `/test-runner`, `/verifier`; `/enterprise-auditor` only for architecture-impacting / pre-merge audits — not day-0 onboarding)
 5. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
 
-**Add your own agent/skill/MCP:** **`/integrator-mas-agent`** + **`/integrator-protocol`**
+**Add your own agent/skill/MCP:** **`/integrator`** + **`/integrator-protocol`**
 
 ---
 
@@ -286,7 +286,7 @@ python3 -m cursor_workflow project status
 | Verify claims | `/verifier` |
 | Architecture audit | `/enterprise-auditor` |
 | Drift check | `/workflow-drift-guard` |
-| Add agents/skills/MCP | `/integrator-mas-agent` |
+| Add agents/skills/MCP | `/integrator` |
 | External MCP setup | `/mcp-connect` |
 | PR workflow | `/review-pr` → `/prepare-pr` → `/merge-pr` |
 | Attach file context | `@` + pick file (not for starting workflows) |

--- a/.ai_infra/docs/operations/mas-infrastructure-integration.md
+++ b/.ai_infra/docs/operations/mas-infrastructure-integration.md
@@ -3,7 +3,7 @@ File: mas-infrastructure-integration.md
 Path: .ai_infra/docs/operations/mas-infrastructure-integration.md
 Role: Consumer-facing procedure for extending MAS Workflow Kit (agents, skills, MCP, scripts).
 Used By:
- - .cursor/agents/integrator-mas-agent.md
+ - .cursor/agents/integrator.md
  - .cursor/skills/integrator-protocol/SKILL.md
 Depends On:
  - .ai_infra/docs/architecture/workflow-architecture.md
@@ -20,7 +20,7 @@ Notes:
 2. **User completes** `.local/user_settings/` (GitHub collaboration + MCP worksheet).
 3. **Integrator agent** extends the system when user adds agents, skills, or tools — without breaking planes or gates.
 
-**Agent:** `.cursor/agents/integrator-mas-agent.md`  
+**Agent:** `.cursor/agents/integrator.md`  
 **Skill:** `.cursor/skills/integrator-protocol/SKILL.md`
 
 ## Three planes (never mix)

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -65,7 +65,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | **implementer** | status + `claim --agent implementer` | `handoff --agent implementer --next … --to in_review` or →Done |
 | **test-runner** | status + slice card | →In review or →Done; `--agent test-runner` |
 | **verifier** | status + related card | →Done or leave In review; `--agent verifier` |
-| **integrator-mas-agent** | status + claim | →Done; `--agent integrator-mas-agent` |
+| **integrator** | status + claim | →Done; `--agent integrator` |
 | **enterprise-auditor** | status + audit card | →In review/Done; `--agent enterprise-auditor` + artifact paths |
 | **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; `--agent workflow-drift-guard`; remediation via Notes/Ready — no silent tracker edits |
 | **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + `AGENT_BRIEF` / pack paths (adaptive intake from chat/Notes) |

--- a/.ai_infra/install/cursor_workflow/activate_cli.py
+++ b/.ai_infra/install/cursor_workflow/activate_cli.py
@@ -116,7 +116,7 @@ def _print_post_activate_hints(root: Path) -> None:
         print("\nOptional:")
         print("  source .venv/bin/activate && python3 -m cursor_workflow integrate validate")
         print("  source .venv/bin/activate && python3 -m cursor_workflow health")
-        print("Add agents/skills later: /integrator-mas-agent (subagent, not a shell command).")
+        print("Add agents/skills later: /integrator (subagent, not a shell command).")
 
 
 def _import_scaffold_refresh() -> object:

--- a/.ai_infra/install/cursor_workflow/research_cli.py
+++ b/.ai_infra/install/cursor_workflow/research_cli.py
@@ -38,7 +38,7 @@ _DEFAULT_LENSES = [
     "decisions",
     "patterns",
 ]
-_DEFAULT_CONSUMERS = ["implementer", "integrator-mas-agent"]
+_DEFAULT_CONSUMERS = ["implementer", "integrator"]
 
 
 def _fail(cmd: str, code: int, reason: str) -> int:

--- a/.ai_infra/scripts/integration/validate.py
+++ b/.ai_infra/scripts/integration/validate.py
@@ -83,7 +83,7 @@ def _paths(root: Path) -> dict[str, Path]:
         "manifest": infra / "manifest.yaml",
         "ops_doc": infra / "docs" / "operations" / "mas-infrastructure-integration.md",
         "checklist": infra / "templates" / "agent-integration" / "INTEGRATION-CHECKLIST.md",
-        "plugin_integrator": root / "agents" / "integrator-mas-agent.md",
+        "plugin_integrator": root / "agents" / "integrator.md",
         "plugin_drift_guard": root / "agents" / "workflow-drift-guard.md",
     }
 
@@ -223,9 +223,9 @@ def _check_int009(root: Path, paths: dict[str, Path]) -> CheckResult:
         severity=Severity.P2,
         passed=exists,
         detail=(
-            "agents/integrator-mas-agent.md present"
+            "agents/integrator.md present"
             if exists
-            else "missing agents/integrator-mas-agent.md — run make sync-plugin"
+            else "missing agents/integrator.md — run make sync-plugin"
         ),
     )
 

--- a/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
+++ b/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
@@ -1,7 +1,7 @@
 <!--
 File: INTEGRATION-CHECKLIST.md
 Path: .ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
-Role: Slice checklist for integrator-mas-agent; copy row into work-tracker.md.
+Role: Slice checklist for integrator; copy row into work-tracker.md.
 Used By:
  - .cursor/skills/integrator-protocol/SKILL.md
 Depends On:
@@ -16,7 +16,7 @@ Notes:
 |-------|--------|
 | **Type** | agent \| skill \| mcp \| script \| doc |
 | **Mode** | MAS-integrated \| independent-governed |
-| **Owner** | integrator-mas-agent |
+| **Owner** | integrator |
 | **Status** | planned \| in_progress \| done |
 
 ## Intake

--- a/.ai_infra/templates/agent-integration/README.md
+++ b/.ai_infra/templates/agent-integration/README.md
@@ -1,6 +1,6 @@
 # Agent integration templates
 
-Copy from here when **`integrator-mas-agent`** adds agents or skills.
+Copy from here when **`integrator`** adds agents or skills.
 
 | File | Purpose |
 |------|---------|

--- a/.ai_infra/templates/local-workspace/ci/kit-dev/user_settings/github.collaboration.yaml
+++ b/.ai_infra/templates/local-workspace/ci/kit-dev/user_settings/github.collaboration.yaml
@@ -55,14 +55,14 @@ pr_collaboration:
     architecture_impacting:
       agents:
         - enterprise-auditor
-        - integrator-mas-agent
+        - integrator
         - review-pr
         - prepare-pr
         - merge-pr
       requires_alignment_artifacts: true
     infrastructure_integration:
       agents:
-        - integrator-mas-agent
+        - integrator
         - enterprise-auditor
         - review-pr
         - prepare-pr
@@ -71,7 +71,7 @@ pr_collaboration:
         - implementer
         - test-runner
         - verifier
-        - integrator-mas-agent
+        - integrator
         - review-pr
         - prepare-pr
       session_pointer: .local/index-and-planning/current/session-pointer.md

--- a/.ai_infra/templates/local-workspace/ci/kit-dev/user_settings/mcp.agents.yaml
+++ b/.ai_infra/templates/local-workspace/ci/kit-dev/user_settings/mcp.agents.yaml
@@ -22,7 +22,7 @@ kit:
     - verifier
     - enterprise-auditor
     - researcher
-    - integrator-mas-agent
+    - integrator
     - workflow-drift-guard
   tools_hint:
     - workflow_run_prepare
@@ -83,7 +83,7 @@ agent_defaults:
   researcher:
     primary_servers: [workflow-kit]
     optional_servers: []
-  integrator-mas-agent:
+  integrator:
     primary_servers: [workflow-kit]
     optional_servers: []
 

--- a/.ai_infra/templates/plugin/skills/workflow-activate/SKILL.md
+++ b/.ai_infra/templates/plugin/skills/workflow-activate/SKILL.md
@@ -57,11 +57,11 @@ runs — not before. Use **`/mcp-connect`** after activate.
 3. When board SSOT enabled: `python3 -m cursor_workflow project doctor` → **`/project-board`** + `board-shell` → `python3 -m cursor_workflow project board-bootstrap --check` until **default Playground shell** green → `python3 -m cursor_workflow project status`
 4. **`/implementer`** to start · audit (`/enterprise-auditor`) is later / architecture-impacting — not day-0.
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator-mas-agent`**.
+Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 
-Invoke subagent **`/integrator-mas-agent`** with skill **`/integrator-protocol`** — not shell commands.
+Invoke subagent **`/integrator`** with skill **`/integrator-protocol`** — not shell commands.
 
 ## Agent delegation
 
@@ -71,7 +71,7 @@ After plugin enable, parent agent or user should:
 1. Run **`workflow_activate`** or `cursor_workflow activate`
 2. Hand user to personalize `user_settings/` + `gh` Project scopes
 3. When SSOT on: **`/project-board`** (board-shell) until `board-bootstrap --check` green
-4. Point to **`/implementer`**; optionally delegate **`/integrator-mas-agent`** for extensions
+4. Point to **`/implementer`**; optionally delegate **`/integrator`** for extensions
 
 ## Success
 

--- a/.ai_infra/templates/project-board/card-body-research.md
+++ b/.ai_infra/templates/project-board/card-body-research.md
@@ -21,7 +21,7 @@
 | **question** | (TBD) |
 | **lenses** | architecture, cli, agents, skills, tests, decisions, patterns |
 | **slug** | (TBD) |
-| **consumers** | implementer, integrator-mas-agent |
+| **consumers** | implementer, integrator |
 
 ## Notes
 

--- a/.ai_infra/templates/research-corpus/AGENT_BRIEF.template.md
+++ b/.ai_infra/templates/research-corpus/AGENT_BRIEF.template.md
@@ -4,7 +4,7 @@ Path: .ai_infra/templates/research-corpus/AGENT_BRIEF.template.md
 Role: Short handoff pack for implementer / integrator (and other consumers).
 Used By:
  - researcher exit
- - implementer / integrator-mas-agent Read first
+ - implementer / integrator Read first
 Depends On:
  - CURATED.md
  - INDEX.json

--- a/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -163,14 +163,14 @@ pr_collaboration:
     architecture_impacting:
       agents:
         - enterprise-auditor
-        - integrator-mas-agent
+        - integrator
         - review-pr
         - prepare-pr
         - merge-pr
       requires_alignment_artifacts: true
     infrastructure_integration:
       agents:
-        - integrator-mas-agent
+        - integrator
         - enterprise-auditor
         - review-pr
         - prepare-pr
@@ -179,7 +179,7 @@ pr_collaboration:
         - implementer
         - test-runner
         - verifier
-        - integrator-mas-agent
+        - integrator
         - review-pr
         - prepare-pr
       session_pointer: .local/index-and-planning/current/session-pointer.md

--- a/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
@@ -22,7 +22,7 @@ kit:
     - verifier
     - enterprise-auditor
     - researcher
-    - integrator-mas-agent
+    - integrator
   tools_hint:
     - workflow_run_prepare
     - workflow_get_tracker
@@ -81,7 +81,7 @@ agent_defaults:
   researcher:
     primary_servers: [workflow-kit]
     optional_servers: []
-  integrator-mas-agent:
+  integrator:
     primary_servers: [workflow-kit]
     optional_servers: []
 

--- a/.cursor/agents/integrator.md
+++ b/.cursor/agents/integrator.md
@@ -1,5 +1,5 @@
 ---
-name: integrator-mas-agent
+name: integrator
 model: auto
 description: Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
@@ -18,7 +18,7 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator` (→ `@owner.github_user/integrator`); atomics `append-notes --agent integrator` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
 **Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
 
@@ -57,7 +57,7 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 ## Loop (one integration slice)
 
 1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator-mas-agent`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
+2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
 3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
 4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
 5. **Verify** — `python -m cursor_workflow contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
@@ -91,7 +91,7 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Tier | Server | Use when |
 |------|--------|----------|
 | Kit | `workflow-kit` | `workflow_list_session_agents`, trackers, governance — prefer over shell |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator-mas-agent` |
+| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator` |
 
 Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -44,7 +44,7 @@ Normalize a **Research Brief** from whatever channel started you — do **not** 
 - `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
 - `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
 - `slug`: repo name lowercased (`grok-build`)
-- `consumers`: implementer, integrator-mas-agent
+- `consumers`: implementer, integrator
 - `rounds_max`: 6
 
 **Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
@@ -110,7 +110,7 @@ Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, 
 | Need | Use |
 |------|-----|
 | Implement features | `implementer` (consume `AGENT_BRIEF.md`) |
-| Integrate kit surfaces | `integrator-mas-agent` |
+| Integrate kit surfaces | `integrator` |
 | PR merge | `pr-workflow/SKILL.md` |
 | Full enterprise audit | `enterprise-auditor` |
 | Verify a claim | `verifier` |

--- a/.cursor/mcp.registry.yaml.example
+++ b/.cursor/mcp.registry.yaml.example
@@ -3,7 +3,7 @@ servers:
   workflow-kit:
     tier: kit
     description: PR workflow, trackers, gates
-    agents: [implementer, test-runner, verifier, enterprise-auditor, researcher, integrator-mas-agent, workflow-drift-guard]
+    agents: [implementer, test-runner, verifier, enterprise-auditor, researcher, integrator, workflow-drift-guard]
     tools_hint: [workflow_run_prepare, workflow_get_tracker, workflow_list_mcp_registry, workflow_integrate_validate, workflow_drift_validate]
   # User adds keys matching mcp.json mcpServers:
   my-custom-server:

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -209,7 +209,7 @@ Rules:
 | **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
 | **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
 | **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
-| **integrator-mas-agent** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
+| **integrator** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
 | **enterprise-auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
 | **workflow-drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to project-board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
 | **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |

--- a/.cursor/skills/integrator-protocol/SKILL.md
+++ b/.cursor/skills/integrator-protocol/SKILL.md
@@ -18,7 +18,7 @@ Integrate **new agents, skills, MCP servers, scripts, or docs** into the kit so 
 - User expands **manifest / install contract / plugin payload**
 - User asks to merge a **standalone agent** into the MAS pipeline (or keep independent but governed)
 
-**Agent card:** `.cursor/agents/integrator-mas-agent.md`
+**Agent card:** `.cursor/agents/integrator.md`
 
 ## Evidence contract
 
@@ -103,7 +103,7 @@ Copy and edit from **`.ai_infra/templates/agent-integration/`**:
 | 1 | Agent + skill with explicit **boundaries** (what it must not do) |
 | 2 | Registry: optional MCP servers scoped to that agent id only |
 | 3 | **Do not** add to core PR pipelines unless it owns a maintainer phase |
-| 4 | Document handoff to `implementer` / `integrator-mas-agent` when work crosses into kit infrastructure |
+| 4 | Document handoff to `implementer` / `integrator` when work crosses into kit infrastructure |
 
 ### C. External MCP server
 

--- a/.cursor/skills/research-corpus/SKILL.md
+++ b/.cursor/skills/research-corpus/SKILL.md
@@ -48,7 +48,7 @@ If only a link/path is given:
 - **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
 - **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
 - **slug:** repo (or directory) name, lowercase with hyphens
-- **consumers:** implementer, integrator-mas-agent (plus the requesting agent if known)
+- **consumers:** implementer, integrator (plus the requesting agent if known)
 - **rounds_max:** 6
 
 Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
@@ -71,7 +71,7 @@ source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
 question: <what MAS / requesting agent needs>
 lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
 rounds_max: 6
-consumers: [implementer, integrator-mas-agent, …]
+consumers: [implementer, integrator, …]
 slug: <derived or explicit>
 ```
 

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -116,11 +116,11 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 **Dashboards (optional):** from project root run `source .venv/bin/activate && python3 -m http.server 8000`, then open
 http://localhost:8000/.local/agents-control-center/dashboards/index.html (not `file://`).
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator-mas-agent`**.
+Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 
-Invoke subagent **`/integrator-mas-agent`** with skill **`/integrator-protocol`** — not shell commands ([Subagents](https://cursor.com/docs/subagents), [Skills](https://cursor.com/docs/skills)).
+Invoke subagent **`/integrator`** with skill **`/integrator-protocol`** — not shell commands ([Subagents](https://cursor.com/docs/subagents), [Skills](https://cursor.com/docs/skills)).
 
 ## Success
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. After mer
 | Implement | `.cursor/agents/implementer.md` + `.cursor/skills/implementer-loop/SKILL.md` |
 | Project board SSOT | `.cursor/agents/project-board.md` + `.cursor/skills/board-ssot/SKILL.md` — `python -m cursor_workflow project …` |
 | Board shell first-run | `/project-board` + `.cursor/skills/board-shell/SKILL.md` + `board-shell.schema.yaml` |
-| Integrate infrastructure | `.cursor/agents/integrator-mas-agent.md` + `.cursor/skills/integrator-protocol/SKILL.md` — validate with `python3 -m cursor_workflow integrate validate` |
+| Integrate infrastructure | `.cursor/agents/integrator.md` + `.cursor/skills/integrator-protocol/SKILL.md` — validate with `python3 -m cursor_workflow integrate validate` |
 | Tests / coverage | `.cursor/agents/test-runner.md` + `.cursor/skills/test-coverage/SKILL.md` |
 | Verify claims | `.cursor/agents/verifier.md` |
 | Operational drift | **`workflow-drift-guard`** — `.cursor/agents/workflow-drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — validate with `python3 -m cursor_workflow drift validate` |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -100,7 +100,7 @@ If the board is unavailable: `fallback: local_trackers` only, then resume board 
 | `test-runner` / `verifier` | Tests and claim verification |
 | `enterprise-auditor` | Alignment / scorecard → `.local/workflow-artifacts/` |
 | `workflow-drift-guard` | DRIFT-009/010; board on Exit |
-| `integrator-mas-agent` | Agents, skills, MCP, kit expansions |
+| `integrator` | Agents, skills, MCP, kit expansions |
 | `researcher` | Shipped/proven corpus researcher — adaptive Brief; packs under `_research_results/` (opt-in after `research init`); hard-stop on product code · live E2E Issue #74 |
 
 Do **not** publish marketplace releases from this repo against upstream `mas-workflow-kit`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## What you get
 
-- **8 agents:** `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `researcher`, `integrator-mas-agent`, `workflow-drift-guard`, `project-board`
+- **8 agents:** `implementer`, `test-runner`, `verifier`, `enterprise-auditor`, `researcher`, `integrator`, `workflow-drift-guard`, `project-board`
 - **12 canonical skills** + maintainer PR slash skills (`/review-pr` → `/prepare-pr` → `/merge-pr`)
 - **Board Pattern A CLI:** `python3 -m cursor_workflow project …` (claim, handoff, Tier-1 fields, outbox)
 - **PR gates** via `prepare.py` · optional MCP (`workflow_mcp`) · research corpus under `_research_results/` (opt-in)
@@ -240,7 +240,7 @@ Schema path should show `.local/user_settings/board-shell.schema.yaml` when usin
 | Verify a claim | `/verifier` |
 | PR lifecycle | `/review-pr` → `/prepare-pr` → `/merge-pr` |
 | Research a repo | `/researcher` + a GitHub URL |
-| Extend agents/skills/MCP | `/integrator-mas-agent` |
+| Extend agents/skills/MCP | `/integrator` |
 | Architecture audit *(later)* | `/enterprise-auditor` — not day-0 onboarding |
 
 **Every session Entry:** if `project_ssot.enabled` → `python3 -m cursor_workflow project status`; else → `.local/index-and-planning/current/session-pointer.md`.

--- a/agents/integrator.md
+++ b/agents/integrator.md
@@ -1,5 +1,5 @@
 ---
-name: integrator-mas-agent
+name: integrator
 model: auto
 description: Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
@@ -18,7 +18,7 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator` (→ `@owner.github_user/integrator`); atomics `append-notes --agent integrator` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
 **Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
 
@@ -57,7 +57,7 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 ## Loop (one integration slice)
 
 1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator-mas-agent`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
+2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
 3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
 4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
 5. **Verify** — `python -m cursor_workflow contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
@@ -91,7 +91,7 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Tier | Server | Use when |
 |------|--------|----------|
 | Kit | `workflow-kit` | `workflow_list_session_agents`, trackers, governance — prefer over shell |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator-mas-agent` |
+| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator` |
 
 Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -44,7 +44,7 @@ Normalize a **Research Brief** from whatever channel started you — do **not** 
 - `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
 - `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
 - `slug`: repo name lowercased (`grok-build`)
-- `consumers`: implementer, integrator-mas-agent
+- `consumers`: implementer, integrator
 - `rounds_max`: 6
 
 **Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
@@ -110,7 +110,7 @@ Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, 
 | Need | Use |
 |------|-----|
 | Implement features | `implementer` (consume `AGENT_BRIEF.md`) |
-| Integrate kit surfaces | `integrator-mas-agent` |
+| Integrate kit surfaces | `integrator` |
 | PR merge | `pr-workflow/SKILL.md` |
 | Full enterprise audit | `enterprise-auditor` |
 | Verify a claim | `verifier` |

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -35,7 +35,7 @@ const ROSTER_NODES = [
   { id: "verifier" },
   { id: "workflow-drift-guard" },
   { id: "enterprise-auditor" },
-  { id: "integrator-mas-agent" },
+  { id: "integrator" },
   { id: "test-runner" },
 ];
 
@@ -46,9 +46,9 @@ const ROSTER_EDGES = [
   { from: "workflow-drift-guard", to: "project-board" },
   { from: "workflow-drift-guard", to: "implementer" },
   { from: "enterprise-auditor", to: "implementer" },
-  { from: "integrator-mas-agent", to: "implementer" },
-  { from: "integrator-mas-agent", to: "test-runner" },
-  { from: "integrator-mas-agent", to: "enterprise-auditor" },
+  { from: "integrator", to: "implementer" },
+  { from: "integrator", to: "test-runner" },
+  { from: "integrator", to: "enterprise-auditor" },
 ];
 
 const EDGE_LABELS: Record<string, string> = {
@@ -58,9 +58,9 @@ const EDGE_LABELS: Record<string, string> = {
   "workflow-drift-guard→project-board": "dual-write remediation",
   "workflow-drift-guard→implementer": "dual-write remediation",
   "enterprise-auditor→implementer": "Notes + artifact paths",
-  "integrator-mas-agent→implementer": "escalate product src/",
-  "integrator-mas-agent→test-runner": "escalate coverage",
-  "integrator-mas-agent→enterprise-auditor": "escalate architecture",
+  "integrator→implementer": "escalate product src/",
+  "integrator→test-runner": "escalate coverage",
+  "integrator→enterprise-auditor": "escalate architecture",
 };
 
 const PER_AGENT_ENTRY_EXIT = [
@@ -85,9 +85,9 @@ const PER_AGENT_ENTRY_EXIT = [
     "→Done or leave In review; --agent verifier",
   ],
   [
-    "integrator-mas-agent",
+    "integrator",
     "status + claim",
-    "→Done; --agent integrator-mas-agent",
+    "→Done; --agent integrator",
   ],
   [
     "enterprise-auditor",
@@ -243,7 +243,7 @@ const SIDE_FLOW = [
   "enterprise-auditor: audit card → write .local/workflow-artifacts/… → Notes paths → implementer",
   "implementer: make drift-validate → P0/P1 → hand off workflow-drift-guard",
   "workflow-drift-guard: must read board In progress → drift artifacts → drift card done; remediation via Notes/Ready to project-board or implementer",
-  "integrator-mas-agent: integration card → validate → escalate to implementer | test-runner | enterprise-auditor",
+  "integrator: integration card → validate → escalate to implementer | test-runner | enterprise-auditor",
 ];
 
 function CollaborationDag({

--- a/canvases/agent-integrator.canvas.tsx
+++ b/canvases/agent-integrator.canvas.tsx
@@ -25,7 +25,7 @@ type SsotMode = "board" | "fallback";
 
 const VERIFIED = "2026-07-20";
 const SOURCES =
-  ".cursor/agents/integrator-mas-agent.md · integrator-protocol/SKILL.md · board-ssot/SKILL.md";
+  ".cursor/agents/integrator.md · integrator-protocol/SKILL.md · board-ssot/SKILL.md";
 
 const GOALS = [
   "Integrates new agents, skills, MCP, and infrastructure expansions",
@@ -98,7 +98,7 @@ const PATTERNS = [
   ["Tier-1", "claim/set-status→In progress Start date; Size/Estimate per skill table"],
   ["STANDALONE", "Product lives only in mas-workflow-kit-project-ssot"],
   ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
-  ["Attribution", "@owner.github_user/integrator-mas-agent via --agent"],
+  ["Attribution", "@owner.github_user/integrator via --agent"],
 ];
 
 const ARTIFACTS = [
@@ -192,7 +192,7 @@ export default function AgentIntegratorMasAgentCanvas() {
     <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
       <Stack gap={8}>
         <Row gap={10} style={{ alignItems: "center" }}>
-          <H1 style={{ margin: 0 }}>integrator-mas-agent</H1>
+          <H1 style={{ margin: 0 }}>integrator</H1>
           <Pill tone="info" size="sm">
             kit agent
           </Pill>

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -32,7 +32,7 @@ type AgentId =
   | "implementer"
   | "verifier"
   | "test-runner"
-  | "integrator-mas-agent"
+  | "integrator"
   | "enterprise-auditor"
   | "workflow-drift-guard"
   | "researcher"
@@ -60,7 +60,7 @@ const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
     lane: "Delivery",
   },
   {
-    id: "integrator-mas-agent",
+    id: "integrator",
     role: "Wire agents/skills/MCP into the kit",
     lane: "Infrastructure",
   },
@@ -143,19 +143,19 @@ const RELATIONS: {
     when: "Spot-check top audit claims vs preflight + repo paths",
   },
   {
-    from: "integrator-mas-agent",
+    from: "integrator",
     to: "implementer",
     via: "escalate product src/",
     when: "Integration needs product code",
   },
   {
-    from: "integrator-mas-agent",
+    from: "integrator",
     to: "test-runner",
     via: "escalate coverage",
     when: "Integration needs test module work",
   },
   {
-    from: "integrator-mas-agent",
+    from: "integrator",
     to: "enterprise-auditor",
     via: "escalate architecture",
     when: "Integration is architecture-impacting",
@@ -192,7 +192,7 @@ const HAPPY_PATH = [
 const LANES: [string, string][] = [
   ["Coordination", "project-board"],
   ["Delivery", "implementer · test-runner · verifier"],
-  ["Infrastructure", "integrator-mas-agent"],
+  ["Infrastructure", "integrator"],
   ["Quality", "enterprise-auditor · workflow-drift-guard"],
   ["Research (opt-in corpus)", "researcher"],
 ];

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -126,7 +126,7 @@ const ARTIFACTS = [
 
 const PEERS = [
   ["Use instead", "implementer", "Product code changes"],
-  ["Use instead", "integrator-mas-agent", "Kit surface integration"],
+  ["Use instead", "integrator", "Kit surface integration"],
   ["Use instead", "pr-workflow", "Git commit/push/PR"],
   ["Use instead", "enterprise-auditor", "Architecture audits"],
   ["Use instead", "verifier", "Claims vs evidence"],

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -48,7 +48,7 @@ const AGENTS = [
       "Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI",
   },
   {
-    id: "integrator-mas-agent",
+    id: "integrator",
     description:
       "Integrates new agents, skills, MCP, and infrastructure expansions — procedural, evidence-only, Pattern A",
   },
@@ -65,7 +65,7 @@ const ROSTER_NODES = [
   { id: "verifier" },
   { id: "workflow-drift-guard" },
   { id: "enterprise-auditor" },
-  { id: "integrator-mas-agent" },
+  { id: "integrator" },
   { id: "test-runner" },
   { id: "researcher" },
 ];
@@ -77,9 +77,9 @@ const ROSTER_EDGES = [
   { from: "workflow-drift-guard", to: "project-board" },
   { from: "workflow-drift-guard", to: "implementer" },
   { from: "enterprise-auditor", to: "implementer" },
-  { from: "integrator-mas-agent", to: "implementer" },
-  { from: "integrator-mas-agent", to: "test-runner" },
-  { from: "integrator-mas-agent", to: "enterprise-auditor" },
+  { from: "integrator", to: "implementer" },
+  { from: "integrator", to: "test-runner" },
+  { from: "integrator", to: "enterprise-auditor" },
 ];
 
 const EDGE_LABELS: Record<string, string> = {
@@ -89,9 +89,9 @@ const EDGE_LABELS: Record<string, string> = {
   "workflow-drift-guard→project-board": "dual-write remediation",
   "workflow-drift-guard→implementer": "dual-write remediation",
   "enterprise-auditor→implementer": "Notes + artifact paths",
-  "integrator-mas-agent→implementer": "escalate product src/",
-  "integrator-mas-agent→test-runner": "escalate coverage",
-  "integrator-mas-agent→enterprise-auditor": "escalate architecture",
+  "integrator→implementer": "escalate product src/",
+  "integrator→test-runner": "escalate coverage",
+  "integrator→enterprise-auditor": "escalate architecture",
 };
 
 const RESEARCHER_REDIRECTS = [
@@ -274,7 +274,7 @@ export default function AgentRosterCanvas() {
               "Notes with artifact paths for implementer",
             ],
             [
-              "integrator-mas-agent",
+              "integrator",
               "implementer | test-runner | enterprise-auditor",
               "Escalation table on integrator card",
             ],

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -127,7 +127,7 @@ const ARTIFACTS = [
 const PEERS = [
   ["Outbound", "next (generic)", "handoff format per card"],
   ["Inbound", "implementer", "Handoff when tests/coverage needed before merge"],
-  ["Inbound", "integrator-mas-agent", "Escalates coverage work to test-runner"],
+  ["Inbound", "integrator", "Escalates coverage work to test-runner"],
 ];
 
 function DagPanel({

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -119,7 +119,7 @@ const WHO_WRITES: string[][] = [
     "Never silent dual-write Status",
   ],
   [
-    "integrator-mas-agent",
+    "integrator",
     "Integration card → Done",
     "integrate validate evidence in Notes",
     "Escalate product/coverage/arch",

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -88,7 +88,7 @@ const PLAN_ROWS: {
   },
   {
     lane: "Infrastructure",
-    agentNow: "integrator-mas-agent",
+    agentNow: "integrator",
     skillsNow: "PRIMARY integrator-protocol",
     agentNext: "integrator",
     skillsNext: "PRIMARY integrator-protocol",
@@ -292,7 +292,7 @@ const AGENT_SCORES: ScoredName[] = [
     note: "guard vs audit dual metaphor; workflow- redundant",
   },
   {
-    id: "integrator-mas-agent",
+    id: "integrator",
     kind: "agent",
     primaryPair: "integrator-protocol",
     dims: { clarity: 3, brevity: 1, pairing: 2, convention: 1, uniqueness: 3 },
@@ -401,7 +401,7 @@ const SKILL_SCORES: ScoredName[] = [
   {
     id: "integrator-protocol",
     kind: "skill-canonical",
-    primaryPair: "integrator-mas-agent",
+    primaryPair: "integrator",
     dims: { clarity: 3, brevity: 1, pairing: 2, convention: 2, uniqueness: 3 },
     note: "Worst skill pairing; prefer integrator-protocol",
   },
@@ -523,7 +523,7 @@ type RenameRow = {
 const RENAME_ROWS: RenameRow[] = [
   {
     layer: "agents",
-    current: "integrator-mas-agent",
+    current: "integrator",
     proposed: "integrator",
     action: "rename",
     priority: "P0",
@@ -748,8 +748,8 @@ export default function NamingRosterAuditCanvas() {
             tone={below18 > 0 ? "warning" : "success"}
           />
           <Stat
-            value={String(total(AGENT_SCORES.find((a) => a.id === "integrator-mas-agent")!.dims))}
-            label="Worst agent (integrator-mas-agent)"
+            value={String(total(AGENT_SCORES.find((a) => a.id === "integrator")!.dims))}
+            label="Worst agent (integrator)"
             tone="danger"
           />
         </Grid>

--- a/payload/.agents/skills/RESEARCH_WORKFLOW.md
+++ b/payload/.agents/skills/RESEARCH_WORKFLOW.md
@@ -86,6 +86,6 @@ No product repo edits; no git commits for research packs; writes only `_research
 |----------|------|
 | PR merge | `pr-workflow/SKILL.md` |
 | Implementation | `implementer` (reads `AGENT_BRIEF.md`) |
-| Integration | `integrator-mas-agent` |
+| Integration | `integrator` |
 | Audit | `enterprise-auditor` |
 | Agent canvas | `canvases/agent-researcher.canvas.tsx` |

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -54,7 +54,7 @@ Gate order: read `.ai_infra/scripts/pr/prepare.py` only — do not duplicate her
 | `verifier` | Evidence checks; board Done / In review |
 | `enterprise-auditor` | Architecture audits; audit card Status + Notes |
 | `researcher` | **Shipped/proven** adaptive Brief multi-round packs under `_research_results/` (opt-in after init); chat/agent/card intake; research card Done + `AGENT_BRIEF` paths |
-| `integrator-mas-agent` | Add agents/skills/MCP; integration card Status |
+| `integrator` | Add agents/skills/MCP; integration card Status |
 | `workflow-drift-guard` | Drift + DRIFT-009; **reads board**, closes drift card |
 | `project-board` | Board triage + **first-run shell coach** (`board-shell`; ADR-006); not in default PR pipelines |
 

--- a/payload/.ai_infra/docs/decisions/ADR-006-agent-integration-model.md
+++ b/payload/.ai_infra/docs/decisions/ADR-006-agent-integration-model.md
@@ -7,7 +7,7 @@
 
 Consumers extend the MAS Workflow Kit by adding agents, skills, MCP servers, and scripts. Without a clear integration contract, new capability drifts from gates, PR pipelines, registry parity, and procedural discipline.
 
-The **integrator-mas-agent** and **integrator-protocol** skill proceduralize extension; this ADR records the architectural decision.
+The **integrator** and **integrator-protocol** skill proceduralize extension; this ADR records the architectural decision.
 
 ## Decision
 
@@ -46,7 +46,7 @@ Standalone agent for a narrow domain; not in default PR pipelines unless explici
 | Work updates trackers, gates, or manifest | Work is read-only or single-shot |
 | Agent id should appear in PR `Agent/s` | Agent should not appear in PR attribution |
 | Multiple agents coordinate on same slice | Single-purpose tool with no PR coupling,
-| Examples: implementer, integrator-mas-agent, enterprise-auditor | Examples: one-off research, external-only automation |
+| Examples: implementer, integrator, enterprise-auditor | Examples: one-off research, external-only automation |
 
 ## Consequences
 
@@ -57,6 +57,6 @@ Standalone agent for a narrow domain; not in default PR pipelines unless explici
 
 ## References
 
-- `.cursor/agents/integrator-mas-agent.md`
+- `.cursor/agents/integrator.md`
 - `.cursor/skills/integrator-protocol/SKILL.md`
 - `.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md`

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -258,7 +258,7 @@ your-project/
 | Implement | `/implementer` |
 | Tests | `/test-runner` |
 | PR lifecycle | `/review-pr` → `/prepare-pr` → `/merge-pr` |
-| Extend kit | `/integrator-mas-agent` |
+| Extend kit | `/integrator` |
 
 ### Terminal commands (project root)
 
@@ -331,7 +331,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **Architecture audit** *(not day-0)* | `/enterprise-auditor` | — (subagent only; no dedicated MCP tool) | [agent-workflow-procedures.md](agent-workflow-procedures.md) §1 — after board shell |
 | **Operational drift** (plan ↔ tracker) | `/workflow-drift-guard` (optional) | `python3 -m cursor_workflow drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
-| **Add agents / skills / MCP** | `/integrator-mas-agent` + `/integrator-protocol` | `integrate validate` | [mas-infrastructure-integration.md](mas-infrastructure-integration.md) |
+| **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [mas-infrastructure-integration.md](mas-infrastructure-integration.md) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
 | **Upgrade / refresh dashboards** | `/workflow-activate` | `python3 -m cursor_workflow activate --directory .` | [upgrade-kit.md](upgrade-kit.md) |
 | **Check install health** | — | `python3 -m cursor_workflow health` | [gate-matrix.md](gate-matrix.md) |
@@ -348,7 +348,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | `/enterprise-auditor` | `.cursor/agents/enterprise-auditor.md` |
 | `/workflow-drift-guard` | `.cursor/agents/workflow-drift-guard.md` |
 | `/researcher` | `.cursor/agents/researcher.md` — **shipped/proven**; adaptive Brief; public/private GitHub (private needs `gh`/git auth); anti-loop ≤6 rounds; `research init\|fetch\|validate`; corpus opt-in after init |
-| `/integrator-mas-agent` | `.cursor/agents/integrator-mas-agent.md` |
+| `/integrator` | `.cursor/agents/integrator.md` |
 | `/project-board` | `.cursor/agents/project-board.md` + `board-ssot` + first-run `board-shell` |
 | `/board-shell` | `.cursor/skills/board-shell/` — first-run coach (also via `/project-board`) |
 | `/review-pr`, `/prepare-pr`, `/merge-pr` | `.agents/skills/` |

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -99,7 +99,7 @@ High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `i
 |-------|------|
 | project-board | Board triage, Status, Tier-1 fields; hand off to implementer |
 | implementer | Slice implementation |
-| integrator-mas-agent | Extend agents/skills/MCP into kit infrastructure |
+| integrator | Extend agents/skills/MCP into kit infrastructure |
 | test-runner | Module tests and coverage |
 | verifier | Evidence-based verification |
 | enterprise-auditor | Architecture audits (alignment / scorecard artifacts) |

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -75,7 +75,7 @@ Cursor lists **subagents**, **skills**, and **commands** in the same **`/`** men
 | Implement a slice | **`/implementer`** | `.cursor/agents/implementer.md` |
 | Run tests | **`/test-runner`** | `.cursor/agents/test-runner.md` |
 | PR review / prepare / merge | **`/review-pr`**, `/prepare-pr`, `/merge-pr` | `.agents/skills/` (loaded as skills) |
-| Extend agents/skills/MCP | **`/integrator-mas-agent`** + `/integrator-protocol` | agent + skill |
+| Extend agents/skills/MCP | **`/integrator`** + `/integrator-protocol` | agent + skill |
 | Attach a file or doc | **`@`** + pick context | — ([Prompting](https://cursor.com/docs/agent/prompting)) |
 
 Agent may also **auto-delegate** subagents or **auto-apply** skills when the task matches their `description` — explicit **`/name`** is the reliable manual path.
@@ -262,7 +262,7 @@ python3 -m cursor_workflow project status
 4. **`/implementer`** (or `/test-runner`, `/verifier`; `/enterprise-auditor` only for architecture-impacting / pre-merge audits — not day-0 onboarding)
 5. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
 
-**Add your own agent/skill/MCP:** **`/integrator-mas-agent`** + **`/integrator-protocol`**
+**Add your own agent/skill/MCP:** **`/integrator`** + **`/integrator-protocol`**
 
 ---
 
@@ -286,7 +286,7 @@ python3 -m cursor_workflow project status
 | Verify claims | `/verifier` |
 | Architecture audit | `/enterprise-auditor` |
 | Drift check | `/workflow-drift-guard` |
-| Add agents/skills/MCP | `/integrator-mas-agent` |
+| Add agents/skills/MCP | `/integrator` |
 | External MCP setup | `/mcp-connect` |
 | PR workflow | `/review-pr` → `/prepare-pr` → `/merge-pr` |
 | Attach file context | `@` + pick file (not for starting workflows) |

--- a/payload/.ai_infra/docs/operations/mas-infrastructure-integration.md
+++ b/payload/.ai_infra/docs/operations/mas-infrastructure-integration.md
@@ -3,7 +3,7 @@ File: mas-infrastructure-integration.md
 Path: .ai_infra/docs/operations/mas-infrastructure-integration.md
 Role: Consumer-facing procedure for extending MAS Workflow Kit (agents, skills, MCP, scripts).
 Used By:
- - .cursor/agents/integrator-mas-agent.md
+ - .cursor/agents/integrator.md
  - .cursor/skills/integrator-protocol/SKILL.md
 Depends On:
  - .ai_infra/docs/architecture/workflow-architecture.md
@@ -20,7 +20,7 @@ Notes:
 2. **User completes** `.local/user_settings/` (GitHub collaboration + MCP worksheet).
 3. **Integrator agent** extends the system when user adds agents, skills, or tools — without breaking planes or gates.
 
-**Agent:** `.cursor/agents/integrator-mas-agent.md`  
+**Agent:** `.cursor/agents/integrator.md`  
 **Skill:** `.cursor/skills/integrator-protocol/SKILL.md`
 
 ## Three planes (never mix)

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -65,7 +65,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | **implementer** | status + `claim --agent implementer` | `handoff --agent implementer --next … --to in_review` or →Done |
 | **test-runner** | status + slice card | →In review or →Done; `--agent test-runner` |
 | **verifier** | status + related card | →Done or leave In review; `--agent verifier` |
-| **integrator-mas-agent** | status + claim | →Done; `--agent integrator-mas-agent` |
+| **integrator** | status + claim | →Done; `--agent integrator` |
 | **enterprise-auditor** | status + audit card | →In review/Done; `--agent enterprise-auditor` + artifact paths |
 | **workflow-drift-guard** | **Must** status + list In progress | Drift card →Done; `--agent workflow-drift-guard`; remediation via Notes/Ready — no silent tracker edits |
 | **researcher** | status (+ research card) | Research card →Done; `--agent researcher` + `AGENT_BRIEF` / pack paths (adaptive intake from chat/Notes) |

--- a/payload/.ai_infra/install/cursor_workflow/activate_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/activate_cli.py
@@ -116,7 +116,7 @@ def _print_post_activate_hints(root: Path) -> None:
         print("\nOptional:")
         print("  source .venv/bin/activate && python3 -m cursor_workflow integrate validate")
         print("  source .venv/bin/activate && python3 -m cursor_workflow health")
-        print("Add agents/skills later: /integrator-mas-agent (subagent, not a shell command).")
+        print("Add agents/skills later: /integrator (subagent, not a shell command).")
 
 
 def _import_scaffold_refresh() -> object:

--- a/payload/.ai_infra/install/cursor_workflow/research_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/research_cli.py
@@ -38,7 +38,7 @@ _DEFAULT_LENSES = [
     "decisions",
     "patterns",
 ]
-_DEFAULT_CONSUMERS = ["implementer", "integrator-mas-agent"]
+_DEFAULT_CONSUMERS = ["implementer", "integrator"]
 
 
 def _fail(cmd: str, code: int, reason: str) -> int:

--- a/payload/.ai_infra/scripts/integration/validate.py
+++ b/payload/.ai_infra/scripts/integration/validate.py
@@ -83,7 +83,7 @@ def _paths(root: Path) -> dict[str, Path]:
         "manifest": infra / "manifest.yaml",
         "ops_doc": infra / "docs" / "operations" / "mas-infrastructure-integration.md",
         "checklist": infra / "templates" / "agent-integration" / "INTEGRATION-CHECKLIST.md",
-        "plugin_integrator": root / "agents" / "integrator-mas-agent.md",
+        "plugin_integrator": root / "agents" / "integrator.md",
         "plugin_drift_guard": root / "agents" / "workflow-drift-guard.md",
     }
 
@@ -223,9 +223,9 @@ def _check_int009(root: Path, paths: dict[str, Path]) -> CheckResult:
         severity=Severity.P2,
         passed=exists,
         detail=(
-            "agents/integrator-mas-agent.md present"
+            "agents/integrator.md present"
             if exists
-            else "missing agents/integrator-mas-agent.md — run make sync-plugin"
+            else "missing agents/integrator.md — run make sync-plugin"
         ),
     )
 

--- a/payload/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
+++ b/payload/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
@@ -1,7 +1,7 @@
 <!--
 File: INTEGRATION-CHECKLIST.md
 Path: .ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
-Role: Slice checklist for integrator-mas-agent; copy row into work-tracker.md.
+Role: Slice checklist for integrator; copy row into work-tracker.md.
 Used By:
  - .cursor/skills/integrator-protocol/SKILL.md
 Depends On:
@@ -16,7 +16,7 @@ Notes:
 |-------|--------|
 | **Type** | agent \| skill \| mcp \| script \| doc |
 | **Mode** | MAS-integrated \| independent-governed |
-| **Owner** | integrator-mas-agent |
+| **Owner** | integrator |
 | **Status** | planned \| in_progress \| done |
 
 ## Intake

--- a/payload/.ai_infra/templates/agent-integration/README.md
+++ b/payload/.ai_infra/templates/agent-integration/README.md
@@ -1,6 +1,6 @@
 # Agent integration templates
 
-Copy from here when **`integrator-mas-agent`** adds agents or skills.
+Copy from here when **`integrator`** adds agents or skills.
 
 | File | Purpose |
 |------|---------|

--- a/payload/.ai_infra/templates/project-board/card-body-research.md
+++ b/payload/.ai_infra/templates/project-board/card-body-research.md
@@ -21,7 +21,7 @@
 | **question** | (TBD) |
 | **lenses** | architecture, cli, agents, skills, tests, decisions, patterns |
 | **slug** | (TBD) |
-| **consumers** | implementer, integrator-mas-agent |
+| **consumers** | implementer, integrator |
 
 ## Notes
 

--- a/payload/.ai_infra/templates/research-corpus/AGENT_BRIEF.template.md
+++ b/payload/.ai_infra/templates/research-corpus/AGENT_BRIEF.template.md
@@ -4,7 +4,7 @@ Path: .ai_infra/templates/research-corpus/AGENT_BRIEF.template.md
 Role: Short handoff pack for implementer / integrator (and other consumers).
 Used By:
  - researcher exit
- - implementer / integrator-mas-agent Read first
+ - implementer / integrator Read first
 Depends On:
  - CURATED.md
  - INDEX.json

--- a/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -163,14 +163,14 @@ pr_collaboration:
     architecture_impacting:
       agents:
         - enterprise-auditor
-        - integrator-mas-agent
+        - integrator
         - review-pr
         - prepare-pr
         - merge-pr
       requires_alignment_artifacts: true
     infrastructure_integration:
       agents:
-        - integrator-mas-agent
+        - integrator
         - enterprise-auditor
         - review-pr
         - prepare-pr
@@ -179,7 +179,7 @@ pr_collaboration:
         - implementer
         - test-runner
         - verifier
-        - integrator-mas-agent
+        - integrator
         - review-pr
         - prepare-pr
       session_pointer: .local/index-and-planning/current/session-pointer.md

--- a/payload/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
@@ -22,7 +22,7 @@ kit:
     - verifier
     - enterprise-auditor
     - researcher
-    - integrator-mas-agent
+    - integrator
   tools_hint:
     - workflow_run_prepare
     - workflow_get_tracker
@@ -81,7 +81,7 @@ agent_defaults:
   researcher:
     primary_servers: [workflow-kit]
     optional_servers: []
-  integrator-mas-agent:
+  integrator:
     primary_servers: [workflow-kit]
     optional_servers: []
 

--- a/payload/.cursor/agents/integrator.md
+++ b/payload/.cursor/agents/integrator.md
@@ -1,5 +1,5 @@
 ---
-name: integrator-mas-agent
+name: integrator
 model: auto
 description: Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
@@ -18,7 +18,7 @@ You **extend the multi-agent system** without breaking planes, gates, or procedu
 
 **Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator-mas-agent` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator-mas-agent` (→ `@owner.github_user/integrator-mas-agent`); atomics `append-notes --agent integrator-mas-agent` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — do not set Iteration/End date/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator` (→ `@owner.github_user/integrator`); atomics `append-notes --agent integrator` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
 
 **Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
 
@@ -57,7 +57,7 @@ Independent agents **never** skip governance scanners, file headers, or Pattern 
 ## Loop (one integration slice)
 
 1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator-mas-agent`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
+2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
 3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
 4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
 5. **Verify** — `python -m cursor_workflow contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
@@ -91,7 +91,7 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Tier | Server | Use when |
 |------|--------|----------|
 | Kit | `workflow-kit` | `workflow_list_session_agents`, trackers, governance — prefer over shell |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator-mas-agent` |
+| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator` |
 
 Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -44,7 +44,7 @@ Normalize a **Research Brief** from whatever channel started you — do **not** 
 - `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
 - `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
 - `slug`: repo name lowercased (`grok-build`)
-- `consumers`: implementer, integrator-mas-agent
+- `consumers`: implementer, integrator
 - `rounds_max`: 6
 
 **Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
@@ -110,7 +110,7 @@ Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, 
 | Need | Use |
 |------|-----|
 | Implement features | `implementer` (consume `AGENT_BRIEF.md`) |
-| Integrate kit surfaces | `integrator-mas-agent` |
+| Integrate kit surfaces | `integrator` |
 | PR merge | `pr-workflow/SKILL.md` |
 | Full enterprise audit | `enterprise-auditor` |
 | Verify a claim | `verifier` |

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -209,7 +209,7 @@ Rules:
 | **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
 | **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
 | **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
-| **integrator-mas-agent** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
+| **integrator** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
 | **enterprise-auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
 | **workflow-drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to project-board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
 | **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |

--- a/payload/.cursor/skills/integrator-protocol/SKILL.md
+++ b/payload/.cursor/skills/integrator-protocol/SKILL.md
@@ -18,7 +18,7 @@ Integrate **new agents, skills, MCP servers, scripts, or docs** into the kit so 
 - User expands **manifest / install contract / plugin payload**
 - User asks to merge a **standalone agent** into the MAS pipeline (or keep independent but governed)
 
-**Agent card:** `.cursor/agents/integrator-mas-agent.md`
+**Agent card:** `.cursor/agents/integrator.md`
 
 ## Evidence contract
 
@@ -103,7 +103,7 @@ Copy and edit from **`.ai_infra/templates/agent-integration/`**:
 | 1 | Agent + skill with explicit **boundaries** (what it must not do) |
 | 2 | Registry: optional MCP servers scoped to that agent id only |
 | 3 | **Do not** add to core PR pipelines unless it owns a maintainer phase |
-| 4 | Document handoff to `implementer` / `integrator-mas-agent` when work crosses into kit infrastructure |
+| 4 | Document handoff to `implementer` / `integrator` when work crosses into kit infrastructure |
 
 ### C. External MCP server
 

--- a/payload/.cursor/skills/research-corpus/SKILL.md
+++ b/payload/.cursor/skills/research-corpus/SKILL.md
@@ -48,7 +48,7 @@ If only a link/path is given:
 - **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
 - **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
 - **slug:** repo (or directory) name, lowercase with hyphens
-- **consumers:** implementer, integrator-mas-agent (plus the requesting agent if known)
+- **consumers:** implementer, integrator (plus the requesting agent if known)
 - **rounds_max:** 6
 
 Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
@@ -71,7 +71,7 @@ source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
 question: <what MAS / requesting agent needs>
 lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
 rounds_max: 6
-consumers: [implementer, integrator-mas-agent, …]
+consumers: [implementer, integrator, …]
 slug: <derived or explicit>
 ```
 

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -116,11 +116,11 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 **Dashboards (optional):** from project root run `source .venv/bin/activate && python3 -m http.server 8000`, then open
 http://localhost:8000/.local/agents-control-center/dashboards/index.html (not `file://`).
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator-mas-agent`**.
+Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 
-Invoke subagent **`/integrator-mas-agent`** with skill **`/integrator-protocol`** — not shell commands ([Subagents](https://cursor.com/docs/subagents), [Skills](https://cursor.com/docs/skills)).
+Invoke subagent **`/integrator`** with skill **`/integrator-protocol`** — not shell commands ([Subagents](https://cursor.com/docs/subagents), [Skills](https://cursor.com/docs/skills)).
 
 ## Success
 

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -209,7 +209,7 @@ Rules:
 | **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
 | **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
 | **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
-| **integrator-mas-agent** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
+| **integrator** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
 | **enterprise-auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
 | **workflow-drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to project-board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
 | **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |

--- a/skills/integrator-protocol/SKILL.md
+++ b/skills/integrator-protocol/SKILL.md
@@ -18,7 +18,7 @@ Integrate **new agents, skills, MCP servers, scripts, or docs** into the kit so 
 - User expands **manifest / install contract / plugin payload**
 - User asks to merge a **standalone agent** into the MAS pipeline (or keep independent but governed)
 
-**Agent card:** `.cursor/agents/integrator-mas-agent.md`
+**Agent card:** `.cursor/agents/integrator.md`
 
 ## Evidence contract
 
@@ -103,7 +103,7 @@ Copy and edit from **`.ai_infra/templates/agent-integration/`**:
 | 1 | Agent + skill with explicit **boundaries** (what it must not do) |
 | 2 | Registry: optional MCP servers scoped to that agent id only |
 | 3 | **Do not** add to core PR pipelines unless it owns a maintainer phase |
-| 4 | Document handoff to `implementer` / `integrator-mas-agent` when work crosses into kit infrastructure |
+| 4 | Document handoff to `implementer` / `integrator` when work crosses into kit infrastructure |
 
 ### C. External MCP server
 

--- a/skills/research-corpus/SKILL.md
+++ b/skills/research-corpus/SKILL.md
@@ -48,7 +48,7 @@ If only a link/path is given:
 - **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
 - **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
 - **slug:** repo (or directory) name, lowercase with hyphens
-- **consumers:** implementer, integrator-mas-agent (plus the requesting agent if known)
+- **consumers:** implementer, integrator (plus the requesting agent if known)
 - **rounds_max:** 6
 
 Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
@@ -71,7 +71,7 @@ source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
 question: <what MAS / requesting agent needs>
 lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
 rounds_max: 6
-consumers: [implementer, integrator-mas-agent, …]
+consumers: [implementer, integrator, …]
 slug: <derived or explicit>
 ```
 

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -116,11 +116,11 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 **Dashboards (optional):** from project root run `source .venv/bin/activate && python3 -m http.server 8000`, then open
 http://localhost:8000/.local/agents-control-center/dashboards/index.html (not `file://`).
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator-mas-agent`**.
+Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 
-Invoke subagent **`/integrator-mas-agent`** with skill **`/integrator-protocol`** — not shell commands ([Subagents](https://cursor.com/docs/subagents), [Skills](https://cursor.com/docs/skills)).
+Invoke subagent **`/integrator`** with skill **`/integrator-protocol`** — not shell commands ([Subagents](https://cursor.com/docs/subagents), [Skills](https://cursor.com/docs/skills)).
 
 ## Success
 


### PR DESCRIPTION
## Summary
- Renames `integrator-mas-agent` → `integrator` (card, canvas, INT-009, MCP/pipelines).
- Replaces closed #142 after stack base cleanup.

## Test plan
- [x] Local tip gates previously green