### PR TITLE
Expand drift-guard goal pulse and auditor CHK-* quality

### DIFF
--- a/.agents/skills/audit-alignment/SKILL.md
+++ b/.agents/skills/audit-alignment/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: audit-alignment
-description: DEPRECATED — use auditor; alignment outputs unchanged for merge gates.
+description: DEPRECATED RETIRE-PENDING — use auditor + auditor-protocol; stub kept for path/DOC count until AA-ROSTER-005 close.
 disable-model-invocation: true
 ---
 
-# Audit alignment (deprecated stub)
+# Audit alignment (deprecated stub — retire pending)
 
 **Do not use this file as the primary workflow.** The canonical audit agent is **`auditor`**.
 
 - **Agent:** `.cursor/agents/auditor.md`
-- **Protocol:** `.cursor/skills/auditor-protocol/SKILL.md`
+- **Protocol:** `.cursor/skills/auditor-protocol/SKILL.md` (CHK-* checklists)
 - **Merge-gate outputs (unchanged):** `.local/workflow-artifacts/alignment/alignment-audit.md`, `alignment-todos.md` per `.ai_infra/docs/roadmap/alignment-audit-schema.md`
 - **Rule:** `.cursor/rules/advisory-audit-alignment-enforcement.mdc`
 
-For architecture-impacting PRs, run a **focused alignment pass** (see `auditor-protocol`) unless a **full** `enterprise-architecture-audit.md` report is explicitly requested.
+**Retirement (AA-ROSTER-005):** Folder remains so maintainer skill count (5) and old links resolve. Delete only after updating AGENTS.md / DOC scans / `sync_plugin_bundle` expectations in a dedicated integrator slice.
 
-This stub remains so old links and governance scans that mention `audit-alignment/` keep resolving to a clear redirect.
+For architecture-impacting PRs, run a **focused alignment pass** (see `auditor-protocol`) unless a **full** `enterprise-architecture-audit.md` report is explicitly requested.

--- a/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -9,6 +9,15 @@ MAS Workflow Kit enforces infrastructure parity via `integrate validate`, govern
 
 The **drift-guard** capability closes that gap without duplicating architecture audits (`auditor`) or claim verification (`verifier`).
 
+### Goal pulse vs EA audit (ownership split)
+
+| Loop | Owner | Cadence | Question |
+|------|-------|---------|----------|
+| **Goal / plan / agent-doctrine / docs coherence** + DRIFT scripts | `drift-guard` + `drift-audit` | Continuous (slice closure / prepare) | Are we still pointed at living goals? |
+| **Architecture / security / perf / granularity / docs quality** | `auditor` + `auditor-protocol` (CHK-*) | Periodic or architecture-impacting PR | Is the system sound and evidenced? |
+
+Drift does **not** rewrite architecture; auditor does **not** own continuous plan-pulse prose.
+
 ## Decision
 
 Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](ADR-006-agent-integration-model.md).
