### PR TITLE
Align docs and canvases with post-rename reality

### DIFF
--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -202,7 +202,9 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Manifest:** `.cursor-plugin/plugin.json` — `author`, `homepage`, `repository`, `logo` aligned with the table above.
 
-**Listing copy review (2026-07-07, archival):** Verified `plugin.json` `description`, the Description row above, and README consumer sections against `IMPLEMENTATION-STATUS.md` on `main` at that date — counts superseded by refreshes below; feature counts (8 agents, 11 skills, 5 PR skills, 7 rules) unchanged.
+**Listing copy review (2026-07-07, archival):** Verified `plugin.json` `description`, the Description row above, and README consumer sections against `IMPLEMENTATION-STATUS.md` on `main` at that date — counts superseded by refreshes below; feature counts at that date (8 agents, **11** skills, 5 PR skills, 7 rules) — **superseded** (skills are **12** since board-shell).
+
+**Listing copy refresh (2026-08-03 naming + docs/canvas reality):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` on `main` @ `9cd09a7` — **1190** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
 
 **Listing copy refresh (2026-07-18 WORKSPACE-CLEAN, archival):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree at that date — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Superseded by 2026-07-19 refreshes below.
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -331,7 +331,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **Architecture audit** *(not day-0)* | `/auditor` | — (subagent only; no dedicated MCP tool) | [agent-workflow-procedures.md](agent-workflow-procedures.md) §1 — after board shell |
 | **Operational drift** (plan ↔ tracker) | `/drift-guard` (optional) | `python3 -m cursor_workflow drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
-| **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [mas-infrastructure-integration.md](mas-infrastructure-integration.md) |
+| **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [integrator-protocol skill](../../.cursor/skills/integrator-protocol/SKILL.md) · [mas-infrastructure-integration.md](mas-infrastructure-integration.md) (ops filename kept) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
 | **Upgrade / refresh dashboards** | `/workflow-activate` | `python3 -m cursor_workflow activate --directory .` | [upgrade-kit.md](upgrade-kit.md) |
 | **Check install health** | — | `python3 -m cursor_workflow health` | [gate-matrix.md](gate-matrix.md) |

--- a/canvases/agent-auditor.canvas.tsx
+++ b/canvases/agent-auditor.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/auditor.md · auditor-protocol/SKILL.md · board-ssot/SKILL.md";
 

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type FlowMode = "slice" | "side";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   "project-board-collaboration.md · board-ssot/SKILL.md · board-shell/SKILL.md · .cursor/agents/*.md · agent-roster edges";
 

--- a/canvases/agent-board.canvas.tsx
+++ b/canvases/agent-board.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/board.md · board-ssot/SKILL.md · board-shell/SKILL.md · ADR-006";
 

--- a/canvases/agent-drift-guard.canvas.tsx
+++ b/canvases/agent-drift-guard.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/drift-guard.md · drift-audit/SKILL.md · board-ssot/SKILL.md";
 

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/implementer.md · implementer-loop/SKILL.md · board-shell · board-ssot § Continuation";
 

--- a/canvases/agent-integrator.canvas.tsx
+++ b/canvases/agent-integrator.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/integrator.md · integrator-protocol/SKILL.md · board-ssot/SKILL.md";
 
