### PR TITLE
chore: fix kit/payload parity P2 follow-ups

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-08-04 (drift goal pulse DRIFT-011 + auditor CHK-*; 1213 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1213
+**Last updated:** 2026-08-04 (drift goal pulse DRIFT-011 + auditor CHK-*; 1214 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1214
 
 ## Shipped (confirmed in repo)
 
@@ -53,13 +53,13 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1213 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1214 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
 `pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
 installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-20
-(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1213
+(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1214
 collected** as of DRIFT-011 goal pulse; intentional live-smoke skips only). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,

--- a/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
+++ b/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
@@ -112,7 +112,7 @@ my-app/
 │   ├── scripts/pr|architecture|integration|workflow|install/
 │   ├── install/cursor_workflow/
 │   ├── docs/operations|governance|roadmap|decisions|architecture/
-│   ├── templates/local-workspace|user-settings|agent-integration/
+│   ├── templates/local-workspace|user-settings|agent-integration|project-board|research-corpus/
 │   ├── mcp_servers/workflow_mcp/   # with_mcp profile
 │   └── workflows/
 ├── overlays/                 # product rules source (copy → .cursor/rules/)

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -204,7 +204,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07, archival):** Verified `plugin.json` `description`, the Description row above, and README consumer sections against `IMPLEMENTATION-STATUS.md` on `main` at that date — counts superseded by refreshes below; feature counts at that date (8 agents, **11** skills, 5 PR skills, 7 rules) — **superseded** (skills are **12** since board-shell).
 
-**Listing copy refresh (2026-08-04 drift/auditor quality):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` — **1213** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
+**Listing copy refresh (2026-08-04 drift/auditor quality):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` — **1214** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
 
 **Listing copy refresh (2026-07-18 WORKSPACE-CLEAN, archival):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree at that date — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Superseded by 2026-07-19 refreshes below.
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -73,7 +73,7 @@ Deep dive: [PLUGIN-ARCHITECTURE.md](PLUGIN-ARCHITECTURE.md).
 | `.cursor/rules/*.mdc` | 7 kit-dev rules | **Here** |
 | `.cursor/skills/*/` | 12 canonical protocols | **Here** |
 | `.agents/skills/*/` | Maintainer slash skills | **Here** |
-| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (17 skill folders = 12 canonical + 5 maintainer PR slash skills) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
+| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (18 skill folders = 12 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
 | `payload/` | Consumer install bundle | `make sync-plugin` from above + manifest |
 | `skills/audit-alignment/` | Deprecated stub in merged `skills/` | `.agents/skills/audit-alignment/` |
 
@@ -90,12 +90,12 @@ my-app/
 │   ├── agents/                     8 agents (from payload; incl. board)
 │   ├── rules/                      7 rules (6 kit + project-ssot-precedence)
 │   └── skills/                     12 canonical skills only (no repo-root skills/ merge)
-├── .agents/skills/                 5 maintainer slash folders (+ audit-alignment stub)
+├── .agents/skills/                 6 maintainer slash folders (incl. full-pr-workflow; + audit-alignment stub)
 ├── .ai_infra/                      Slim bundle (manifest copy_ai_infra only)
 │   ├── scripts/pr|architecture|integration|workflow|install/
 │   ├── install/cursor_workflow/
 │   ├── docs/operations|governance|roadmap|decisions|architecture/
-│   ├── templates/local-workspace|user-settings|agent-integration/
+│   ├── templates/local-workspace|user-settings|agent-integration|project-board|research-corpus/
 │   ├── workflows/                  PR lane hub (shipped — see workflows/README.md)
 │   └── mcp_servers/workflow_mcp/   (with_mcp profile)
 ├── cursor_workflow/                CLI entrypoint
@@ -168,13 +168,14 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `review-pr` | Active | |
 | `prepare-pr` | Active | |
 | `merge-pr` | Active | |
+| `full-pr-workflow` | Active | Optional cleanup path: `pr-workflow` + `finalize.py` (branch cleanup, `finalize.md`) |
 | **`audit-alignment`** | **Deprecated stub** | Redirect → `auditor`; outputs unchanged (`alignment-audit.md`, `alignment-todos.md`) |
 
 Also under `.agents/skills/`: `README.md`, `PR_WORKFLOW.md` (legacy redirect), `RESEARCH_WORKFLOW.md` (research hub pointer).
 
 ### Repo-root `skills/` — Marketplace plugin mirror only
 
-Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (12) and `.agents/skills/` (5); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
+Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (12) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1213 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1214 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 

--- a/tests/modules/release/test_sync_plugin_bundle.py
+++ b/tests/modules/release/test_sync_plugin_bundle.py
@@ -133,6 +133,33 @@ def test_payload_install_dry_run(tmp_path: Path) -> None:
     assert "SCAFFOLD DONE" in joined
 
 
+def test_sync_payload_excludes_maintainer_only_fixtures(tmp_path: Path) -> None:
+    """Consumer payload must not ship kit-dev-only ci/ fixtures or maintainer docs.
+
+    Covers AA-test-001: exclusion filters in consumer_bundle_paths.py
+    (ignore_local_workspace_ci, ignore_operations_maintainer) were only
+    covered indirectly by scaffold/purity tests; assert the concrete
+    excluded paths directly here.
+    """
+    mod = _load_sync()
+    plugin_dir = tmp_path / "plugin"
+    payload_dir = tmp_path / "payload"
+    mod.sync_plugin_surface(plugin_dir)
+    mod.sync_payload(payload_dir, plugin_dir, profile="with_mcp")
+
+    local_workspace = payload_dir / ".ai_infra" / "templates" / "local-workspace"
+    assert local_workspace.is_dir()
+    assert not (local_workspace / "ci").exists(), (
+        "kit-dev-only ci/ fixtures must not ship to consumer payload"
+    )
+
+    operations = payload_dir / ".ai_infra" / "docs" / "operations"
+    assert operations.is_dir()
+    assert not (operations / "documentation-maintenance-checklist.md").exists(), (
+        "maintainer-only documentation-maintenance-checklist.md must not ship to consumer payload"
+    )
+
+
 def test_plugin_canonical_skills_not_overwritten_by_stubs(tmp_path: Path) -> None:
     mod = _load_sync()
     plugin_dir = tmp_path / "plugin"


### PR DESCRIPTION
## Summary
- Sync repository-map.md and PLUGIN-ARCHITECTURE.md consumer trees to list `templates/project-board` and `templates/research-corpus`
- Add regression test guarding payload sync excludes maintainer-only fixtures (`ci/`, `documentation-maintenance-checklist.md`)
- Sync hardcoded test count (1214) across README/IMPLEMENTATION-STATUS/marketplace-publish docs

Closes out the 3 P2 items (AA-docs-001/002, AA-test-001) from the kit/payload parity alignment review.

## Test plan
- [x] pytest -q (1212 passed, 2 skipped)

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: review-pr | prepare-pr | merge-pr