### PR TITLE
Prefix agent descriptions with name + MAS-SSOT-KIT

### DIFF
--- a/.cursor/agents/auditor.md
+++ b/.cursor/agents/auditor.md
@@ -1,7 +1,7 @@
 ---
 name: auditor
 model: auto
-description: Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
+description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
 ---
 
 # Enterprise auditor

--- a/.cursor/agents/board.md
+++ b/.cursor/agents/board.md
@@ -1,7 +1,7 @@
 ---
 name: board
 model: auto
-description: Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
+description: board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
 ---
 
 # Project board

--- a/.cursor/agents/drift-guard.md
+++ b/.cursor/agents/drift-guard.md
@@ -1,7 +1,7 @@
 ---
 name: drift-guard
 model: auto
-description: Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
+description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
 ---
 
 # Workflow drift guard

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 model: auto
-description: Disciplined implementation slices with trackers and Pattern A gates.
+description: implementer MAS-SSOT-KIT — Disciplined implementation slices with trackers and Pattern A gates.
 ---
 
 # Implementer

--- a/.cursor/agents/integrator.md
+++ b/.cursor/agents/integrator.md
@@ -1,7 +1,7 @@
 ---
 name: integrator
 model: auto
-description: Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
+description: integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
 
 # MAS infrastructure integrator

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 model: auto
-description: Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
+description: researcher MAS-SSOT-KIT — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
 # Researcher (shipped; opt-in corpus)

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-runner
 model: auto
-description: Module-focused tests, regressions, coverage.
+description: test-runner MAS-SSOT-KIT — Module-focused tests, regressions, coverage.
 ---
 
 # Test runner

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 model: auto
-description: Claims vs evidence; minimal high-signal checks.
+description: verifier MAS-SSOT-KIT — Claims vs evidence; minimal high-signal checks.
 ---
 
 # Verifier

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -1,7 +1,7 @@
 ---
 name: auditor
 model: auto
-description: Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
+description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
 ---
 
 # Enterprise auditor

--- a/agents/board.md
+++ b/agents/board.md
@@ -1,7 +1,7 @@
 ---
 name: board
 model: auto
-description: Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
+description: board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
 ---
 
 # Project board

--- a/agents/drift-guard.md
+++ b/agents/drift-guard.md
@@ -1,7 +1,7 @@
 ---
 name: drift-guard
 model: auto
-description: Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
+description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
 ---
 
 # Workflow drift guard

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 model: auto
-description: Disciplined implementation slices with trackers and Pattern A gates.
+description: implementer MAS-SSOT-KIT — Disciplined implementation slices with trackers and Pattern A gates.
 ---
 
 # Implementer

--- a/agents/integrator.md
+++ b/agents/integrator.md
@@ -1,7 +1,7 @@
 ---
 name: integrator
 model: auto
-description: Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
+description: integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
 
 # MAS infrastructure integrator

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 model: auto
-description: Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
+description: researcher MAS-SSOT-KIT — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
 # Researcher (shipped; opt-in corpus)

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-runner
 model: auto
-description: Module-focused tests, regressions, coverage.
+description: test-runner MAS-SSOT-KIT — Module-focused tests, regressions, coverage.
 ---
 
 # Test runner

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 model: auto
-description: Claims vs evidence; minimal high-signal checks.
+description: verifier MAS-SSOT-KIT — Claims vs evidence; minimal high-signal checks.
 ---
 
 # Verifier

--- a/payload/.cursor/agents/auditor.md
+++ b/payload/.cursor/agents/auditor.md
@@ -1,7 +1,7 @@
 ---
 name: auditor
 model: auto
-description: Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
+description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
 ---
 
 # Enterprise auditor

--- a/payload/.cursor/agents/board.md
+++ b/payload/.cursor/agents/board.md
@@ -1,7 +1,7 @@
 ---
 name: board
 model: auto
-description: Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
+description: board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
 ---
 
 # Project board

--- a/payload/.cursor/agents/drift-guard.md
+++ b/payload/.cursor/agents/drift-guard.md
@@ -1,7 +1,7 @@
 ---
 name: drift-guard
 model: auto
-description: Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
+description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
 ---
 
 # Workflow drift guard

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 model: auto
-description: Disciplined implementation slices with trackers and Pattern A gates.
+description: implementer MAS-SSOT-KIT — Disciplined implementation slices with trackers and Pattern A gates.
 ---
 
 # Implementer

--- a/payload/.cursor/agents/integrator.md
+++ b/payload/.cursor/agents/integrator.md
@@ -1,7 +1,7 @@
 ---
 name: integrator
 model: auto
-description: Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
+description: integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
 
 # MAS infrastructure integrator

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 model: auto
-description: Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
+description: researcher MAS-SSOT-KIT — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
 # Researcher (shipped; opt-in corpus)

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-runner
 model: auto
-description: Module-focused tests, regressions, coverage.
+description: test-runner MAS-SSOT-KIT — Module-focused tests, regressions, coverage.
 ---
 
 # Test runner

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 model: auto
-description: Claims vs evidence; minimal high-signal checks.
+description: verifier MAS-SSOT-KIT — Claims vs evidence; minimal high-signal checks.
 ---
 
 # Verifier


### PR DESCRIPTION
## Summary
- Prefix all 8 agent YAML `description` fields with `{name} MAS-SSOT-KIT — …` so Task/agent pickers identify kit agents at a glance.
- Keep `.cursor/agents/`, `agents/`, and `payload/.cursor/agents/` mirrors in sync (24 files).

## Test plan
- [x] `python3 -m cursor_workflow integrate validate` (pre-commit session)
- [x] `python3 .ai_infra/scripts/architecture/check_governance_consistency.py`
- [ ] Confirm Kit Quality green on this PR
- [ ] Spot-check one agent card description in GitHub diff