@@ -69,7 +69,7 @@ const FALLBACK_EDGES = [
 
 const BOARD_LABELS: Record<string, string> = {
   status: "project status",
-  skill: "mas-infrastructure",
+  skill: "integrator-protocol",
   claim: "claim / create card",
   intake: "Intake → Plan",
   wire: "templates → wire",

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -20,7 +20,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/*.md PEERS · audit-orchestration Phase 3 · board-ssot § Continuation · agent-roster edges";
 

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/researcher.md · research-corpus/SKILL.md · research_cli.py · .agents/skills/RESEARCH_WORKFLOW.md · live pack flexiai-toolsmith + verifier";
 

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -16,46 +16,47 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES = "Aggregated from .cursor/agents/*.md";
 
 const AGENTS = [
   {
     id: "implementer",
-    description: "Disciplined implementation slices with trackers and Pattern A gates",
+    description:
+      "implementer MAS-SSOT-KIT — Disciplined implementation slices with trackers and Pattern A gates.",
   },
   {
     id: "verifier",
-    description: "Claims vs evidence; minimal high-signal checks",
+    description: "verifier MAS-SSOT-KIT — Claims vs evidence; minimal high-signal checks.",
   },
   {
     id: "test-runner",
-    description: "Module-focused tests, regressions, coverage",
+    description: "test-runner MAS-SSOT-KIT — Module-focused tests, regressions, coverage.",
   },
   {
     id: "drift-guard",
     description:
-      "Operational workflow drift detection; plan/tracker/session coherence and handoff parity",
+      "drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.",
   },
   {
     id: "auditor",
     description:
-      "Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents",
+      "auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.",
   },
   {
     id: "board",
     description:
-      "Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI",
+      "board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.",
   },
   {
     id: "integrator",
     description:
-      "Integrates new agents, skills, MCP, and infrastructure expansions — procedural, evidence-only, Pattern A",
+      "integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.",
   },
   {
     id: "researcher",
     description:
-      "Shipped/proven corpus researcher — adaptive Brief; packs under _research_results/ (opt-in after init); hard-stop on product code",
+      "researcher MAS-SSOT-KIT — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.",
   },
 ];
 

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   ".cursor/agents/test-runner.md · test-coverage/SKILL.md · board-ssot/SKILL.md";
 

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES = ".cursor/agents/verifier.md · board-ssot/SKILL.md § Continuation";
 
 const GOALS = [

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -26,7 +26,7 @@ import {
  * Not an agent-* canvas — excluded from DOC-008 roster scan (same as board-ssot-vs-kit).
  */
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 const SOURCES =
   "ADR-008 · board-ssot/SKILL.md · project-board-collaboration.md · agent cards · HYGIENE post-COV100";
 

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -26,7 +26,7 @@ import {
 
 type Mode = "classic" | "shipped" | "compare";
 
-const VERIFIED = "2026-07-20";
+const VERIFIED = "2026-08-03";
 
 const CLASSIC_NODES = [
   { id: "agent" },
@@ -143,7 +143,7 @@ const FOLLOWUP_SLICES = [
     items: [
       "Issue body, GraphQL errors, merge Notes warn",
       "set_item_status PVTI-only paths; outbox queue/flush",
-      "1168 tests collected; COV-100 7089 stmts / 100%; drift validate green",
+      "1190 tests collected; COV-100 7089 stmts / 100%; drift validate green",
     ],
   },
   {
@@ -332,7 +332,7 @@ export default function BoardSsotVsKitCanvas() {
         <Text tone="secondary">
           Before/after comparison for mas-workflow-kit-project-ssot as of {VERIFIED}.
           PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift residuals, EA-001/004,
-          and expanded tests (1168 collected) are shipped on main.
+          and expanded tests (1190 collected) are shipped on main.
         </Text>
       </Stack>
 
@@ -628,7 +628,7 @@ export default function BoardSsotVsKitCanvas() {
               <Text size="small">ADR-008 + project-ssot-precedence overlay</Text>
               <Text size="small">A→B→C merged (PR #2); FIX-NOTES-DI on main (PR #3)</Text>
               <Text size="small">
-                1168 tests collected; COV-100 7089 stmts / 100%; DRIFT validate
+                1190 tests collected; COV-100 7089 stmts / 100%; DRIFT validate
                 P0=0 P1=0 P2=0
               </Text>
               <Text size="small">STANDALONE decided — this repo is the product</Text>
@@ -670,7 +670,7 @@ export default function BoardSsotVsKitCanvas() {
 
       <Text size="small" tone="tertiary">
         Source: HANDOFF §1 · ADR-008 · STANDALONE 2026-07-18 · PR #2/#3 merged ·
-        drift validate green · verified {VERIFIED} · 1168 tests · COV-100 7089 stmts
+        drift validate green · verified {VERIFIED} · 1190 tests · COV-100 7089 stmts
       </Text>
     </Stack>
   );

--- a/canvases/github-api-safety.canvas.tsx
+++ b/canvases/github-api-safety.canvas.tsx
@@ -19,7 +19,7 @@ import {
 /**
  * Inventory of GitHub API hammering / safety protections in MAS Workflow Kit.
  * Source: project_outbox.py, project_cli/handlers, agent Board-rights, ADR-008.
- * Verified: 2026-07-20 — post PR #83 (G1–G5) + #85 (soft-align docs/schema)
+ * Verified: 2026-08-03 — post rename ship + docs/canvas reality align; API safety content unchanged (agent ids: auditor/board/drift-guard/integrator)
  */
 
 const FIXED = [

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -11,7 +11,7 @@
  *  - .agents/skills (maintainer SKILL.md folders)
  * Notes:
  *  - Concept hub (not agent-*). Excluded from DOC-008 roster scan like board-ssot-vs-kit.
- *  - Advisory only until human confirms rename appetite; no renames applied by this canvas.
+ *  - B-safe rename SHIPPED 2026-08-03 (#140, #146–#149); plan table is historical → keep/keep.
  *  - Avoid "star-slash" globs in this block comment — they terminate the comment early.
  */
 
@@ -56,8 +56,8 @@ const PLAN_ROWS: {
     skillsNow: "PRIMARY board-ssot · ALSO board-shell",
     agentNext: "board",
     skillsNext: "PRIMARY board-ssot · ALSO board-shell",
-    agentChange: "rename",
-    skillChange: "rename",
+    agentChange: "keep",
+    skillChange: "keep",
   },
   {
     lane: "Delivery",
@@ -66,7 +66,7 @@ const PLAN_ROWS: {
     agentNext: "implementer",
     skillsNext: "PRIMARY implementer-loop",
     agentChange: "keep",
-    skillChange: "rename",
+    skillChange: "keep",
   },
   {
     lane: "Delivery",
@@ -75,7 +75,7 @@ const PLAN_ROWS: {
     agentNext: "test-runner",
     skillsNext: "PRIMARY test-coverage",
     agentChange: "keep",
-    skillChange: "rename",
+    skillChange: "keep",
   },
   {
     lane: "Delivery",
@@ -92,8 +92,8 @@ const PLAN_ROWS: {
     skillsNow: "PRIMARY integrator-protocol",
     agentNext: "integrator",
     skillsNext: "PRIMARY integrator-protocol",
-    agentChange: "rename",
-    skillChange: "rename",
+    agentChange: "keep",
+    skillChange: "keep",
   },
   {
     lane: "Quality",
@@ -103,8 +103,8 @@ const PLAN_ROWS: {
     agentNext: "auditor",
     skillsNext:
       "PRIMARY auditor-protocol · ALSO audit-orchestration, audit-module-map (keep)",
-    agentChange: "rename",
-    skillChange: "rename",
+    agentChange: "keep",
+    skillChange: "keep",
   },
   {
     lane: "Quality",
@@ -112,8 +112,8 @@ const PLAN_ROWS: {
     skillsNow: "PRIMARY drift-audit",
     agentNext: "drift-guard",
     skillsNext: "PRIMARY drift-audit",
-    agentChange: "rename",
-    skillChange: "rename",
+    agentChange: "keep",
+    skillChange: "keep",
   },
   {
     lane: "Research",
@@ -122,13 +122,13 @@ const PLAN_ROWS: {
     agentNext: "researcher",
     skillsNext: "PRIMARY research-corpus",
     agentChange: "keep",
-    skillChange: "rename",
+    skillChange: "keep",
   },
 ];
 
 const SHARED_SKILLS = [
   [
-    "board-ssot → board-ssot",
+    "board-ssot (shipped)",
     "Shared by ALL agents for board Entry/Exit — not one agent's exclusive skill",
   ],
   [
@@ -136,7 +136,7 @@ const SHARED_SKILLS = [
     "Skill-only — consumer install; no agent twin",
   ],
   [
-    "mcp-connect → mcp-connect (optional)",
+    "mcp-connect (shipped)",
     "Skill-only — MCP wiring",
   ],
   [
@@ -144,8 +144,8 @@ const SHARED_SKILLS = [
     "Maintainer slash namespace (.agents/skills) — not Task agents",
   ],
   [
-    "audit-alignment (retire later)",
-    "DEPRECATED stub → points at auditor",
+    "audit-alignment (stub)",
+    "DEPRECATED stub → points at auditor + auditor-protocol",
   ],
 ];
 type PillTone = "neutral" | "added" | "deleted" | "renamed" | "success" | "warning" | "info";
@@ -768,17 +768,17 @@ export default function NamingRosterAuditCanvas() {
 
       {view === "plan" ? (
         <Stack gap={16}>
-          <Callout tone="warning" title="Plan only — no renames applied yet">
-            Current skills are confirmed from each agent card (.cursor/agents/*.md).
-            Almost every agent ALSO loads board-ssot for board Entry/Exit — that is
-            a shared skill, not their primary protocol. Suggested names are a design target;
-            auditor advised deferring agent-id renames in v1 due to Notes/DOC/Task blast radius.
+          <Callout tone="success" title="B-safe rename SHIPPED — 2026-08-03">
+            Agent/skill renames landed via #140 + #146–#149 (tip before CI: 333321d;
+            descriptions later prefixed MAS-SSOT-KIT in #153). Plan rows below are
+            keep/keep historical record — filesystem roster is current truth
+            (8 agents / 12 skills / 7 rules). Shared board-ssot remains Entry/Exit for all agents.
           </Callout>
 
           <Stack gap={8}>
-            <H2>Agent ↔ skill plan (4 columns)</H2>
+            <H2>Agent ↔ skill roster (shipped)</H2>
             <Text tone="secondary" size="small">
-              Column meaning: now agent · now skills · suggested agent · suggested skills
+              Column meaning: agent · skills · same (post-rename) · change = keep
             </Text>
             <Table
               headers={[
@@ -981,9 +981,9 @@ export default function NamingRosterAuditCanvas() {
             ])}
             striped
           />
-          <Callout tone="warning" title="Projected scores after rename">
-            integrator 23 · auditor 22 · drift-guard 21 · board 21 · implementer pair ~23
-            once implementer-loop ships — all above admission bar.
+          <Callout tone="success" title="Post-rename scores (shipped roster)">
+            Current ids score at or above admission bar: integrator / auditor /
+            drift-guard / board / implementer↔implementer-loop — rename debt closed.
           </Callout>
         </Stack>
       ) : null}

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -331,7 +331,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **Architecture audit** *(not day-0)* | `/auditor` | — (subagent only; no dedicated MCP tool) | [agent-workflow-procedures.md](agent-workflow-procedures.md) §1 — after board shell |
 | **Operational drift** (plan ↔ tracker) | `/drift-guard` (optional) | `python3 -m cursor_workflow drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
-| **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [mas-infrastructure-integration.md](mas-infrastructure-integration.md) |
+| **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [integrator-protocol skill](../../.cursor/skills/integrator-protocol/SKILL.md) · [mas-infrastructure-integration.md](mas-infrastructure-integration.md) (ops filename kept) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
 | **Upgrade / refresh dashboards** | `/workflow-activate` | `python3 -m cursor_workflow activate --directory .` | [upgrade-kit.md](upgrade-kit.md) |
 | **Check install health** | — | `python3 -m cursor_workflow health` | [gate-matrix.md](gate-matrix.md) |


### PR DESCRIPTION
## Summary
- Apply auditor docs/canvas alignment findings (AA-CANVAS-001..006, AA-DOCS-001/002).
- Sync agent roster descriptions with `MAS-SSOT-KIT` prefixes; mark naming hub SHIPPED; fix 1190 test counts; link `integrator-protocol` in PLUGIN-USER-GUIDE (+ payload sync).

## Test plan
- [x] `integrate validate` / `check_doc_facts` / `governance_consistency` / `make check-plugin`
- [x] `rg mas-infrastructure canvases/` → empty
- [ ] Kit Quality green on PR