### PR TITLE
Align canvases and kit docs with post-rename live ids

### DIFF
--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -23,7 +23,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs
 1. Install kit via `cursor_workflow activate` (plugin) or `cursor_workflow install` (kit clone).
 2. When `project_ssot.enabled` + `board_only`: Entry = board (`project status` / claim); Exit = Status + Notes. Local trackers = offline fallback only.
 3. Else: agents read `.local/` trackers (`session-pointer.md` → `plan.md` → `work-tracker.md`).
-4. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A + `prepare.py` GATES).
+4. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A + `prepare.py` `resolve_gates()`).
 5. Optional MCP (`workflow-kit`) wraps the same scripts.
 
 ## Core abbreviations
@@ -36,7 +36,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs
 | CLI | Command-line interface — here mainly `python3 -m cursor_workflow …` and `gh` |
 | PR | Pull request — maintainer merge workflow (Pattern A) |
 | ADR | Architecture Decision Record — `.ai_infra/docs/decisions/` (ADR-001…008) |
-| GATES | Hardcoded subprocess list in `.ai_infra/scripts/pr/prepare.py` |
+| GATES | 2-gate back-compat alias in `.ai_infra/scripts/pr/prepare.py`; SSOT is `resolve_gates()` (kit-dev may append drift + doc facts) |
 | Pattern A | Script-first workflow; agents invoke **one** command per maintainer action |
 | YAML | Config format for `github.collaboration.yaml`, registries, manifests |
 | UTC / ISO-8601 | Board Notes timestamps (`YYYY-MM-DDTHH:MM:SSZ`); CLI stamps UTC |

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -18,7 +18,7 @@
     "cursor-workflow",
     "pr-workflow",
     "github-projects",
-    "enterprise-audit",
+    "architecture-audit",
     "mcp"
   ],
   "category": "developer-tools",

--- a/.cursor/agents/auditor.md
+++ b/.cursor/agents/auditor.md
@@ -4,7 +4,7 @@ model: auto
 description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
 ---
 
-# Enterprise auditor
+# Auditor
 
 ## Anchor (mandatory)
 

--- a/.cursor/agents/board.md
+++ b/.cursor/agents/board.md
@@ -4,7 +4,7 @@ model: auto
 description: board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
 ---
 
-# Project board
+# Board
 
 ## Anchor (mandatory)
 

--- a/.cursor/agents/drift-guard.md
+++ b/.cursor/agents/drift-guard.md
@@ -4,7 +4,7 @@ model: auto
 description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
 ---
 
-# Workflow drift guard
+# Drift guard
 
 ## Anchor (mandatory)
 

--- a/.cursor/agents/integrator.md
+++ b/.cursor/agents/integrator.md
@@ -4,7 +4,7 @@ model: auto
 description: integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
 
-# MAS infrastructure integrator
+# Integrator
 
 ## Role
 

--- a/.cursor/skills/auditor-protocol/SKILL.md
+++ b/.cursor/skills/auditor-protocol/SKILL.md
@@ -15,7 +15,7 @@ Notes:
  - Advisory-only: no auto-remediation during the audit pass unless the user explicitly asks for edits.
 -->
 
-# Enterprise Architecture Audit (Python, audit-grade)
+# Auditor protocol
 
 ## Goal
 

--- a/.cursor/skills/board-shell/SKILL.md
+++ b/.cursor/skills/board-shell/SKILL.md
@@ -18,7 +18,7 @@ Notes:
  - Do not call undocumented GraphQL view mutations.
 -->
 
-# Board shell onboard (first-run coach)
+# Board shell
 
 ## When
 

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -24,7 +24,7 @@ Notes:
  - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
 -->
 
-# Project board SSOT
+# Board SSOT
 
 ## Goal
 

--- a/.cursor/skills/drift-audit/SKILL.md
+++ b/.cursor/skills/drift-audit/SKILL.md
@@ -15,7 +15,7 @@ Notes:
  - Advisory-only: no auto-remediation unless user explicitly asks.
 -->
 
-# Workflow drift audit
+# Drift audit
 
 ## Goal
 

--- a/.cursor/skills/implementer-loop/SKILL.md
+++ b/.cursor/skills/implementer-loop/SKILL.md
@@ -3,7 +3,7 @@ name: implementer-loop
 description: Disciplined implementation slices with board SSOT continuation and Pattern A gates.
 ---
 
-# Implementation execution loop
+# Implementer loop
 
 ## When
 

--- a/.cursor/skills/integrator-protocol/SKILL.md
+++ b/.cursor/skills/integrator-protocol/SKILL.md
@@ -3,7 +3,7 @@ name: integrator-protocol
 description: Procedural integration of new agents, skills, MCP servers, and kit expansions into MAS Workflow Kit — templates, scripts, three-plane discipline.
 ---
 
-# MAS infrastructure integration
+# Integrator protocol
 
 ## Goal
 

--- a/.cursor/skills/mcp-connect/SKILL.md
+++ b/.cursor/skills/mcp-connect/SKILL.md
@@ -3,7 +3,7 @@ name: mcp-connect
 description: Connect external MCP servers to MAS Workflow Kit agents via mcp.user.json and mcp.registry.yaml.
 ---
 
-# Connect external MCP
+# MCP connect
 
 ## When
 

--- a/.cursor/skills/research-corpus/SKILL.md
+++ b/.cursor/skills/research-corpus/SKILL.md
@@ -3,7 +3,7 @@ name: research-corpus
 description: Brief-driven multi-round research into _research_results packs (external GitHub/local or host self).
 ---
 
-# Research corpus execution
+# Research corpus
 
 ## When
 

--- a/.cursor/skills/test-coverage/SKILL.md
+++ b/.cursor/skills/test-coverage/SKILL.md
@@ -3,7 +3,7 @@ name: test-coverage
 description: Module-focused tests and coverage evidence for workflow scripts and project code.
 ---
 
