### PR TITLE
fix: pin mcp&lt;2 so CI FastMCP import works

### DIFF
--- a/.ai_infra/docs/operations/workflow-complete.md
+++ b/.ai_infra/docs/operations/workflow-complete.md
@@ -98,6 +98,18 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 
 Canonical detail: **`.local/index-and-planning/current/plan.md`** / board card body; skill `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
 
+## Stacked PRs (feature → feature → main)
+
+When landing a stack of dependent PRs:
+
+1. Merge the **bottom** PR into `main` first.
+2. **Retarget** the next PR’s base to `main` (or merge `main` into its head and push) **before** deleting the parent remote branch.
+3. Only then run `finalize.py` / remote branch delete for the parent.
+4. Prefer **not** `--skip-gates` unless the **same SHA** just ran `resolve_gates()`; prefer **not** `--skip-board-sync` when `board-bootstrap --check` is green (else Notes + outbox later).
+5. Pattern A artifacts (`review.md` / `prep.md` / `merge.md`) are tip-of-session files under `.local/workflow-artifacts/pr/` — they overwrite per PR; optional dated copies under `pr/archive/` only if you need an audit trail.
+
+Never `finalize` a stacked parent head while a child PR still lists that branch as its base.
+
 ## File retention policy (explicit)
 
 - **Do not delete** workflow sources: `.agents/skills/**`, versioned `.cursor/rules`, `.cursor/agents`, `.cursor/skills` (see `.gitignore` exceptions), tracked `.ai_infra/scripts/pr/**`, or this checklist.

--- a/.github/workflows/kit-quality.yml
+++ b/.github/workflows/kit-quality.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m venv .venv
+          .venv/bin/pip install -q -U pip
           .venv/bin/pip install -q -e ".[dev,mcp]"
+          .venv/bin/python -c "from mcp.server.fastmcp import FastMCP; print('mcp FastMCP OK', FastMCP.__module__)"
 
       - name: Seed CI workspace
         run: .venv/bin/python .ai_infra/scripts/ci/seed_kit_workspace.py --directory .

--- a/payload/.ai_infra/docs/operations/workflow-complete.md
+++ b/payload/.ai_infra/docs/operations/workflow-complete.md
@@ -98,6 +98,18 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 
 Canonical detail: **`.local/index-and-planning/current/plan.md`** / board card body; skill `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
 
+## Stacked PRs (feature → feature → main)
+
+When landing a stack of dependent PRs:
+
+1. Merge the **bottom** PR into `main` first.
+2. **Retarget** the next PR’s base to `main` (or merge `main` into its head and push) **before** deleting the parent remote branch.
+3. Only then run `finalize.py` / remote branch delete for the parent.
+4. Prefer **not** `--skip-gates` unless the **same SHA** just ran `resolve_gates()`; prefer **not** `--skip-board-sync` when `board-bootstrap --check` is green (else Notes + outbox later).
+5. Pattern A artifacts (`review.md` / `prep.md` / `merge.md`) are tip-of-session files under `.local/workflow-artifacts/pr/` — they overwrite per PR; optional dated copies under `pr/archive/` only if you need an audit trail.
+
+Never `finalize` a stacked parent head while a child PR still lists that branch as its base.
+
 ## File retention policy (explicit)
 
 - **Do not delete** workflow sources: `.agents/skills/**`, versioned `.cursor/rules`, `.cursor/agents`, `.cursor/skills` (see `.gitignore` exceptions), tracked `.ai_infra/scripts/pr/**`, or this checklist.

--- a/payload/requirements-mcp.txt
+++ b/payload/requirements-mcp.txt
@@ -1,2 +1,3 @@
-# workflow_mcp server — FastMCP is mcp.server.fastmcp (official MCP SDK)
-mcp>=1.2
+# workflow_mcp server — FastMCP is mcp.server.fastmcp (official MCP SDK 1.x).
+# Cap <2: mcp 2.0 removed that import path; migrate FastMCP before lifting the pin.
+mcp>=1.2,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.2"]
+# Pin <2: mcp 2.0 removed mcp.server.fastmcp (workflow_mcp still uses FastMCP 1.x API).
+mcp = ["mcp>=1.2,<2"]
 dev = ["pytest>=8.0", "pytest-cov>=4.0", "pyright>=1.1"]
 
 [project.scripts]

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,2 +1,3 @@
-# workflow_mcp server — FastMCP is mcp.server.fastmcp (official MCP SDK)
-mcp>=1.2
+# workflow_mcp server — FastMCP is mcp.server.fastmcp (official MCP SDK 1.x).
+# Cap <2: mcp 2.0 removed that import path; migrate FastMCP before lifting the pin.
+mcp>=1.2,<2


### PR DESCRIPTION
## Summary
- Pin `mcp>=1.2,<2` in `pyproject.toml` / `requirements-mcp.txt` — MCP SDK 2.0 removed `mcp.server.fastmcp`, which broke Kit Quality on fresh CI installs.
- Add CI smoke import after `pip install -e ".[dev,mcp]"`.
- Document stacked-PR finalize order in `workflow-complete.md` (gap-closure process lesson).

## Test plan
- [x] Clean venv: `pip install -e ".[dev,mcp]"` → `from mcp.server.fastmcp import FastMCP` OK (1.29.0)
- [ ] Kit Quality green on this PR
- [ ] prepare.py gates locally