@@ -28,7 +37,7 @@ Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](
 
 | Profile | When | Checks |
 |---------|------|--------|
-| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…010 + 004b (full set; 004b/009–010 when `board_only`) |
+| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…011 + 004b (full set; 004b/009–011 when applicable) |
 | `consumer` | `work-tracker.md` contains exemplar `STARTER-001` | DRIFT-005, DRIFT-008 (relaxed tracker rules) |
 
 Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
@@ -48,6 +57,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-008 | P2 | consumer | Scaffold trackers present |
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
 | DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
+| DRIFT-011 | P1 | kit-dev | Agent roster coherence: `.cursor/agents/*.md` basenames match the eight live kit agent ids (goal/doctrine pulse — falsifiable) |
 
 **Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`). Pending `project_ssot.outbox` ops are **not** a drift failure — cite `project outbox status` in artifacts when relevant.
 

--- a/.ai_infra/docs/governance/drift-prevention.md
+++ b/.ai_infra/docs/governance/drift-prevention.md
@@ -45,21 +45,21 @@ Additionally when changing governance, workflows, `.cursor/`, `.agents/`, or tra
 
 Follow **`agent-workflow-procedures.md` §3b**. Includes **`AGENTS.md`**, **`rules-overlap-matrix.md`**, **`workflow-source-owners.md`**, PR scripts, and mirrored `.cursor/` / `.agents/` skills. Run **`check_governance_consistency.py`** when tracked policy paths change.
 
-## Operational drift (drift-guard)
+## Operational drift + goal pulse (drift-guard)
 
-Script-first checks for plan ↔ tracker ↔ session-pointer coherence and handoff doc parity. See [ADR-007](../decisions/ADR-007-workflow-drift-guard.md).
+Script-first checks for plan ↔ tracker ↔ session-pointer coherence, handoff doc parity, and **falsifiable goal/doctrine pulse** (DRIFT-011 roster ids). Prose goal pulse (board Acceptance vs plan vs `AGENTS.md`) lives in drift artifacts — not in `auditor`. See [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) § Goal pulse vs EA audit.
 
 **Kit-dev PR prep:** `prepare.py` `resolve_gates()` auto-runs `drift validate` before merge (with doc facts). Optional: Task **`drift-guard`** after pass to refresh `.local/workflow-artifacts/drift/` artifacts.
 
 | Concern | Owner | Do NOT duplicate in drift |
 |---------|-------|---------------------------|
 | Bare paths, brand terms | `check_governance_consistency.py`, `check_debrand.py` | Path/brand scans |
-| Agent Anchor/MCP, registry parity | `integrate validate` INT-001…014 | Agent file structure |
+| Agent Anchor/MCP, registry parity | `integrate validate` INT-001…014 | Full agent file structure (DRIFT-011 is id set only) |
 | Canonical doc facts (roster, counts) | `check_doc_facts.py` / INT-013 | Path/brand scans |
 | test-plan/index existence | `check_testing_artifacts.py` | File exists checks |
 | Plugin/payload SHA drift | `sync_plugin_bundle.py --check` | Bundle sync |
 | Slice claim verification | `verifier` | Subjective verification |
-| Architecture scorecard | `auditor` | Module deep-dive |
+| Architecture / security / perf scorecard (CHK-*) | `auditor` | Module deep-dive / EA phases |
 
 **Command:** `python -m cursor_workflow drift validate --directory .` or `make drift-validate`.
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-08-03 (naming-roster-audit concept hub; 15 canvases; 1190 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1190
+**Last updated:** 2026-08-04 (drift goal pulse DRIFT-011 + auditor CHK-*; 1193 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1193
 
 ## Shipped (confirmed in repo)
 
@@ -30,7 +30,7 @@ Notes:
 | workflow-activate skill | Kit dev + plugin | `.cursor/skills/workflow-activate/` |
 | PR scripts + prepare gates | Pattern A — **2** universal; **4** on kit-dev (drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` |
 | Governance + debrand scanners | CI-ready | `.ai_infra/scripts/architecture/` |
-| Workflow drift validate | ADR-007 (+ DRIFT-004b) | `.ai_infra/scripts/workflow/check_drift.py` |
+| Workflow drift validate | ADR-007 (+ DRIFT-004b, DRIFT-011 roster pulse) | `.ai_infra/scripts/workflow/check_drift.py` |
 | Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_recipes.py` / `project_cli.py` + skill § Notes |
 | Tier-1 Size/Estimate + Start date | Size↔Estimate **points** table in skill; Start date on claim / `set-status` / `handoff` → `in_progress`; `create-from-template --priority` required | `board-ssot` skill · `project_atomics.ensure_start_date_if_starting` · PR #70 |
 | Local continuity-index | Rolling ≥3-day UTC rows; board Notes = full card lifetime | `history/continuity-index.md` (+ exemplar) |
@@ -53,14 +53,14 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1190 collected (1168 passed + 2 skipped on full green run; intentional live-smoke skips) | `tests/modules/` |
+| Tests | 1193 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-20
-(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1190
-collected** as of board-shell completeness; intentional live-smoke skips only). One import-order `sys.path` bootstrap in
+(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1193
+collected** as of DRIFT-011 goal pulse; intentional live-smoke skips only). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,
 `check_debrand.py`, `check_consumer_purity.py`, `check_file_headers.py`) have

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -204,7 +204,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07, archival):** Verified `plugin.json` `description`, the Description row above, and README consumer sections against `IMPLEMENTATION-STATUS.md` on `main` at that date — counts superseded by refreshes below; feature counts at that date (8 agents, **11** skills, 5 PR skills, 7 rules) — **superseded** (skills are **12** since board-shell).
 
-**Listing copy refresh (2026-08-03 naming + docs/canvas reality):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` on `main` @ `9cd09a7` — **1190** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
+**Listing copy refresh (2026-08-04 drift/auditor quality):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` — **1193** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
 
 **Listing copy refresh (2026-07-18 WORKSPACE-CLEAN, archival):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree at that date — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Superseded by 2026-07-19 refreshes below.
 

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -83,7 +83,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs
 | P0 / P1 / P2 / P3 | Priority — board uses `p0\|p1\|p2`; chat P3 → board `p2` + Notes `deferred` | `board-ssot` skill |
 | xs…xl | Size options on the board (Tier-1) | Size↔Estimate table in skill |
 
-High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`).
+High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`), **DRIFT-011** (`.cursor/agents` basenames == eight live kit agent ids — goal/doctrine pulse).
 
 ## Planes
 

--- a/.ai_infra/scripts/workflow/drift_checks.py
+++ b/.ai_infra/scripts/workflow/drift_checks.py
@@ -1,7 +1,7 @@
 """
 File: drift_checks.py
 Path: .ai_infra/scripts/workflow/drift_checks.py
-Role: Individual DRIFT-001…010 (+004b) check functions for workflow drift validation.
+Role: Individual DRIFT-001…011 (+004b) check functions for workflow drift validation.
 Used By:
  - .ai_infra/scripts/workflow/check_drift.py
 Depends On:
@@ -19,6 +19,11 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+
+_AI_INFRA = Path(__file__).resolve().parents[2]
+if str(_AI_INFRA) not in sys.path:
+    sys.path.insert(0, str(_AI_INFRA))
+from paths import resolve_project_python  # noqa: E402
 
 
 class Severity(str, Enum):
@@ -133,8 +138,6 @@ def _parse_implementation_test_count(text: str) -> int | None:
 
 
 def _collect_pytest_count(root: Path) -> int:
-    from paths import resolve_project_python
-
     proc = subprocess.run(
         [resolve_project_python(root), "-m", "pytest", "--collect-only", "-q"],
         cwd=root,
@@ -809,6 +812,57 @@ def check_drift010(paths: DriftPaths) -> CheckResult:
     )
 
 
+# Live kit agent ids (post B-safe rename). Keep in sync with AGENTS.md / DOC-008.
+LIVE_KIT_AGENT_IDS: frozenset[str] = frozenset(
+    {
+        "auditor",
+        "board",
+        "drift-guard",
+        "implementer",
+        "integrator",
+        "researcher",
+        "test-runner",
+        "verifier",
+    }
+)
+
+
+def check_drift011(paths: DriftPaths) -> CheckResult:
+    """
+    Goal/doctrine pulse (falsifiable): `.cursor/agents/*.md` basenames must equal
+    the eight live kit agent ids. Missing/extra agents = doctrine drift.
+    """
+    agents_dir = paths.root / ".cursor" / "agents"
+    if not agents_dir.is_dir():
+        return CheckResult(
+            check_id="DRIFT-011",
+            severity=Severity.P1,
+            passed=False,
+            detail=".cursor/agents/ missing — cannot verify agent roster",
+        )
+    on_disk = {p.stem for p in agents_dir.glob("*.md") if p.is_file()}
+    missing = sorted(LIVE_KIT_AGENT_IDS - on_disk)
+    extra = sorted(on_disk - LIVE_KIT_AGENT_IDS)
+    if not missing and not extra:
+        return CheckResult(
+            check_id="DRIFT-011",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"agent roster coherent ({len(LIVE_KIT_AGENT_IDS)} live ids)",
+        )
+    parts: list[str] = []
+    if missing:
+        parts.append(f"missing={','.join(missing)}")
+    if extra:
+        parts.append(f"extra={','.join(extra)}")
+    return CheckResult(
+        check_id="DRIFT-011",
+        severity=Severity.P1,
+        passed=False,
+        detail="; ".join(parts),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_drift001,
     check_drift002,
@@ -821,6 +875,7 @@ KIT_DEV_CHECKS = (
     check_drift008,
     check_drift009,
     check_drift010,
+    check_drift011,
 )
 
 CONSUMER_CHECKS = (

--- a/.cursor/agents/auditor.md
+++ b/.cursor/agents/auditor.md
@@ -1,10 +1,16 @@
 ---
 name: auditor
 model: auto
-description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
+description: auditor MAS-SSOT-KIT — Deep/periodic evidence architecture audit (CHK-* security/perf/granularity/docs); not continuous plan pulse.
 ---
 
 # Auditor
+
+## What we own (deep / periodic)
+
+**Own:** Evidence-only enterprise architecture and engineering audit — architecture, security (code + agent contracts), performance, granularity/boundaries, documentation quality — via `auditor-protocol` CHK-* checklists. Full scorecard or focused alignment for architecture-impacting PRs.
+
+**Do not own:** Continuous goal/plan/agent-doctrine coherence when plans change — that is **`drift-guard`** (script + goal pulse). Do not auto-fix product code unless the user explicitly asks.
 
 ## Anchor (mandatory)
 

--- a/.cursor/agents/drift-guard.md
+++ b/.cursor/agents/drift-guard.md
@@ -1,10 +1,16 @@
 ---
 name: drift-guard
 model: auto
-description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
+description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts; handoff remediations only.
 ---
 
 # Drift guard
+
+## What we guard (continuous)
+
+**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…011 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
+
+**Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
 
 ## Anchor (mandatory)
 
@@ -23,10 +29,11 @@ description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** when project SSOT enabled; prefer a fresh `project export` snapshot for DRIFT-010).
-3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
-4. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
-5. Do not duplicate governance, integrate, or auditor scope (ADR-007 / ADR-008).
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when applicable; prefer a fresh `project export` snapshot for DRIFT-010).
+3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
+4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
+5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
+6. Do not duplicate governance, integrate, or auditor deep scorecard scope (ADR-007 / ADR-008).
 
 ## Read first
 

--- a/.cursor/skills/audit-orchestration/SKILL.md
+++ b/.cursor/skills/audit-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-orchestration
-description: Orchestrate verify-all preflight, auditor, implementer doc-sync, drift-guard, and verifier with Task delegation.
+description: Orchestrate verify-all preflight, auditor (CHK-*), implementer doc-sync, drift-guard goal pulse, and verifier with Task delegation.
 ---
 <!--
 File: SKILL.md
@@ -15,6 +15,7 @@ Depends On:
  - .cursor/skills/implementer-loop/SKILL.md
 Notes:
  - Human-triggered only; scripts run before prose agents consume results.
+ - Full CHK-* on quarterly/release only — not every PR.
 -->
 
 # Audit orchestration
@@ -22,6 +23,16 @@ Notes:
 ## Goal
 
 Run a **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts and apply approved fixes — without one agent re-running every shell command.
+
+## Cadence
+
+| Trigger | Auditor depth | Drift |
+|---------|---------------|-------|
+| **Architecture-impacting PR** | Focused alignment + scoped CHK-* tick table | `drift validate` via prepare; optional drift-guard artifacts |
+| **Quarterly / kit release readiness** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
+| **Ad-hoc full audit** | Same as quarterly | Same |
+
+Do **not** run full CHK-* scorecard on every PR.
 
 ## When
 
@@ -38,6 +49,7 @@ make verify-all
 # or with artifacts for agents:
 python -m cursor_workflow verify all --write-preflight
 python -m cursor_workflow doc validate --write-preflight
+python -m cursor_workflow drift validate --directory .
 ```
 
 **MCP (preferred in Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
@@ -52,7 +64,7 @@ Launch concurrently:
 
 | Subagent | Mode | Deliverable |
 |----------|------|-------------|
-| `auditor` | artifact-write (`.local/` only) | `enterprise-architecture-audit.md`, `enterprise-audit-actions.md` |
+| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + **CHK-* tick table**. PR-scoped: alignment artifacts only |
 | `audit-module-map` skill (optional) | artifact-write (`.local/` only) | `.local/module-map.md` summary for audit §3 |
 
 Parent **does not** duplicate inventory searches — consumes subagent outputs + preflight JSON.
@@ -77,7 +89,7 @@ make doc-validate
 
 | Subagent | When |
 |----------|------|
-| `drift-guard` | After tracker/doc edits; P0/P1 drift findings |
+| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift findings |
 | `verifier` | Spot-check top audit claims vs preflight + repo paths |
 
 ## Phase 4 — Maintainer PR
@@ -91,7 +103,8 @@ Human or maintainer agent: `review-pr` → `prepare-pr` → `merge-pr` on a `fea
 3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`. Under `board_only`, do not auto-edit board card body or local `plan.md` / `work-tracker.md`; offline fallback: do not auto-edit `plan.md` / `work-tracker.md`.
 4. **Canvases** — optional IDE artifacts; not merge gates.
 5. **Token efficiency** — cite preflight pass/fail in chat; paste failing command output only.
+6. **Ownership** — continuous plan/agent-doctrine coherence = `drift-guard`; deep CHK-* = `auditor`. No new trash agents.
 
 ## Handoff format
 
-Preflight exit • audit artifact paths • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR
+Preflight exit • audit artifact paths • CHK-* gaps • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR

--- a/.cursor/skills/auditor-protocol/SKILL.md
+++ b/.cursor/skills/auditor-protocol/SKILL.md
@@ -100,7 +100,9 @@ When the **maintainer workflow** requires alignment files for `--arch-impacting`
   - `.local/workflow-artifacts/alignment/alignment-todos.md`
 - Use **`.ai_infra/docs/roadmap/alignment-audit-schema.md`** for finding shape and P0/P1/P2 handling.
 - Scope: compare **touched** roadmap/plan/strategy docs, rules/skills/agents, `src/` + `tests/modules/` relevant to the PR — not a whole-repo scorecard.
+- Include a short **CHK-*** tick table (below) for dimensions that touch the PR; mark N/A for untouched dimensions.
 - **Optional:** note in `alignment-audit.md` that a full enterprise scorecard was deferred.
+- Continuous plan/agent-doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 prose here.
 
 ---
 
@@ -174,6 +176,20 @@ Python-specific analysis mode: ON
 
 ## Mandatory phases (execute in order; show phase boundaries in the written report)
 
+### Named checklists (CHK-*) — mandatory coverage
+
+Map each checklist into the matching phase. In the written report (or focused alignment), include a **CHK tick table**: id · status (Pass / Gap / N/A / Unknown) · evidence paths. **Do not** invent new skill folders for these dimensions.
+
+| Id | Phase | Must cite |
+|----|-------|-----------|
+| `CHK-ARCH` | 2 | Style, dependency direction, cycles |
+| `CHK-GRANULARITY` | 2 / 4 | God modules, blurred boundaries vs `.ai_infra/docs/governance/module-boundaries.md` (kit planes) or consumer `src/` modules |
+| `CHK-PERF` | 3 | Hot paths, N+1/queue clues; **Unknown** if none observable |
+| `CHK-SEC-CODE` | 3 | Secrets handling, injection/trust boundaries in kit scripts / app code in scope |
+| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, hard-stops, MCP `.cursor/mcp.registry.yaml` allowlists, no product auto-fix — **contract compliance**, not LLM jailbreak proof |
+| `CHK-INFRA-KIT` | 1 / 3 | Three planes, install/activate, `integrate validate` clues — **not** consumer cloud infra product |
+| `CHK-DOCS` | 5 | Stated goals vs docs; stale HANDOFF / AGENTS / IMPLEMENTATION-STATUS |
+
 ### PHASE 1 — Repository inventory (descriptive only)
 
 Establish facts: Python version(s), dependency tooling, frameworks, entry points, main packages, workers/jobs, APIs/CLI/scripts, data stores, messaging, infra/deployment clues, test layout, docs/ADRs/config.  
@@ -181,22 +197,22 @@ Establish facts: Python version(s), dependency tooling, frameworks, entry points
 
 ### PHASE 2 — Implemented architecture
 
-Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles.  
+Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles. Complete **CHK-ARCH** and start **CHK-GRANULARITY**.  
 **Output:** detected profile, boundary analysis, layering assessment, risks visible from structure.
 
 ### PHASE 3 — Python engineering and runtime
 
-Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security.  
+Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security. Complete **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**.  
 **Output:** evidence-backed findings only; label Confirmed / Probable risk / Unknown.
 
 ### PHASE 4 — Module-by-module audit
 
-For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later).  
+For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later). Finish **CHK-GRANULARITY**.  
 Use **Unknown** where needed. **Do not skip** module-level sections for major roots.
 
 ### PHASE 5 — Goal and plan alignment
 
-For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice.
+For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice. Complete **CHK-DOCS**. Continuous plan pulse when plans change is **`drift-guard`** — reference drift artifacts if present; do not re-run DRIFT scripts as a substitute for this phase.
 
 ### PHASE 6 — Recommended direction
 
@@ -258,6 +274,7 @@ Write `enterprise-architecture-audit.md` with these sections:
 
 1. Executive Summary  
 2. Audit Method (must satisfy the **Evidence contract**: sources, searches, commands, scope limits)  
+2b. **CHK-* tick table** (all seven ids: Pass / Gap / N/A / Unknown + evidence)  
 3. Repository Inventory  
 4. Detected Architecture Profile  
 5. Python-Specific Engineering Assessment  
@@ -333,7 +350,8 @@ Deliverables: full report + enterprise-audit-actions.md under .local/workflow-ar
 ## Exit criteria
 
 - Phases 1–6 completed in order in the written report; no early recommendation dump.  
+- **CHK-*** tick table present (full audit) or scoped tick table (focused alignment).  
 - **Evidence contract** satisfied: §2 lists reproducible sources/commands; Confirmed claims and scorecard categories cite paths; no finding in §7 or actions file without **Evidence** paths (or explicit **Unknown**).  
 - Scorecard populated with evidence and confidence; no score without justification.  
-- `enterprise-audit-actions.md` exists with prioritized, repo-tied items.  
+- `enterprise-audit-actions.md` exists with prioritized, repo-tied items (full audit).  
 - Unknowns and human-validation items explicitly listed.

--- a/.cursor/skills/drift-audit/SKILL.md
+++ b/.cursor/skills/drift-audit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: drift-audit
-description: Run drift validate first; write drift-audit.md and drift-todos.md with evidence contract.
+description: Run drift validate first; write drift-audit.md and drift-todos.md with evidence contract; goal/plan/agent-doctrine pulse.
 ---
 <!--
 File: SKILL.md
 Path: .cursor/skills/drift-audit/SKILL.md
-Role: Operational workflow drift audit protocol for plan/tracker/session coherence.
+Role: Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts.
 Used By:
  - .cursor/agents/drift-guard.md
 Depends On:
@@ -13,36 +13,52 @@ Depends On:
  - .ai_infra/scripts/workflow/check_drift.py
 Notes:
  - Advisory-only: no auto-remediation unless user explicitly asks.
+ - Deep architecture/security/perf is auditor — not this skill.
 -->
 
 # Drift audit
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **session Board vs export (DRIFT-004b)**, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `auditor` or `verifier`.
+Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:
+
+- plan ↔ tracker ↔ session-pointer incoherence
+- **DRIFT-004b** session Board vs export; **DRIFT-009** dual-write; **DRIFT-010** board vs PRs
+- **DRIFT-011** `.cursor/agents` basenames == eight live kit agent ids
+- Prose goal pulse: board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards (flag gaps; hand off — do not rewrite architecture)
+
+Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 
 ## When
 
 - Substantive implementer slice closure (recommended)
+- After plans / board Acceptance / agent doctrine docs change
 - Optional pre-review drift pass before PR workflow
-- After tracker or handoff doc edits
 - When `project_ssot.enabled` — every pass should include board Status evidence
+
+## Entry checklist (goal pulse)
+
+1. Board (when enabled): `project status` + `list --status in_progress` — read Acceptance / Notes on In progress cards.
+2. Plan pointers: `.local/index-and-planning/current/plan.md` (or board card body as SSOT) — Current focus / goals.
+3. Doctrine: `AGENTS.md` skills/agents table vs `.cursor/agents/*.md` (script: DRIFT-011).
+4. Docs freshness vs goals: note Probable if HANDOFF / IMPLEMENTATION-STATUS look stale relative to Current focus (prose only).
 
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when kit-dev / board_only as applicable (ADR-007/008).
 3. Capture profile, check IDs, severities, and details from output.
-4. Write artifacts under `.local/workflow-artifacts/drift/` only.
-5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
-6. Print handoff line with `item_id` when applicable.
+4. Add prose **Goal pulse** section in drift-audit.md (board/plan/AGENTS gaps). Fuzzy “vision mismatch” stays Probable — not CI.
+5. Write artifacts under `.local/workflow-artifacts/drift/` only.
+6. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write or roster gaps, Notes on offending card or Ready handoff to board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+7. Print handoff line with `item_id` when applicable.
 
 ## Evidence contract
 
 | Label | Meaning |
 |-------|---------|
 | Confirmed | Script output + file path cited |
-| Probable | Inference from trackers; label explicitly |
+| Probable | Inference from trackers/docs; label explicitly |
 | Unknown | Not verifiable from repo |
 
 ## Artifact frontmatter (both files)
@@ -61,7 +77,7 @@ Command: python -m cursor_workflow drift validate --directory . [--profile consu
 
 ## drift-audit.md
 
-Summary, per-check table (ID, severity, pass/fail, detail, evidence path), verdict (GO / blocked on P0).
+Summary, per-check table (ID, severity, pass/fail, detail, evidence path), **Goal pulse** subsection, verdict (GO / blocked on P0).
 
 ## drift-todos.md
 
@@ -77,8 +93,8 @@ Open findings with id, severity, evidence, recommendation, status (`open` | `fix
 
 ## Overlap (do NOT duplicate)
 
-Governance/debrand → `check_governance_consistency.py`. Agent/registry → `integrate validate`. Architecture → `auditor`. Claims → `verifier`.
+Governance/debrand → `check_governance_consistency.py`. Agent/registry deep structure → `integrate validate`. Architecture / CHK-* → `auditor`. Claims → `verifier`.
 
 ## Exit criteria
 
-Script run captured; both artifacts written; P0 count explicit; handoff names next agent if blocked.
+Script run captured; both artifacts written; P0 count explicit; Goal pulse noted; handoff names next agent if blocked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,8 @@ Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. After mer
 | Integrate infrastructure | `.cursor/agents/integrator.md` + `.cursor/skills/integrator-protocol/SKILL.md` — validate with `python3 -m cursor_workflow integrate validate` |
 | Tests / coverage | `.cursor/agents/test-runner.md` + `.cursor/skills/test-coverage/SKILL.md` |
 | Verify claims | `.cursor/agents/verifier.md` |
-| Operational drift | **`drift-guard`** — `.cursor/agents/drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — validate with `python3 -m cursor_workflow drift validate` |
-| Audits (canonical) | **`auditor`** — `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md` |
+| Continuous goal/plan/agent-doctrine coherence + DRIFT scripts | **`drift-guard`** — `.cursor/agents/drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — `python3 -m cursor_workflow drift validate` (incl. DRIFT-011) |
+| Deep / periodic architecture + CHK-* (security/perf/granularity/docs) | **`auditor`** — `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md` — not continuous plan pulse |
 | Audit orchestration | `.cursor/skills/audit-orchestration/SKILL.md` — parent runs verify-all + Task delegation (no dedicated agent) |
 | Audit module map | `.cursor/skills/audit-module-map/SKILL.md` — optional deep map; invoke via **`auditor`** |
 | Maintainer PR | `.agents/skills/pr-workflow/SKILL.md` → `review-pr` → `prepare-pr` → `merge-pr` |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1190 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1193 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -1,10 +1,16 @@
 ---
 name: auditor
 model: auto
-description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
+description: auditor MAS-SSOT-KIT — Deep/periodic evidence architecture audit (CHK-* security/perf/granularity/docs); not continuous plan pulse.
 ---
 
 # Auditor
+
+## What we own (deep / periodic)
+
+**Own:** Evidence-only enterprise architecture and engineering audit — architecture, security (code + agent contracts), performance, granularity/boundaries, documentation quality — via `auditor-protocol` CHK-* checklists. Full scorecard or focused alignment for architecture-impacting PRs.
+
+**Do not own:** Continuous goal/plan/agent-doctrine coherence when plans change — that is **`drift-guard`** (script + goal pulse). Do not auto-fix product code unless the user explicitly asks.
 
 ## Anchor (mandatory)
 

--- a/agents/drift-guard.md
+++ b/agents/drift-guard.md
@@ -1,10 +1,16 @@
 ---
 name: drift-guard
 model: auto
-description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
+description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts; handoff remediations only.
 ---
 
 # Drift guard
+
+## What we guard (continuous)
+
+**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…011 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
+
+**Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
 
 ## Anchor (mandatory)
 
@@ -23,10 +29,11 @@ description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** when project SSOT enabled; prefer a fresh `project export` snapshot for DRIFT-010).
-3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
-4. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
-5. Do not duplicate governance, integrate, or auditor scope (ADR-007 / ADR-008).
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when applicable; prefer a fresh `project export` snapshot for DRIFT-010).
+3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
+4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
+5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
+6. Do not duplicate governance, integrate, or auditor deep scorecard scope (ADR-007 / ADR-008).
 
 ## Read first
 

--- a/canvases/agent-auditor.canvas.tsx
+++ b/canvases/agent-auditor.canvas.tsx
@@ -133,7 +133,7 @@ const ARTIFACTS = [
 
 const PEERS = [
   ["Outbound", "implementer", "Continue from Notes with artifact paths"],
-  ["Outbound", "drift-guard", "audit-orchestration Phase 3 — P0/P1 drift artifacts"],
+  ["Outbound", "drift-guard", "orch Phase 3 — goal pulse + DRIFT validate"],
   ["Outbound", "verifier", "audit-orchestration Phase 3 — spot-check top claims"],
 ];
 
@@ -267,7 +267,11 @@ export default function AgentAuditorCanvas() {
       <CollapsibleSection title="Loop steps (canon)" defaultOpen>
         <Stack gap={6}>
           <Text>1. project status; create [AUDIT] slice card if needed; claim.</Text>
-          <Text>2. Evidence-only audit per auditor-protocol/SKILL.md.</Text>
+          <Text>
+            2. Evidence-only audit per auditor-protocol — tick CHK-ARCH /
+            GRANULARITY / PERF / SEC-CODE / SEC-AGENT / INFRA-KIT / DOCS (full or
+            focused table for touched surfaces).
+          </Text>
           <Text>
             3. Write .local/workflow-artifacts/enterprise-architecture-audit/
             enterprise-architecture-audit.md + enterprise-audit-actions.md
@@ -277,7 +281,8 @@ export default function AgentAuditorCanvas() {
           <Text>4. Propose tracker edits in audit-actions — implementer applies.</Text>
           <Text>
             5. Exit: artifacts + change-index + updates-log; Status in_review/done;
-            Notes with artifact paths for implementer.
+            Notes with artifact paths; orch Phase 3 → drift-guard goal pulse /
+            verifier as needed.
           </Text>
         </Stack>
       </CollapsibleSection>

--- a/canvases/agent-auditor.canvas.tsx
+++ b/canvases/agent-auditor.canvas.tsx
@@ -23,14 +23,14 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-04";
 const SOURCES =
   ".cursor/agents/auditor.md · auditor-protocol/SKILL.md · board-ssot/SKILL.md";
 
 const GOALS = [
-  "Evidence-only enterprise architecture audit",
-  "Writes workflow artifacts and tracker hooks for other agents",
-  "Propose edits in audit-actions; implementer applies",
+  "Deep/periodic evidence architecture audit (CHK-* checklists)",
+  "Security/perf/granularity/docs/agent-contracts — not continuous plan pulse",
+  "Artifacts only; implementer applies Ready cards from actions/todos",
 ];
 
 const BOARD_NODES = [
@@ -83,9 +83,9 @@ const FALLBACK_LABELS: Record<string, string> = {
 };
 
 const READ_FIRST = [
-  [".cursor/skills/auditor-protocol/SKILL.md", "Audit canon"],
+  [".cursor/skills/auditor-protocol/SKILL.md", "CHK-* checklists + phases"],
   [".cursor/skills/audit-module-map/SKILL.md", "Optional deep map"],
-  [".cursor/skills/audit-orchestration/SKILL.md", "Optional orchestration"],
+  [".cursor/skills/audit-orchestration/SKILL.md", "Quarterly vs PR cadence"],
   [".cursor/skills/board-ssot/SKILL.md", "When project_ssot.enabled"],
   [".ai_infra/docs/roadmap/alignment-audit-schema.md", "Alignment schema"],
 ];
@@ -220,8 +220,9 @@ export default function AgentAuditorCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit;
-          writes workflow artifacts and tracker hooks for other agents.
+          auditor MAS-SSOT-KIT — Deep/periodic evidence architecture audit
+          (CHK-* security/perf/granularity/docs); continuous plan pulse is
+          drift-guard. Writes workflow artifacts for other agents.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -23,9 +23,9 @@ import {
 
 type FlowMode = "slice" | "side";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-04";
 const SOURCES =
-  "project-board-collaboration.md · board-ssot/SKILL.md · board-shell/SKILL.md · agent-relations · agent-roster · .cursor/agents/*.md";
+  "project-board-collaboration.md · board-ssot/SKILL.md · board-shell/SKILL.md · agent-relations · agent-roster · .cursor/agents/*.md · ADR-007";
 
 const STATUS_STEPS = ["Ready", "In progress", "In review", "Done"];
 
@@ -59,12 +59,12 @@ const EDGE_LABELS: Record<string, string> = {
   "board→implementer": "handoff next=implementer",
   "implementer→verifier": "Exit --next verifier",
   "implementer→test-runner": "when tests/coverage gate PR",
-  "implementer→drift-guard": "P0/P1 after drift-validate",
+  "implementer→drift-guard": "P0/P1 after drift-validate / goal pulse",
   "test-runner→verifier": "tests gate the PR",
-  "drift-guard→board": "dual-write remediation",
-  "drift-guard→implementer": "dual-write remediation",
-  "auditor→implementer": "Notes + artifact paths",
-  "auditor→drift-guard": "audit-orchestration Phase 3",
+  "drift-guard→board": "remediation Notes/Ready",
+  "drift-guard→implementer": "remediation Notes/Ready",
+  "auditor→implementer": "CHK-* artifacts → Ready",
+  "auditor→drift-guard": "orch Phase 3 goal pulse",
   "auditor→verifier": "audit-orchestration Phase 3",
   "integrator→implementer": "escalate product src/",
   "integrator→test-runner": "escalate coverage",
@@ -100,12 +100,12 @@ const PER_AGENT_ENTRY_EXIT = [
   [
     "auditor",
     "status + audit card",
-    "→In review/Done; --agent auditor + artifact paths",
+    "→In review/Done; --agent auditor + CHK-* / alignment artifact paths",
   ],
   [
     "drift-guard",
     "Must status + list In progress",
-    "Drift card →Done; --agent drift-guard; remediation via Notes/Ready — no silent tracker edits",
+    "Drift card →Done; goal pulse + DRIFT-001…011; remediation via Notes/Ready — no silent tracker edits",
   ],
   [
     "researcher",
@@ -219,7 +219,7 @@ const ARTIFACT_FLOWS = [
   [
     ".local/generated-data/project-board-snapshot.json",
     "project export (read-only)",
-    "DRIFT-010 refresh",
+    "DRIFT-010 refresh (+ kit-dev DRIFT-011 roster in validate)",
     "drift-guard · ICC (EA-010)",
     "Read-only export; never writes Status",
   ],
@@ -248,9 +248,9 @@ const SLICE_FLOW = [
 ];
 
 const SIDE_FLOW = [
-  "auditor: audit card → write .local/workflow-artifacts/enterprise-architecture-audit/ + alignment/ → Notes paths → implementer (Phase 3: drift-guard / verifier)",
-  "implementer: make drift-validate → P0/P1 → hand off drift-guard",
-  "drift-guard: must read board In progress → .local/workflow-artifacts/drift/ → drift card done; remediation via Notes/Ready to board or implementer",
+  "auditor: audit card → CHK-* / enterprise-architecture-audit/ + alignment/ → Notes paths → implementer (Phase 3: drift-guard goal pulse / verifier)",
+  "implementer: make drift-validate → P0/P1 or goal-pulse gaps → hand off drift-guard",
+  "drift-guard: board In progress + Acceptance/Notes → drift validate (DRIFT-001…011 kit-dev) → .local/workflow-artifacts/drift/ → card done; remediation via Notes/Ready",
   "integrator: integration card → integrate validate → escalate to implementer | test-runner | auditor",
 ];
 

--- a/canvases/agent-drift-guard.canvas.tsx
+++ b/canvases/agent-drift-guard.canvas.tsx
@@ -23,14 +23,14 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-04";
 const SOURCES =
-  ".cursor/agents/drift-guard.md · drift-audit/SKILL.md · board-ssot/SKILL.md";
+  ".cursor/agents/drift-guard.md · drift-audit/SKILL.md · board-ssot/SKILL.md · ADR-007";
 
 const GOALS = [
-  "Operational workflow drift detection",
-  "Plan/tracker/session coherence and handoff parity",
-  "Write drift artifacts only — no product code",
+  "Continuous goal/plan/agent-doctrine/docs coherence (+ DRIFT scripts)",
+  "DRIFT-001…011 script-first; goal pulse prose in drift artifacts",
+  "Write drift/ only — no product code; remediations via Notes/Ready",
 ];
 
 const BOARD_NODES = [
@@ -86,10 +86,10 @@ const FALLBACK_LABELS: Record<string, string> = {
 };
 
 const READ_FIRST = [
-  [".cursor/skills/drift-audit/SKILL.md", "Drift audit canon"],
+  [".cursor/skills/drift-audit/SKILL.md", "Drift audit + goal pulse"],
   [".cursor/skills/board-ssot/SKILL.md", "Board SSOT when enabled"],
   ["python3 -m cursor_workflow drift validate", "CLI entry"],
-  ["DRIFT-009 / DRIFT-010", "Board vs tracker checks"],
+  ["DRIFT-009 / 010 / 011", "Board + agent roster pulse"],
   ["project export", "DRIFT-010 evidence"],
 ];
 
@@ -205,8 +205,9 @@ export default function AgentDriftGuardCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          drift-guard MAS-SSOT-KIT — Operational workflow drift detection;
-          plan/tracker/session coherence and handoff parity.
+          drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/docs
+          coherence + DRIFT-001…011; remediations via Notes/Ready (not auditor
+          deep scorecard).
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only
@@ -215,7 +216,7 @@ export default function AgentDriftGuardCanvas() {
 
       <Grid columns={3} gap={12}>
         <Stat value="MUST status" label="Entry when board on" />
-        <Stat value="DRIFT-009/010" label="Board vs tracker" />
+        <Stat value="DRIFT-009…011" label="Board + roster pulse" />
         <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
       </Grid>
 

--- a/canvases/agent-drift-guard.canvas.tsx
+++ b/canvases/agent-drift-guard.canvas.tsx
@@ -252,14 +252,15 @@ export default function AgentDriftGuardCanvas() {
       <CollapsibleSection title="Loop steps (canon)" defaultOpen>
         <Stack gap={6}>
           <Text>1. project status + list in_progress (board required when on).</Text>
-          <Text>2. Run drift validate; check DRIFT-009 / DRIFT-010.</Text>
-          <Text>3. project export for DRIFT-010 evidence when needed.</Text>
+          <Text>2. Run drift validate; check DRIFT-009 / 010 / 011 (kit-dev).</Text>
+          <Text>3. Goal pulse: board Acceptance/Notes + plan pointers + roster.</Text>
+          <Text>4. project export for DRIFT-010 evidence when needed.</Text>
           <Text>
-            4. Write drift-audit.md + drift-todos.md under
+            5. Write drift-audit.md + drift-todos.md under
             .local/workflow-artifacts/drift/.
           </Text>
           <Text>
-            5. drift-pass card done/in_review; dual-write → Notes or handoff to
+            6. drift-pass card done/in_review; gaps → Notes or handoff to
             board/implementer via Ready; updates-log.
           </Text>
         </Stack>

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -20,9 +20,9 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-04";
 const SOURCES =
-  "agent-relations edges · audit-orchestration Phase 3 · board-ssot § Continuation · per-agent canvas PEERS";
+  "agent-relations edges · audit-orchestration (quarterly CHK-* vs PR focused) · board-ssot § Continuation · per-agent canvas PEERS";
 
 const NODE_W = 128;
 const NODE_H = 40;
@@ -66,12 +66,12 @@ const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   },
   {
     id: "auditor",
-    role: "auditor MAS-SSOT-KIT · skill auditor-protocol",
+    role: "auditor MAS-SSOT-KIT · auditor-protocol (CHK-* deep/periodic)",
     lane: "Quality",
   },
   {
     id: "drift-guard",
-    role: "drift-guard MAS-SSOT-KIT · skill drift-audit",
+    role: "drift-guard MAS-SSOT-KIT · drift-audit (goal pulse + DRIFT-001…011)",
     lane: "Quality",
   },
   {
@@ -110,31 +110,31 @@ const RELATIONS: {
     from: "implementer",
     to: "drift-guard",
     via: "invoke after drift-validate",
-    when: "P0/P1 findings need drift artifacts",
+    when: "P0/P1 findings or goal-pulse gaps need drift artifacts",
   },
   {
     from: "drift-guard",
     to: "board",
     via: "Ready / Notes remediation",
-    when: "Confirmed dual-write — triage card",
+    when: "Dual-write or roster/goal pulse — triage card",
   },
   {
     from: "drift-guard",
     to: "implementer",
     via: "Ready / Notes remediation",
-    when: "Confirmed dual-write — fix in slice",
+    when: "Dual-write or goal pulse — fix in slice",
   },
   {
     from: "auditor",
     to: "implementer",
-    via: "Notes + artifact paths",
-    when: "Audit card closed; implementer applies actions",
+    via: "Notes + CHK-* artifact paths",
+    when: "Audit/alignment closed; implementer applies Ready cards",
   },
   {
     from: "auditor",
     to: "drift-guard",
     via: "audit-orchestration Phase 3",
-    when: "After tracker/doc edits; P0/P1 drift findings",
+    when: "After tracker/doc edits; run goal pulse + DRIFT validate",
   },
   {
     from: "auditor",
@@ -343,15 +343,16 @@ export default function AgentRelationsCanvas() {
         </Row>
         <Text tone="secondary">
           How kit agents hand off work — edges from agent cards plus
-          audit-orchestration Phase 3. Live ids only (post B-safe rename). Primary
-          skills: board-ssot, implementer-loop, test-coverage, integrator-protocol,
-          auditor-protocol, drift-audit, research-corpus. Select an agent to
-          highlight its neighbors.
+          audit-orchestration (full CHK-* quarterly; focused alignment on
+          arch-impacting PRs; Phase 3 → drift-guard goal pulse). Live ids only.
+          Primary skills: board-ssot, implementer-loop, test-coverage,
+          integrator-protocol, auditor-protocol, drift-audit, research-corpus.
+          Select an agent to highlight its neighbors.
         </Text>
-        <Callout tone="info" title="Not old names">
-          Retired Task ids (enterprise-auditor, project-board, workflow-drift-guard,
-          integrator-mas-agent) do not appear here. Deeper per-agent hubs:
-          canvases/agent-*.canvas.tsx · overview: agent-roster.
+        <Callout tone="info" title="Quality lane (no trash agents)">
+          drift-guard = continuous goal/plan/agent-doctrine pulse + DRIFT scripts.
+          auditor = deep CHK-* (sec/perf/granularity/docs). Retired Task ids
+          (enterprise-auditor, workflow-drift-guard, …) do not appear here.
         </Callout>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED}

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -16,8 +16,8 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-08-03";
-const SOURCES = "Aggregated from .cursor/agents/*.md";
+const VERIFIED = "2026-08-04";
+const SOURCES = "Aggregated from .cursor/agents/*.md (post goal-pulse / CHK-*)";
 
 const AGENTS = [
   {
@@ -36,12 +36,12 @@ const AGENTS = [
   {
     id: "drift-guard",
     description:
-      "drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.",
+      "drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts; handoff remediations only.",
   },
   {
     id: "auditor",
     description:
-      "auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.",
+      "auditor MAS-SSOT-KIT — Deep/periodic evidence architecture audit (CHK-* security/perf/granularity/docs); not continuous plan pulse.",
   },
   {
     id: "board",
@@ -91,12 +91,12 @@ const EDGE_LABELS: Record<string, string> = {
   "board→implementer": "handoff next=implementer",
   "implementer→verifier": "Exit --next verifier",
   "implementer→test-runner": "when tests/coverage gate PR",
-  "implementer→drift-guard": "P0/P1 after drift-validate",
+  "implementer→drift-guard": "P0/P1 after drift-validate / goal pulse",
   "test-runner→verifier": "tests gate the PR",
-  "drift-guard→board": "dual-write remediation",
-  "drift-guard→implementer": "dual-write remediation",
-  "auditor→implementer": "Notes + artifact paths",
-  "auditor→drift-guard": "audit-orchestration Phase 3",
+  "drift-guard→board": "remediation Notes/Ready",
+  "drift-guard→implementer": "remediation Notes/Ready",
+  "auditor→implementer": "CHK-* artifacts → Ready",
+  "auditor→drift-guard": "orch Phase 3 goal pulse",
   "auditor→verifier": "audit-orchestration Phase 3",
   "integrator→implementer": "escalate product src/",
   "integrator→test-runner": "escalate coverage",
@@ -213,7 +213,12 @@ export default function AgentRosterCanvas() {
         <Callout tone="info" title="Live ids (post B-safe rename)">
           auditor · board · drift-guard · implementer · integrator · researcher ·
           test-runner · verifier — skills: board-ssot, implementer-loop,
-          test-coverage, auditor-protocol, drift-audit, integrator-protocol, …
+          test-coverage, auditor-protocol (CHK-*), drift-audit (goal pulse +
+          DRIFT-001…011), integrator-protocol, …
+        </Callout>
+        <Callout tone="neutral" title="Quality lane split (2026-08-04)">
+          Continuous plan/agent/docs coherence → drift-guard. Deep
+          security/perf/granularity/docs scorecard → auditor. No extra agents.
         </Callout>
         <Callout tone="neutral" title="Board lifecycle (all 8)">
           Tier-1: Start date on claim or first In progress; Size↔Estimate points

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -26,9 +26,9 @@ import {
  * Not an agent-* canvas — excluded from DOC-008 roster scan (same as board-ssot-vs-kit).
  */
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-04";
 const SOURCES =