-# Test module coverage
+# Test coverage
 
 ## When
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Required in every commit message (see **`.cursor/rules/commit-trailer-format.mdc
 | Root | Role |
 |------|------|
 | `.cursor/agents/` | Subagent cards (8) — Task delegation; **`model: auto`**; audit agents write `.local/` artifacts only |
-| `.cursor/skills/` | **Canonical protocols** (12 folders: audit, drift, implement loop, activate, board, board-shell, …) |
+| `.cursor/skills/` | **Canonical protocols** (12 folders: `auditor-protocol`, `audit-orchestration`, `audit-module-map`, `board-ssot`, `board-shell`, `drift-audit`, `implementer-loop`, `integrator-protocol`, `mcp-connect`, `research-corpus`, `test-coverage`, `workflow-activate`) — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
 | `.agents/skills/` | **Maintainer slash skills** (5 folders: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `audit-alignment` stub → `auditor`) — additive in plugin sync |
 | `.cursor/rules/` | **7** `alwaysApply` rules in this product repo (6 kit + `project-ssot-precedence`) — high context cost by design |
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -123,4 +123,4 @@ Mirrored from `mas-workflow-kit` on 2026-07-17 (`1cb6dd7`). Board SSOT, Pattern 
 
 ---
 
-**Last updated:** 2026-07-19 · **Next:** `project status` → claim Ready (or schedule deferred Backlog, e.g. EA-019 live Marketplace when ready)
+**Last updated:** 2026-08-03 · **Next:** `project status` → claim Ready (see IMPLEMENTATION-STATUS for B-safe rename ship / board SSOT; schedule deferred Backlog e.g. EA-019 live Marketplace when ready)

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -4,7 +4,7 @@ model: auto
 description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
 ---
 
-# Enterprise auditor
+# Auditor
 
 ## Anchor (mandatory)
 

--- a/agents/board.md
+++ b/agents/board.md
@@ -4,7 +4,7 @@ model: auto
 description: board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
 ---
 
-# Project board
+# Board
 
 ## Anchor (mandatory)
 

--- a/agents/drift-guard.md
+++ b/agents/drift-guard.md
@@ -4,7 +4,7 @@ model: auto
 description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
 ---
 
-# Workflow drift guard
+# Drift guard
 
 ## Anchor (mandatory)
 

--- a/agents/integrator.md
+++ b/agents/integrator.md
@@ -4,7 +4,7 @@ model: auto
 description: integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
 
-# MAS infrastructure integrator
+# Integrator
 
 ## Role
 

--- a/canvases/agent-auditor.canvas.tsx
+++ b/canvases/agent-auditor.canvas.tsx
@@ -133,6 +133,8 @@ const ARTIFACTS = [
 
 const PEERS = [
   ["Outbound", "implementer", "Continue from Notes with artifact paths"],
+  ["Outbound", "drift-guard", "audit-orchestration Phase 3 — P0/P1 drift artifacts"],
+  ["Outbound", "verifier", "audit-orchestration Phase 3 — spot-check top claims"],
 ];
 
 function DagPanel({
@@ -145,53 +147,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -204,7 +203,7 @@ function DagPanel({
   );
 }
 
-export default function AgentEnterpriseAuditorCanvas() {
+export default function AgentAuditorCanvas() {
   const { tokens } = useHostTheme();
   const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
 
@@ -221,8 +220,8 @@ export default function AgentEnterpriseAuditorCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Evidence-only enterprise architecture audit; writes workflow artifacts and
-          tracker hooks for other agents.
+          auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit;
+          writes workflow artifacts and tracker hooks for other agents.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -269,8 +268,10 @@ export default function AgentEnterpriseAuditorCanvas() {
           <Text>1. project status; create [AUDIT] slice card if needed; claim.</Text>
           <Text>2. Evidence-only audit per auditor-protocol/SKILL.md.</Text>
           <Text>
-            3. Write enterprise-architecture-audit.md + enterprise-audit-actions.md;
-            optional alignment artifacts for merge workflow.
+            3. Write .local/workflow-artifacts/enterprise-architecture-audit/
+            enterprise-architecture-audit.md + enterprise-audit-actions.md
+            (artifact dir name kept; skill is auditor-protocol); optional
+            alignment/ for merge workflow.
           </Text>
           <Text>4. Propose tracker edits in audit-actions — implementer applies.</Text>
           <Text>

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -25,7 +25,7 @@ type FlowMode = "slice" | "side";
 
 const VERIFIED = "2026-08-03";
 const SOURCES =
-  "project-board-collaboration.md · board-ssot/SKILL.md · board-shell/SKILL.md · .cursor/agents/*.md · agent-roster edges";
+  "project-board-collaboration.md · board-ssot/SKILL.md · board-shell/SKILL.md · agent-relations · agent-roster · .cursor/agents/*.md";
 
 const STATUS_STEPS = ["Ready", "In progress", "In review", "Done"];
 
@@ -42,10 +42,14 @@ const ROSTER_NODES = [
 const ROSTER_EDGES = [
   { from: "board", to: "implementer" },
   { from: "implementer", to: "verifier" },
+  { from: "implementer", to: "test-runner" },
   { from: "implementer", to: "drift-guard" },
+  { from: "test-runner", to: "verifier" },
   { from: "drift-guard", to: "board" },
   { from: "drift-guard", to: "implementer" },
   { from: "auditor", to: "implementer" },
+  { from: "auditor", to: "drift-guard" },
+  { from: "auditor", to: "verifier" },
   { from: "integrator", to: "implementer" },
   { from: "integrator", to: "test-runner" },
   { from: "integrator", to: "auditor" },
@@ -54,10 +58,14 @@ const ROSTER_EDGES = [
 const EDGE_LABELS: Record<string, string> = {
   "board→implementer": "handoff next=implementer",
   "implementer→verifier": "Exit --next verifier",
+  "implementer→test-runner": "when tests/coverage gate PR",
   "implementer→drift-guard": "P0/P1 after drift-validate",
+  "test-runner→verifier": "tests gate the PR",
   "drift-guard→board": "dual-write remediation",
   "drift-guard→implementer": "dual-write remediation",
   "auditor→implementer": "Notes + artifact paths",
+  "auditor→drift-guard": "audit-orchestration Phase 3",
+  "auditor→verifier": "audit-orchestration Phase 3",
   "integrator→implementer": "escalate product src/",
   "integrator→test-runner": "escalate coverage",
   "integrator→auditor": "escalate architecture",
@@ -234,16 +242,16 @@ const NEXT_AGENT_STEPS = [
 
 const SLICE_FLOW = [
   "board: status + list → triage Ready → handoff next=implementer",
-  "implementer: claim --agent implementer → code + gates → handoff --next verifier (typical)",
-  "test-runner (when tests gate PR): status + slice card → test-index / test-plan → in_review",
+  "implementer: claim --agent implementer → code + prepare.py resolve_gates() → handoff --next verifier (or test-runner when tests gate)",
+  "test-runner (when tests gate PR): status + slice card → test-index / test-plan → in_review → verifier",
   "verifier: status + related card → evidence check → done or in_review with failure Notes",
 ];
 
 const SIDE_FLOW = [
-  "auditor: audit card → write .local/workflow-artifacts/… → Notes paths → implementer",
+  "auditor: audit card → write .local/workflow-artifacts/enterprise-architecture-audit/ + alignment/ → Notes paths → implementer (Phase 3: drift-guard / verifier)",
   "implementer: make drift-validate → P0/P1 → hand off drift-guard",
-  "drift-guard: must read board In progress → drift artifacts → drift card done; remediation via Notes/Ready to board or implementer",
-  "integrator: integration card → validate → escalate to implementer | test-runner | auditor",
+  "drift-guard: must read board In progress → .local/workflow-artifacts/drift/ → drift card done; remediation via Notes/Ready to board or implementer",
+  "integrator: integration card → integrate validate → escalate to implementer | test-runner | auditor",
 ];
 
 function CollaborationDag({
@@ -251,39 +259,38 @@ function CollaborationDag({
 }: {
   tokens: ReturnType<typeof useHostTheme>["tokens"];
 }) {
-  const layout = computeDAGLayout(ROSTER_NODES, ROSTER_EDGES, {
+  const nodeW = 130;
+  const nodeH = 40;
+  const layout = computeDAGLayout({
+    nodes: ROSTER_NODES,
+    edges: ROSTER_EDGES,
     direction: "horizontal",
-    nodeWidth: 130,
-    nodeHeight: 40,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 48,
     nodeGap: 20,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 24;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 24;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 960 }}>
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 960 }}
+    >
       {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
         const label = EDGE_LABELS[`${e.from}→${e.to}`] ?? "";
-        const mx = (x1 + x2) / 2;
-        const my = (y1 + y2) / 2 - 6;
+        const mx = (e.sourceX + e.targetX) / 2;
+        const my = (e.sourceY + e.targetY) / 2 - 6;
         return (
           <g key={i}>
             <line
-              x1={x1}
-              y1={y1}
-              x2={x2}
-              y2={y2}
+              x1={e.sourceX}
+              y1={e.sourceY}
+              x2={e.targetX}
+              y2={e.targetY}
               stroke={tokens.stroke.secondary}
               strokeWidth={1.5}
+              strokeDasharray={e.isBackEdge ? "4 3" : undefined}
             />
             {label ? (
               <text
@@ -304,8 +311,8 @@ function CollaborationDag({
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={
               n.id === "board"
@@ -319,8 +326,8 @@ function CollaborationDag({
             }
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={9}
@@ -341,7 +348,7 @@ export default function AgentBoardCollaborationCanvas() {
     <Stack gap={20} style={{ padding: 20, maxWidth: 980 }}>
       <Stack gap={8}>
         <Row gap={10} style={{ alignItems: "center" }}>
-          <H1 style={{ margin: 0 }}>Agent × Project board collaboration</H1>
+          <H1 style={{ margin: 0 }}>Agent × GitHub Project collaboration</H1>
           <Pill tone="info" size="sm">
             board SSOT
           </Pill>

--- a/canvases/agent-board.canvas.tsx
+++ b/canvases/agent-board.canvas.tsx
@@ -25,7 +25,7 @@ type SsotMode = "board" | "fallback";
 
 const VERIFIED = "2026-08-03";
 const SOURCES =
-  ".cursor/agents/board.md · board-ssot/SKILL.md · board-shell/SKILL.md · ADR-006";
+  ".cursor/agents/board.md · board-ssot/SKILL.md · board-shell/SKILL.md · ADR-006 · ADR-008";
 
 const GOALS = [
   "Independent-governed helper for GitHub Project SSOT",
@@ -90,6 +90,7 @@ const READ_FIRST = [
   [".local/user_settings/github.collaboration.yaml", "project_ssot block"],
   [".ai_infra/templates/project-board/README.md", "Card templates"],
   ["ADR-006", "Independent-governed agent"],
+  ["ADR-008", "Project board SSOT (board_only)"],
 ];
 
 const PATTERNS = [
@@ -124,53 +125,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -183,7 +181,7 @@ function DagPanel({
   );
 }
 
-export default function AgentProjectBoardCanvas() {
+export default function AgentBoardCanvas() {
   const { tokens } = useHostTheme();
   const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
 
@@ -200,8 +198,8 @@ export default function AgentProjectBoardCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Independent-governed helper — list/create/move GitHub Project SSOT cards via
-          project_ssot CLI.
+          board MAS-SSOT-KIT — Independent-governed helper — list/create/move
+          GitHub Project SSOT cards via project_ssot CLI.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -294,7 +292,7 @@ export default function AgentProjectBoardCanvas() {
               Rate-limit: EXIT_QUEUED (6) → outbox status / flush; do not hammer
               GraphQL.
             </Text>
-            <Text>CLI helper: project guide. ADR-006 independent-governed.</Text>
+            <Text>CLI helper: project guide. ADR-006 independent-governed · ADR-008 board_only SSOT.</Text>
           </Stack>
         </CardBody>
       </Card>

--- a/canvases/agent-drift-guard.canvas.tsx
+++ b/canvases/agent-drift-guard.canvas.tsx
@@ -119,6 +119,7 @@ const PEERS = [
   ["Outbound", "board", "Dual-write remediation via Ready"],
   ["Outbound", "implementer", "Dual-write remediation via Ready"],
   ["Inbound", "implementer", "Invokes on P0/P1 after drift-validate"],
+  ["Inbound", "auditor", "audit-orchestration Phase 3 — after tracker/doc edits"],
 ];
 
 function DagPanel({
@@ -131,53 +132,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -190,7 +188,7 @@ function DagPanel({
   );
 }
 
-export default function AgentWorkflowDriftGuardCanvas() {
+export default function AgentDriftGuardCanvas() {
   const { tokens } = useHostTheme();
   const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
 
@@ -207,8 +205,8 @@ export default function AgentWorkflowDriftGuardCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Operational workflow drift detection; plan/tracker/session coherence and
-          handoff parity.
+          drift-guard MAS-SSOT-KIT — Operational workflow drift detection;
+          plan/tracker/session coherence and handoff parity.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -84,7 +84,7 @@ const BOARD_LABELS: Record<string, string> = {
   status: "project status",
   claim: "claim (+ Start date if empty)",
   code: "contracts → code → tests",
-  gates: "prepare.py GATES",
+  gates: "prepare.py resolve_gates()",
   evidence: "change-index + updates-log",
   promote: "promote / mention-pr",
   handoff: "handoff --next verifier",
@@ -96,7 +96,7 @@ const FALLBACK_LABELS: Record<string, string> = {
   plan: "plan.md",
   tracker: "work-tracker.md",
   code: "contracts → code → tests",
-  gates: "prepare.py GATES",
+  gates: "prepare.py resolve_gates()",
   evidence: "change-index + updates-log",
   close: "close tracker (offline)",
 };
@@ -154,13 +154,14 @@ const PATTERNS = [
   ["Templates", "slice (feature/chore) · bug (defect/fix)"],
   ["Module headers", "file-docstring-header-relations.mdc on new sources"],
   ["Commit trailers", "Author + GitHub-User via contributors commit-trailers"],
-  ["Gates", "prepare.py GATES; check_governance_consistency when policy docs change"],
+  ["Gates", "prepare.py resolve_gates(); check_governance_consistency when policy docs change"],
   ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/implementer via --agent implementer"],
 ];
 
 const PEERS = [
   ["Outbound", "verifier", "handoff --next verifier (Exit recipe)"],
+  ["Outbound", "test-runner", "When tests/coverage needed before merge"],
   ["Outbound", "drift-guard", "When make drift-validate finds P0/P1 needing artifacts"],
   ["Inbound", "board", "Triage hands Ready cards for implementation"],
   ["Inbound", "auditor", "Audit Notes / artifact paths for implementer to apply"],
@@ -177,53 +178,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -253,7 +251,8 @@ export default function AgentImplementerCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Disciplined implementation slices with trackers and Pattern A gates.
+          implementer MAS-SSOT-KIT — Disciplined implementation slices with
+          trackers and Pattern A gates.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -306,7 +305,8 @@ export default function AgentImplementerCanvas() {
             (file-docstring-header-relations.mdc).
           </Text>
           <Text>
-            3. Gates: python .ai_infra/scripts/pr/prepare.py (or its GATES). Add
+            3. Gates: python .ai_infra/scripts/pr/prepare.py (resolve_gates() SSOT;
+            GATES = 2-gate back-compat alias). Add
             check_governance_consistency.py if governance/policy docs changed.
           </Text>
           <Text>

--- a/canvases/agent-integrator.canvas.tsx
+++ b/canvases/agent-integrator.canvas.tsx
@@ -73,7 +73,7 @@ const BOARD_LABELS: Record<string, string> = {
   claim: "claim / create card",
   intake: "Intake → Plan",
   wire: "templates → wire",
-  verify: "validate + gates",
+  verify: "integrate validate + resolve_gates()",
   handoff: "escalate / close",
 };
 
@@ -81,7 +81,7 @@ const FALLBACK_LABELS: Record<string, string> = {
   session: "session-pointer.md",
   intake: "Intake → Plan",
   wire: "templates → wire",
-  verify: "validate + gates",
+  verify: "integrate validate + resolve_gates()",
   handoff: "escalate / close",
 };
 
@@ -89,6 +89,7 @@ const READ_FIRST = [
   [".cursor/skills/integrator-protocol/SKILL.md", "Integration canon"],
   [".cursor/skills/board-ssot/SKILL.md", "When project_ssot.enabled"],
   ["python3 -m cursor_workflow integrate validate", "Wire verification"],
+  ["prepare.py resolve_gates()", "PR / kit-dev gate SSOT"],
   ["check_governance_consistency.py", "When policy docs change"],
 ];
 
@@ -96,6 +97,7 @@ const PATTERNS = [
   ["Pattern A", "claim --last / handoff --last / create-from-template"],
   ["Promote before PR", "promote-to-issue OR mention-pr when shipping integration"],
   ["Tier-1", "claim/set-status→In progress Start date; Size/Estimate per skill table"],
+  ["Verify", "integrate validate + prepare.py resolve_gates() + governance when needed"],
   ["STANDALONE", "Product lives only in mas-workflow-kit-project-ssot"],
   ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/integrator via --agent"],
@@ -109,10 +111,10 @@ const ARTIFACTS = [
 ];
 
 const PEERS = [
-  ["Escalation", "auditor", "Architecture-impacting integration"],
-  ["Escalation", "test-runner", "Coverage work"],
-  ["Escalation", "implementer", "Product src/ handoff"],
-  ["Escalation", "PR maintainer skills", "pr-workflow pipeline"],
+  ["Escalation", "auditor", "Architecture-impacting → auditor-protocol"],
+  ["Escalation", "test-runner", "Coverage → test-coverage"],
+  ["Escalation", "implementer", "Product src/ → implementer-loop"],
+  ["Escalation", "pr-workflow", "Maintainer PR pipeline (.agents/skills)"],
 ];
 
 function DagPanel({
@@ -125,53 +127,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -184,7 +183,7 @@ function DagPanel({
   );
 }
 
-export default function AgentIntegratorMasAgentCanvas() {
+export default function AgentIntegratorCanvas() {
   const { tokens } = useHostTheme();
   const [mode, setMode] = useCanvasState<SsotMode>("ssotMode", "board");
 
@@ -201,8 +200,9 @@ export default function AgentIntegratorMasAgentCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Integrates new agents, skills, MCP, and infrastructure expansions —
-          procedural, evidence-only, Pattern A.
+          integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and
+          infrastructure expansions into the MAS Workflow Kit — procedural,
+          evidence-only, Pattern A compliant.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -250,8 +250,8 @@ export default function AgentIntegratorMasAgentCanvas() {
           <Text>2. Plan: board card with scope and acceptance criteria.</Text>
           <Text>3. Templates → wire agents/skills/MCP into kit structure.</Text>
           <Text>
-            4. Verify: contributors validate, gates, governance consistency,
-            integrate validate.
+            4. Verify: integrate validate; prepare.py resolve_gates(); contributors
+            validate; check_governance_consistency when policy docs change.
           </Text>
           <Text>
             5. Handoff: Status done or in_review if verify failed; Notes with

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -22,7 +22,7 @@ import {
 
 const VERIFIED = "2026-08-03";
 const SOURCES =
-  ".cursor/agents/*.md PEERS · audit-orchestration Phase 3 · board-ssot § Continuation · agent-roster edges";
+  "agent-relations edges · audit-orchestration Phase 3 · board-ssot § Continuation · per-agent canvas PEERS";
 
 const NODE_W = 128;
 const NODE_H = 40;
@@ -41,42 +41,42 @@ type AgentId =
 const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   {
     id: "board",
-    role: "Triage Ready; create cards; hand off work",
+    role: "board MAS-SSOT-KIT · skill board-ssot (+ board-shell)",
     lane: "Coordination",
   },
   {
     id: "implementer",
-    role: "Ship slices: code, tests, promote, PR path",
+    role: "implementer MAS-SSOT-KIT · skill implementer-loop",
     lane: "Delivery",
   },
   {
     id: "test-runner",
-    role: "Module tests / coverage on existing card",
+    role: "test-runner MAS-SSOT-KIT · skill test-coverage",
     lane: "Delivery",
   },
   {
     id: "verifier",
-    role: "Claims vs evidence; no implement",
+    role: "verifier MAS-SSOT-KIT · claims vs evidence (no primary skill folder)",
     lane: "Delivery",
   },
   {
     id: "integrator",
-    role: "Wire agents/skills/MCP into the kit",
+    role: "integrator MAS-SSOT-KIT · skill integrator-protocol",
     lane: "Infrastructure",
   },
   {
     id: "auditor",
-    role: "Evidence-only architecture audit artifacts",
+    role: "auditor MAS-SSOT-KIT · skill auditor-protocol",
     lane: "Quality",
   },
   {
     id: "drift-guard",
-    role: "Drift validate; dual-write remediation",
+    role: "drift-guard MAS-SSOT-KIT · skill drift-audit",
     lane: "Quality",
   },
   {
     id: "researcher",
-    role: "Shipped corpus researcher — packs under _research_results/ (opt-in)",
+    role: "researcher MAS-SSOT-KIT · skill research-corpus (opt-in packs)",
     lane: "Research (opt-in corpus)",
   },
 ];
@@ -175,10 +175,12 @@ const RELATIONS: {
 ];
 
 const RESEARCHER_REDIRECTS: [string, string][] = [
-  ["implementer", "Product code / commits / PRs"],
-  ["verifier", "Claims vs evidence checks"],
+  ["implementer", "Product code / commits"],
+  ["verifier", "Claims vs evidence"],
   ["auditor", "Architecture audits"],
   ["drift-guard", "Drift / tracker coherence"],
+  ["integrator", "Kit surface integration"],
+  ["pr-workflow", "Git commit/push/PR (maintainer skills)"],
 ];
 
 const HAPPY_PATH = [
@@ -333,14 +335,24 @@ export default function AgentRelationsCanvas() {
         <Row gap={10} style={{ alignItems: "center" }}>
           <H1 style={{ margin: 0 }}>Agent relations</H1>
           <Pill tone="info" size="sm">
+            hub · not an agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
             8 agents
           </Pill>
         </Row>
         <Text tone="secondary">
-          How kit agents hand off work — edges from agent cards plus skill chain
-          (e.g. test-runner→verifier when tests gate the PR). Select an agent to
+          How kit agents hand off work — edges from agent cards plus
+          audit-orchestration Phase 3. Live ids only (post B-safe rename). Primary
+          skills: board-ssot, implementer-loop, test-coverage, integrator-protocol,
+          auditor-protocol, drift-audit, research-corpus. Select an agent to
           highlight its neighbors.
         </Text>
+        <Callout tone="info" title="Not old names">
+          Retired Task ids (enterprise-auditor, project-board, workflow-drift-guard,
+          integrator-mas-agent) do not appear here. Deeper per-agent hubs:
+          canvases/agent-*.canvas.tsx · overview: agent-roster.
+        </Callout>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED}
         </Text>

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -125,11 +125,12 @@ const ARTIFACTS = [
 ];
 
 const PEERS = [
-  ["Use instead", "implementer", "Product code changes"],
-  ["Use instead", "integrator", "Kit surface integration"],
-  ["Use instead", "pr-workflow", "Git commit/push/PR"],
-  ["Use instead", "auditor", "Architecture audits"],
+  ["Use instead", "implementer", "Product code / commits"],
   ["Use instead", "verifier", "Claims vs evidence"],
+  ["Use instead", "auditor", "Architecture audits"],
+  ["Use instead", "drift-guard", "Drift / tracker coherence"],
+  ["Use instead", "integrator", "Kit surface integration"],
+  ["Use instead", "pr-workflow", "Git commit/push/PR (maintainer skills)"],
   ["Consumes from", "any agent", "Notes / handoff / cited pack path"],
   ["Proven with", "verifier", "Post-pack Claim A/B check (optional)"],
 ];
@@ -144,53 +145,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -223,9 +221,10 @@ export default function AgentResearcherCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Brief-driven multi-round research (GitHub HTTPS / github: / local path).
-          Adaptive intake from chat or peer agents; hard-stop on product code.
-          Agent is fully functional; corpus packs are opt-in after research init.
+          researcher MAS-SSOT-KIT — Brief-driven multi-round research
+          (GitHub/local) into _research_results packs; hard-stop on product code.
+          Adaptive intake from chat or peer agents; corpus packs are opt-in after
+          research init.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -292,8 +291,8 @@ export default function AgentResearcherCanvas() {
         </Callout>
         <Callout tone="warning" title="Hard stop">
           Write only _research_results/. No src/tests/scripts. No git commit/push/PR.
-          Use implementer, integrator, pr-workflow, auditor, or verifier
-          for those tasks.
+          Redirect to: implementer · integrator · verifier · auditor · drift-guard ·
+          pr-workflow (maintainer skills) — see Peers.
         </Callout>
         <DagPanel mode={mode} tokens={tokens} />
       </Stack>

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -74,10 +74,14 @@ const ROSTER_NODES = [
 const ROSTER_EDGES = [
   { from: "board", to: "implementer" },
   { from: "implementer", to: "verifier" },
+  { from: "implementer", to: "test-runner" },
   { from: "implementer", to: "drift-guard" },
+  { from: "test-runner", to: "verifier" },
   { from: "drift-guard", to: "board" },
   { from: "drift-guard", to: "implementer" },
   { from: "auditor", to: "implementer" },
+  { from: "auditor", to: "drift-guard" },
+  { from: "auditor", to: "verifier" },
   { from: "integrator", to: "implementer" },
   { from: "integrator", to: "test-runner" },
   { from: "integrator", to: "auditor" },
@@ -86,56 +90,61 @@ const ROSTER_EDGES = [
 const EDGE_LABELS: Record<string, string> = {
   "board→implementer": "handoff next=implementer",
   "implementer→verifier": "Exit --next verifier",
+  "implementer→test-runner": "when tests/coverage gate PR",
   "implementer→drift-guard": "P0/P1 after drift-validate",
+  "test-runner→verifier": "tests gate the PR",
   "drift-guard→board": "dual-write remediation",
   "drift-guard→implementer": "dual-write remediation",
   "auditor→implementer": "Notes + artifact paths",
+  "auditor→drift-guard": "audit-orchestration Phase 3",
+  "auditor→verifier": "audit-orchestration Phase 3",
   "integrator→implementer": "escalate product src/",
   "integrator→test-runner": "escalate coverage",
   "integrator→auditor": "escalate architecture",
 };
 
 const RESEARCHER_REDIRECTS = [
-  ["implementer", "Product code changes"],
+  ["implementer", "Product code / commits"],
   ["verifier", "Claims vs evidence"],
   ["auditor", "Architecture audits"],
-  ["pr-workflow", "Git commit/push/PR (not researcher)"],
+  ["drift-guard", "Drift / tracker coherence"],
+  ["integrator", "Kit surface integration"],
+  ["pr-workflow", "Git commit/push/PR (maintainer skills)"],
 ];
 
 function RosterDag({ tokens }: { tokens: ReturnType<typeof useHostTheme>["tokens"] }) {
-  const layout = computeDAGLayout(ROSTER_NODES, ROSTER_EDGES, {
+  const nodeW = 130;
+  const nodeH = 40;
+  const layout = computeDAGLayout({
+    nodes: ROSTER_NODES,
+    edges: ROSTER_EDGES,
     direction: "horizontal",
-    nodeWidth: 130,
-    nodeHeight: 40,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 48,
     nodeGap: 20,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 24;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 24;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 960 }}>
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 960 }}
+    >
       {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
         const label = EDGE_LABELS[`${e.from}→${e.to}`] ?? "";
-        const mx = (x1 + x2) / 2;
-        const my = (y1 + y2) / 2 - 6;
+        const mx = (e.sourceX + e.targetX) / 2;
+        const my = (e.sourceY + e.targetY) / 2 - 6;
         return (
           <g key={i}>
             <line
-              x1={x1}
-              y1={y1}
-              x2={x2}
-              y2={y2}
+              x1={e.sourceX}
+              y1={e.sourceY}
+              x2={e.targetX}
+              y2={e.targetY}
               stroke={tokens.stroke.secondary}
               strokeWidth={1.5}
+              strokeDasharray={e.isBackEdge ? "4 3" : undefined}
             />
             {label ? (
               <text
@@ -156,8 +165,8 @@ function RosterDag({ tokens }: { tokens: ReturnType<typeof useHostTheme>["tokens
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={
               n.id === "researcher"
@@ -167,8 +176,8 @@ function RosterDag({ tokens }: { tokens: ReturnType<typeof useHostTheme>["tokens
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={9}
@@ -190,20 +199,28 @@ export default function AgentRosterCanvas() {
         <Row gap={10} style={{ alignItems: "center" }}>
           <H1 style={{ margin: 0 }}>Kit agent roster</H1>
           <Pill tone="info" size="sm">
+            hub · not an agent
+          </Pill>
+          <Pill tone="neutral" size="sm">
             8 agents
           </Pill>
         </Row>
         <Text tone="secondary">
-          Explicit handoff edges from agent cards (skill chain test-runner→verifier
-          when tests gate PR). researcher is shipped/proven and non-product —
-          corpus opt-in; redirects to product agents for code/PR.
+          Overview of all live agents (ids match .cursor/agents/*.md). This file is
+          a DOC-008 roster hub — there is no agent named &quot;roster&quot;. Deeper
+          graph: agent-relations. Per-agent Entry/Exit: agent-board-collaboration.
         </Text>
-        <Callout tone="info" title="Board lifecycle (all 8)">
+        <Callout tone="info" title="Live ids (post B-safe rename)">
+          auditor · board · drift-guard · implementer · integrator · researcher ·
+          test-runner · verifier — skills: board-ssot, implementer-loop,
+          test-coverage, auditor-protocol, drift-audit, integrator-protocol, …
+        </Callout>
+        <Callout tone="neutral" title="Board lifecycle (all 8)">
           Tier-1: Start date on claim or first In progress; Size↔Estimate points
-          table in board-ssot skill. Promote Draft→Issue via promote-to-issue or mention-pr (auto when
-          promote_to_issue_on_pr) before shippable PR — claim does not auto-promote.
-          Notes: @owner.github_user/&lt;agent&gt; · YYYY-MM-DDTHH:MM:SSZ · … via
-          append-notes --agent. See agent-board-collaboration canvas.
+          table in board-ssot skill. Promote Draft→Issue via promote-to-issue or
+          mention-pr (auto when promote_to_issue_on_pr) before shippable PR —
+          claim does not auto-promote. Notes: @owner.github_user/&lt;agent&gt; ·
+          YYYY-MM-DDTHH:MM:SSZ · … via append-notes --agent.
         </Callout>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -239,10 +256,7 @@ export default function AgentRosterCanvas() {
       <Card>
         <CardHeader>researcher → use instead</CardHeader>
         <CardBody>
-          <Table
-            headers={["Agent", "When"]}
-            rows={RESEARCHER_REDIRECTS}
-          />
+          <Table headers={["Agent", "When"]} rows={RESEARCHER_REDIRECTS} />
           <Callout tone="info" title="Shipped non-product agent">
             researcher is fully functional (live E2E + verifier PASS 2026-07-19).
             Writes only _research_results/ after research init (opt-in corpus).
@@ -258,6 +272,8 @@ export default function AgentRosterCanvas() {
           headers={["From", "To", "Evidence"]}
           rows={[
             ["implementer", "verifier", "Exit recipe --next verifier"],
+            ["implementer", "test-runner", "When tests/coverage gate PR"],
+            ["test-runner", "verifier", "When tests gate the PR"],
             [
               "implementer",
               "drift-guard",
@@ -271,8 +287,8 @@ export default function AgentRosterCanvas() {
             ],
             [
               "auditor",
-              "implementer",
-              "Notes with artifact paths for implementer",
+              "implementer | drift-guard | verifier",
+              "Notes + audit-orchestration Phase 3",
             ],
             [
               "integrator",

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -80,7 +80,7 @@ const BOARD_LABELS: Record<string, string> = {
   coverage: "coverage.json",
   artifacts: "test-plan + change-index",
   handoff: "handoff",
-  next: "next agent",
+  next: "verifier (if tests gate)",
 };
 
 const FALLBACK_LABELS: Record<string, string> = {
@@ -113,7 +113,7 @@ const PATTERNS = [
 ];
 
 const ARTIFACTS = [
-  ["tests/modules/<module>/", "Implementation / regression", "CI / prepare.py"],
+  ["tests/modules/<module>/", "Implementation / regression", "CI / prepare.py resolve_gates()"],
   ["coverage.json", "Coverage evidence run", "test-runner / DOC-006"],
   ["coverage-index.md", "After meaningful coverage / 100% closure", "test-runner / implementer"],
   ["IMPLEMENTATION-STATUS.md", "After scoped 100% / count change", "DOC-006 / maintainers"],
@@ -125,7 +125,8 @@ const ARTIFACTS = [
 ];
 
 const PEERS = [
-  ["Outbound", "next (generic)", "handoff format per card"],
+  ["Outbound", "verifier", "When tests gate the PR — handoff --to in_review"],
+  ["Outbound", "next (generic)", "handoff format per card when not gating"],
   ["Inbound", "implementer", "Handoff when tests/coverage needed before merge"],
   ["Inbound", "integrator", "Escalates coverage work to test-runner"],
 ];
@@ -140,53 +141,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -216,7 +214,8 @@ export default function AgentTestRunnerCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Module-focused tests, regressions, coverage.
+          test-runner MAS-SSOT-KIT — Module-focused tests, regressions, coverage.
+          Primary skill: test-coverage.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -325,8 +324,9 @@ export default function AgentTestRunnerCanvas() {
       </Stack>
 
       <Callout tone="neutral" title="MCP">
-        Kit server workflow-kit for PR scripts/gates — prefer cursor_workflow project
-        for board. External: only servers listed for this agent in mcp.registry.yaml.
+        Kit server workflow-kit for PR scripts / prepare.py resolve_gates() —
+        prefer cursor_workflow project for board. External: only servers listed
+        for this agent in mcp.registry.yaml.
       </Callout>
 
       <Text tone="tertiary" size="small">

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -98,7 +98,7 @@ const PATTERNS = [
   ["Consume only", "Do NOT create-from-template"],
   ["Board lifecycle", "Evidence on handed-off card; promote not primary path"],
   ["Tier-1", "Shared Board rights; Start date on claim / first In progress"],
-  ["Checks", "pytest · GATES category · governance · verify_publish"],
+  ["Checks", "pytest · prepare.py resolve_gates() · governance · verify_publish"],
   ["Merge gate", "Do not approve merge without pr/ artifacts when maintainer workflow active"],
   ["Notes timestamp", "@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · … via --agent"],
   ["Attribution", "@owner.github_user/verifier via --agent verifier"],
@@ -111,8 +111,10 @@ const ARTIFACTS = [
 ];
 
 const PEERS = [
-  ["Outbound", "next (generic)", "handoff format per card"],
   ["Inbound", "implementer", "Exit recipe prefers --next verifier"],
+  ["Inbound", "test-runner", "When tests gate the PR"],
+  ["Outbound", "implementer", "Not verified — stay in_review + failure Notes"],
+  ["Outbound", "next (generic)", "handoff format per card when verified"],
 ];
 
 function DagPanel({
@@ -125,53 +127,50 @@ function DagPanel({
   const nodes = mode === "board" ? BOARD_NODES : FALLBACK_NODES;
   const edges = mode === "board" ? BOARD_EDGES : FALLBACK_EDGES;
   const labels = mode === "board" ? BOARD_LABELS : FALLBACK_LABELS;
-  const layout = computeDAGLayout(nodes, edges, {
+  const nodeW = 118;
+  const nodeH = 36;
+  const layout = computeDAGLayout({
+    nodes,
+    edges,
     direction: "horizontal",
-    nodeWidth: 118,
-    nodeHeight: 36,
+    nodeWidth: nodeW,
+    nodeHeight: nodeH,
     rankGap: 36,
     nodeGap: 16,
   });
-  const w = Math.max(...layout.nodes.map((n) => n.x + n.width)) + 16;
-  const h = Math.max(...layout.nodes.map((n) => n.y + n.height)) + 16;
-  const byId = Object.fromEntries(layout.nodes.map((n) => [n.id, n]));
 
   return (
-    <svg width="100%" viewBox={`0 0 ${w} ${h}`} style={{ maxWidth: 920 }}>
-      {layout.edges.map((e, i) => {
-        const a = byId[e.from];
-        const b = byId[e.to];
-        if (!a || !b) return null;
-        const x1 = a.x + a.width;
-        const y1 = a.y + a.height / 2;
-        const x2 = b.x;
-        const y2 = b.y + b.height / 2;
-        return (
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={tokens.stroke.secondary}
-            strokeWidth={1.5}
-          />
-        );
-      })}
+    <svg
+      width="100%"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      style={{ maxWidth: 920 }}
+    >
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.sourceX}
+          y1={e.sourceY}
+          x2={e.targetX}
+          y2={e.targetY}
+          stroke={tokens.stroke.secondary}
+          strokeWidth={1.5}
+          strokeDasharray={e.isBackEdge ? "4 3" : undefined}
+        />
+      ))}
       {layout.nodes.map((n) => (
         <g key={n.id}>
           <rect
             x={n.x}
             y={n.y}
-            width={n.width}
-            height={n.height}
+            width={nodeW}
+            height={nodeH}
             rx={4}
             fill={tokens.fill.secondary}
             stroke={tokens.stroke.primary}
           />
           <text
-            x={n.x + n.width / 2}
-            y={n.y + n.height / 2 + 4}
+            x={n.x + nodeW / 2}
+            y={n.y + nodeH / 2 + 4}
             textAnchor="middle"
             fill={tokens.text.primary}
             fontSize={10}
@@ -201,7 +200,8 @@ export default function AgentVerifierCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          Claims vs evidence; minimal high-signal checks.
+          verifier MAS-SSOT-KIT — Claims vs evidence; minimal high-signal checks.
+          No primary skill folder (agent card is canon).
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -248,8 +248,8 @@ export default function AgentVerifierCanvas() {
           <Text>1. Restate the claim under verification.</Text>
           <Text>2. Gather evidence from repo, artifacts, and board Notes.</Text>
           <Text>
-            3. Run smallest decisive checks (pytest, GATES category, governance,
-            verify_publish).
+            3. Run smallest decisive checks (pytest; same category as prepare.py
+            resolve_gates(); governance when policy docs change; verify_publish).
           </Text>
           <Text>4. Verdict: Verified | Partial | Not verified.</Text>
           <Text>5. One next action; handoff/claim. Status done or in_review with failure Notes.</Text>
@@ -308,8 +308,9 @@ export default function AgentVerifierCanvas() {
       </Stack>
 
       <Callout tone="neutral" title="MCP">
-        Kit server workflow-kit for PR scripts/gates — prefer cursor_workflow project
-        for board. External: only servers listed for this agent in mcp.registry.yaml.
+        Kit server workflow-kit for PR scripts / prepare.py resolve_gates() —
+        prefer cursor_workflow project for board. External: only servers listed
+        for this agent in mcp.registry.yaml.
       </Callout>
 
       <Text tone="tertiary" size="small">

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -103,19 +103,19 @@ const WHO_WRITES: string[][] = [
   [
     "verifier",
     "Done or In review + failure Notes",
-    "verification-*.md under workflow-artifacts",
+    ".local/workflow-artifacts/pr/ (claims vs evidence Notes)",
     "Claims vs evidence",
   ],
   [
     "auditor",
     "Audit card Status + artifact paths in Notes",
-    "auditor-protocol/ · alignment/",
+    ".local/workflow-artifacts/enterprise-architecture-audit/ · alignment/",
     "Evidence-only — no product fixes",
   ],
   [
     "drift-guard",
     "Drift-pass card Done; remediation via Ready",
-    "drift/drift-audit.md · drift-todos.md",
+    ".local/workflow-artifacts/drift/drift-audit.md · drift-todos.md",
     "Never silent dual-write Status",
   ],
   [
@@ -149,7 +149,7 @@ const ARTIFACT_LANES: string[][] = [
     "PR Pattern A (local evidence)",
     ".local/workflow-artifacts/pr/{review,prep,merge}.md",
     "review-pr · prepare-pr · merge-pr",
-    "Gates in prepare.py — not a second Status",
+    "prepare.py resolve_gates() — not a second Status",
   ],
   [
     "Audit / alignment",
@@ -337,10 +337,17 @@ export default function AgentsArtifactsBoardCanvas() {
   return (
     <Stack gap={20} style={{ padding: 20, maxWidth: 1040 }}>
       <Stack gap={6}>
-        <H1>Agents · artifacts · board</H1>
+        <Row gap={10} style={{ alignItems: "center", flexWrap: "wrap" }}>
+          <H1 style={{ margin: 0 }}>Agents · artifacts · board</H1>
+          <Pill size="sm" tone="info">
+            hub · not an agent
+          </Pill>
+        </Row>
         <Text tone="secondary">
           Whole picture for board_only SSOT — who writes Status, who writes
-          evidence, and how they meet on Exit.
+          evidence, and how they meet on Exit. Live agent ids only (board ·
+          implementer · test-runner · verifier · integrator · auditor ·
+          drift-guard · researcher).
         </Text>
         <Row gap={8} style={{ flexWrap: "wrap" }}>
           <Pill size="sm" tone="neutral" active>

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -328,11 +328,18 @@ export default function BoardSsotVsKitCanvas() {
   return (
     <Stack gap={24} style={{ padding: 24, maxWidth: 960 }}>
       <Stack gap={8}>
-        <H1>MAS Workflow Kit → Board SSOT (shipped)</H1>
+        <Row gap={10} style={{ alignItems: "center", flexWrap: "wrap" }}>
+          <H1 style={{ margin: 0 }}>MAS Workflow Kit → Board SSOT (shipped)</H1>
+          <Pill size="sm" tone="info">
+            hub · not an agent
+          </Pill>
+        </Row>
         <Text tone="secondary">
-          Before/after comparison for mas-workflow-kit-project-ssot as of {VERIFIED}.
-          PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift residuals, EA-001/004,
-          and expanded tests (1190 collected) are shipped on main.
+          Before/after comparison for mas-workflow-kit-project-ssot (MAS-SSOT-KIT)
+          as of {VERIFIED}. PR #2 merged A→B→C on main; FIX-NOTES-DI, doc-drift
+          residuals, EA-001/004, and expanded tests (1190 collected) are shipped
+          on main. Live agents: board · implementer · test-runner · verifier ·
+          integrator · auditor · drift-guard · researcher.
         </Text>
       </Stack>
 
@@ -453,7 +460,7 @@ export default function BoardSsotVsKitCanvas() {
                 </Text>
                 <Text size="small">3. Implement → tests → update trackers</Text>
                 <Text size="small">
-                  4. PR Pattern A (prepare.py GATES) — merge is code-side only
+                  4. PR Pattern A (prepare.py resolve_gates()) — merge is code-side only
                 </Text>
               </Stack>
             </CardBody>
@@ -465,8 +472,9 @@ export default function BoardSsotVsKitCanvas() {
         <Stack gap={10}>
           <H2>Shipped — GitHub Project as only writable SSOT</H2>
           <Text tone="secondary">
-            Same agents and Pattern A gates. Coordination bus is board Status /
-            Notes. Solid edges = writable; dashed = read-only export for DRIFT-010.
+            Same agents and prepare.py resolve_gates(). Coordination bus is board
+            Status / Notes. Solid edges = writable; dashed = read-only export for
+            DRIFT-010.
           </Text>
           <Legend />
           <FlowDiagram mode="shipped" />
@@ -566,7 +574,11 @@ export default function BoardSsotVsKitCanvas() {
           ["Post-merge card", "Manual / tracker only", "merge.py → Done + Notes"],
           ["Dual writers", "Single (markdown)", "Forbidden — DRIFT-009"],
           ["Stale PR detection", "N/A", "DRIFT-010 + export snapshot"],
-          ["PR merge gates", "prepare.py Pattern A", "Unchanged (local_only)"],
+          [
+            "PR merge gates",
+            "prepare.py resolve_gates()",
+            "Unchanged (local_only)",
+          ],
           ["Offline / no gh", "N/A (always local)", "fallback: local_trackers"],
           [
             "Day-0 board shell",

--- a/canvases/github-api-safety.canvas.tsx
+++ b/canvases/github-api-safety.canvas.tsx
@@ -19,13 +19,13 @@ import {
 /**
  * Inventory of GitHub API hammering / safety protections in MAS Workflow Kit.
  * Source: project_outbox.py, project_cli/handlers, agent Board-rights, ADR-008.
- * Verified: 2026-08-03 — post rename ship + docs/canvas reality align; API safety content unchanged (agent ids: auditor/board/drift-guard/integrator)
+ * Verified: 2026-08-03 — post rename + canvas reality; G1 wording aligned to GraphQL remaining via REST cache (agent ids: auditor/board/drift-guard/integrator)
  */
 
 const FIXED = [
   {
     id: "G1",
-    what: "Cached REST rate_limit precheck (TTL 45s) before Pattern A writes — EXIT_QUEUED without GraphQL",
+    what: "Cached GraphQL remaining via REST rate_limit (TTL 45s) before Pattern A writes — EXIT_QUEUED without GraphQL mutation",
   },
   {
     id: "G2",
@@ -163,8 +163,8 @@ const GAPS = [
 const CONFIG = [
   ["outbox.enabled", "true", "Master switch"],
   ["min_graphql_remaining", "200", "Flush + precheck gate"],
-  ["precheck_writes", "true", "Cached REST before Pattern A writes"],
-  ["quota_cache_ttl_seconds", "45", "REST cache TTL"],
+  ["precheck_writes", "true", "Cached GraphQL remaining before Pattern A writes"],
+  ["quota_cache_ttl_seconds", "45", "REST→GraphQL quota cache TTL"],
   ["quota_cache_path", ".local/…/graphql-quota-cache.json", "Cache file"],
   ["dedupe_pending", "true", "One pending row per fingerprint"],
   ["max_flush_per_run", "10", "Ops per flush"],
@@ -181,8 +181,10 @@ export default function GithubApiSafetyCanvas() {
           <Pill tone="success">G1–G5 done</Pill>
         </Row>
         <Text tone="secondary">
-          How MAS Workflow Kit limits API hammering on Project writes — hard
-          (code), soft (policy), and accepted residual gaps. Post G1–G5.
+          How MAS-SSOT-KIT limits API hammering on Project writes — hard (code),
+          soft (policy), and accepted residual gaps. Post G1–G5. Soft layer
+          binds all 8 live agents (auditor · board · drift-guard · implementer ·
+          integrator · researcher · test-runner · verifier).
         </Text>
       </Stack>
 
@@ -192,11 +194,13 @@ export default function GithubApiSafetyCanvas() {
         <Stat value="CODE=6" label="Do not retry" />
       </Grid>
 
-      <Callout tone="info">
-        Verdict: Pattern A writes use cached precheck + Forbidden/429 queue +
-        pending dedupe. Safe when agents use{" "}
+      <Callout tone="info" title="Verdict">
+        Pattern A writes use cached precheck + Forbidden/429 queue + pending
+        dedupe. Safe when agents use{" "}
         <Text weight="semibold">python3 -m cursor_workflow project …</Text> and
-        treat EXIT_QUEUED (6) as soft-success (no retry loop).
+        treat EXIT_QUEUED (6) as soft-success (no retry loop). Ops doc path
+        project-board-collaboration.md is intentional (not the retired
+        project-board agent id).
       </Callout>
 
       <H2>Fixed (G1–G5)</H2>

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -11,7 +11,10 @@
  *  - .agents/skills (maintainer SKILL.md folders)
  * Notes:
  *  - Concept hub (not agent-*). Excluded from DOC-008 roster scan like board-ssot-vs-kit.
- *  - B-safe rename SHIPPED 2026-08-03 (#140, #146–#149); plan table is historical → keep/keep.
+ *  - B-safe rename SHIPPED 2026-08-03 (#140, #146–#149); Plan/Scores/Stack = live roster.
+ *  - Renames tab = historical old→live ledger only (not current Task subagent_type).
+ *  - Intentional non-renames: artifact dir enterprise-architecture-audit/, ops doc
+ *    project-board-collaboration.md, snapshot project-board-snapshot.json.
  *  - Avoid "star-slash" globs in this block comment — they terminate the comment early.
  */
 
@@ -128,19 +131,19 @@ const PLAN_ROWS: {
 
 const SHARED_SKILLS = [
   [
-    "board-ssot (shipped)",
+    "board-ssot",
     "Shared by ALL agents for board Entry/Exit — not one agent's exclusive skill",
   ],
   [
-    "workflow-activate (keep)",
+    "workflow-activate",
     "Skill-only — consumer install; no agent twin",
   ],
   [
-    "mcp-connect (shipped)",
+    "mcp-connect",
     "Skill-only — MCP wiring",
   ],
   [
-    "review-pr / prepare-pr / merge-pr / pr-workflow (keep)",
+    "review-pr / prepare-pr / merge-pr / pr-workflow",
     "Maintainer slash namespace (.agents/skills) — not Task agents",
   ],
   [
@@ -282,21 +285,21 @@ const AGENT_SCORES: ScoredName[] = [
     kind: "agent",
     primaryPair: "auditor-protocol",
     dims: { clarity: 4, brevity: 2, pairing: 3, convention: 4, uniqueness: 4 },
-    note: "enterprise- brand noise; auditor vs architecture-audit",
+    note: "Live id auditor; residual: auditor vs architecture-audit artifact path",
   },
   {
     id: "drift-guard",
     kind: "agent",
     primaryPair: "drift-audit",
     dims: { clarity: 3, brevity: 2, pairing: 3, convention: 4, uniqueness: 4 },
-    note: "guard vs audit dual metaphor; workflow- redundant",
+    note: "Live id drift-guard; residual: guard vs audit metaphor (score <18)",
   },
   {
     id: "integrator",
     kind: "agent",
     primaryPair: "integrator-protocol",
-    dims: { clarity: 3, brevity: 1, pairing: 2, convention: 1, uniqueness: 3 },
-    note: "Only -agent suffix; stem mismatch with skill",
+    dims: { clarity: 5, brevity: 4, pairing: 3, convention: 4, uniqueness: 4 },
+    note: "Live id integrator; residual pairing debt with integrator-protocol",
   },
 ];
 
@@ -355,55 +358,55 @@ const SKILL_SCORES: ScoredName[] = [
     kind: "skill-canonical",
     primaryPair: "board",
     dims: { clarity: 4, brevity: 3, pairing: 4, convention: 4, uniqueness: 4 },
-    note: "onboard is mode noise; could be board-shell",
+    note: "Shipped board-shell; residual -shell vs onboard mnemonic",
   },
   {
     id: "test-coverage",
     kind: "skill-canonical",
     primaryPair: "test-runner",
     dims: { clarity: 4, brevity: 3, pairing: 3, convention: 4, uniqueness: 4 },
-    note: "Prefer test-coverage to pair with test-runner",
+    note: "Shipped test-coverage; runner↔coverage stem gap remains",
   },
   {
     id: "mcp-connect",
     kind: "skill-canonical",
     dims: { clarity: 4, brevity: 2, pairing: 4, convention: 3, uniqueness: 4 },
-    note: "Prefer mcp-connect",
+    note: "Shipped mcp-connect; brevity still weak",
   },
   {
     id: "research-corpus",
     kind: "skill-canonical",
     primaryPair: "researcher",
     dims: { clarity: 4, brevity: 2, pairing: 3, convention: 3, uniqueness: 4 },
-    note: "execution suffix noise",
+    note: "Shipped research-corpus; former -execution suffix retired",
   },
   {
     id: "auditor-protocol",
     kind: "skill-canonical",
     primaryPair: "auditor",
     dims: { clarity: 4, brevity: 2, pairing: 3, convention: 3, uniqueness: 3 },
-    note: "Long; stem ≠ auditor",
+    note: "Shipped auditor-protocol; long stem vs short agent id",
   },
   {
     id: "drift-audit",
     kind: "skill-canonical",
     primaryPair: "drift-guard",
     dims: { clarity: 3, brevity: 2, pairing: 3, convention: 3, uniqueness: 3 },
-    note: "guard/audit split; prefer drift-audit",
+    note: "Shipped drift-audit; guard vs audit metaphor remains",
   },
   {
     id: "implementer-loop",
     kind: "skill-canonical",
     primaryPair: "implementer",
     dims: { clarity: 3, brevity: 2, pairing: 2, convention: 3, uniqueness: 3 },
-    note: "Prefer implementer-loop",
+    note: "Shipped implementer-loop; loop suffix still long",
   },
   {
     id: "integrator-protocol",
     kind: "skill-canonical",
     primaryPair: "integrator",
     dims: { clarity: 3, brevity: 1, pairing: 2, convention: 2, uniqueness: 3 },
-    note: "Worst skill pairing; prefer integrator-protocol",
+    note: "Worst pairing on roster (short agent / long skill)",
   },
   {
     id: "audit-alignment",
@@ -523,59 +526,35 @@ type RenameRow = {
 const RENAME_ROWS: RenameRow[] = [
   {
     layer: "agents",
-    current: "integrator",
+    current: "integrator-mas-agent",
     proposed: "integrator",
     action: "rename",
-    priority: "P0",
-    rationale: "Only -agent suffix",
-  },
-  {
-    layer: "skills",
-    current: "integrator-protocol",
-    proposed: "integrator-protocol",
-    action: "rename",
-    priority: "P0",
-    rationale: "Pair with integrator",
+    priority: "P2",
+    rationale: "SHIPPED #147 — live id integrator",
   },
   {
     layer: "agents",
-    current: "auditor",
+    current: "enterprise-auditor",
     proposed: "auditor",
     action: "rename",
-    priority: "P1",
-    rationale: "Drop enterprise- noise",
+    priority: "P2",
+    rationale: "SHIPPED #148 — live id auditor",
   },
   {
     layer: "agents",
-    current: "drift-guard",
+    current: "workflow-drift-guard",
     proposed: "drift-guard",
     action: "rename",
-    priority: "P1",
-    rationale: "Align with drift-audit",
+    priority: "P2",
+    rationale: "SHIPPED #148 — live id drift-guard",
   },
   {
     layer: "agents",
-    current: "board",
+    current: "project-board",
     proposed: "board",
     action: "rename",
-    priority: "P1",
-    rationale: "Shorter Notes stamp",
-  },
-  {
-    layer: "skills",
-    current: "implementer-loop",
-    proposed: "implementer-loop",
-    action: "rename",
-    priority: "P1",
-    rationale: "Agent stem",
-  },
-  {
-    layer: "skills",
-    current: "test-coverage",
-    proposed: "test-coverage",
-    action: "rename",
-    priority: "P1",
-    rationale: "Pair with test-runner",
+    priority: "P2",
+    rationale: "SHIPPED #149 — live id board",
   },
   {
     layer: "agents",
@@ -583,7 +562,7 @@ const RENAME_ROWS: RenameRow[] = [
     proposed: "implementer",
     action: "keep",
     priority: "P2",
-    rationale: "Excellent score",
+    rationale: "unchanged (never renamed)",
   },
   {
     layer: "agents",
@@ -591,7 +570,7 @@ const RENAME_ROWS: RenameRow[] = [
     proposed: "verifier",
     action: "keep",
     priority: "P2",
-    rationale: "Excellent score",
+    rationale: "unchanged (never renamed)",
   },
   {
     layer: "agents",
@@ -599,7 +578,7 @@ const RENAME_ROWS: RenameRow[] = [
     proposed: "researcher",
     action: "keep",
     priority: "P2",
-    rationale: "Excellent score",
+    rationale: "unchanged (never renamed)",
   },
   {
     layer: "agents",
@@ -607,7 +586,80 @@ const RENAME_ROWS: RenameRow[] = [
     proposed: "test-runner",
     action: "keep",
     priority: "P2",
-    rationale: "Good; polish skill only",
+    rationale: "unchanged (never renamed)",
+  },
+  {
+    layer: "skills",
+    current: "mas-infrastructure-integration",
+    proposed: "integrator-protocol",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #146 — live skill integrator-protocol",
+  },
+  {
+    layer: "skills",
+    current: "enterprise-architecture-audit",
+    proposed: "auditor-protocol",
+    action: "rename",
+    priority: "P2",
+    rationale:
+      "SHIPPED #146 — live skill auditor-protocol (artifact dir path kept)",
+  },
+  {
+    layer: "skills",
+    current: "workflow-drift-audit",
+    proposed: "drift-audit",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #146 — live skill drift-audit",
+  },
+  {
+    layer: "skills",
+    current: "implementation-execution-loop",
+    proposed: "implementer-loop",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #140 — live skill implementer-loop",
+  },
+  {
+    layer: "skills",
+    current: "test-module-coverage",
+    proposed: "test-coverage",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #140 — live skill test-coverage",
+  },
+  {
+    layer: "skills",
+    current: "project-board-ssot",
+    proposed: "board-ssot",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #140 — live skill board-ssot",
+  },
+  {
+    layer: "skills",
+    current: "board-shell-onboard",
+    proposed: "board-shell",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #140 — live skill board-shell",
+  },
+  {
+    layer: "skills",
+    current: "connect-external-mcp",
+    proposed: "mcp-connect",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #140 — live skill mcp-connect",
+  },
+  {
+    layer: "skills",
+    current: "research-corpus-execution",
+    proposed: "research-corpus",
+    action: "rename",
+    priority: "P2",
+    rationale: "SHIPPED #140 — live skill research-corpus",
   },
 ];
 
@@ -704,7 +756,7 @@ function changeTone(
 }
 
 export default function NamingRosterAuditCanvas() {
-  const [view, setView] = useCanvasState<View>("view", "plan");
+  const [view, setView] = useCanvasState<View>("view", "stack");
   const [layer, setLayer] = useCanvasState<Layer>("layer", "all");
 
   const agentAvg =
@@ -720,6 +772,9 @@ export default function NamingRosterAuditCanvas() {
         10,
     ) / 10;
   const below18 = AGENT_SCORES.filter((a) => total(a.dims) < 18).length;
+  const lowestAgent = [...AGENT_SCORES].sort(
+    (a, b) => total(a.dims) - total(b.dims),
+  )[0]!;
   const sortedAgents = [...AGENT_SCORES].sort(
     (a, b) => total(b.dims) - total(a.dims),
   );
@@ -731,10 +786,22 @@ export default function NamingRosterAuditCanvas() {
   return (
     <Stack gap={20} style={{ padding: 20, maxWidth: 1140 }}>
       <Stack gap={6}>
-        <H1>Naming roster — scores & stack</H1>
+        <Row gap={10} style={{ alignItems: "center", flexWrap: "wrap" }}>
+          <H1 style={{ margin: 0 }}>Naming roster — live stack</H1>
+          <Pill tone="info" size="sm">
+            hub · not an agent
+          </Pill>
+          <Pill tone="success" size="sm">
+            B-safe SHIPPED
+          </Pill>
+          <Pill tone="neutral" size="sm">
+            8 agents · 12 skills
+          </Pill>
+        </Row>
         <Text tone="secondary" size="small">
-          Verified {AUDIT_DATE} · Dimensions Clarity+Brevity+Pairing+Convention+Uniqueness
-          (/25) · Advisory only
+          Verified {AUDIT_DATE} · Clarity+Brevity+Pairing+Convention+Uniqueness
+          (/25) · Advisory. Default view = live Target stack. Plan/Scores use live
+          ids. Renames tab = historical old→live ledger only (not Task types).
         </Text>
       </Stack>
 
@@ -748,19 +815,19 @@ export default function NamingRosterAuditCanvas() {
             tone={below18 > 0 ? "warning" : "success"}
           />
           <Stat
-            value={String(total(AGENT_SCORES.find((a) => a.id === "integrator")!.dims))}
-            label="Worst agent (integrator)"
-            tone="danger"
+            value={String(total(lowestAgent.dims))}
+            label={`Lowest agent (${lowestAgent.id})`}
+            tone={total(lowestAgent.dims) < 18 ? "danger" : "warning"}
           />
         </Grid>
         <Select
           value={view}
           onChange={(v) => setView(v as View)}
           options={[
-            { value: "plan", label: "Plan table" },
+            { value: "stack", label: "Target stack (live)" },
+            { value: "plan", label: "Plan table (live)" },
             { value: "scores", label: "Scores" },
-            { value: "stack", label: "Target stack" },
-            { value: "renames", label: "Renames" },
+            { value: "renames", label: "Old→live ledger" },
             { value: "future", label: "Future agents" },
           ]}
         />
@@ -769,24 +836,24 @@ export default function NamingRosterAuditCanvas() {
       {view === "plan" ? (
         <Stack gap={16}>
           <Callout tone="success" title="B-safe rename SHIPPED — 2026-08-03">
-            Agent/skill renames landed via #140 + #146–#149 (tip before CI: 333321d;
-            descriptions later prefixed MAS-SSOT-KIT in #153). Plan rows below are
-            keep/keep historical record — filesystem roster is current truth
-            (8 agents / 12 skills / 7 rules). Shared board-ssot remains Entry/Exit for all agents.
+            Live filesystem roster: 8 agents / 12 canonical skills / 7 rules.
+            Agent descriptions prefixed MAS-SSOT-KIT (#153). Shared board-ssot is
+            Entry/Exit for all agents. Plan rows below are keep/keep against the
+            shipped names — not a pending rename plan.
           </Callout>
 
           <Stack gap={8}>
-            <H2>Agent ↔ skill roster (shipped)</H2>
+            <H2>Agent ↔ skill roster (live)</H2>
             <Text tone="secondary" size="small">
-              Column meaning: agent · skills · same (post-rename) · change = keep
+              Columns are live ids (post-rename). Δ keep = no further rename planned.
             </Text>
             <Table
               headers={[
                 "Lane",
-                "Agent now",
-                "Skills now",
-                "Suggested agent",
-                "Suggested skills",
+                "Agent (live)",
+                "Skills (live)",
+                "Agent (same)",
+                "Skills (same)",
                 "Δ agent",
                 "Δ skill",
               ]}
@@ -820,11 +887,18 @@ export default function NamingRosterAuditCanvas() {
           <Stack gap={8}>
             <H2>Shared / skill-only (not owned by one agent)</H2>
             <Table
-              headers={["Skill (now → suggested)", "Role"]}
+              headers={["Skill (live)", "Role"]}
               rows={SHARED_SKILLS.map(([a, b]) => [a, b])}
               striped
             />
           </Stack>
+
+          <Callout tone="neutral" title="Intentional non-renames">
+            Artifact dir .local/workflow-artifacts/enterprise-architecture-audit/
+            · ops doc project-board-collaboration.md · snapshot
+            project-board-snapshot.json — paths kept on purpose (not agent/skill
+            ids).
+          </Callout>
 
           <Card>
             <CardHeader>Confidence</CardHeader>
@@ -834,11 +908,11 @@ export default function NamingRosterAuditCanvas() {
                   Sure about current primary pairings — taken from agent cards.
                 </Text>
                 <Text size="small">
-                  Sure about suggested stems as a clarity target (scores + pairing).
+                  Residual score debt (pairing/brevity) remains advisory — rename
+                  appetite for B-safe is closed.
                 </Text>
                 <Text size="small">
-                  Not sure you should rename agents in one PR — blast radius is high;
-                  skill-only renames (appetite A lite) are safer first.
+                  Historical: skills #140 then agents #146–#149 — B-safe SHIPPED.
                 </Text>
               </Stack>
             </CardBody>
@@ -971,7 +1045,7 @@ export default function NamingRosterAuditCanvas() {
 
       {view === "stack" ? (
         <Stack gap={12}>
-          <H2>Target stack (recommended)</H2>
+          <H2>Live stack (shipped roster)</H2>
           <Table
             headers={["Lane", "Agent", "Primary skill"]}
             rows={STACK.map(([lane, agent, skill]) => [
@@ -981,17 +1055,29 @@ export default function NamingRosterAuditCanvas() {
             ])}
             striped
           />
-          <Callout tone="success" title="Post-rename scores (shipped roster)">
-            Current ids score at or above admission bar: integrator / auditor /
-            drift-guard / board / implementer↔implementer-loop — rename debt closed.
+          <Callout tone="success" title="B-safe rename debt closed">
+            Live ids: board · implementer · test-runner · verifier · integrator ·
+            auditor · drift-guard · researcher. Primary skills match STACK above.
+            Residual score debt (drift-guard / auditor still &lt;18 on pairing/
+            brevity) is advisory only — not a reopen of rename appetite.
+          </Callout>
+          <Callout tone="neutral" title="Intentional path keeps">
+            enterprise-architecture-audit/ (artifact dir) ·
+            project-board-collaboration.md (ops) · project-board-snapshot.json —
+            not agent or skill folder names.
           </Callout>
         </Stack>
       ) : null}
 
       {view === "renames" ? (
         <Stack gap={12}>
+          <Callout tone="warning" title="Historical ledger — not live Task ids">
+            Old = pre-rename id (retired). Live = today’s id after B-safe (#140,
+            #146–#149). Action rename = completed rename; keep = never renamed.
+            Do not treat Old as today’s subagent_type.
+          </Callout>
           <Row gap={12} align="center" justify="space-between">
-            <H2>Current → proposed</H2>
+            <H2>Old → live (SHIPPED)</H2>
             <Select
               value={layer}
               onChange={(v) => setLayer(v as Layer)}
@@ -999,13 +1085,11 @@ export default function NamingRosterAuditCanvas() {
                 { value: "all", label: "All" },
                 { value: "agents", label: "Agents" },
                 { value: "skills", label: "Skills" },
-                { value: "rules", label: "Rules" },
-                { value: "canvases", label: "Canvases" },
               ]}
             />
           </Row>
           <Table
-            headers={["Pri", "Layer", "Current", "Proposed", "Action", "Why"]}
+            headers={["Pri", "Layer", "Old (retired)", "Live (shipped)", "Action", "Why"]}
             rows={filteredRenames.map((r) => [
               <Pill tone={priorityTone(r.priority)} size="sm">
                 {r.priority}
@@ -1023,14 +1107,18 @@ export default function NamingRosterAuditCanvas() {
             striped
           />
           <Card>
-            <CardHeader>Rename appetite</CardHeader>
+            <CardHeader>Rename appetite (closed)</CardHeader>
             <CardBody>
               <Stack gap={6}>
-                <Text size="small">A) P0 only — integrator + integrator-protocol</Text>
                 <Text size="small">
-                  B) A+B — also auditor / drift-guard / board + skill pairs
+                  B-safe SHIPPED 2026-08-03 — this tab is the audit trail only.
                 </Text>
-                <Text size="small">C) Full — include rules *-policy</Text>
+                <Text size="small">
+                  Was B) A+B — auditor / drift-guard / board + skill pairs (done)
+                </Text>
+                <Text size="small">
+                  Was C) Full — rules *-policy (deferred / not in B-safe)
+                </Text>
               </Stack>
             </CardBody>
           </Card>
@@ -1167,8 +1255,9 @@ export default function NamingRosterAuditCanvas() {
 
       <Divider />
       <Text tone="tertiary" size="small">
-        Evidence: .local/workflow-artifacts/audits/naming-roster-audit-2026-08-03.md ·
-        alignment-audit.md
+        Live truth: .cursor/agents/*.md · .cursor/skills/*/SKILL.md · Evidence:
+        .local/workflow-artifacts/alignment/alignment-audit.md · verified{" "}
+        {AUDIT_DATE}
       </Text>
     </Stack>
   );

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -23,7 +23,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs
 1. Install kit via `cursor_workflow activate` (plugin) or `cursor_workflow install` (kit clone).
 2. When `project_ssot.enabled` + `board_only`: Entry = board (`project status` / claim); Exit = Status + Notes. Local trackers = offline fallback only.
 3. Else: agents read `.local/` trackers (`session-pointer.md` → `plan.md` → `work-tracker.md`).
-4. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A + `prepare.py` GATES).
+4. Maintainer PR workflow runs via `.ai_infra/scripts/pr/*` (Pattern A + `prepare.py` `resolve_gates()`).
 5. Optional MCP (`workflow-kit`) wraps the same scripts.
 
 ## Core abbreviations
@@ -36,7 +36,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs
 | CLI | Command-line interface — here mainly `python3 -m cursor_workflow …` and `gh` |
 | PR | Pull request — maintainer merge workflow (Pattern A) |
 | ADR | Architecture Decision Record — `.ai_infra/docs/decisions/` (ADR-001…008) |
-| GATES | Hardcoded subprocess list in `.ai_infra/scripts/pr/prepare.py` |
+| GATES | 2-gate back-compat alias in `.ai_infra/scripts/pr/prepare.py`; SSOT is `resolve_gates()` (kit-dev may append drift + doc facts) |
 | Pattern A | Script-first workflow; agents invoke **one** command per maintainer action |
 | YAML | Config format for `github.collaboration.yaml`, registries, manifests |
 | UTC / ISO-8601 | Board Notes timestamps (`YYYY-MM-DDTHH:MM:SSZ`); CLI stamps UTC |

--- a/payload/.cursor/agents/auditor.md
+++ b/payload/.cursor/agents/auditor.md
@@ -4,7 +4,7 @@ model: auto
 description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
 ---
 
-# Enterprise auditor
+# Auditor
 
 ## Anchor (mandatory)
 

--- a/payload/.cursor/agents/board.md
+++ b/payload/.cursor/agents/board.md
@@ -4,7 +4,7 @@ model: auto
 description: board MAS-SSOT-KIT — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
 ---
 
-# Project board
+# Board
 
 ## Anchor (mandatory)
 

--- a/payload/.cursor/agents/drift-guard.md
+++ b/payload/.cursor/agents/drift-guard.md
@@ -4,7 +4,7 @@ model: auto
 description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
 ---
 
-# Workflow drift guard
+# Drift guard
 
 ## Anchor (mandatory)
 

--- a/payload/.cursor/agents/integrator.md
+++ b/payload/.cursor/agents/integrator.md
@@ -4,7 +4,7 @@ model: auto
 description: integrator MAS-SSOT-KIT — Integrates new agents, skills, MCP, and infrastructure expansions into the MAS Workflow Kit — procedural, evidence-only, Pattern A compliant.
 ---
 
-# MAS infrastructure integrator
+# Integrator
 
 ## Role
 

--- a/payload/.cursor/skills/auditor-protocol/SKILL.md
+++ b/payload/.cursor/skills/auditor-protocol/SKILL.md
@@ -15,7 +15,7 @@ Notes:
  - Advisory-only: no auto-remediation during the audit pass unless the user explicitly asks for edits.
 -->
 
-# Enterprise Architecture Audit (Python, audit-grade)
+# Auditor protocol
 
 ## Goal
 

--- a/payload/.cursor/skills/board-shell/SKILL.md
+++ b/payload/.cursor/skills/board-shell/SKILL.md
@@ -18,7 +18,7 @@ Notes:
  - Do not call undocumented GraphQL view mutations.
 -->
 
-# Board shell onboard (first-run coach)
+# Board shell
 
 ## When
 

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -24,7 +24,7 @@ Notes:
  - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
 -->
 
-# Project board SSOT
+# Board SSOT
 
 ## Goal
 

--- a/payload/.cursor/skills/drift-audit/SKILL.md
+++ b/payload/.cursor/skills/drift-audit/SKILL.md
@@ -15,7 +15,7 @@ Notes:
  - Advisory-only: no auto-remediation unless user explicitly asks.
 -->
 
-# Workflow drift audit
+# Drift audit
 
 ## Goal
 

--- a/payload/.cursor/skills/implementer-loop/SKILL.md
+++ b/payload/.cursor/skills/implementer-loop/SKILL.md
@@ -3,7 +3,7 @@ name: implementer-loop
 description: Disciplined implementation slices with board SSOT continuation and Pattern A gates.
 ---
 
-# Implementation execution loop
+# Implementer loop
 
 ## When
 

--- a/payload/.cursor/skills/integrator-protocol/SKILL.md
+++ b/payload/.cursor/skills/integrator-protocol/SKILL.md
@@ -3,7 +3,7 @@ name: integrator-protocol
 description: Procedural integration of new agents, skills, MCP servers, and kit expansions into MAS Workflow Kit — templates, scripts, three-plane discipline.
 ---
 
-# MAS infrastructure integration
+# Integrator protocol
 
 ## Goal
 

--- a/payload/.cursor/skills/mcp-connect/SKILL.md
+++ b/payload/.cursor/skills/mcp-connect/SKILL.md
@@ -3,7 +3,7 @@ name: mcp-connect
 description: Connect external MCP servers to MAS Workflow Kit agents via mcp.user.json and mcp.registry.yaml.
 ---
 
-# Connect external MCP
+# MCP connect
 
 ## When
 

--- a/payload/.cursor/skills/research-corpus/SKILL.md
+++ b/payload/.cursor/skills/research-corpus/SKILL.md
@@ -3,7 +3,7 @@ name: research-corpus
 description: Brief-driven multi-round research into _research_results packs (external GitHub/local or host self).
 ---
 
-# Research corpus execution
+# Research corpus
 
 ## When
 

--- a/payload/.cursor/skills/test-coverage/SKILL.md
+++ b/payload/.cursor/skills/test-coverage/SKILL.md
@@ -3,7 +3,7 @@ name: test-coverage
 description: Module-focused tests and coverage evidence for workflow scripts and project code.
 ---
 
-# Test module coverage
+# Test coverage
 
 ## When
 

--- a/skills/auditor-protocol/SKILL.md
+++ b/skills/auditor-protocol/SKILL.md
@@ -15,7 +15,7 @@ Notes:
  - Advisory-only: no auto-remediation during the audit pass unless the user explicitly asks for edits.
 -->
 
-# Enterprise Architecture Audit (Python, audit-grade)
+# Auditor protocol
 
 ## Goal
 

--- a/skills/board-shell/SKILL.md
+++ b/skills/board-shell/SKILL.md
@@ -18,7 +18,7 @@ Notes:
  - Do not call undocumented GraphQL view mutations.
 -->
 
-# Board shell onboard (first-run coach)
+# Board shell
 
 ## When
 

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -24,7 +24,7 @@ Notes:
  - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
 -->
 
-# Project board SSOT
+# Board SSOT
 
 ## Goal
 

--- a/skills/drift-audit/SKILL.md
+++ b/skills/drift-audit/SKILL.md
@@ -15,7 +15,7 @@ Notes:
  - Advisory-only: no auto-remediation unless user explicitly asks.
 -->
 
-# Workflow drift audit
+# Drift audit
 
 ## Goal
 

--- a/skills/implementer-loop/SKILL.md
+++ b/skills/implementer-loop/SKILL.md
@@ -3,7 +3,7 @@ name: implementer-loop
 description: Disciplined implementation slices with board SSOT continuation and Pattern A gates.
 ---
 
-# Implementation execution loop
+# Implementer loop
 
 ## When
 

--- a/skills/integrator-protocol/SKILL.md
+++ b/skills/integrator-protocol/SKILL.md
@@ -3,7 +3,7 @@ name: integrator-protocol
 description: Procedural integration of new agents, skills, MCP servers, and kit expansions into MAS Workflow Kit — templates, scripts, three-plane discipline.
 ---
 
-# MAS infrastructure integration
+# Integrator protocol
 
 ## Goal
 

--- a/skills/mcp-connect/SKILL.md
+++ b/skills/mcp-connect/SKILL.md
@@ -3,7 +3,7 @@ name: mcp-connect
 description: Connect external MCP servers to MAS Workflow Kit agents via mcp.user.json and mcp.registry.yaml.
 ---
 
-# Connect external MCP
+# MCP connect
 
 ## When
 

--- a/skills/research-corpus/SKILL.md
+++ b/skills/research-corpus/SKILL.md
@@ -3,7 +3,7 @@ name: research-corpus
 description: Brief-driven multi-round research into _research_results packs (external GitHub/local or host self).
 ---
 
-# Research corpus execution
+# Research corpus
 
 ## When
 

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -3,7 +3,7 @@ name: test-coverage
 description: Module-focused tests and coverage evidence for workflow scripts and project code.
 ---
 
-# Test module coverage
+# Test coverage
 
 ## When
 

--- a/tests/modules/architecture_scripts/test_check_doc_facts.py
+++ b/tests/modules/architecture_scripts/test_check_doc_facts.py
@@ -82,7 +82,7 @@ def test_missing_agent_in_roster_hub_fails_doc008(tmp_path: Path) -> None:
     needle = (
         '  {\n'
         '    id: "researcher",\n'
-        '    role: "Shipped corpus researcher — packs under _research_results/ (opt-in)",\n'
+        '    role: "researcher MAS-SSOT-KIT · skill research-corpus (opt-in packs)",\n'
         '    lane: "Research (opt-in corpus)",\n'
         "  },\n"
     )

--- a/tests/modules/workflow_mcp/test_workflow_mcp.py
+++ b/tests/modules/workflow_mcp/test_workflow_mcp.py
@@ -83,7 +83,8 @@ def test_read_skill() -> None:
     from workflow_mcp.resources import read_skill
 
     body = read_skill(REPO_ROOT, "implementer-loop")
-    assert "implementation execution loop" in body.lower()
+    assert "implementer loop" in body.lower()
+    assert "board ssot" in body.lower()
 
 
 def test_read_pr_artifact_invalid_phase() -> None:


### PR DESCRIPTION
## Summary
- Align agent/hub canvases with live post-rename ids (MAS-SSOT-KIT blurbs, `prepare.py resolve_gates()`, PEERS, DAG layout API).
- Post-ship UX for `naming-roster-audit` (live stack default; Old→live ledger; fixed lowest-agent Stat).
- Sync agent/skill H1s, AGENTS.md skill list, HANDOFF date, plugin/payload/skills mirrors.

## Test plan
- [x] `python3 .ai_infra/scripts/architecture/check_doc_facts.py` (DOC-008 PASS)
- [ ] `python .ai_infra/scripts/pr/prepare.py --pipeline architecture_impacting` gates
- [ ] `pytest -q`

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: implementer | auditor | review-pr | prepare-pr | merge-pr
- Alignment: `.local/workflow-artifacts/alignment/`
- Board-Item: PVTI_lAHOBl46-84A9KZxzg1LX54
- Issue: #158