### PR TITLE
Document Cursor Task subagent_type after agent renames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,17 @@ Required in every commit message (see **`.cursor/rules/commit-trailer-format.mdc
 
 Do not duplicate skill folder names across `.cursor/skills/` and `.agents/skills/`.
 
+### Cursor Task `subagent_type` (human sync)
+
+After agent renames, update the IDE/plugin Task registry so `subagent_type` matches **on-disk** agent ids:
+
+| Use | Retire (legacy) |
+|-----|-----------------|
+| `integrator`, `auditor`, `drift-guard`, `board` | `integrator-mas-agent`, `enterprise-auditor`, `workflow-drift-guard`, `project-board` |
+| Keep: `implementer`, `test-runner`, `researcher`, `verifier` | — |
+
+In-repo cards under `.cursor/agents/<id>.md` are the source of truth; Task enum is Cursor-side and is not updated by git merge.
+
 ## Branching
 
 Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. After merge: sync `main` with `origin/main`, remove local + remote feature branch.


### PR DESCRIPTION
## Summary
- Document Task `subagent_type` Use/Retire table in `AGENTS.md` after B-safe agent renames.
- Completes gap-closure Phase 4 in-repo checklist (spawn of `board` already verified in session).

## Test plan
- [x] Confirm new agent ids listed: `integrator`, `auditor`, `drift-guard`, `board`
- [x] Confirm legacy ids listed as retire targets
- [ ] Skim AGENTS.md section in rendered preview