-  "ADR-008 · board-ssot/SKILL.md · project-board-collaboration.md · agent cards · HYGIENE post-COV100";
+  "ADR-008 · ADR-007 · board-ssot/SKILL.md · project-board-collaboration.md · agent cards · drift/auditor quality split";
 
 const NODE_W = 118;
 const NODE_H = 36;
@@ -108,15 +108,15 @@ const WHO_WRITES: string[][] = [
   ],
   [
     "auditor",
-    "Audit card Status + artifact paths in Notes",
+    "Audit card Status + CHK-* / alignment paths in Notes",
     ".local/workflow-artifacts/enterprise-architecture-audit/ · alignment/",
-    "Evidence-only — no product fixes",
+    "Deep/periodic — no product fixes; not continuous plan pulse",
   ],
   [
     "drift-guard",
     "Drift-pass card Done; remediation via Ready",
     ".local/workflow-artifacts/drift/drift-audit.md · drift-todos.md",
-    "Never silent dual-write Status",
+    "Goal pulse + DRIFT scripts; never silent dual-write Status",
   ],
   [
     "integrator",
@@ -161,7 +161,7 @@ const ARTIFACT_LANES: string[][] = [
     "Drift",
     ".local/workflow-artifacts/drift/",
     "drift-guard",
-    "DRIFT-009 watches dual-write",
+    "Goal pulse + DRIFT-009…011 (011 kit-dev roster)",
   ],
   [
     "Release / smoke",
@@ -441,13 +441,14 @@ export default function AgentsArtifactsBoardCanvas() {
       <CollapsibleSection title="Side paths (audit / drift)">
         <Stack gap={8}>
           <Text size="small">
-            auditor → .local audit artifacts → Notes paths →
-            implementer Ready cards. Does not mutate product code during audit.
+            auditor → CHK-* / .local audit + alignment artifacts → Notes paths →
+            implementer Ready cards (deep/periodic; not continuous plan pulse).
+            Does not mutate product code during audit.
           </Text>
           <Text size="small">
-            implementer makes drift-validate → P0/P1 → drift-guard writes
-            drift artifacts → remediation via Notes/Ready (never silent tracker
-            Status).
+            implementer makes drift-validate → P0/P1 or goal-pulse gaps →
+            drift-guard writes drift artifacts (DRIFT-001…011 kit-dev) →
+            remediation via Notes/Ready (never silent tracker Status).
           </Text>
           <Text size="small">
             Rate-limit EXIT_QUEUED (6) → board-outbox.jsonl → project outbox flush

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -26,7 +26,7 @@ import {
 
 type Mode = "classic" | "shipped" | "compare";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-04";
 
 const CLASSIC_NODES = [
   { id: "agent" },
@@ -112,12 +112,13 @@ const ABC_SLICES = [
   {
     id: "c",
     card: "BOARD-EXPORT-006",
-    title: "C — Export + DRIFT-010",
+    title: "C — Export + DRIFT-010 (+ kit DRIFT-011)",
     color: "purple" as const,
     items: [
       "project export → read-only snapshot",
       ".local/generated-data/project-board-snapshot.json",
       "Never writes Status — DRIFT-010 stale PR / board drift",
+      "Kit-dev: DRIFT-011 agent roster coherence (goal pulse)",
       "Deprecated HTML ICC Project Board tab (EA-010) — offline export only; prefer live board + Open Canvas",
     ],
   },
@@ -574,6 +575,7 @@ export default function BoardSsotVsKitCanvas() {
           ["Post-merge card", "Manual / tracker only", "merge.py → Done + Notes"],
           ["Dual writers", "Single (markdown)", "Forbidden — DRIFT-009"],
           ["Stale PR detection", "N/A", "DRIFT-010 + export snapshot"],
+          ["Agent roster pulse", "N/A", "DRIFT-011 kit-dev (.cursor/agents)"],
           [
             "PR merge gates",
             "prepare.py resolve_gates()",
@@ -682,7 +684,7 @@ export default function BoardSsotVsKitCanvas() {
 
       <Text size="small" tone="tertiary">
         Source: HANDOFF §1 · ADR-008 · STANDALONE 2026-07-18 · PR #2/#3 merged ·
-        drift validate green · verified {VERIFIED} · 1190 tests · COV-100 7089 stmts
+        drift validate green · verified {VERIFIED} · 1193 tests · COV-100 7089 stmts
       </Text>
     </Stack>
   );

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -13,6 +13,7 @@
  *  - Concept hub (not agent-*). Excluded from DOC-008 roster scan like board-ssot-vs-kit.
  *  - B-safe rename SHIPPED 2026-08-03 (#140, #146–#149); Plan/Scores/Stack = live roster.
  *  - Renames tab = historical old→live ledger only (not current Task subagent_type).
+ *  - Roster scorecard 2026-08-04 (AA-ROSTER-001…008) mirrored on Stack/Future views.
  *  - Intentional non-renames: artifact dir enterprise-architecture-audit/, ops doc
  *    project-board-collaboration.md, snapshot project-board-snapshot.json.
  *  - Avoid "star-slash" globs in this block comment — they terminate the comment early.
@@ -39,7 +40,7 @@ import {
   useCanvasState,
 } from "cursor/canvas";
 
-const AUDIT_DATE = "2026-08-03";
+const AUDIT_DATE = "2026-08-04";
 
 type View = "plan" | "scores" | "stack" | "renames" | "future";
 
@@ -498,20 +499,78 @@ const FUTURE_EXAMPLES: {
     proposed: "releaser",
     skill: "releaser-protocol",
     dims: { clarity: 5, brevity: 5, pairing: 5, convention: 5, uniqueness: 4 },
-    verdict: "PASS — admit if lane gap is real",
+    verdict:
+      "AA-ROSTER-002 deferred P2 — admit when release pain repeats (not this slice)",
   },
   {
-    proposed: "ci-fixer-agent",
-    skill: "ci-fix-execution-loop",
-    dims: { clarity: 3, brevity: 2, pairing: 2, convention: 1, uniqueness: 3 },
-    verdict: "FAIL — drop -agent; prefer ci-fixer + ci-fixer-protocol",
+    proposed: "ci-fixer",
+    skill: "ci-fixer-protocol",
+    dims: { clarity: 4, brevity: 4, pairing: 4, convention: 5, uniqueness: 4 },
+    verdict:
+      "AA-ROSTER-003 deferred P3 — prefer absorb into implementer (no new agent)",
   },
   {
     proposed: "enterprise-security-auditor",
     skill: "enterprise-security-architecture-audit",
     dims: { clarity: 3, brevity: 1, pairing: 3, convention: 2, uniqueness: 2 },
-    verdict: "FAIL — collide with auditor lane; extend auditor skill instead",
+    verdict:
+      "AA-ROSTER-004 reject — collide with auditor; extend auditor-protocol",
   },
+];
+
+/** Roster scorecard 2026-08-04 — mirror of alignment-audit AA-ROSTER-* */
+const SCORECARD_KEEP_AGENTS: string[][] = [
+  ["implementer", "22", "implementer-loop", "KEEP"],
+  ["verifier", "22", "(none — optional verify-claims later)", "KEEP"],
+  ["researcher", "22", "research-corpus", "KEEP"],
+  ["test-runner", "21", "test-coverage", "KEEP"],
+  ["board", "20", "board-ssot (+ board-shell)", "KEEP"],
+  ["integrator", "20", "integrator-protocol", "KEEP"],
+  ["auditor", "17", "auditor-protocol", "KEEP"],
+  ["drift-guard", "16", "drift-audit", "KEEP"],
+];
+
+const SCORECARD_ADD: string[][] = [
+  [
+    "releaser",
+    "releaser-protocol",
+    "P2 deferred",
+    "AA-ROSTER-002 — release lane gap; admit when pain repeats",
+  ],
+  [
+    "ci-fixer",
+    "ci-fixer-protocol",
+    "P3 absorb",
+    "AA-ROSTER-003 — prefer implementer; do not ship agent now",
+  ],
+];
+
+const SCORECARD_REMOVE: string[][] = [
+  ["(none)", "—", "AA-ROSTER-001 — all 8 agents kept; low scores = naming debt"],
+];
+
+const SCORECARD_RETIRE_SKILLS: string[][] = [
+  [
+    "audit-alignment",
+    "Retire when safe",
+    "AA-ROSTER-005 open — DEPRECATED stub → auditor (11/25)",
+  ],
+  [
+    "verify-claims (new)",
+    "Optional later",
+    "AA-ROSTER-006 deferred — skill for verifier, not a new agent",
+  ],
+];
+
+const SCORECARD_REJECT: string[][] = [
+  [
+    "enterprise-security-auditor",
+    "AA-ROSTER-004",
+    "Collides with auditor lane",
+  ],
+  ["onboarder", "AA-ROSTER-004", "Overlap board + board-shell + workflow-activate"],
+  ["mcp-agent", "AA-ROSTER-004", "mcp-connect is skill-only by design"],
+  ["documenter", "AA-ROSTER-004", "Doc-sync belongs to implementer"],
 ];
 
 type RenameRow = {
@@ -1055,16 +1114,22 @@ export default function NamingRosterAuditCanvas() {
             ])}
             striped
           />
-          <Callout tone="success" title="B-safe rename debt closed">
+          <Callout tone="success" title="B-safe rename debt closed · AA-ROSTER-001">
             Live ids: board · implementer · test-runner · verifier · integrator ·
-            auditor · drift-guard · researcher. Primary skills match STACK above.
-            Residual score debt (drift-guard / auditor still &lt;18 on pairing/
-            brevity) is advisory only — not a reopen of rename appetite.
+            auditor · drift-guard · researcher. KEEP all 8 — residual score debt
+            (drift-guard 16 / auditor 17) is naming debt, not redundancy.
           </Callout>
+          <H2>Scorecard keep (agent /25)</H2>
+          <Table
+            headers={["Agent", "/25", "Primary skill", "Verdict"]}
+            rows={SCORECARD_KEEP_AGENTS}
+            striped
+          />
           <Callout tone="neutral" title="Intentional path keeps">
             enterprise-architecture-audit/ (artifact dir) ·
             project-board-collaboration.md (ops) · project-board-snapshot.json —
-            not agent or skill folder names.
+            not agent or skill folder names. Evidence: alignment-audit.md § Roster
+            scorecard 2026-08-04.
           </Callout>
         </Stack>
       ) : null}
@@ -1127,6 +1192,49 @@ export default function NamingRosterAuditCanvas() {
 
       {view === "future" ? (
         <Stack gap={16}>
+          <Callout tone="info" title="Roster scorecard 2026-08-04 (AA-ROSTER)">
+            Advisory only — no new agents for security/perf/infra/docs/
+            granularity (AA-ROSTER-004). Retire = audit-alignment stub kept
+            RETIRE-PENDING until DOC/count integrator slice (AA-ROSTER-005).
+            Full tables: .local/workflow-artifacts/alignment/alignment-audit.md
+          </Callout>
+
+          <Stack gap={8}>
+            <H2>Agents to add (advisory)</H2>
+            <Table
+              headers={["Candidate", "Skill", "Priority", "Finding"]}
+              rows={SCORECARD_ADD}
+              striped
+            />
+          </Stack>
+
+          <Stack gap={8}>
+            <H2>Agents to remove</H2>
+            <Table
+              headers={["Agent", "Action", "Rationale"]}
+              rows={SCORECARD_REMOVE}
+              striped
+            />
+          </Stack>
+
+          <Stack gap={8}>
+            <H2>Skills to retire / optional add</H2>
+            <Table
+              headers={["Skill", "Action", "Finding"]}
+              rows={SCORECARD_RETIRE_SKILLS}
+              striped
+            />
+          </Stack>
+
+          <Stack gap={8}>
+            <H2>Do not add (rejected)</H2>
+            <Table
+              headers={["Candidate", "Finding", "Why"]}
+              rows={SCORECARD_REJECT}
+              striped
+            />
+          </Stack>
+
           <Callout tone="info" title="Admission gate for new agents">
             Before merge, score the proposed agent id + primary skill with the same
             rubric. Require total ≥18/25 and FG-1…FG-6 green. Prefer extending an
@@ -1255,9 +1363,9 @@ export default function NamingRosterAuditCanvas() {
 
       <Divider />
       <Text tone="tertiary" size="small">
-        Live truth: .cursor/agents/*.md · .cursor/skills/*/SKILL.md · Evidence:
-        .local/workflow-artifacts/alignment/alignment-audit.md · verified{" "}
-        {AUDIT_DATE}
+        Live truth: .cursor/agents/*.md · .cursor/skills/*/SKILL.md · Roster
+        scorecard: .local/workflow-artifacts/alignment/alignment-audit.md §
+        2026-08-04 · AA-ROSTER-001…008 · verified {AUDIT_DATE}
       </Text>
     </Stack>
   );

--- a/payload/.agents/skills/audit-alignment/SKILL.md
+++ b/payload/.agents/skills/audit-alignment/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: audit-alignment
-description: DEPRECATED — use auditor; alignment outputs unchanged for merge gates.
+description: DEPRECATED RETIRE-PENDING — use auditor + auditor-protocol; stub kept for path/DOC count until AA-ROSTER-005 close.
 disable-model-invocation: true
 ---
 
-# Audit alignment (deprecated stub)
+# Audit alignment (deprecated stub — retire pending)
 
 **Do not use this file as the primary workflow.** The canonical audit agent is **`auditor`**.
 
 - **Agent:** `.cursor/agents/auditor.md`
-- **Protocol:** `.cursor/skills/auditor-protocol/SKILL.md`
+- **Protocol:** `.cursor/skills/auditor-protocol/SKILL.md` (CHK-* checklists)
 - **Merge-gate outputs (unchanged):** `.local/workflow-artifacts/alignment/alignment-audit.md`, `alignment-todos.md` per `.ai_infra/docs/roadmap/alignment-audit-schema.md`
 - **Rule:** `.cursor/rules/advisory-audit-alignment-enforcement.mdc`
 
-For architecture-impacting PRs, run a **focused alignment pass** (see `auditor-protocol`) unless a **full** `enterprise-architecture-audit.md` report is explicitly requested.
+**Retirement (AA-ROSTER-005):** Folder remains so maintainer skill count (5) and old links resolve. Delete only after updating AGENTS.md / DOC scans / `sync_plugin_bundle` expectations in a dedicated integrator slice.
 
-This stub remains so old links and governance scans that mention `audit-alignment/` keep resolving to a clear redirect.
+For architecture-impacting PRs, run a **focused alignment pass** (see `auditor-protocol`) unless a **full** `enterprise-architecture-audit.md` report is explicitly requested.

--- a/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -9,6 +9,15 @@ MAS Workflow Kit enforces infrastructure parity via `integrate validate`, govern
 
 The **drift-guard** capability closes that gap without duplicating architecture audits (`auditor`) or claim verification (`verifier`).
 
+### Goal pulse vs EA audit (ownership split)
+
+| Loop | Owner | Cadence | Question |
+|------|-------|---------|----------|
+| **Goal / plan / agent-doctrine / docs coherence** + DRIFT scripts | `drift-guard` + `drift-audit` | Continuous (slice closure / prepare) | Are we still pointed at living goals? |
+| **Architecture / security / perf / granularity / docs quality** | `auditor` + `auditor-protocol` (CHK-*) | Periodic or architecture-impacting PR | Is the system sound and evidenced? |
+
+Drift does **not** rewrite architecture; auditor does **not** own continuous plan-pulse prose.
+
 ## Decision
 
 Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](ADR-006-agent-integration-model.md).
@@ -28,7 +37,7 @@ Introduce a script-first drift validator and MAS-integrated agent per [ADR-006](
 
 | Profile | When | Checks |
 |---------|------|--------|
-| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…010 + 004b (full set; 004b/009–010 when `board_only`) |
+| `kit-dev` | Default for `mas-workflow-kit-project-ssot` (kit product repo) | DRIFT-001…011 + 004b (full set; 004b/009–011 when applicable) |
 | `consumer` | `work-tracker.md` contains exemplar `STARTER-001` | DRIFT-005, DRIFT-008 (relaxed tracker rules) |
 
 Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
@@ -48,6 +57,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-008 | P2 | consumer | Scaffold trackers present |
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
 | DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
+| DRIFT-011 | P1 | kit-dev | Agent roster coherence: `.cursor/agents/*.md` basenames match the eight live kit agent ids (goal/doctrine pulse — falsifiable) |
 
 **Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`). Pending `project_ssot.outbox` ops are **not** a drift failure — cite `project outbox status` in artifacts when relevant.
 

--- a/payload/.ai_infra/docs/governance/drift-prevention.md
+++ b/payload/.ai_infra/docs/governance/drift-prevention.md
@@ -45,21 +45,21 @@ Additionally when changing governance, workflows, `.cursor/`, `.agents/`, or tra
 
 Follow **`agent-workflow-procedures.md` §3b**. Includes **`AGENTS.md`**, **`rules-overlap-matrix.md`**, **`workflow-source-owners.md`**, PR scripts, and mirrored `.cursor/` / `.agents/` skills. Run **`check_governance_consistency.py`** when tracked policy paths change.
 
-## Operational drift (drift-guard)
+## Operational drift + goal pulse (drift-guard)
 
-Script-first checks for plan ↔ tracker ↔ session-pointer coherence and handoff doc parity. See [ADR-007](../decisions/ADR-007-workflow-drift-guard.md).
+Script-first checks for plan ↔ tracker ↔ session-pointer coherence, handoff doc parity, and **falsifiable goal/doctrine pulse** (DRIFT-011 roster ids). Prose goal pulse (board Acceptance vs plan vs `AGENTS.md`) lives in drift artifacts — not in `auditor`. See [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) § Goal pulse vs EA audit.
 
 **Kit-dev PR prep:** `prepare.py` `resolve_gates()` auto-runs `drift validate` before merge (with doc facts). Optional: Task **`drift-guard`** after pass to refresh `.local/workflow-artifacts/drift/` artifacts.
 
 | Concern | Owner | Do NOT duplicate in drift |
 |---------|-------|---------------------------|
 | Bare paths, brand terms | `check_governance_consistency.py`, `check_debrand.py` | Path/brand scans |
-| Agent Anchor/MCP, registry parity | `integrate validate` INT-001…014 | Agent file structure |
+| Agent Anchor/MCP, registry parity | `integrate validate` INT-001…014 | Full agent file structure (DRIFT-011 is id set only) |
 | Canonical doc facts (roster, counts) | `check_doc_facts.py` / INT-013 | Path/brand scans |
 | test-plan/index existence | `check_testing_artifacts.py` | File exists checks |
 | Plugin/payload SHA drift | `sync_plugin_bundle.py --check` | Bundle sync |
 | Slice claim verification | `verifier` | Subjective verification |
-| Architecture scorecard | `auditor` | Module deep-dive |
+| Architecture / security / perf scorecard (CHK-*) | `auditor` | Module deep-dive / EA phases |
 
 **Command:** `python -m cursor_workflow drift validate --directory .` or `make drift-validate`.
 

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -83,7 +83,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, `HANDOFF.md`, and kit docs
 | P0 / P1 / P2 / P3 | Priority — board uses `p0\|p1\|p2`; chat P3 → board `p2` + Notes `deferred` | `board-ssot` skill |
 | xs…xl | Size options on the board (Tier-1) | Size↔Estimate table in skill |
 
-High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`).
+High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`), **DRIFT-011** (`.cursor/agents` basenames == eight live kit agent ids — goal/doctrine pulse).
 
 ## Planes
 

--- a/payload/.ai_infra/scripts/workflow/drift_checks.py
+++ b/payload/.ai_infra/scripts/workflow/drift_checks.py
@@ -1,7 +1,7 @@
 """
 File: drift_checks.py
 Path: .ai_infra/scripts/workflow/drift_checks.py
-Role: Individual DRIFT-001…010 (+004b) check functions for workflow drift validation.
+Role: Individual DRIFT-001…011 (+004b) check functions for workflow drift validation.
 Used By:
  - .ai_infra/scripts/workflow/check_drift.py
 Depends On:
@@ -19,6 +19,11 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+
+_AI_INFRA = Path(__file__).resolve().parents[2]
+if str(_AI_INFRA) not in sys.path:
+    sys.path.insert(0, str(_AI_INFRA))
+from paths import resolve_project_python  # noqa: E402
 
 
 class Severity(str, Enum):
@@ -133,8 +138,6 @@ def _parse_implementation_test_count(text: str) -> int | None:
 
 
 def _collect_pytest_count(root: Path) -> int:
-    from paths import resolve_project_python
-
     proc = subprocess.run(
         [resolve_project_python(root), "-m", "pytest", "--collect-only", "-q"],
         cwd=root,
@@ -809,6 +812,57 @@ def check_drift010(paths: DriftPaths) -> CheckResult:
     )
 
 
+# Live kit agent ids (post B-safe rename). Keep in sync with AGENTS.md / DOC-008.
+LIVE_KIT_AGENT_IDS: frozenset[str] = frozenset(
+    {
+        "auditor",
+        "board",
+        "drift-guard",
+        "implementer",
+        "integrator",
+        "researcher",
+        "test-runner",
+        "verifier",
+    }
+)
+
+
+def check_drift011(paths: DriftPaths) -> CheckResult:
+    """
+    Goal/doctrine pulse (falsifiable): `.cursor/agents/*.md` basenames must equal
+    the eight live kit agent ids. Missing/extra agents = doctrine drift.
+    """
+    agents_dir = paths.root / ".cursor" / "agents"
+    if not agents_dir.is_dir():
+        return CheckResult(
+            check_id="DRIFT-011",
+            severity=Severity.P1,
+            passed=False,
+            detail=".cursor/agents/ missing — cannot verify agent roster",
+        )
+    on_disk = {p.stem for p in agents_dir.glob("*.md") if p.is_file()}
+    missing = sorted(LIVE_KIT_AGENT_IDS - on_disk)
+    extra = sorted(on_disk - LIVE_KIT_AGENT_IDS)
+    if not missing and not extra:
+        return CheckResult(
+            check_id="DRIFT-011",
+            severity=Severity.P1,
+            passed=True,
+            detail=f"agent roster coherent ({len(LIVE_KIT_AGENT_IDS)} live ids)",
+        )
+    parts: list[str] = []
+    if missing:
+        parts.append(f"missing={','.join(missing)}")
+    if extra:
+        parts.append(f"extra={','.join(extra)}")
+    return CheckResult(
+        check_id="DRIFT-011",
+        severity=Severity.P1,
+        passed=False,
+        detail="; ".join(parts),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_drift001,
     check_drift002,
@@ -821,6 +875,7 @@ KIT_DEV_CHECKS = (
     check_drift008,
     check_drift009,
     check_drift010,
+    check_drift011,
 )
 
 CONSUMER_CHECKS = (

--- a/payload/.cursor/agents/auditor.md
+++ b/payload/.cursor/agents/auditor.md
@@ -1,10 +1,16 @@
 ---
 name: auditor
 model: auto
-description: auditor MAS-SSOT-KIT — Evidence-only enterprise architecture audit; writes workflow artifacts and tracker hooks for other agents.
+description: auditor MAS-SSOT-KIT — Deep/periodic evidence architecture audit (CHK-* security/perf/granularity/docs); not continuous plan pulse.
 ---
 
 # Auditor
+
+## What we own (deep / periodic)
+
+**Own:** Evidence-only enterprise architecture and engineering audit — architecture, security (code + agent contracts), performance, granularity/boundaries, documentation quality — via `auditor-protocol` CHK-* checklists. Full scorecard or focused alignment for architecture-impacting PRs.
+
+**Do not own:** Continuous goal/plan/agent-doctrine coherence when plans change — that is **`drift-guard`** (script + goal pulse). Do not auto-fix product code unless the user explicitly asks.
 
 ## Anchor (mandatory)
 

--- a/payload/.cursor/agents/drift-guard.md
+++ b/payload/.cursor/agents/drift-guard.md
@@ -1,10 +1,16 @@
 ---
 name: drift-guard
 model: auto
-description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; plan/tracker/session coherence and handoff parity.
+description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts; handoff remediations only.
 ---
 
 # Drift guard
+
+## What we guard (continuous)
+
+**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…011 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
+
+**Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
 
 ## Anchor (mandatory)
 
@@ -23,10 +29,11 @@ description: drift-guard MAS-SSOT-KIT — Operational workflow drift detection; 
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** when project SSOT enabled; prefer a fresh `project export` snapshot for DRIFT-010).
-3. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
-4. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
-5. Do not duplicate governance, integrate, or auditor scope (ADR-007 / ADR-008).
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when applicable; prefer a fresh `project export` snapshot for DRIFT-010).
+3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
+4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
+5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
+6. Do not duplicate governance, integrate, or auditor deep scorecard scope (ADR-007 / ADR-008).
 
 ## Read first
 

--- a/payload/.cursor/skills/audit-orchestration/SKILL.md
+++ b/payload/.cursor/skills/audit-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-orchestration
-description: Orchestrate verify-all preflight, auditor, implementer doc-sync, drift-guard, and verifier with Task delegation.
+description: Orchestrate verify-all preflight, auditor (CHK-*), implementer doc-sync, drift-guard goal pulse, and verifier with Task delegation.
 ---
 <!--
 File: SKILL.md
@@ -15,6 +15,7 @@ Depends On:
  - .cursor/skills/implementer-loop/SKILL.md
 Notes:
  - Human-triggered only; scripts run before prose agents consume results.
+ - Full CHK-* on quarterly/release only — not every PR.
 -->
 
 # Audit orchestration
@@ -22,6 +23,16 @@ Notes:
 ## Goal
 
 Run a **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts and apply approved fixes — without one agent re-running every shell command.
+
+## Cadence
+
+| Trigger | Auditor depth | Drift |
+|---------|---------------|-------|
+| **Architecture-impacting PR** | Focused alignment + scoped CHK-* tick table | `drift validate` via prepare; optional drift-guard artifacts |
+| **Quarterly / kit release readiness** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
+| **Ad-hoc full audit** | Same as quarterly | Same |
+
+Do **not** run full CHK-* scorecard on every PR.
 
 ## When
 
@@ -38,6 +49,7 @@ make verify-all
 # or with artifacts for agents:
 python -m cursor_workflow verify all --write-preflight
 python -m cursor_workflow doc validate --write-preflight
+python -m cursor_workflow drift validate --directory .
 ```
 
 **MCP (preferred in Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
@@ -52,7 +64,7 @@ Launch concurrently:
 
 | Subagent | Mode | Deliverable |
 |----------|------|-------------|
-| `auditor` | artifact-write (`.local/` only) | `enterprise-architecture-audit.md`, `enterprise-audit-actions.md` |
+| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + **CHK-* tick table**. PR-scoped: alignment artifacts only |
 | `audit-module-map` skill (optional) | artifact-write (`.local/` only) | `.local/module-map.md` summary for audit §3 |
 
 Parent **does not** duplicate inventory searches — consumes subagent outputs + preflight JSON.
@@ -77,7 +89,7 @@ make doc-validate
 
 | Subagent | When |
 |----------|------|
-| `drift-guard` | After tracker/doc edits; P0/P1 drift findings |
+| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift findings |
 | `verifier` | Spot-check top audit claims vs preflight + repo paths |
 
 ## Phase 4 — Maintainer PR
@@ -91,7 +103,8 @@ Human or maintainer agent: `review-pr` → `prepare-pr` → `merge-pr` on a `fea
 3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`. Under `board_only`, do not auto-edit board card body or local `plan.md` / `work-tracker.md`; offline fallback: do not auto-edit `plan.md` / `work-tracker.md`.
 4. **Canvases** — optional IDE artifacts; not merge gates.
 5. **Token efficiency** — cite preflight pass/fail in chat; paste failing command output only.
+6. **Ownership** — continuous plan/agent-doctrine coherence = `drift-guard`; deep CHK-* = `auditor`. No new trash agents.
 
 ## Handoff format
 
-Preflight exit • audit artifact paths • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR
+Preflight exit • audit artifact paths • CHK-* gaps • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR

--- a/payload/.cursor/skills/auditor-protocol/SKILL.md
+++ b/payload/.cursor/skills/auditor-protocol/SKILL.md
@@ -100,7 +100,9 @@ When the **maintainer workflow** requires alignment files for `--arch-impacting`
   - `.local/workflow-artifacts/alignment/alignment-todos.md`
 - Use **`.ai_infra/docs/roadmap/alignment-audit-schema.md`** for finding shape and P0/P1/P2 handling.
 - Scope: compare **touched** roadmap/plan/strategy docs, rules/skills/agents, `src/` + `tests/modules/` relevant to the PR — not a whole-repo scorecard.
+- Include a short **CHK-*** tick table (below) for dimensions that touch the PR; mark N/A for untouched dimensions.
 - **Optional:** note in `alignment-audit.md` that a full enterprise scorecard was deferred.
+- Continuous plan/agent-doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 prose here.
 
 ---
 
@@ -174,6 +176,20 @@ Python-specific analysis mode: ON
 
 ## Mandatory phases (execute in order; show phase boundaries in the written report)
 
+### Named checklists (CHK-*) — mandatory coverage
+
+Map each checklist into the matching phase. In the written report (or focused alignment), include a **CHK tick table**: id · status (Pass / Gap / N/A / Unknown) · evidence paths. **Do not** invent new skill folders for these dimensions.
+
+| Id | Phase | Must cite |
+|----|-------|-----------|
+| `CHK-ARCH` | 2 | Style, dependency direction, cycles |
+| `CHK-GRANULARITY` | 2 / 4 | God modules, blurred boundaries vs `.ai_infra/docs/governance/module-boundaries.md` (kit planes) or consumer `src/` modules |
+| `CHK-PERF` | 3 | Hot paths, N+1/queue clues; **Unknown** if none observable |
+| `CHK-SEC-CODE` | 3 | Secrets handling, injection/trust boundaries in kit scripts / app code in scope |
+| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, hard-stops, MCP `.cursor/mcp.registry.yaml` allowlists, no product auto-fix — **contract compliance**, not LLM jailbreak proof |
+| `CHK-INFRA-KIT` | 1 / 3 | Three planes, install/activate, `integrate validate` clues — **not** consumer cloud infra product |
+| `CHK-DOCS` | 5 | Stated goals vs docs; stale HANDOFF / AGENTS / IMPLEMENTATION-STATUS |
+
 ### PHASE 1 — Repository inventory (descriptive only)
 
 Establish facts: Python version(s), dependency tooling, frameworks, entry points, main packages, workers/jobs, APIs/CLI/scripts, data stores, messaging, infra/deployment clues, test layout, docs/ADRs/config.  
@@ -181,22 +197,22 @@ Establish facts: Python version(s), dependency tooling, frameworks, entry points
 
 ### PHASE 2 — Implemented architecture
 
-Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles.  
+Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles. Complete **CHK-ARCH** and start **CHK-GRANULARITY**.  
 **Output:** detected profile, boundary analysis, layering assessment, risks visible from structure.
 
 ### PHASE 3 — Python engineering and runtime
 
-Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security.  
+Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security. Complete **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**.  
 **Output:** evidence-backed findings only; label Confirmed / Probable risk / Unknown.
 
 ### PHASE 4 — Module-by-module audit
 
-For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later).  
+For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later). Finish **CHK-GRANULARITY**.  
 Use **Unknown** where needed. **Do not skip** module-level sections for major roots.
 
 ### PHASE 5 — Goal and plan alignment
 
-For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice.
+For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice. Complete **CHK-DOCS**. Continuous plan pulse when plans change is **`drift-guard`** — reference drift artifacts if present; do not re-run DRIFT scripts as a substitute for this phase.
 
 ### PHASE 6 — Recommended direction
 
@@ -258,6 +274,7 @@ Write `enterprise-architecture-audit.md` with these sections:
 
 1. Executive Summary  
 2. Audit Method (must satisfy the **Evidence contract**: sources, searches, commands, scope limits)  
+2b. **CHK-* tick table** (all seven ids: Pass / Gap / N/A / Unknown + evidence)  
 3. Repository Inventory  
 4. Detected Architecture Profile  
 5. Python-Specific Engineering Assessment  
@@ -333,7 +350,8 @@ Deliverables: full report + enterprise-audit-actions.md under .local/workflow-ar
 ## Exit criteria
 
 - Phases 1–6 completed in order in the written report; no early recommendation dump.  
+- **CHK-*** tick table present (full audit) or scoped tick table (focused alignment).  
 - **Evidence contract** satisfied: §2 lists reproducible sources/commands; Confirmed claims and scorecard categories cite paths; no finding in §7 or actions file without **Evidence** paths (or explicit **Unknown**).  
 - Scorecard populated with evidence and confidence; no score without justification.  
-- `enterprise-audit-actions.md` exists with prioritized, repo-tied items.  
+- `enterprise-audit-actions.md` exists with prioritized, repo-tied items (full audit).  
 - Unknowns and human-validation items explicitly listed.

--- a/payload/.cursor/skills/drift-audit/SKILL.md
+++ b/payload/.cursor/skills/drift-audit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: drift-audit
-description: Run drift validate first; write drift-audit.md and drift-todos.md with evidence contract.
+description: Run drift validate first; write drift-audit.md and drift-todos.md with evidence contract; goal/plan/agent-doctrine pulse.
 ---
 <!--
 File: SKILL.md
 Path: .cursor/skills/drift-audit/SKILL.md
-Role: Operational workflow drift audit protocol for plan/tracker/session coherence.
+Role: Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts.
 Used By:
  - .cursor/agents/drift-guard.md
 Depends On:
@@ -13,36 +13,52 @@ Depends On:
  - .ai_infra/scripts/workflow/check_drift.py
 Notes:
  - Advisory-only: no auto-remediation unless user explicitly asks.
+ - Deep architecture/security/perf is auditor — not this skill.
 -->
 
 # Drift audit
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **session Board vs export (DRIFT-004b)**, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `auditor` or `verifier`.
+Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:
+
+- plan ↔ tracker ↔ session-pointer incoherence
+- **DRIFT-004b** session Board vs export; **DRIFT-009** dual-write; **DRIFT-010** board vs PRs
+- **DRIFT-011** `.cursor/agents` basenames == eight live kit agent ids
+- Prose goal pulse: board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards (flag gaps; hand off — do not rewrite architecture)
+
+Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 
 ## When
 
 - Substantive implementer slice closure (recommended)
+- After plans / board Acceptance / agent doctrine docs change
 - Optional pre-review drift pass before PR workflow
-- After tracker or handoff doc edits
 - When `project_ssot.enabled` — every pass should include board Status evidence
+
+## Entry checklist (goal pulse)
+
+1. Board (when enabled): `project status` + `list --status in_progress` — read Acceptance / Notes on In progress cards.
+2. Plan pointers: `.local/index-and-planning/current/plan.md` (or board card body as SSOT) — Current focus / goals.
+3. Doctrine: `AGENTS.md` skills/agents table vs `.cursor/agents/*.md` (script: DRIFT-011).
+4. Docs freshness vs goals: note Probable if HANDOFF / IMPLEMENTATION-STATUS look stale relative to Current focus (prose only).
 
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when kit-dev / board_only as applicable (ADR-007/008).
 3. Capture profile, check IDs, severities, and details from output.
-4. Write artifacts under `.local/workflow-artifacts/drift/` only.
-5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
-6. Print handoff line with `item_id` when applicable.
+4. Add prose **Goal pulse** section in drift-audit.md (board/plan/AGENTS gaps). Fuzzy “vision mismatch” stays Probable — not CI.
+5. Write artifacts under `.local/workflow-artifacts/drift/` only.
+6. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write or roster gaps, Notes on offending card or Ready handoff to board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+7. Print handoff line with `item_id` when applicable.
 
 ## Evidence contract
 
 | Label | Meaning |
 |-------|---------|
 | Confirmed | Script output + file path cited |
-| Probable | Inference from trackers; label explicitly |
+| Probable | Inference from trackers/docs; label explicitly |
 | Unknown | Not verifiable from repo |
 
 ## Artifact frontmatter (both files)
@@ -61,7 +77,7 @@ Command: python -m cursor_workflow drift validate --directory . [--profile consu
 
 ## drift-audit.md
 
-Summary, per-check table (ID, severity, pass/fail, detail, evidence path), verdict (GO / blocked on P0).
+Summary, per-check table (ID, severity, pass/fail, detail, evidence path), **Goal pulse** subsection, verdict (GO / blocked on P0).
 
 ## drift-todos.md
 
@@ -77,8 +93,8 @@ Open findings with id, severity, evidence, recommendation, status (`open` | `fix
 
 ## Overlap (do NOT duplicate)
 
-Governance/debrand → `check_governance_consistency.py`. Agent/registry → `integrate validate`. Architecture → `auditor`. Claims → `verifier`.
+Governance/debrand → `check_governance_consistency.py`. Agent/registry deep structure → `integrate validate`. Architecture / CHK-* → `auditor`. Claims → `verifier`.
 
 ## Exit criteria
 
-Script run captured; both artifacts written; P0 count explicit; handoff names next agent if blocked.
+Script run captured; both artifacts written; P0 count explicit; Goal pulse noted; handoff names next agent if blocked.

--- a/skills/audit-alignment/SKILL.md
+++ b/skills/audit-alignment/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: audit-alignment
-description: DEPRECATED — use auditor; alignment outputs unchanged for merge gates.
+description: DEPRECATED RETIRE-PENDING — use auditor + auditor-protocol; stub kept for path/DOC count until AA-ROSTER-005 close.
 disable-model-invocation: true
 ---
 
-# Audit alignment (deprecated stub)
+# Audit alignment (deprecated stub — retire pending)
 
 **Do not use this file as the primary workflow.** The canonical audit agent is **`auditor`**.
 
 - **Agent:** `.cursor/agents/auditor.md`
-- **Protocol:** `.cursor/skills/auditor-protocol/SKILL.md`
+- **Protocol:** `.cursor/skills/auditor-protocol/SKILL.md` (CHK-* checklists)
 - **Merge-gate outputs (unchanged):** `.local/workflow-artifacts/alignment/alignment-audit.md`, `alignment-todos.md` per `.ai_infra/docs/roadmap/alignment-audit-schema.md`
 - **Rule:** `.cursor/rules/advisory-audit-alignment-enforcement.mdc`
 
-For architecture-impacting PRs, run a **focused alignment pass** (see `auditor-protocol`) unless a **full** `enterprise-architecture-audit.md` report is explicitly requested.
+**Retirement (AA-ROSTER-005):** Folder remains so maintainer skill count (5) and old links resolve. Delete only after updating AGENTS.md / DOC scans / `sync_plugin_bundle` expectations in a dedicated integrator slice.
 
-This stub remains so old links and governance scans that mention `audit-alignment/` keep resolving to a clear redirect.
+For architecture-impacting PRs, run a **focused alignment pass** (see `auditor-protocol`) unless a **full** `enterprise-architecture-audit.md` report is explicitly requested.

--- a/skills/audit-orchestration/SKILL.md
+++ b/skills/audit-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-orchestration
-description: Orchestrate verify-all preflight, auditor, implementer doc-sync, drift-guard, and verifier with Task delegation.
+description: Orchestrate verify-all preflight, auditor (CHK-*), implementer doc-sync, drift-guard goal pulse, and verifier with Task delegation.
 ---
 <!--
 File: SKILL.md
@@ -15,6 +15,7 @@ Depends On:
  - .cursor/skills/implementer-loop/SKILL.md
 Notes:
  - Human-triggered only; scripts run before prose agents consume results.
+ - Full CHK-* on quarterly/release only — not every PR.
 -->
 
 # Audit orchestration
@@ -22,6 +23,16 @@ Notes:
 ## Goal
 
 Run a **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts and apply approved fixes — without one agent re-running every shell command.
+
+## Cadence
+
+| Trigger | Auditor depth | Drift |
+|---------|---------------|-------|
+| **Architecture-impacting PR** | Focused alignment + scoped CHK-* tick table | `drift validate` via prepare; optional drift-guard artifacts |
+| **Quarterly / kit release readiness** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
+| **Ad-hoc full audit** | Same as quarterly | Same |
+
+Do **not** run full CHK-* scorecard on every PR.
 
 ## When
 
@@ -38,6 +49,7 @@ make verify-all
 # or with artifacts for agents:
 python -m cursor_workflow verify all --write-preflight
 python -m cursor_workflow doc validate --write-preflight
+python -m cursor_workflow drift validate --directory .
 ```
 
 **MCP (preferred in Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
@@ -52,7 +64,7 @@ Launch concurrently:
 
 | Subagent | Mode | Deliverable |
 |----------|------|-------------|
-| `auditor` | artifact-write (`.local/` only) | `enterprise-architecture-audit.md`, `enterprise-audit-actions.md` |
+| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + **CHK-* tick table**. PR-scoped: alignment artifacts only |
 | `audit-module-map` skill (optional) | artifact-write (`.local/` only) | `.local/module-map.md` summary for audit §3 |
 
 Parent **does not** duplicate inventory searches — consumes subagent outputs + preflight JSON.
@@ -77,7 +89,7 @@ make doc-validate
 
 | Subagent | When |
 |----------|------|
-| `drift-guard` | After tracker/doc edits; P0/P1 drift findings |
+| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift findings |
 | `verifier` | Spot-check top audit claims vs preflight + repo paths |
 
 ## Phase 4 — Maintainer PR
@@ -91,7 +103,8 @@ Human or maintainer agent: `review-pr` → `prepare-pr` → `merge-pr` on a `fea
 3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`. Under `board_only`, do not auto-edit board card body or local `plan.md` / `work-tracker.md`; offline fallback: do not auto-edit `plan.md` / `work-tracker.md`.
 4. **Canvases** — optional IDE artifacts; not merge gates.
 5. **Token efficiency** — cite preflight pass/fail in chat; paste failing command output only.
+6. **Ownership** — continuous plan/agent-doctrine coherence = `drift-guard`; deep CHK-* = `auditor`. No new trash agents.
 
 ## Handoff format
 
-Preflight exit • audit artifact paths • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR
+Preflight exit • audit artifact paths • CHK-* gaps • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR

--- a/skills/auditor-protocol/SKILL.md
+++ b/skills/auditor-protocol/SKILL.md
@@ -100,7 +100,9 @@ When the **maintainer workflow** requires alignment files for `--arch-impacting`
   - `.local/workflow-artifacts/alignment/alignment-todos.md`
 - Use **`.ai_infra/docs/roadmap/alignment-audit-schema.md`** for finding shape and P0/P1/P2 handling.
 - Scope: compare **touched** roadmap/plan/strategy docs, rules/skills/agents, `src/` + `tests/modules/` relevant to the PR — not a whole-repo scorecard.
+- Include a short **CHK-*** tick table (below) for dimensions that touch the PR; mark N/A for untouched dimensions.
 - **Optional:** note in `alignment-audit.md` that a full enterprise scorecard was deferred.
+- Continuous plan/agent-doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 prose here.
 
 ---
 
@@ -174,6 +176,20 @@ Python-specific analysis mode: ON
 
 ## Mandatory phases (execute in order; show phase boundaries in the written report)
 
+### Named checklists (CHK-*) — mandatory coverage
+
+Map each checklist into the matching phase. In the written report (or focused alignment), include a **CHK tick table**: id · status (Pass / Gap / N/A / Unknown) · evidence paths. **Do not** invent new skill folders for these dimensions.
+
+| Id | Phase | Must cite |
+|----|-------|-----------|
+| `CHK-ARCH` | 2 | Style, dependency direction, cycles |
+| `CHK-GRANULARITY` | 2 / 4 | God modules, blurred boundaries vs `.ai_infra/docs/governance/module-boundaries.md` (kit planes) or consumer `src/` modules |
+| `CHK-PERF` | 3 | Hot paths, N+1/queue clues; **Unknown** if none observable |
+| `CHK-SEC-CODE` | 3 | Secrets handling, injection/trust boundaries in kit scripts / app code in scope |
+| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, hard-stops, MCP `.cursor/mcp.registry.yaml` allowlists, no product auto-fix — **contract compliance**, not LLM jailbreak proof |
+| `CHK-INFRA-KIT` | 1 / 3 | Three planes, install/activate, `integrate validate` clues — **not** consumer cloud infra product |
+| `CHK-DOCS` | 5 | Stated goals vs docs; stale HANDOFF / AGENTS / IMPLEMENTATION-STATUS |
+
 ### PHASE 1 — Repository inventory (descriptive only)
 
 Establish facts: Python version(s), dependency tooling, frameworks, entry points, main packages, workers/jobs, APIs/CLI/scripts, data stores, messaging, infra/deployment clues, test layout, docs/ADRs/config.  
@@ -181,22 +197,22 @@ Establish facts: Python version(s), dependency tooling, frameworks, entry points
 
 ### PHASE 2 — Implemented architecture
 
-Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles.  
+Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles. Complete **CHK-ARCH** and start **CHK-GRANULARITY**.  
 **Output:** detected profile, boundary analysis, layering assessment, risks visible from structure.
 
 ### PHASE 3 — Python engineering and runtime
 
-Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security.  
+Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security. Complete **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**.  
 **Output:** evidence-backed findings only; label Confirmed / Probable risk / Unknown.
 
 ### PHASE 4 — Module-by-module audit
 
-For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later).  
+For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later). Finish **CHK-GRANULARITY**.  
 Use **Unknown** where needed. **Do not skip** module-level sections for major roots.
 
 ### PHASE 5 — Goal and plan alignment
 
-For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice.
+For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice. Complete **CHK-DOCS**. Continuous plan pulse when plans change is **`drift-guard`** — reference drift artifacts if present; do not re-run DRIFT scripts as a substitute for this phase.
 
 ### PHASE 6 — Recommended direction
 
@@ -258,6 +274,7 @@ Write `enterprise-architecture-audit.md` with these sections:
 
 1. Executive Summary  
 2. Audit Method (must satisfy the **Evidence contract**: sources, searches, commands, scope limits)  
+2b. **CHK-* tick table** (all seven ids: Pass / Gap / N/A / Unknown + evidence)  
 3. Repository Inventory  
 4. Detected Architecture Profile  
 5. Python-Specific Engineering Assessment  
@@ -333,7 +350,8 @@ Deliverables: full report + enterprise-audit-actions.md under .local/workflow-ar
 ## Exit criteria
 
 - Phases 1–6 completed in order in the written report; no early recommendation dump.  
+- **CHK-*** tick table present (full audit) or scoped tick table (focused alignment).  
 - **Evidence contract** satisfied: §2 lists reproducible sources/commands; Confirmed claims and scorecard categories cite paths; no finding in §7 or actions file without **Evidence** paths (or explicit **Unknown**).  
 - Scorecard populated with evidence and confidence; no score without justification.  
-- `enterprise-audit-actions.md` exists with prioritized, repo-tied items.  
+- `enterprise-audit-actions.md` exists with prioritized, repo-tied items (full audit).  
 - Unknowns and human-validation items explicitly listed.

--- a/skills/drift-audit/SKILL.md
+++ b/skills/drift-audit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: drift-audit
-description: Run drift validate first; write drift-audit.md and drift-todos.md with evidence contract.
+description: Run drift validate first; write drift-audit.md and drift-todos.md with evidence contract; goal/plan/agent-doctrine pulse.
 ---
 <!--
 File: SKILL.md
 Path: .cursor/skills/drift-audit/SKILL.md
-Role: Operational workflow drift audit protocol for plan/tracker/session coherence.
+Role: Continuous goal/plan/agent-doctrine/docs coherence plus operational DRIFT scripts.
 Used By:
  - .cursor/agents/drift-guard.md
 Depends On:
@@ -13,36 +13,52 @@ Depends On:
  - .ai_infra/scripts/workflow/check_drift.py
 Notes:
  - Advisory-only: no auto-remediation unless user explicitly asks.
+ - Deep architecture/security/perf is auditor — not this skill.
 -->
 
 # Drift audit
 
 ## Goal
 
-Detect **operational workflow drift** — plan ↔ tracker ↔ session-pointer incoherence, **session Board vs export (DRIFT-004b)**, **board vs tracker dual-write (DRIFT-009)**, **board Status vs open PRs / stale In progress (DRIFT-010)**, handoff doc parity, slice-closure signals — without replacing `auditor` or `verifier`.
+Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:
+
+- plan ↔ tracker ↔ session-pointer incoherence
+- **DRIFT-004b** session Board vs export; **DRIFT-009** dual-write; **DRIFT-010** board vs PRs
+- **DRIFT-011** `.cursor/agents` basenames == eight live kit agent ids
+- Prose goal pulse: board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards (flag gaps; hand off — do not rewrite architecture)
+
+Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 
 ## When
 
 - Substantive implementer slice closure (recommended)
+- After plans / board Acceptance / agent doctrine docs change
 - Optional pre-review drift pass before PR workflow
-- After tracker or handoff doc edits
 - When `project_ssot.enabled` — every pass should include board Status evidence
+
+## Entry checklist (goal pulse)
+
+1. Board (when enabled): `project status` + `list --status in_progress` — read Acceptance / Notes on In progress cards.
+2. Plan pointers: `.local/index-and-planning/current/plan.md` (or board card body as SSOT) — Current focus / goals.
+3. Doctrine: `AGENTS.md` skills/agents table vs `.cursor/agents/*.md` (script: DRIFT-011).
+4. Docs freshness vs goals: note Probable if HANDOFF / IMPLEMENTATION-STATUS look stale relative to Current focus (prose only).
 
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** when `project_ssot` board_only is enabled (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when kit-dev / board_only as applicable (ADR-007/008).
 3. Capture profile, check IDs, severities, and details from output.
-4. Write artifacts under `.local/workflow-artifacts/drift/` only.
-5. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write, Notes on offending card or Ready handoff to board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
-6. Print handoff line with `item_id` when applicable.
+4. Add prose **Goal pulse** section in drift-audit.md (board/plan/AGENTS gaps). Fuzzy “vision mismatch” stays Probable — not CI.
+5. Write artifacts under `.local/workflow-artifacts/drift/` only.
+6. **Board Exit:** set drift-pass card → `done` (or `in_review` if P0/P1 need human). For Confirmed dual-write or roster gaps, Notes on offending card or Ready handoff to board/implementer — do **not** auto-edit `plan.md`, `work-tracker.md`, or `session-pointer.md`.
+7. Print handoff line with `item_id` when applicable.
 
 ## Evidence contract
 
 | Label | Meaning |
 |-------|---------|
 | Confirmed | Script output + file path cited |
-| Probable | Inference from trackers; label explicitly |
+| Probable | Inference from trackers/docs; label explicitly |
 | Unknown | Not verifiable from repo |
 
 ## Artifact frontmatter (both files)
@@ -61,7 +77,7 @@ Command: python -m cursor_workflow drift validate --directory . [--profile consu
 
 ## drift-audit.md
 
-Summary, per-check table (ID, severity, pass/fail, detail, evidence path), verdict (GO / blocked on P0).
+Summary, per-check table (ID, severity, pass/fail, detail, evidence path), **Goal pulse** subsection, verdict (GO / blocked on P0).
 
 ## drift-todos.md
 
@@ -77,8 +93,8 @@ Open findings with id, severity, evidence, recommendation, status (`open` | `fix
 
 ## Overlap (do NOT duplicate)
 
-Governance/debrand → `check_governance_consistency.py`. Agent/registry → `integrate validate`. Architecture → `auditor`. Claims → `verifier`.
+Governance/debrand → `check_governance_consistency.py`. Agent/registry deep structure → `integrate validate`. Architecture / CHK-* → `auditor`. Claims → `verifier`.
 
 ## Exit criteria
 
-Script run captured; both artifacts written; P0 count explicit; handoff names next agent if blocked.
+Script run captured; both artifacts written; P0 count explicit; Goal pulse noted; handoff names next agent if blocked.

--- a/tests/modules/workflow_drift/test_drift_checks.py
+++ b/tests/modules/workflow_drift/test_drift_checks.py
@@ -22,6 +22,7 @@ if str(WORKFLOW_DIR) not in sys.path:
 from drift_checks import (  # noqa: E402
     _parse_owned_test_paths,
     _path_exists,
+    LIVE_KIT_AGENT_IDS,
     check_drift001,
     check_drift002,
     check_drift003,
@@ -30,6 +31,7 @@ from drift_checks import (  # noqa: E402
     check_drift006,
     check_drift007,
     check_drift008,
+    check_drift011,
     detect_profile,
     drift_paths,
 )
@@ -357,3 +359,36 @@ def test_drift_validate_passes_p0_on_kit_repo() -> None:
     p0_failures = [r for r in results if not r.passed and r.severity.value == "P0"]
     assert not p0_failures, "\n".join(f"{r.check_id}: {r.detail}" for r in p0_failures)
     assert check_drift.exit_code_for(results) == 0
+    drift011 = next(r for r in results if r.check_id == "DRIFT-011")
+    assert drift011.passed, drift011.detail
+
+
+def test_drift011_passes_with_live_roster(tmp_path: Path) -> None:
+    agents = tmp_path / ".cursor" / "agents"
+    agents.mkdir(parents=True)
+    for name in LIVE_KIT_AGENT_IDS:
+        (agents / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+    result = check_drift011(drift_paths(tmp_path))
+    assert result.passed
+    assert result.check_id == "DRIFT-011"
+
+
+def test_drift011_fails_when_agent_missing(tmp_path: Path) -> None:
+    agents = tmp_path / ".cursor" / "agents"
+    agents.mkdir(parents=True)
+    for name in LIVE_KIT_AGENT_IDS - {"researcher"}:
+        (agents / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+    result = check_drift011(drift_paths(tmp_path))
+    assert not result.passed
+    assert "missing=researcher" in result.detail
+
+
+def test_drift011_fails_on_extra_agent(tmp_path: Path) -> None:
+    agents = tmp_path / ".cursor" / "agents"
+    agents.mkdir(parents=True)
+    for name in LIVE_KIT_AGENT_IDS:
+        (agents / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+    (agents / "ghost-agent.md").write_text("# ghost\n", encoding="utf-8")
+    result = check_drift011(drift_paths(tmp_path))
+    assert not result.passed
+    assert "extra=ghost-agent" in result.detail


### PR DESCRIPTION
## Summary
- Clarifies **drift-guard** (continuous goal/plan/agent-doctrine pulse + DRIFT-001…011) vs **auditor** (deep/periodic CHK-* security/perf/granularity/docs) — no new agents or skill folders.
- Adds **DRIFT-011** (live `.cursor/agents` roster coherence), expands drift-audit / auditor-protocol / audit-orchestration, refreshes canvases; `audit-alignment` remains RETIRE-PENDING.
- Fixes `_collect_pytest_count` to import `.ai_infra/paths` reliably; bumps documented test count to **1193**.

## Test plan
- [x] `python3 -m cursor_workflow drift validate` (incl. DRIFT-011 PASS)
- [x] `python3 .ai_infra/scripts/architecture/check_doc_facts.py`
- [x] `python3 .ai_infra/scripts/architecture/check_governance_consistency.py`
- [x] `pytest tests/modules/workflow_drift/test_drift_checks.py -q` (28 passed)
- [ ] `/review-pr` → `/prepare-pr` → `/merge-pr` Pattern A