### PR TITLE
ADR-010 canvas/plan doctrine + cursor_workflow install Miss=0

### DIFF
--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -68,9 +68,11 @@ Drift validation: `make drift-validate` — see [gate-matrix.md](../operations/g
 
 | Root | Contents |
 |------|----------|
-| `.cursor/skills/` | Canonical protocols (**12**): `workflow-activate`, `board-ssot`, `board-shell`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
+| `.cursor/skills/` | Canonical protocols (**13**): `workflow-activate`, `board-ssot`, `board-shell`, `canvas-artifacts`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
 | `.agents/skills/` | Maintainer slash skills: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` (redirect) |
 
 Plugin bundle copies `.cursor/skills/` first; maintainer skills are **additive only** (no overwrite).
+
+Canvas/plan local artifacts: [ADR-010](../decisions/ADR-010-canvas-plan-local-artifacts.md) · skill `canvas-artifacts`.
 
 See [folder-charter.md](../governance/folder-charter.md) and [decisions/README.md](../decisions/README.md).

--- a/.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md
+++ b/.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md
@@ -21,8 +21,9 @@ Registry maps agent ids → server keys → tool hints. Agents read registry bef
 ## Consequences
 
 - `cursor_workflow mcp link` / `mcp validate` CLI (Phase 5b)
+- Pattern A transport: `mcp doctor|list-tools|call|auth|smoke` — see [ADR-009](ADR-009-mcp-pattern-a-cli.md)
 - `mcp-connect` skill and ops doc
-- Secrets in `.cursor/mcp.user.json` (gitignored)
+- Transport in `.cursor/mcp.user.json` (gitignored); auth secrets in `.local/user_settings/mcp.secrets.yaml`
 
 ## Reference implementation
 

--- a/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -58,6 +58,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
 | DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
 | DRIFT-011 | P1 | kit-dev | Agent roster coherence: `.cursor/agents/*.md` basenames match the eight live kit agent ids (goal/doctrine pulse — falsifiable) |
+| DRIFT-012 | P2 | kit-dev | When `board_only`, `.local/plans/` is snapshot-only — no live/current plan SSOT in that dir (ADR-010) |
 
 **Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`). Pending `project_ssot.outbox` ops are **not** a drift failure — cite `project outbox status` in artifacts when relevant.
 

--- a/.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md
+++ b/.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md
@@ -1,0 +1,30 @@
+# ADR-009: MCP Pattern A CLI (universal agent transport)
+
+**Status:** accepted  
+**Date:** 2026-08-05
+
+## Context
+
+ADR-003/004 define kit + user MCP tiers and a registry. Cursor agent sessions often load only plugin MCPs, not project `.cursor/mcp.json` servers (`workflow-kit`, DeepWiki). Agents need a transport that works in shell, CI, and chat without depending on Cursor host loading.
+
+## Decision
+
+1. **CLI is canonical:** `python3 -m cursor_workflow mcp doctor|list-tools|call|auth|smoke` (plus existing `validate` / `link`).
+2. **Registry allowlist:** `mcp call` / `list-tools` only target servers present in `.cursor/mcp.registry.yaml` (when that file exists); `--agent` filters to servers that list the agent.
+3. **Secrets:** `.local/user_settings/mcp.secrets.yaml` (gitignored); `mcp.user.json` stays transport-only.
+4. **Cursor `CallMcpTool` is optional** when the IDE host loads the same server; docs/skills must not require it.
+5. **Kit `workflow-kit` stdio server unchanged** — still wraps `.ai_infra/scripts/`; CLI client talks to it over MCP stdio.
+6. **Exit codes:** align with project CLI (`0/2/3/4/5`); remote outbox / `EXIT_QUEUED=6` deferred.
+
+## Consequences
+
+- Modules: `mcp_cli.py`, `mcp_client.py`, `mcp_secrets.py` beside `mcp_manage.py`
+- Evidence under `.local/workflow-artifacts/mcp/`
+- Agent MCP sections prefer CLI recipes
+- Extends ADR-004; does not replace ADR-003 boundaries
+
+## References
+
+- [ADR-003](ADR-003-plugin-mcp-boundaries.md), [ADR-004](ADR-004-user-mcp-registry.md)
+- Ops: `.ai_infra/docs/operations/connect-external-mcp.md`
+- Skill: `.cursor/skills/mcp-connect/SKILL.md`

--- a/.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md
+++ b/.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md
@@ -1,0 +1,30 @@
+# ADR-010: Canvas and plan local artifacts (Pattern A)
+
+**Status:** accepted  
+**Date:** 2026-08-05
+
+## Context
+
+Kit canvases live in git under `canvases/*.canvas.tsx`, but Cursor IDE only compiles canvases from `~/.cursor/projects/<workspace>/canvases/`. Plan-mode output lands in global `~/.cursor/plans/`, while live slice plans under `board_only` belong on the GitHub Project card (ADR-008). Agents need durable, project-scoped history for ephemeral canvases and plan snapshots without creating a second writable SSOT.
+
+## Decision
+
+1. **Three canvas tiers:** repo `canvases/` (git SSOT for product docs), Cursor managed path (render bridge only), `.local/canvases/` (session evidence, gitignored).
+2. **Two plan tiers:** live plan on board card body (or `plan.md` offline fallback); `.local/plans/` holds dated **snapshots only** — never competing backlog/status.
+3. **CLI is canonical:** `python3 -m cursor_workflow canvas doctor|list|sync|save` and `plan snapshot|list|open`.
+4. **Explicit sync:** no silent overwrite of Cursor managed canvases on activate; `canvas sync --all` requires `--force`; `--missing` copies only absent managed files.
+5. **Evidence:** optional doctor reports under `.local/workflow-artifacts/canvas/`.
+
+## Consequences
+
+- Modules: `cursor_host_paths.py`, `canvas_manage.py`, `canvas_cli.py`, `plan_manage.py`, `plan_cli.py`
+- Skill: `.cursor/skills/canvas-artifacts/SKILL.md`
+- **`plan open`** copies the latest `.local/plans/<date>-<slug>.plan.md` snapshot to `~/.cursor/plans/<slug>.plan.md` so humans get IDE Build; requires `--force` when the Cursor twin already exists (same safety model as `canvas sync --all`)
+- **Agents build from `.local/plans/`** via `plan list` + read snapshot — never depend on Build or the global Cursor plan store
+- Extends ADR-008 (no dual-write); complements Cursor global canvas/plan skills
+
+## References
+
+- [ADR-008](ADR-008-project-board-ssot.md)
+- Ops: `.ai_infra/docs/operations/local-workspace-layout.md`, `PLUGIN-USER-GUIDE.md`
+- Skill: `.cursor/skills/canvas-artifacts/SKILL.md`

--- a/.ai_infra/docs/decisions/README.md
+++ b/.ai_infra/docs/decisions/README.md
@@ -10,5 +10,7 @@
 | [ADR-006](ADR-006-agent-integration-model.md) | Agent integration model (MAS vs independent) | accepted |
 | [ADR-007](ADR-007-workflow-drift-guard.md) | Workflow drift guard (operational drift detection) | accepted |
 | [ADR-008](ADR-008-project-board-ssot.md) | GitHub Project board as agent SSOT (product doctrine) | accepted |
+| [ADR-009](ADR-009-mcp-pattern-a-cli.md) | MCP Pattern A CLI (universal agent transport) | accepted |
+| [ADR-010](ADR-010-canvas-plan-local-artifacts.md) | Canvas and plan local artifacts (Pattern A) | accepted |
 
 New decisions: add `ADR-NNN-short-title.md` and update this index.

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-08-04 (MCP SDK v2 migration + DeepWiki demo wiring; 1218 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1218
+**Last updated:** 2026-08-05 (cursor_workflow install COV-100; 1411 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1411
 
 ## Shipped (confirmed in repo)
 
@@ -24,13 +24,13 @@ Notes:
 |------|--------|----------|
 | Universal rules | 7 `.mdc` | `.cursor/rules/` **and** `payload/.cursor/rules/` (6 kit + `project-ssot-precedence`) |
 | Agents | 8 core; `model: auto`; audit agents write `.local/` artifacts only (no `readonly`) | `.cursor/agents/` |
-| Canonical skills | 12 folders | `.cursor/skills/` |
+| Canonical skills | 13 folders | `.cursor/skills/` |
 | Maintainer skills | 6 folders (additive plugin merge; includes `full-pr-workflow`) | `.agents/skills/` |
 | Cursor skill merge | Canonical wins in plugin sync | `sync_plugin_bundle.py` |
 | workflow-activate skill | Kit dev + plugin | `.cursor/skills/workflow-activate/` |
 | PR scripts + prepare gates | Pattern A — **2** universal; **4** on kit-dev (drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` |
 | Governance + debrand scanners | CI-ready | `.ai_infra/scripts/architecture/` |
-| Workflow drift validate | ADR-007 (+ DRIFT-004b, DRIFT-011 roster pulse) | `.ai_infra/scripts/workflow/check_drift.py` |
+| Workflow drift validate | ADR-007 (+ DRIFT-004b, DRIFT-011 roster, DRIFT-012 plan snapshots) | `.ai_infra/scripts/workflow/check_drift.py` |
 | Timestamped board Notes (CONT-TS) | `@user/agent · <ISO-8601-UTC> · …` via CLI (`claim`/`handoff`/`append-notes`) | `project_recipes.py` / `project_cli.py` + skill § Notes |
 | Tier-1 Size/Estimate + Start date | Size↔Estimate **points** table in skill; Start date on claim / `set-status` / `handoff` → `in_progress`; `create-from-template --priority` required | `board-ssot` skill · `project_atomics.ensure_start_date_if_starting` · PR #70 |
 | Local continuity-index | Rolling ≥3-day UTC rows; board Notes = full card lifetime | `history/continuity-index.md` (+ exemplar) |
@@ -46,25 +46,30 @@ Notes:
 | Install scaffold + contract | `install-contract.json`; idempotent trackers/`AGENTS.md`/`pages.json` on re-activate | `.ai_infra/scripts/install/scaffold.py` |
 | Local artifact tiers | Tier 1 scaffold: all `workflow-artifacts/*` buckets + README stubs; SSOT `local_workflow_paths.py` | `.ai_infra/templates/local-workspace/`, `pages.json` |
 | Integrate validate | INT-001…014; INT-009/011 plugin parity **kit-dev only** | `.ai_infra/scripts/integration/validate.py` |
-| Install CLI | install, **activate**, gates, health, mcp, contributors, integrate, drift, doc, verify, **project**, **research** | `.ai_infra/install/cursor_workflow/cli.py` |
+| Canvas / plan CLI | ADR-010 Pattern A — `canvas doctor|sync|save`, `plan snapshot|list|open` | `.ai_infra/install/cursor_workflow/canvas_cli.py`, `plan_cli.py` · `canvas-artifacts` skill |
+| Install CLI | install, **activate**, gates, health, mcp, contributors, integrate, drift, doc, verify, **project**, **research**, **canvas**, **plan** | `.ai_infra/install/cursor_workflow/cli.py` |
 | Editable install | `pyproject.toml` — `pip install -e ".[dev,mcp]"` | repo root |
 | Three-plane activate | Idempotent plugin consumer setup | `.ai_infra/install/cursor_workflow/activate_cli.py`, `plane_status.py` |
 | User MCP registry | ADR-004 | `.cursor/mcp.registry.yaml.example`, `mcp_manage.py` |
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1218 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1411 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 
-`pytest --cov=.ai_infra --cov=cursor_workflow` measures the **import surface** of the
-installable kit (CLI, scripts invoked in-process, MCP server). As of 2026-07-20
-(COV-100 closure): **7089 statements, 100.00%** on a full suite pass (**1218
-collected** as of DRIFT-011 goal pulse; intentional live-smoke skips only). One import-order `sys.path` bootstrap in
+Two metrics (do not conflate):
+
+| Metric | Command | As of 2026-08-05 |
+|--------|---------|------------------|
+| **(A) Install package** | `pytest tests/modules/ -q --cov=.ai_infra/install/cursor_workflow --cov-report=term-missing` | **5199 statements, 100.00%, Miss=0** (all 27 modules) |
+| **(B) Broader kit import surface** | `pytest --cov=.ai_infra --cov=cursor_workflow` | **8650 statements, 99% (23 miss)** — honest post-COV-CW; not claimed 100% when only install package is closed |
+
+Metric (A) is the trust gate for Pattern A CLI (`project`, `mcp`, `canvas`, `plan`). Metric (B) tracks the installable kit import surface (CLI, scripts invoked in-process, MCP server). One import-order `sys.path` bootstrap in
 `merge.py` is `# pragma: no cover` (justified — import-order bootstrap only).
 Subprocess-only maintainer scanners (`check_governance_consistency.py`,
 `check_debrand.py`, `check_consumer_purity.py`, `check_file_headers.py`) have
-dedicated module tests but are excluded from this metric by design — they are
+dedicated module tests but are excluded from metric (B) by design — they are
 launched via `subprocess` / `make gates`, not imported by the coverage run.
 Running `--cov=.` (tests included) reports higher because of order-dependent
 branches in test-helper cleanup code; scope shipped source for readiness claims.

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -204,7 +204,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy review (2026-07-07, archival):** Verified `plugin.json` `description`, the Description row above, and README consumer sections against `IMPLEMENTATION-STATUS.md` on `main` at that date — counts superseded by refreshes below; feature counts at that date (8 agents, **11** skills, 5 PR skills, 7 rules) — **superseded** (skills are **12** since board-shell).
 
-**Listing copy refresh (2026-08-04 drift/auditor quality):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` — **1218** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
+**Listing copy refresh (2026-08-05 MCP Pattern A):** Re-verified against filesystem + `IMPLEMENTATION-STATUS.md` — **1229** tests; agent/skill/rule counts (**8** / **12** / **7**); B-safe rename shipped; agent descriptions prefixed `{name} MAS-SSOT-KIT`.
 
 **Listing copy refresh (2026-07-18 WORKSPACE-CLEAN, archival):** Re-verified README/AGENTS.md/repository-map/canvases against shipped tree at that date — **931** tests collected (DOC-008 added), **5352** stmts / **100%** coverage on `--cov=.ai_infra --cov=cursor_workflow` per `IMPLEMENTATION-STATUS.md`; agent/skill/rule counts unchanged (8 / 11 / 7). Superseded by 2026-07-19 refreshes below.
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -73,7 +73,7 @@ Deep dive: [PLUGIN-ARCHITECTURE.md](PLUGIN-ARCHITECTURE.md).
 | `.cursor/rules/*.mdc` | 7 kit-dev rules | **Here** |
 | `.cursor/skills/*/` | 13 canonical protocols | **Here** |
 | `.agents/skills/*/` | Maintainer slash skills | **Here** |
-| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (18 skill folders = 12 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
+| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (19 skill folders = 13 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
 | `payload/` | Consumer install bundle | `make sync-plugin` from above + manifest |
 | `skills/audit-alignment/` | Deprecated stub in merged `skills/` | `.agents/skills/audit-alignment/` |
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -71,7 +71,7 @@ Deep dive: [PLUGIN-ARCHITECTURE.md](PLUGIN-ARCHITECTURE.md).
 |------|------|------------|
 | `.cursor/agents/*.md` | 8 agent cards | **Here** |
 | `.cursor/rules/*.mdc` | 7 kit-dev rules | **Here** |
-| `.cursor/skills/*/` | 12 canonical protocols | **Here** |
+| `.cursor/skills/*/` | 13 canonical protocols | **Here** |
 | `.agents/skills/*/` | Maintainer slash skills | **Here** |
 | `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (18 skill folders = 12 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
 | `payload/` | Consumer install bundle | `make sync-plugin` from above + manifest |
@@ -89,7 +89,7 @@ my-app/
 ├── .cursor/
 │   ├── agents/                     8 agents (from payload; incl. board)
 │   ├── rules/                      7 rules (6 kit + project-ssot-precedence)
-│   └── skills/                     12 canonical skills only (no repo-root skills/ merge)
+│   └── skills/                     13 canonical skills only (no repo-root skills/ merge)
 ├── .agents/skills/                 6 maintainer slash folders (incl. full-pr-workflow; + audit-alignment stub)
 ├── .ai_infra/                      Slim bundle (manifest copy_ai_infra only)
 │   ├── scripts/pr|architecture|integration|workflow|install/
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1180; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1411; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 
@@ -143,7 +143,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 
 ## Skills
 
-### Canonical — `.cursor/skills/` (12) → consumer `.cursor/skills/`
+### Canonical — `.cursor/skills/` (13) → consumer `.cursor/skills/`
 
 | Skill | Paired agent |
 |-------|----------------|
@@ -156,6 +156,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `integrator-protocol` | `integrator` |
 | `board-ssot` | `board` (board Entry/Exit; ADR-008) |
 | `board-shell` | `board` (first-run shell coach) |
+| `canvas-artifacts` | Canvas/plan Pattern A CLI (ADR-010) |
 | `workflow-activate` | Install / re-activate |
 | `mcp-connect` | MCP setup |
 | `research-corpus` | `researcher` |
@@ -175,7 +176,7 @@ Also under `.agents/skills/`: `README.md`, `PR_WORKFLOW.md` (legacy redirect), `
 
 ### Repo-root `skills/` — Marketplace plugin mirror only
 
-Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (12) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
+Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (13) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
 
 ---
 
@@ -220,6 +221,8 @@ Product overlays: `overlays/rules/*.mdc` remains the source for domain overlays;
 | `workflow-artifacts/enterprise-architecture-audit/` | 2 | `auditor` |
 | `agents-control-center/` | 1 + refresh | scaffold / activate |
 | `user_settings/` | 1 | human (gitignored) |
+| `canvases/` | 2 | agents — `canvas save` session evidence (ADR-010) |
+| `plans/` | 2 | agents — `plan snapshot` history only; live plan on board / `plan.md` (DRIFT-012) |
 | `generated-data/` | 2 | pytest / CI |
 
 **Kit repo `.local/`** is a CI seed fixture — not what consumers receive. Consumers get neutral exemplars from `templates/local-workspace/exemplars/`.

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -296,6 +296,21 @@ Versioned under repo `canvases/*.canvas.tsx` (git SSOT). **Rendering** uses Curs
 
 Clicking a file in the repo explorer opens **source**, not the visualization. To view diagrams: **Ctrl+Shift+P → Open Canvas** (pick e.g. `agents-artifacts-board` or an `agent-*` canvas). See hub canvas `canvases/agents-artifacts-board.canvas.tsx` for the same note.
 
+**Three-tier model (ADR-010):** repo `canvases/` (git SSOT) → sync → Cursor managed path (preview) → optional save → `.local/canvases/` (session evidence). Plan snapshots: `.local/plans/` (history only; live plan stays on board or `plan.md`). Agents execute plans from `.local/plans/`; humans bridge to IDE Build with `plan open --slug <slug>` (requires `--force` if a Cursor twin already exists).
+
+```bash
+python3 -m cursor_workflow canvas doctor
+python3 -m cursor_workflow canvas list
+python3 -m cursor_workflow canvas sync --name mcp-onboarding
+python3 -m cursor_workflow canvas save --name <stem>
+python3 -m cursor_workflow canvas sync --missing
+python3 -m cursor_workflow plan snapshot --slug my-slice
+python3 -m cursor_workflow plan list
+python3 -m cursor_workflow plan open --slug my-slice
+```
+
+Skill: `.cursor/skills/canvas-artifacts/SKILL.md`
+
 Legacy browser UI still ships on activate. **Do not open HTML via `file://`**. From project root:
 
 ```bash

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -82,7 +82,9 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 | P0 / P1 / P2 / P3 | Priority — board uses `p0\|p1\|p2`; chat P3 → board `p2` + Notes `deferred` | `board-ssot` skill |
 | xs…xl | Size options on the board (Tier-1) | Size↔Estimate table in skill |
 
-High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`), **DRIFT-011** (`.cursor/agents` basenames == eight live kit agent ids — goal/doctrine pulse).
+High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`), **DRIFT-011** (`.cursor/agents` basenames == eight live kit agent ids — goal/doctrine pulse), **DRIFT-012** (`.local/plans/` snapshot-only under `board_only`).
+
+**Canvas / plan (ADR-010):** repo `canvases/` → `canvas sync` → IDE preview → optional `canvas save` → `.local/canvases/`; plan history in `.local/plans/` via `plan snapshot|list|open` (live plan on board card).
 
 ## Planes
 

--- a/.ai_infra/docs/operations/agent-workflow-procedures.md
+++ b/.ai_infra/docs/operations/agent-workflow-procedures.md
@@ -70,6 +70,7 @@ When **`resolve_gates()`** / **`GATES`** in `prepare.py` change, update in the *
 | Always-applied rule | `.cursor/rules/pr-workflow-enforcement.mdc` |
 | Onboarding | `README.md`, `AGENTS.md` |
 | Checklist | `.ai_infra/docs/operations/workflow-complete.md` |
+| Canvas / plan artifacts | `.cursor/skills/canvas-artifacts/SKILL.md` (ADR-010) |
 | Maintainer skills | `.agents/skills/pr-workflow/SKILL.md`, `prepare-pr/SKILL.md`, `review-pr/SKILL.md`, `merge-pr/SKILL.md`, `full-pr-workflow/SKILL.md` |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` (via `full-pr-workflow`) |
 

--- a/.ai_infra/docs/operations/connect-external-mcp.md
+++ b/.ai_infra/docs/operations/connect-external-mcp.md
@@ -45,7 +45,20 @@ cursor-workflow mcp validate
 | Kit | `mcp.json.kit.example` → merged into `mcp.json` | `workflow-kit` tools (PR, trackers, gates) |
 | User | `mcp.user.json` + registry YAML | External servers per agent |
 
-See [ADR-004](../decisions/ADR-004-user-mcp-registry.md).
+See [ADR-004](../decisions/ADR-004-user-mcp-registry.md) and [ADR-009](../decisions/ADR-009-mcp-pattern-a-cli.md) (Pattern A CLI).
+
+## Pattern A CLI (canonical agent transport)
+
+```bash
+python3 -m cursor_workflow mcp doctor
+python3 -m cursor_workflow mcp validate [--strict]
+python3 -m cursor_workflow mcp list-tools --server workflow-kit
+python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_TOKEN
+python3 -m cursor_workflow mcp smoke --server workflow-kit
+```
+
+Cursor IDE MCP loading is optional. Registry YAML is the allowlist for `call` / `list-tools`.
 
 ## Worked example: DeepWiki (zero auth)
 
@@ -74,29 +87,44 @@ servers:
     tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
 ```
 
-3. **Merge + validate, then reload Cursor MCP:**
+4. **Pattern A smoke (preferred — no Cursor host required):**
 
 ```bash
-cursor-workflow mcp validate
+python3 -m cursor_workflow mcp doctor
+python3 -m cursor_workflow mcp smoke --server deepwiki
+python3 -m cursor_workflow mcp call --server deepwiki --tool ask_question \
+  --args-json '{"repo":"cloudflare/workers-sdk","question":"What are Workers KV limits?"}'
 ```
 
-4. **Try it** — ask an agent (e.g. `researcher`) to read the wiki structure or ask a question
-   about any public GitHub repo; no secrets, no local process, no `secrets_checklist` entry
-   needed in `.local/user_settings/mcp.agents.yaml`.
+Optional: reload Cursor MCP so `CallMcpTool` also works when the IDE host loads the server.
+
+5. **Try it in chat** — ask an agent (e.g. `researcher`) to use Pattern A CLI or CallMcpTool;
+   no secrets, no local process, no `secrets_checklist` entry needed in
+   `.local/user_settings/mcp.agents.yaml` for DeepWiki.
 
 Both example files (`.cursor/mcp.registry.yaml.example`, `.cursor/mcp.user.example.json`) already
 ship this entry alongside the command-based `my-custom-server` example, so you can see the
 URL-based and command-based transport shapes side by side.
+
+### Auth (Pattern A)
+
+```bash
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_API_TOKEN
+# stores under .local/user_settings/mcp.secrets.yaml (gitignored)
+```
+
+See [ADR-009](../decisions/ADR-009-mcp-pattern-a-cli.md).
 
 ### Stretch: GitHub official remote MCP
 
 GitHub's official remote MCP server (`https://api.githubcopilot.com/mcp/`) is documented as a
 secondary/stretch example in `.local/user_settings/mcp.agents.yaml` (commented `github-remote`
 block). It is **not** zero-auth: it requires either a Copilot seat (OAuth) or a personal access
-token sent as a `Bearer` header, so it is not wired live in the kit demo to avoid auth friction —
-uncomment and fill in a token to try it yourself.
+token sent as a `Bearer` header — use `mcp auth --server github-remote --token-env GITHUB_TOKEN`.
 
 ## Troubleshooting
 
 - `mcp validate` fails: ensure every registry `servers` key exists in merged `mcp.json` `mcpServers`
-- Secrets: never commit `mcp.user.json` — scaffold adds it to `.gitignore`
+- `mcp validate --strict` fails without a live `.cursor/mcp.registry.yaml` — copy the example when enforcing user tier
+- `mcp doctor` shows configured but NOT host-loaded: expected until Cursor enables project `mcp.json`; use Pattern A CLI anyway
+- Secrets: never commit `mcp.user.json` or `.local/user_settings/mcp.secrets.yaml` — `mcp link` / `mcp auth` update `.gitignore`

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -260,7 +260,8 @@ python3 -m cursor_workflow project status
 2. Claim/update the board card (Status + Notes `@user/agent · <ISO-8601-UTC> · …`); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`; optional `history/continuity-index.md` (≥3-day local rollup)
 3. If board writes hit GraphQL rate-limit (EXIT_QUEUED): `project outbox status` / later `outbox flush` — enable `project_ssot.outbox` defaults after activate
 4. **`/implementer`** (or `/test-runner`, `/verifier`; `/auditor` only for architecture-impacting / pre-merge audits — not day-0 onboarding)
-5. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
+5. Canvas/plan (ADR-010): `canvas doctor` · `canvas sync --name <stem>` · `plan snapshot|list|open` — see [canvas-artifacts](../../.cursor/skills/canvas-artifacts/SKILL.md)
+6. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
 
 **Add your own agent/skill/MCP:** **`/integrator`** + **`/integrator-protocol`**
 

--- a/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/.ai_infra/docs/operations/local-workspace-layout.md
@@ -55,6 +55,9 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | `workflow-artifacts/audit/` | `preflight.json`, `doc-facts-preflight.json` (verify-all / doc validate) |
 | `user_settings/` | Gitignored YAML worksheets: GitHub collaboration + MCP agent wiring (from kit exemplars) |
 | `generated-data/` | Coverage JSON, `project-board-snapshot.json` (read-only board export for ICC), and similar machine output |
+| `canvases/` | Ephemeral session canvases (gitignored); index at `index.md`; sync via `cursor_workflow canvas` |
+| `plans/` | Dated plan-mode snapshots only (not live SSOT under `board_only`); index at `index.md` |
+| `workflow-artifacts/canvas/` | Optional `canvas doctor` reports (ADR-010) |
 
 ## Git commits vs `.local` markdown
 

--- a/.ai_infra/docs/operations/workflow-complete.md
+++ b/.ai_infra/docs/operations/workflow-complete.md
@@ -95,7 +95,8 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 3. **`change-index.md`** — one row; do **not** dual-write tracker `in_progress` under `board_only`.
 4. **`test-plan.md` / `test-index.md`** — when tests changed.
 5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); `find-by-pr` resolves from the PR body, or pass `--item-id` when known. Prefer `- Board-Item: <id>` in the PR Collaboration section (never paste docs placeholders).
-6. **`make drift-validate`** — on P0/P1, hand off to **`drift-guard`** (reads + updates the board; DRIFT-009/010).
+6. When plan-mode was used: `plan snapshot --slug <kebab> --agent <name> --board-item <PVTI_>` (`.local/plans/` history only under `board_only`).
+7. **`make drift-validate`** — on P0/P1, hand off to **`drift-guard`** (reads + updates the board; DRIFT-009/010/012).
 
 **Offline fallback (project_ssot disabled / no gh):**
 

--- a/.ai_infra/install/cursor_workflow/activate_cli.py
+++ b/.ai_infra/install/cursor_workflow/activate_cli.py
@@ -107,6 +107,8 @@ def _print_post_activate_hints(root: Path) -> None:
         print("     Until shell green (2-view overlay or six-view default; Tier-1 columns on both primary views).")
         print("  9. Run: source .venv/bin/activate && python3 -m cursor_workflow project status")
         print(" 10. In Agent chat: /implementer — local trackers are offline fallback under board_only.")
+        print(" 11. Canvas preview: python3 -m cursor_workflow canvas doctor")
+        print("     (sync repo canvases: canvas sync --missing)")
     else:
         print("\nYou're almost done — 3 quick steps:")
         print(f"  1. Edit {yaml_path}")
@@ -116,6 +118,7 @@ def _print_post_activate_hints(root: Path) -> None:
         print("\nOptional:")
         print("  source .venv/bin/activate && python3 -m cursor_workflow integrate validate")
         print("  source .venv/bin/activate && python3 -m cursor_workflow health")
+        print("  source .venv/bin/activate && python3 -m cursor_workflow canvas doctor")
         print("Add agents/skills later: /integrator (subagent, not a shell command).")
 
 

--- a/.ai_infra/install/cursor_workflow/canvas_cli.py
+++ b/.ai_infra/install/cursor_workflow/canvas_cli.py
@@ -1,0 +1,147 @@
+"""
+File: canvas_cli.py
+Path: .ai_infra/install/cursor_workflow/canvas_cli.py
+Role: Pattern A canvas CLI — doctor, list, sync, save (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/cli.py
+Depends On:
+ - canvas_manage, cursor_host_paths
+Notes:
+ - Exit codes align with project CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import canvas_manage
+
+
+def _artifact_dir(root: Path) -> Path:
+    path = root / ".local" / "workflow-artifacts" / "canvas"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_artifact(root: Path, prefix: str, body: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = _artifact_dir(root) / f"{prefix}-{stamp}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def cmd_canvas_doctor(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    report = canvas_manage.build_doctor_report(root)
+    body = canvas_manage.format_doctor_markdown(report)
+    print(body)
+    art = _write_artifact(root, "doctor", body)
+    print(f"artifact: {art}")
+    return canvas_manage.EXIT_OK
+
+
+def cmd_canvas_list(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    tier = args.tier
+    by_tier = canvas_manage.list_by_tier(root, tier)  # type: ignore[arg-type]
+    for name, files in by_tier.items():
+        print(f"[{name}]")
+        for filename in files:
+            print(f"  {filename}")
+        if not files:
+            print("  (none)")
+    return canvas_manage.EXIT_OK
+
+
+def cmd_canvas_sync(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        copied = canvas_manage.sync_canvas(
+            root,
+            name=args.name,
+            missing=bool(args.missing),
+            sync_all=bool(args.all),
+            force=bool(args.force),
+            source=args.from_tier,  # type: ignore[arg-type]
+        )
+    except FileNotFoundError as exc:
+        print(f"canvas sync: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"canvas sync: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_USAGE
+    if not copied:
+        print("canvas sync: nothing to copy")
+    else:
+        print(f"canvas sync: copied {len(copied)} file(s)")
+        for name in copied:
+            print(f" - {name}")
+    return canvas_manage.EXIT_OK
+
+
+def cmd_canvas_save(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        dst = canvas_manage.save_canvas(
+            root,
+            slug=args.slug,
+            source=args.from_tier,  # type: ignore[arg-type]
+            agent=args.agent,
+        )
+    except FileNotFoundError as exc:
+        print(f"canvas save: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"canvas save: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_VALIDATION
+    text = dst.read_text(encoding="utf-8")
+    for warning in canvas_manage.validate_canvas_source(text):
+        print(f"canvas save: WARN — {warning}", file=sys.stderr)
+    print(f"canvas save: {dst}")
+    return canvas_manage.EXIT_OK
+
+
+def register_canvas_subcommands(sub: Any) -> None:
+    """Attach canvas subcommands to the root parser group."""
+    doctor = sub.add_parser("doctor", help="Report repo vs managed vs local canvas drift")
+    doctor.add_argument("--directory", type=Path, default=".")
+    doctor.set_defaults(func=cmd_canvas_doctor)
+
+    list_p = sub.add_parser("list", help="List canvases by tier")
+    list_p.add_argument("--directory", type=Path, default=".")
+    list_p.add_argument(
+        "--tier",
+        choices=("repo", "managed", "local", "all"),
+        default="all",
+    )
+    list_p.set_defaults(func=cmd_canvas_list)
+
+    sync = sub.add_parser("sync", help="Copy canvases to Cursor managed render path")
+    sync.add_argument("--directory", type=Path, default=".")
+    sync.add_argument("--name", default=None, help="Canvas base name (no .canvas.tsx)")
+    sync.add_argument("--missing", action="store_true", help="Copy only absent managed files")
+    sync.add_argument("--all", action="store_true", help="Copy all from source (requires --force)")
+    sync.add_argument("--force", action="store_true", help="Allow --all overwrite")
+    sync.add_argument(
+        "--from",
+        dest="from_tier",
+        choices=("repo", "local"),
+        default="repo",
+    )
+    sync.set_defaults(func=cmd_canvas_sync)
+
+    save = sub.add_parser("save", help="Save canvas to .local/canvases/")
+    save.add_argument("--directory", type=Path, default=".")
+    save.add_argument("--slug", required=True, help="Canvas base name (kebab-case)")
+    save.add_argument("--agent", default=None)
+    save.add_argument(
+        "--from",
+        dest="from_tier",
+        choices=("managed", "repo", "local"),
+        default="managed",
+    )
+    save.set_defaults(func=cmd_canvas_save)

--- a/.ai_infra/install/cursor_workflow/canvas_manage.py
+++ b/.ai_infra/install/cursor_workflow/canvas_manage.py
@@ -1,0 +1,253 @@
+"""
+File: canvas_manage.py
+Path: .ai_infra/install/cursor_workflow/canvas_manage.py
+Role: Canvas tier paths, list/sync/save, doctor drift detection (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/canvas_cli.py
+Depends On:
+ - cursor_host_paths
+Notes:
+ - Repo canvases/ is git SSOT; Cursor managed path is render bridge only.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import cursor_host_paths
+
+CANVAS_SUFFIX = ".canvas.tsx"
+CANVAS_NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+
+Tier = Literal["repo", "managed", "local", "all"]
+SourceTier = Literal["repo", "local"]
+
+
+def _load_local_workflow_paths(root: Path):
+    pr_scripts = root / ".ai_infra" / "scripts" / "pr"
+    pr_str = str(pr_scripts)
+    if pr_str not in sys.path:
+        sys.path.insert(0, pr_str)
+    import local_workflow_paths
+
+    return local_workflow_paths
+
+
+def canvas_filename(base: str) -> str:
+    if not CANVAS_NAME_RE.match(base):
+        raise ValueError(f"invalid canvas base name: {base!r} (use kebab-case)")
+    return f"{base}{CANVAS_SUFFIX}"
+
+
+def list_canvases_in_dir(directory: Path | None) -> list[str]:
+    if directory is None or not directory.is_dir():
+        return []
+    return sorted(p.name for p in directory.glob(f"*{CANVAS_SUFFIX}") if p.is_file())
+
+
+def canvas_base(name: str) -> str:
+    if name.endswith(CANVAS_SUFFIX):
+        return name[: -len(CANVAS_SUFFIX)]
+    return name
+
+
+def tier_dir(root: Path, tier: SourceTier | Literal["managed"]) -> Path | None:
+    lwp = _load_local_workflow_paths(root)
+    if tier == "repo":
+        path = root / lwp.REPO_CANVASES_DIR
+        return path if path.is_dir() else None
+    if tier == "local":
+        path = root / lwp.LOCAL_CANVASES_DIR
+        return path if path.is_dir() else None
+    return cursor_host_paths.cursor_canvases_dir(root)
+
+
+def list_by_tier(root: Path, tier: Tier) -> dict[str, list[str]]:
+    tiers: dict[str, list[str]] = {}
+    if tier in ("repo", "all"):
+        tiers["repo"] = list_canvases_in_dir(tier_dir(root, "repo"))
+    if tier in ("managed", "all"):
+        tiers["managed"] = list_canvases_in_dir(tier_dir(root, "managed"))
+    if tier in ("local", "all"):
+        tiers["local"] = list_canvases_in_dir(tier_dir(root, "local"))
+    return tiers
+
+
+def validate_canvas_source(text: str) -> list[str]:
+    warnings: list[str] = []
+    if "export default function" not in text:
+        if re.search(r"export\s+default\s+\w+\s*;", text):
+            warnings.append(
+                "uses separate `export default Name` — prefer `export default function …()` "
+                "for Cursor canvas indexing"
+            )
+        else:
+            warnings.append("missing `export default function` export")
+    return warnings
+
+
+def build_doctor_report(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    by_tier = list_by_tier(root, "all")
+    repo_set = {canvas_base(n) for n in by_tier.get("repo", [])}
+    managed_set = {canvas_base(n) for n in by_tier.get("managed", [])}
+    local_set = {canvas_base(n) for n in by_tier.get("local", [])}
+
+    repo_dir = tier_dir(root, "repo")
+    managed_dir = tier_dir(root, "managed")
+    stale: list[str] = []
+    for base in sorted(repo_set & managed_set):
+        assert repo_dir is not None and managed_dir is not None
+        repo_file = repo_dir / canvas_filename(base)
+        managed_file = managed_dir / canvas_filename(base)
+        if repo_file.stat().st_mtime > managed_file.stat().st_mtime:
+            stale.append(base)
+
+    return {
+        "root": str(root),
+        "repo_dir": str(repo_dir) if repo_dir else None,
+        "managed_dir": str(managed_dir) if managed_dir else None,
+        "local_dir": str(tier_dir(root, "local")),
+        "repo": by_tier.get("repo", []),
+        "managed": by_tier.get("managed", []),
+        "local": by_tier.get("local", []),
+        "repo_not_managed": sorted(repo_set - managed_set),
+        "managed_not_repo": sorted(managed_set - repo_set),
+        "stale_managed": stale,
+        "local_only": sorted(local_set - repo_set - managed_set),
+    }
+
+
+def format_doctor_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Canvas doctor",
+        "",
+        f"- root: `{report['root']}`",
+        f"- repo: `{report['repo_dir'] or '(missing)'}`",
+        f"- managed: `{report['managed_dir'] or '(not found)'}`",
+        f"- local: `{report['local_dir'] or '(missing)'}`",
+        "",
+        "## Counts",
+        "",
+        f"- repo: {len(report['repo'])}",
+        f"- managed: {len(report['managed'])}",
+        f"- local: {len(report['local'])}",
+        "",
+        "## Drift",
+        "",
+        f"- repo not in managed: {', '.join(report['repo_not_managed']) or '(none)'}",
+        f"- managed not in repo: {', '.join(report['managed_not_repo']) or '(none)'}",
+        f"- stale managed (repo newer): {', '.join(report['stale_managed']) or '(none)'}",
+        f"- local-only slugs: {', '.join(report['local_only']) or '(none)'}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _copy_canvas(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def sync_canvas(
+    root: Path,
+    *,
+    name: str | None = None,
+    missing: bool = False,
+    sync_all: bool = False,
+    force: bool = False,
+    source: SourceTier = "repo",
+) -> list[str]:
+    root = root.resolve()
+    src_dir = tier_dir(root, source)
+    dst_dir = tier_dir(root, "managed")
+    if src_dir is None:
+        raise FileNotFoundError(f"source tier {source!r} directory missing")
+    if dst_dir is None:
+        project = cursor_host_paths.cursor_project_dir(root)
+        if project is None:
+            raise FileNotFoundError("Cursor managed project dir not found")
+        dst_dir = project / "canvases"
+        dst_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    if sync_all:
+        if not force:
+            raise ValueError("sync --all requires --force")
+        for filename in list_canvases_in_dir(src_dir):
+            _copy_canvas(src_dir / filename, dst_dir / filename)
+            copied.append(filename)
+        return copied
+
+    if missing:
+        for filename in list_canvases_in_dir(src_dir):
+            dst = dst_dir / filename
+            if not dst.is_file():
+                _copy_canvas(src_dir / filename, dst)
+                copied.append(filename)
+        return copied
+
+    if not name:
+        raise ValueError("pass --name, --missing, or --all")
+    filename = canvas_filename(name)
+    src = src_dir / filename
+    if not src.is_file():
+        raise FileNotFoundError(f"missing source canvas: {src}")
+    _copy_canvas(src, dst_dir / filename)
+    copied.append(filename)
+    return copied
+
+
+def save_canvas(
+    root: Path,
+    *,
+    slug: str,
+    source: Literal["managed", "repo", "local"] = "managed",
+    agent: str | None = None,
+) -> Path:
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    lwp.ensure_local_artifact_tree(root=root)
+
+    if source == "managed":
+        src_dir = tier_dir(root, "managed")
+    elif source == "repo":
+        src_dir = tier_dir(root, "repo")
+    else:
+        src_dir = tier_dir(root, "local")
+    if src_dir is None:
+        raise FileNotFoundError(f"source tier {source!r} directory missing")
+
+    filename = canvas_filename(slug)
+    src = src_dir / filename
+    if not src.is_file():
+        raise FileNotFoundError(f"missing canvas to save: {src}")
+
+    dst = root / lwp.LOCAL_CANVASES_DIR / filename
+    _copy_canvas(src, dst)
+    _append_canvas_index(root, slug=slug, agent=agent)
+    return dst
+
+
+def _append_canvas_index(root: Path, *, slug: str, agent: str | None) -> None:
+    lwp = _load_local_workflow_paths(root)
+    index_path = root / lwp.LOCAL_CANVASES_INDEX
+    if not index_path.is_file():
+        return
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    agent_col = agent or "—"
+    row = f"| {slug} | {stamp} | {agent_col} | saved via canvas save |"
+    text = index_path.read_text(encoding="utf-8")
+    if slug in text:
+        return
+    index_path.write_text(text.rstrip() + "\n" + row + "\n", encoding="utf-8")

--- a/.ai_infra/install/cursor_workflow/cli.py
+++ b/.ai_infra/install/cursor_workflow/cli.py
@@ -8,8 +8,10 @@ Depends On:
  - .ai_infra/bootstrap.py
  - .ai_infra/scripts/install/scaffold.py
  - .ai_infra/install/cursor_workflow/mcp_manage.py
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
 Notes:
  - install forwards to scaffold.py; gates runs prepare-aligned checks.
+ - ADR-009 MCP; ADR-010 canvas/plan Pattern A CLI.
 """
 
 from __future__ import annotations
@@ -39,6 +41,9 @@ _MCP_PKG = Path(__file__).resolve().parent
 if str(_MCP_PKG) not in sys.path:
     sys.path.insert(0, str(_MCP_PKG))
 import mcp_manage  # noqa: E402
+import mcp_cli  # noqa: E402
+import canvas_cli  # noqa: E402
+import plan_cli  # noqa: E402
 import contributors_cli  # noqa: E402
 import integrate_cli  # noqa: E402
 import drift_cli  # noqa: E402
@@ -189,35 +194,6 @@ def cmd_health(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_mcp_validate(args: argparse.Namespace) -> int:
-    root = Path(args.directory).resolve()
-    try:
-        mcp_manage.write_merged_mcp(root)
-        errors = mcp_manage.validate_registry(root)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"mcp validate: FAIL — {exc}", file=sys.stderr)
-        return 1
-    if errors:
-        print("mcp validate: FAIL")
-        for err in errors:
-            print(f" - {err}")
-        return 1
-    print("mcp validate: PASS")
-    return 0
-
-
-def cmd_mcp_link(args: argparse.Namespace) -> int:
-    root = Path(args.directory).resolve()
-    try:
-        mcp_manage.link_user_server(root, args.name, args.file.resolve())
-        mcp_manage.ensure_mcp_gitignore(root)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"mcp link: FAIL — {exc}", file=sys.stderr)
-        return 1
-    print(f"mcp link: linked '{args.name}' from {args.file}")
-    return 0
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="cursor-workflow",
@@ -266,18 +242,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     health.set_defaults(func=cmd_health)
 
-    mcp = sub.add_parser("mcp", help="MCP config merge and registry validation")
+    mcp = sub.add_parser(
+        "mcp",
+        help="Pattern A MCP: validate, link, doctor, list-tools, call, auth, smoke",
+    )
     mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+    mcp_cli.register_mcp_subcommands(mcp_sub)
 
-    mcp_validate = mcp_sub.add_parser("validate", help="Merge kit+user MCP and validate registry")
-    mcp_validate.add_argument("--directory", type=Path, default=".")
-    mcp_validate.set_defaults(func=cmd_mcp_validate)
+    canvas = sub.add_parser(
+        "canvas",
+        help="Pattern A canvas: doctor, list, sync, save (ADR-010)",
+    )
+    canvas_sub = canvas.add_subparsers(dest="canvas_command", required=True)
+    canvas_cli.register_canvas_subcommands(canvas_sub)
 
-    mcp_link = mcp_sub.add_parser("link", help="Link external MCP server fragment into mcp.user.json")
-    mcp_link.add_argument("--name", required=True, help="Server name in mcp.user.json")
-    mcp_link.add_argument("--file", required=True, type=Path, help="JSON fragment with mcpServers")
-    mcp_link.add_argument("--directory", type=Path, default=".")
-    mcp_link.set_defaults(func=cmd_mcp_link)
+    plan = sub.add_parser(
+        "plan",
+        help="Pattern A plan snapshots: snapshot, list, open (ADR-010)",
+    )
+    plan_sub = plan.add_subparsers(dest="plan_command", required=True)
+    plan_cli.register_plan_subcommands(plan_sub)
 
     contributors_cli.register_contributors_subparser(sub)
     integrate_cli.register_integrate_subparser(sub)

--- a/.ai_infra/install/cursor_workflow/cursor_host_paths.py
+++ b/.ai_infra/install/cursor_workflow/cursor_host_paths.py
@@ -1,0 +1,65 @@
+"""
+File: cursor_host_paths.py
+Path: .ai_infra/install/cursor_workflow/cursor_host_paths.py
+Role: Resolve Cursor IDE managed paths for workspace (canvases, mcps, global plans).
+Used By:
+ - .ai_infra/install/cursor_workflow/mcp_manage.py
+ - .ai_infra/install/cursor_workflow/canvas_manage.py
+Depends On:
+ - pathlib, re
+Notes:
+ - Best-effort fuzzy match for WSL/Linux workspace slugs. ADR-010.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def cursor_projects_home() -> Path:
+    return Path.home() / ".cursor" / "projects"
+
+
+def cursor_plans_dir() -> Path:
+    """Global Cursor plan-mode store (not project-scoped)."""
+    return Path.home() / ".cursor" / "plans"
+
+
+def cursor_project_dir(root: Path) -> Path | None:
+    """Best-effort path to Cursor's per-project cache for this workspace."""
+    home = cursor_projects_home()
+    if not home.is_dir():
+        return None
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", str(root).strip("/")).strip("-")
+    candidates = [
+        home / f"home-{slug}" if not str(root).startswith("/home/") else None,
+        home / ("home-" + str(root).lstrip("/").replace("/", "-")),
+    ]
+    rel = str(root)
+    if rel.startswith("/"):
+        candidates.append(home / ("home-" + rel[1:].replace("/", "-")))
+    for candidate in candidates:
+        if candidate is not None and candidate.is_dir():
+            return candidate
+    name = root.name
+    for path in sorted(home.iterdir()):
+        if path.is_dir() and path.name.endswith(name):
+            return path
+    return None
+
+
+def cursor_canvases_dir(root: Path) -> Path | None:
+    project = cursor_project_dir(root)
+    if project is None:
+        return None
+    canvases = project / "canvases"
+    return canvases if canvases.is_dir() else None
+
+
+def cursor_project_mcps_dir(root: Path) -> Path | None:
+    project = cursor_project_dir(root)
+    if project is None:
+        return None
+    mcps = project / "mcps"
+    return mcps if mcps.is_dir() else None

--- a/.ai_infra/install/cursor_workflow/mcp_cli.py
+++ b/.ai_infra/install/cursor_workflow/mcp_cli.py
@@ -1,0 +1,338 @@
+"""
+File: mcp_cli.py
+Path: .ai_infra/install/cursor_workflow/mcp_cli.py
+Role: Pattern A MCP CLI handlers — doctor, list-tools, call, auth, smoke.
+Used By:
+ - .ai_infra/install/cursor_workflow/cli.py
+Depends On:
+ - mcp_manage, mcp_client, mcp_secrets
+Notes:
+ - ADR-009. Exit codes align with project CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import mcp_client
+import mcp_manage
+import mcp_secrets
+
+
+def _artifact_dir(root: Path) -> Path:
+    path = root / ".local" / "workflow-artifacts" / "mcp"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_artifact(root: Path, prefix: str, body: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = _artifact_dir(root) / f"{prefix}-{stamp}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def build_doctor_report(root: Path) -> dict[str, Any]:
+    try:
+        merged = mcp_manage.load_merged_servers(root, write=False)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        merged = {}
+        merge_error = str(exc)
+    else:
+        merge_error = None
+
+    reg_path = mcp_manage.registry_path_used(root)
+    reg_live = (root / mcp_manage.REGISTRY).is_file()
+    user_live = (root / mcp_manage.USER_FRAGMENT).is_file()
+    servers_reg = mcp_manage.registry_servers(root)
+
+    agent_map: dict[str, list[str]] = {}
+    for name, spec in servers_reg.items():
+        if not isinstance(spec, dict):
+            continue
+        agents = spec.get("agents") or []
+        if isinstance(agents, list):
+            for agent in agents:
+                if isinstance(agent, str) and agent:
+                    agent_map.setdefault(agent, []).append(name)
+
+    mcps_dir = mcp_manage.cursor_project_mcps_dir(root)
+    host_loaded = mcp_manage.list_cursor_host_servers(mcps_dir)
+    configured = sorted(merged.keys())
+    host_set = set(host_loaded)
+    cfg_set = set(configured)
+
+    import_info = mcp_manage.check_workflow_mcp_import(root)
+
+    return {
+        "root": str(root),
+        "merged_servers": configured,
+        "merge_error": merge_error,
+        "user_fragment_present": user_live,
+        "registry_path": str(reg_path) if reg_path else None,
+        "registry_live": reg_live,
+        "registry_servers": sorted(servers_reg.keys()),
+        "agent_mappings": {k: sorted(v) for k, v in sorted(agent_map.items())},
+        "workflow_mcp": import_info,
+        "cursor_mcps_dir": str(mcps_dir) if mcps_dir else None,
+        "cursor_host_loaded": host_loaded,
+        "configured_not_host_loaded": sorted(cfg_set - host_set),
+        "host_loaded_not_configured": sorted(host_set - cfg_set),
+    }
+
+
+def format_doctor_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# MCP doctor",
+        "",
+        f"- root: `{report['root']}`",
+        f"- user fragment (mcp.user.json): {'yes' if report['user_fragment_present'] else 'no'}",
+        f"- registry: `{report['registry_path']}` "
+        f"({'live' if report['registry_live'] else 'example/fallback'})",
+        f"- merged servers: {', '.join(report['merged_servers']) or '(none)'}",
+        f"- registry servers: {', '.join(report['registry_servers']) or '(none)'}",
+        "",
+        "## Configured vs Cursor host",
+        "",
+        f"- cursor mcps dir: `{report['cursor_mcps_dir'] or '(not found)'}`",
+        f"- host-loaded: {', '.join(report['cursor_host_loaded']) or '(none)'}",
+        f"- configured but NOT host-loaded: "
+        f"{', '.join(report['configured_not_host_loaded']) or '(none)'}",
+        f"- host-loaded but not in mcp.json: "
+        f"{', '.join(report['host_loaded_not_configured']) or '(none)'}",
+        "",
+        "## workflow_mcp import",
+        "",
+        f"- venv: `{report['workflow_mcp'].get('venv_python')}`",
+        f"- import_ok: {report['workflow_mcp'].get('import_ok')}",
+    ]
+    if report["workflow_mcp"].get("error"):
+        lines.append(f"- error: {report['workflow_mcp']['error']}")
+    if report.get("merge_error"):
+        lines.extend(["", f"**merge error:** {report['merge_error']}"])
+    lines.extend(["", "## Agent mappings", ""])
+    mappings = report.get("agent_mappings") or {}
+    if not mappings:
+        lines.append("(none)")
+    else:
+        for agent, servers in mappings.items():
+            lines.append(f"- `{agent}`: {', '.join(servers)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def cmd_mcp_doctor(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.write_merged_mcp(root)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp doctor: WARN — merge failed: {exc}", file=sys.stderr)
+    report = build_doctor_report(root)
+    body = format_doctor_markdown(report)
+    print(body)
+    art = _write_artifact(root, "doctor", body)
+    print(f"artifact: {art}")
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_validate(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    strict = bool(getattr(args, "strict", False))
+    try:
+        mcp_manage.write_merged_mcp(root)
+        errors = mcp_manage.validate_registry(root, strict=strict)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp validate: FAIL — {exc}", file=sys.stderr)
+        return 1
+    if errors:
+        print("mcp validate: FAIL")
+        for err in errors:
+            print(f" - {err}")
+        return 1
+    print("mcp validate: PASS" + (" (strict)" if strict else ""))
+    return 0
+
+
+def cmd_mcp_link(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.link_user_server(root, args.name, args.file.resolve())
+        mcp_manage.ensure_mcp_gitignore(root)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp link: FAIL — {exc}", file=sys.stderr)
+        return 1
+    print(f"mcp link: linked '{args.name}' from {args.file}")
+    return 0
+
+
+def cmd_mcp_list_tools(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.write_merged_mcp(root)
+        tools = mcp_client.list_tools(root, args.server, agent=args.agent)
+    except mcp_client.McpClientError as exc:
+        print(f"mcp list-tools: FAIL — {exc}", file=sys.stderr)
+        return int(exc.code)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp list-tools: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    for tool in tools:
+        desc = (tool.get("description") or "").replace("\n", " ")
+        print(f"{tool['name']}\t{desc}")
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_call(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.write_merged_mcp(root)
+        arguments = mcp_client.parse_args_json(args.args_json)
+        result = mcp_client.call_tool(
+            root,
+            args.server,
+            args.tool,
+            arguments,
+            agent=args.agent,
+        )
+    except mcp_client.McpClientError as exc:
+        print(f"mcp call: FAIL — {exc}", file=sys.stderr)
+        return int(exc.code)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp call: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    if isinstance(result, (dict, list)):
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(result)
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_auth(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    token = args.token
+    if not token and args.token_env:
+        import os
+
+        token = os.environ.get(args.token_env)
+        if not token:
+            print(
+                f"mcp auth: FAIL — env {args.token_env} empty",
+                file=sys.stderr,
+            )
+            return mcp_manage.EXIT_USAGE
+    if not token and not args.env_pair:
+        print(
+            "mcp auth: FAIL — pass --token, --token-env, or --env KEY=VALUE",
+            file=sys.stderr,
+        )
+        return mcp_manage.EXIT_USAGE
+    env_map: dict[str, str] = {}
+    for pair in args.env_pair or []:
+        if "=" not in pair:
+            print(f"mcp auth: FAIL — bad --env {pair}", file=sys.stderr)
+            return mcp_manage.EXIT_USAGE
+        k, v = pair.split("=", 1)
+        env_map[k] = v
+    try:
+        path = mcp_secrets.set_server_secret(
+            root,
+            args.server,
+            token=token,
+            header_name=args.header,
+            env=env_map or None,
+        )
+        mcp_manage.ensure_mcp_gitignore(root)
+    except (OSError, ValueError) as exc:
+        print(f"mcp auth: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    print(f"mcp auth: stored secrets for '{args.server}' at {path} (values not printed)")
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_smoke(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    server = args.server
+    try:
+        mcp_manage.write_merged_mcp(root)
+        result = mcp_client.smoke_server(root, server, agent=args.agent)
+    except mcp_client.McpClientError as exc:
+        print(f"mcp smoke: FAIL — {exc}", file=sys.stderr)
+        body = f"# MCP smoke FAIL\n\n- server: `{server}`\n- error: {exc}\n"
+        art = _write_artifact(root, "smoke", body)
+        print(f"artifact: {art}", file=sys.stderr)
+        return int(exc.code)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp smoke: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    body = (
+        f"# MCP smoke OK\n\n"
+        f"- server: `{server}`\n"
+        f"- tool_count: {result['tool_count']}\n"
+        f"- tools: {', '.join(result['tools'])}\n"
+    )
+    print(body)
+    art = _write_artifact(root, "smoke", body)
+    print(f"artifact: {art}")
+    return mcp_manage.EXIT_OK
+
+
+def register_mcp_subcommands(mcp_sub: Any) -> None:
+    """Attach Pattern A MCP subparsers to an existing `mcp` subparser group."""
+    mcp_validate = mcp_sub.add_parser("validate", help="Merge kit+user MCP and validate registry")
+    mcp_validate.add_argument("--directory", type=Path, default=".")
+    mcp_validate.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail when live registry is missing or external entries absent from mcp.json",
+    )
+    mcp_validate.set_defaults(func=cmd_mcp_validate)
+
+    mcp_link = mcp_sub.add_parser("link", help="Link external MCP server fragment into mcp.user.json")
+    mcp_link.add_argument("--name", required=True, help="Server name in mcp.user.json")
+    mcp_link.add_argument("--file", required=True, type=Path, help="JSON fragment with mcpServers")
+    mcp_link.add_argument("--directory", type=Path, default=".")
+    mcp_link.set_defaults(func=cmd_mcp_link)
+
+    doctor = mcp_sub.add_parser("doctor", help="Report MCP config vs Cursor host load status")
+    doctor.add_argument("--directory", type=Path, default=".")
+    doctor.set_defaults(func=cmd_mcp_doctor)
+
+    list_tools = mcp_sub.add_parser("list-tools", help="List tools for an allowlisted MCP server")
+    list_tools.add_argument("--directory", type=Path, default=".")
+    list_tools.add_argument("--server", required=True)
+    list_tools.add_argument("--agent", default=None, help="Filter by registry agent mapping")
+    list_tools.set_defaults(func=cmd_mcp_list_tools)
+
+    call = mcp_sub.add_parser("call", help="Call a tool on an allowlisted MCP server")
+    call.add_argument("--directory", type=Path, default=".")
+    call.add_argument("--server", required=True)
+    call.add_argument("--tool", required=True)
+    call.add_argument("--args-json", default=None, help='JSON object, e.g. \'{"repo":"org/name"}\'')
+    call.add_argument("--agent", default=None)
+    call.set_defaults(func=cmd_mcp_call)
+
+    auth = mcp_sub.add_parser("auth", help="Store MCP secrets under .local/user_settings")
+    auth.add_argument("--directory", type=Path, default=".")
+    auth.add_argument("--server", required=True)
+    auth.add_argument("--token", default=None, help="Bearer/token value (not echoed later)")
+    auth.add_argument("--token-env", default=None, help="Read token from environment variable")
+    auth.add_argument("--header", default=None, help="HTTP header name (default Authorization)")
+    auth.add_argument(
+        "--env",
+        dest="env_pair",
+        action="append",
+        default=[],
+        help="KEY=VALUE env injected for stdio servers (repeatable)",
+    )
+    auth.set_defaults(func=cmd_mcp_auth)
+
+    smoke = mcp_sub.add_parser("smoke", help="Initialize server and list tools; write evidence")
+    smoke.add_argument("--directory", type=Path, default=".")
+    smoke.add_argument("--server", required=True)
+    smoke.add_argument("--agent", default=None)
+    smoke.set_defaults(func=cmd_mcp_smoke)

--- a/.ai_infra/install/cursor_workflow/mcp_client.py
+++ b/.ai_infra/install/cursor_workflow/mcp_client.py
@@ -1,0 +1,200 @@
+"""
+File: mcp_client.py
+Path: .ai_infra/install/cursor_workflow/mcp_client.py
+Role: Pattern A MCP client — stdio + URL transports for list-tools/call/smoke.
+Used By:
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
+Depends On:
+ - mcp (SDK), mcp_manage, mcp_secrets
+Notes:
+ - ADR-009. Does not print secrets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import mcp_manage
+import mcp_secrets
+
+EXIT_OK = mcp_manage.EXIT_OK
+EXIT_USAGE = mcp_manage.EXIT_USAGE
+EXIT_GH = mcp_manage.EXIT_GH
+EXIT_NOT_FOUND = mcp_manage.EXIT_NOT_FOUND
+EXIT_VALIDATION = mcp_manage.EXIT_VALIDATION
+
+
+class McpClientError(Exception):
+    def __init__(self, message: str, *, code: int = EXIT_GH) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _resolve_spec(root: Path, server: str) -> dict[str, Any]:
+    err = mcp_manage.assert_server_allowed(root, server)
+    if err:
+        raise McpClientError(err, code=EXIT_VALIDATION)
+    merged = mcp_manage.load_merged_servers(root)
+    raw = merged[server]
+    return mcp_manage.expand_server_env(raw, root)
+
+
+@asynccontextmanager
+async def _open_session(
+    root: Path,
+    server: str,
+    *,
+    agent: str | None = None,
+) -> AsyncIterator[Any]:
+    err = mcp_manage.assert_server_allowed(root, server, agent=agent)
+    if err:
+        raise McpClientError(err, code=EXIT_VALIDATION)
+
+    from mcp import ClientSession
+
+    spec = _resolve_spec(root, server)
+    secret = mcp_secrets.secrets_for_server(root, server)
+
+    if "url" in spec and isinstance(spec["url"], str):
+        url = spec["url"]
+        headers = mcp_secrets.http_headers_from_secrets(secret)
+        try:
+            from mcp.client.streamable_http import streamable_http_client
+            from mcp.client.streamable_http import create_mcp_http_client
+        except ImportError as exc:  # pragma: no cover
+            raise McpClientError(f"streamable HTTP transport unavailable: {exc}") from exc
+
+        if headers:
+            async with create_mcp_http_client(headers=headers) as http_client:
+                async with streamable_http_client(url, http_client=http_client) as streams:
+                    read, write = streams[0], streams[1]
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        yield session
+        else:
+            async with streamable_http_client(url) as streams:
+                read, write = streams[0], streams[1]
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    yield session
+        return
+
+    command = spec.get("command")
+    if not isinstance(command, str) or not command:
+        raise McpClientError(
+            f"server '{server}' needs 'command' (stdio) or 'url' (HTTP)",
+            code=EXIT_VALIDATION,
+        )
+
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    args = spec.get("args") or []
+    if not isinstance(args, list):
+        raise McpClientError(f"server '{server}' args must be a list", code=EXIT_VALIDATION)
+    env_spec = spec.get("env") if isinstance(spec.get("env"), dict) else {}
+    env = {**os.environ, **{str(k): str(v) for k, v in env_spec.items()}}
+    env.update(mcp_secrets.env_from_secrets(secret))
+    params = StdioServerParameters(
+        command=command,
+        args=[str(a) for a in args],
+        env=env,
+        cwd=str(root),
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+async def _list_tools_async(root: Path, server: str, *, agent: str | None) -> list[dict[str, Any]]:
+    async with _open_session(root, server, agent=agent) as session:
+        result = await session.list_tools()
+        out: list[dict[str, Any]] = []
+        for tool in result.tools:
+            out.append(
+                {
+                    "name": tool.name,
+                    "description": getattr(tool, "description", None) or "",
+                }
+            )
+        return out
+
+
+async def _call_tool_async(
+    root: Path,
+    server: str,
+    tool: str,
+    arguments: dict[str, Any],
+    *,
+    agent: str | None,
+) -> Any:
+    async with _open_session(root, server, agent=agent) as session:
+        result = await session.call_tool(tool, arguments=arguments)
+        # Prefer structured content when present
+        if getattr(result, "structuredContent", None) is not None:
+            return result.structuredContent
+        texts: list[str] = []
+        for block in getattr(result, "content", None) or []:
+            text = getattr(block, "text", None)
+            if text is not None:
+                texts.append(str(text))
+            else:
+                texts.append(str(block))
+        if len(texts) == 1:
+            return texts[0]
+        return texts
+
+
+def list_tools(root: Path, server: str, *, agent: str | None = None) -> list[dict[str, Any]]:
+    try:
+        return asyncio.run(_list_tools_async(root, server, agent=agent))
+    except McpClientError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise McpClientError(str(exc), code=EXIT_GH) from exc
+
+
+def call_tool(
+    root: Path,
+    server: str,
+    tool: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    agent: str | None = None,
+) -> Any:
+    try:
+        return asyncio.run(
+            _call_tool_async(root, server, tool, arguments or {}, agent=agent)
+        )
+    except McpClientError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise McpClientError(str(exc), code=EXIT_GH) from exc
+
+
+def smoke_server(root: Path, server: str, *, agent: str | None = None) -> dict[str, Any]:
+    tools = list_tools(root, server, agent=agent)
+    return {
+        "server": server,
+        "ok": True,
+        "tool_count": len(tools),
+        "tools": [t["name"] for t in tools],
+    }
+
+
+def parse_args_json(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise McpClientError(f"invalid --args-json: {exc}", code=EXIT_USAGE) from exc
+    if not isinstance(data, dict):
+        raise McpClientError("--args-json must be a JSON object", code=EXIT_USAGE)
+    return data

--- a/.ai_infra/install/cursor_workflow/mcp_manage.py
+++ b/.ai_infra/install/cursor_workflow/mcp_manage.py
@@ -1,24 +1,28 @@
 """
 File: mcp_manage.py
 Path: .ai_infra/install/cursor_workflow/mcp_manage.py
-Role: Merge kit + user MCP JSON; validate registry against mcp.json.
+Role: Merge kit + user MCP JSON; validate registry against mcp.json; doctor helpers.
 Used By:
  - .ai_infra/install/cursor_workflow/cli.py
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
  - .ai_infra/scripts/install/scaffold.py
 Depends On:
  - json, yaml (PyYAML)
 Notes:
  - Never overwrites existing mcp.user.json on install.
+ - Pattern A CLI: ADR-009.
 """
 
 from __future__ import annotations
 
 import json
-import shutil
+import os
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+import cursor_host_paths
 
 KIT_FRAGMENT = Path(".cursor") / "mcp.json.kit.example"
 USER_FRAGMENT = Path(".cursor") / "mcp.user.json"
@@ -26,6 +30,13 @@ USER_EXAMPLE = Path(".cursor") / "mcp.user.example.json"
 REGISTRY = Path(".cursor") / "mcp.registry.yaml"
 REGISTRY_EXAMPLE = Path(".cursor") / "mcp.registry.yaml.example"
 MCP_JSON = Path(".cursor") / "mcp.json"
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_GH = 3
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+EXIT_QUEUED = 6
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -94,11 +105,16 @@ def load_registry(root: Path) -> dict[str, Any]:
     return data
 
 
-def validate_registry(root: Path) -> list[str]:
+def validate_registry(root: Path, *, strict: bool = False) -> list[str]:
     errors: list[str] = []
     registry_path = root / REGISTRY
     if not registry_path.is_file():
-        return []
+        if strict:
+            errors.append(
+                f"strict: missing live registry {registry_path} "
+                f"(copy from {REGISTRY_EXAMPLE})"
+            )
+        return errors
     try:
         registry = load_registry(root)
     except (FileNotFoundError, ValueError) as exc:
@@ -126,8 +142,157 @@ def validate_registry(root: Path) -> list[str]:
         agents = spec.get("agents", [])
         if agents is not None and not isinstance(agents, list):
             errors.append(f"registry server '{name}' agents must be a list")
+        if strict and isinstance(spec, dict):
+            tier = str(spec.get("tier") or "")
+            if tier == "external" and name not in mcp_servers:
+                # already covered above; keep for clarity
+                pass
+
+    if strict and not (root / USER_FRAGMENT).is_file():
+        # Kit-only is OK unless registry lists external servers missing from merge
+        for name, spec in servers.items():
+            if not isinstance(spec, dict):
+                continue
+            if str(spec.get("tier") or "") == "external" and name not in mcp_servers:
+                errors.append(
+                    f"strict: external registry server '{name}' missing from mcp.json "
+                    f"(add to {USER_FRAGMENT} and re-validate)"
+                )
 
     return errors
+
+
+def load_merged_servers(root: Path, *, write: bool = False) -> dict[str, Any]:
+    """Return mcpServers from merged kit+user (optionally rewrite mcp.json)."""
+    if write:
+        write_merged_mcp(root)
+    mcp_path = root / MCP_JSON
+    if not mcp_path.is_file():
+        write_merged_mcp(root)
+    mcp = _read_json(root / MCP_JSON)
+    servers = mcp.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("mcp.json mcpServers must be an object")
+    return {k: v for k, v in servers.items() if isinstance(v, dict)}
+
+
+def registry_path_used(root: Path) -> Path | None:
+    live = root / REGISTRY
+    if live.is_file():
+        return live
+    example = root / REGISTRY_EXAMPLE
+    if example.is_file():
+        return example
+    return None
+
+
+def registry_servers(root: Path) -> dict[str, Any]:
+    try:
+        data = load_registry(root)
+    except FileNotFoundError:
+        return {}
+    servers = data.get("servers") or {}
+    return servers if isinstance(servers, dict) else {}
+
+
+def servers_for_agent(root: Path, agent: str | None) -> set[str] | None:
+    """
+    If agent is None, return None (no filter).
+    If agent set, return allowlisted server names for that agent from registry.
+    """
+    if not agent:
+        return None
+    servers = registry_servers(root)
+    allowed: set[str] = set()
+    for name, spec in servers.items():
+        if not isinstance(spec, dict):
+            continue
+        agents = spec.get("agents") or []
+        if isinstance(agents, list) and agent in agents:
+            allowed.add(name)
+    return allowed
+
+
+def assert_server_allowed(
+    root: Path,
+    server: str,
+    *,
+    agent: str | None = None,
+) -> str | None:
+    """Return error message if server not allowlisted; None if OK."""
+    reg_live = root / REGISTRY
+    if reg_live.is_file():
+        servers = registry_servers(root)
+        if server not in servers:
+            return f"server '{server}' not in registry {reg_live}"
+        if agent:
+            allowed = servers_for_agent(root, agent)
+            if allowed is not None and server not in allowed:
+                return f"server '{server}' not mapped to agent '{agent}' in registry"
+    merged = load_merged_servers(root)
+    if server not in merged:
+        return f"server '{server}' not in merged mcp.json mcpServers"
+    return None
+
+
+def expand_server_env(spec: dict[str, Any], root: Path) -> dict[str, Any]:
+    """Expand ${workspaceFolder} in command/args/env for local spawn."""
+    root_s = str(root)
+    out = dict(spec)
+
+    def _expand(val: Any) -> Any:
+        if isinstance(val, str):
+            return val.replace("${workspaceFolder}", root_s)
+        if isinstance(val, list):
+            return [_expand(v) for v in val]
+        if isinstance(val, dict):
+            return {k: _expand(v) for k, v in val.items()}
+        return val
+
+    return _expand(out)  # type: ignore[return-value]
+
+
+def cursor_project_mcps_dir(root: Path) -> Path | None:
+    """Best-effort path to Cursor's per-project mcps cache for this workspace."""
+    return cursor_host_paths.cursor_project_mcps_dir(root)
+
+
+def list_cursor_host_servers(mcps_dir: Path | None) -> list[str]:
+    if mcps_dir is None or not mcps_dir.is_dir():
+        return []
+    return sorted(p.name for p in mcps_dir.iterdir() if p.is_dir() and not p.name.startswith("."))
+
+
+def check_workflow_mcp_import(root: Path) -> dict[str, Any]:
+    """Report venv python + whether workflow_mcp is importable with kit PYTHONPATH."""
+    venv_py = root / ".venv" / "bin" / "python"
+    servers_path = root / ".ai_infra" / "mcp_servers"
+    result: dict[str, Any] = {
+        "venv_python": str(venv_py) if venv_py.is_file() else None,
+        "mcp_servers_path": str(servers_path) if servers_path.is_dir() else None,
+        "import_ok": False,
+        "error": None,
+    }
+    if not venv_py.is_file() or not servers_path.is_dir():
+        result["error"] = "missing .venv/bin/python or .ai_infra/mcp_servers"
+        return result
+    import subprocess
+
+    env = {**os.environ, "PYTHONPATH": str(servers_path)}
+    proc = subprocess.run(
+        [str(venv_py), "-c", "import workflow_mcp; print(workflow_mcp.__file__)"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode == 0:
+        result["import_ok"] = True
+        result["module_file"] = proc.stdout.strip()
+    else:
+        result["error"] = (proc.stderr or proc.stdout or "import failed").strip()
+    return result
 
 
 def link_user_server(root: Path, name: str, fragment_file: Path) -> None:
@@ -165,10 +330,14 @@ def link_user_server(root: Path, name: str, fragment_file: Path) -> None:
 
 def ensure_mcp_gitignore(root: Path) -> None:
     gitignore = root / ".gitignore"
-    line = ".cursor/mcp.user.json"
+    lines = [
+        ".cursor/mcp.user.json",
+        ".local/user_settings/mcp.secrets.yaml",
+    ]
     if gitignore.is_file():
         text = gitignore.read_text(encoding="utf-8")
-        if line not in text:
-            gitignore.write_text(text.rstrip() + f"\n{line}\n", encoding="utf-8")
+        additions = [ln for ln in lines if ln not in text]
+        if additions:
+            gitignore.write_text(text.rstrip() + "\n" + "\n".join(additions) + "\n", encoding="utf-8")
     else:
-        gitignore.write_text(f"# MCP secrets\n{line}\n", encoding="utf-8")
+        gitignore.write_text("# MCP secrets\n" + "\n".join(lines) + "\n", encoding="utf-8")

--- a/.ai_infra/install/cursor_workflow/mcp_secrets.py
+++ b/.ai_infra/install/cursor_workflow/mcp_secrets.py
@@ -1,0 +1,113 @@
+"""
+File: mcp_secrets.py
+Path: .ai_infra/install/cursor_workflow/mcp_secrets.py
+Role: Read/write MCP secrets under .local/user_settings (gitignored).
+Used By:
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
+ - .ai_infra/install/cursor_workflow/mcp_client.py
+Depends On:
+ - yaml
+Notes:
+ - Never print secret values. ADR-009.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SECRETS_REL = Path(".local") / "user_settings" / "mcp.secrets.yaml"
+SECRETS_EXEMPLAR_REL = (
+    Path(".ai_infra") / "templates" / "user-settings" / "exemplars" / "mcp.secrets.yaml"
+)
+
+
+def secrets_path(root: Path) -> Path:
+    return root / SECRETS_REL
+
+
+def load_secrets(root: Path) -> dict[str, Any]:
+    path = secrets_path(root)
+    if not path.is_file():
+        return {"version": 1, "servers": {}}
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"invalid secrets file: {path}")
+    servers = data.get("servers")
+    if servers is None:
+        data["servers"] = {}
+    elif not isinstance(servers, dict):
+        raise ValueError("secrets servers must be a mapping")
+    return data
+
+
+def save_secrets(root: Path, data: dict[str, Any]) -> Path:
+    path = secrets_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def set_server_secret(
+    root: Path,
+    server: str,
+    *,
+    token: str | None = None,
+    header_name: str | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    data = load_secrets(root)
+    servers = data.setdefault("servers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("secrets servers must be a mapping")
+    entry: dict[str, Any] = {}
+    if token is not None:
+        entry["token"] = token
+    if header_name:
+        entry["header"] = header_name
+    if env:
+        entry["env"] = dict(env)
+    existing = servers.get(server)
+    if isinstance(existing, dict):
+        existing.update(entry)
+        servers[server] = existing
+    else:
+        servers[server] = entry
+    data["version"] = int(data.get("version") or 1)
+    return save_secrets(root, data)
+
+
+def secrets_for_server(root: Path, server: str) -> dict[str, Any]:
+    data = load_secrets(root)
+    servers = data.get("servers") or {}
+    if not isinstance(servers, dict):
+        return {}
+    entry = servers.get(server)
+    return dict(entry) if isinstance(entry, dict) else {}
+
+
+def http_headers_from_secrets(entry: dict[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    token = entry.get("token")
+    if isinstance(token, str) and token:
+        header = entry.get("header")
+        name = header if isinstance(header, str) and header else "Authorization"
+        if name.lower() == "authorization" and not token.lower().startswith("bearer "):
+            headers[name] = f"Bearer {token}"
+        else:
+            headers[name] = token
+    extra = entry.get("headers")
+    if isinstance(extra, dict):
+        for k, v in extra.items():
+            if isinstance(k, str) and isinstance(v, str):
+                headers[k] = v
+    return headers
+
+
+def env_from_secrets(entry: dict[str, Any]) -> dict[str, str]:
+    env = entry.get("env")
+    if not isinstance(env, dict):
+        return {}
+    return {str(k): str(v) for k, v in env.items()}

--- a/.ai_infra/install/cursor_workflow/plan_cli.py
+++ b/.ai_infra/install/cursor_workflow/plan_cli.py
@@ -1,0 +1,124 @@
+"""
+File: plan_cli.py
+Path: .ai_infra/install/cursor_workflow/plan_cli.py
+Role: Pattern A plan snapshot CLI (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/cli.py
+Depends On:
+ - plan_manage
+Notes:
+ - History snapshots only; live SSOT remains board/plan.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import plan_manage
+
+
+def cmd_plan_snapshot(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        dst, meta = plan_manage.snapshot_plan(
+            root,
+            slug=args.slug,
+            from_spec=args.from_spec,
+            agent=args.agent,
+            board_item=args.board_item,
+            parent_chat=args.parent_chat,
+        )
+    except FileNotFoundError as exc:
+        print(f"plan snapshot: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"plan snapshot: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_VALIDATION
+    print(f"plan snapshot: {dst}")
+    if meta:
+        print(f"meta: {meta}")
+    return plan_manage.EXIT_OK
+
+
+def cmd_plan_list(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    rows = plan_manage.list_snapshots(root)
+    if not rows:
+        print("plan list: (none)")
+        return plan_manage.EXIT_OK
+    print("snapshot\tslug\tagent\tboard_item\tsource")
+    seen_slugs: set[str] = set()
+    for row in rows:
+        slug = row.get("slug") or "—"
+        if slug != "—":
+            seen_slugs.add(slug)
+        print(
+            f"{row['file']}\t{slug}\t"
+            f"{row.get('agent') or '—'}\t{row.get('board_item') or '—'}\t"
+            f"{row.get('source') or '—'}"
+        )
+        if args.verbose and slug != "—":
+            local_path = root / ".local" / "plans" / row["file"]
+            print(f"# local: {local_path}")
+            print(f"# build_bridge: plan open --slug {slug}")
+    if seen_slugs and not args.verbose:
+        for slug in sorted(seen_slugs):
+            print(f"build_bridge: plan open --slug {slug}")
+    return plan_manage.EXIT_OK
+
+
+def cmd_plan_open(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        dest = plan_manage.open_plan(root, slug=args.slug, force=args.force)
+    except FileNotFoundError as exc:
+        print(f"plan open: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"plan open: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_VALIDATION
+    print(f"plan open: {dest}")
+    print("hint: Open in Plans UI for Build; agents build from .local/plans")
+    return plan_manage.EXIT_OK
+
+
+def register_plan_subcommands(sub: Any) -> None:
+    """Attach plan subcommands to the root parser group."""
+    snapshot = sub.add_parser("snapshot", help="Save dated plan snapshot under .local/plans/")
+    snapshot.add_argument("--directory", type=Path, default=".")
+    snapshot.add_argument("--slug", required=True, help="Kebab-case slug for this plan")
+    snapshot.add_argument(
+        "--from",
+        dest="from_spec",
+        default="plan.md",
+        help="Source: plan.md, path, or cursor-plan:<basename>",
+    )
+    snapshot.add_argument("--agent", default=None)
+    snapshot.add_argument("--board-item", default=None)
+    snapshot.add_argument("--parent-chat", default=None)
+    snapshot.set_defaults(func=cmd_plan_snapshot)
+
+    list_p = sub.add_parser("list", help="List plan snapshots")
+    list_p.add_argument("--directory", type=Path, default=".")
+    list_p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print local path and build_bridge hint per row",
+    )
+    list_p.set_defaults(func=cmd_plan_list)
+
+    open_p = sub.add_parser(
+        "open",
+        help="Copy latest local snapshot to ~/.cursor/plans/ for IDE Build",
+    )
+    open_p.add_argument("--directory", type=Path, default=".")
+    open_p.add_argument("--slug", required=True, help="Kebab-case slug for this plan")
+    open_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing Cursor plan twin",
+    )
+    open_p.set_defaults(func=cmd_plan_open)

--- a/.ai_infra/install/cursor_workflow/plan_manage.py
+++ b/.ai_infra/install/cursor_workflow/plan_manage.py
@@ -1,0 +1,202 @@
+"""
+File: plan_manage.py
+Path: .ai_infra/install/cursor_workflow/plan_manage.py
+Role: Plan snapshot paths and copy logic (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/plan_cli.py
+Depends On:
+ - cursor_host_paths
+Notes:
+ - Snapshots only; never mutates live plan.md or board SSOT.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import cursor_host_paths
+import yaml
+
+SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+
+
+def _load_local_workflow_paths(root: Path):
+    pr_scripts = root / ".ai_infra" / "scripts" / "pr"
+    pr_str = str(pr_scripts)
+    if pr_str not in sys.path:
+        sys.path.insert(0, pr_str)
+    import local_workflow_paths
+
+    return local_workflow_paths
+
+
+def validate_slug(slug: str) -> None:
+    if not SLUG_RE.match(slug):
+        raise ValueError(f"invalid slug: {slug!r} (use kebab-case)")
+
+
+def resolve_plan_source(root: Path, from_spec: str) -> Path:
+    root = root.resolve()
+    if from_spec == "plan.md":
+        lwp = _load_local_workflow_paths(root)
+        return root / lwp.PLANNING_CURRENT_DIR / "plan.md"
+    if from_spec.startswith("cursor-plan:"):
+        basename = from_spec.split(":", 1)[1].strip()
+        if not basename.endswith(".plan.md"):
+            basename = f"{basename}.plan.md"
+        path = cursor_host_paths.cursor_plans_dir() / basename
+        return path
+    path = Path(from_spec)
+    if not path.is_absolute():
+        path = root / path
+    return path
+
+
+def snapshot_plan(
+    root: Path,
+    *,
+    slug: str,
+    from_spec: str = "plan.md",
+    agent: str | None = None,
+    board_item: str | None = None,
+    parent_chat: str | None = None,
+) -> tuple[Path, Path | None]:
+    validate_slug(slug)
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    lwp.ensure_local_artifact_tree(root=root)
+
+    src = resolve_plan_source(root, from_spec)
+    if not src.is_file():
+        raise FileNotFoundError(f"plan source missing: {src}")
+
+    today = date.today().isoformat()
+    base = f"{today}-{slug}"
+    dst = root / lwp.LOCAL_PLANS_DIR / f"{base}.plan.md"
+    if dst.is_file():
+        stamp = datetime.now(timezone.utc).strftime("%H%M%S")
+        base = f"{today}-{slug}-{stamp}"
+        dst = root / lwp.LOCAL_PLANS_DIR / f"{base}.plan.md"
+
+    shutil.copy2(src, dst)
+
+    meta_path: Path | None = None
+    meta = {
+        "slug": slug,
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "source": str(src),
+        "agent": agent,
+        "board_item": board_item,
+        "parent_chat": parent_chat,
+    }
+    meta_path = dst.parent / f"{base}.meta.yaml"
+    meta_path.write_text(yaml.safe_dump(meta, sort_keys=False), encoding="utf-8")
+
+    _append_plan_index(root, snapshot=base, slug=slug, agent=agent, board_item=board_item, source=from_spec)
+    return dst, meta_path
+
+
+def list_snapshots(root: Path) -> list[dict[str, Any]]:
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    plans_dir = root / lwp.LOCAL_PLANS_DIR
+    if not plans_dir.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for path in sorted(plans_dir.glob("*.plan.md")):
+        # Snapshot files are `<base>.plan.md`; meta is sibling `<base>.meta.yaml`
+        # (not Path.with_suffix(".meta.yaml"), which yields `<base>.plan.meta.yaml`).
+        meta_path = path.parent / f"{path.name.removesuffix('.plan.md')}.meta.yaml"
+        meta: dict[str, Any] = {}
+        if meta_path.is_file():
+            loaded = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                meta = loaded
+        rows.append(
+            {
+                "file": path.name,
+                "slug": meta.get("slug", canvas_base_from_plan(path.name)),
+                "agent": meta.get("agent"),
+                "board_item": meta.get("board_item"),
+                "source": meta.get("source"),
+            }
+        )
+    return rows
+
+
+def canvas_base_from_plan(filename: str) -> str:
+    name = filename.removesuffix(".plan.md")
+    parts = name.split("-", 3)
+    if len(parts) >= 4 and parts[0].isdigit() and parts[1].isdigit() and parts[2].isdigit():
+        return "-".join(parts[3:])
+    return name
+
+
+def _snapshot_slug(path: Path) -> str:
+    meta_path = path.parent / f"{path.name.removesuffix('.plan.md')}.meta.yaml"
+    if meta_path.is_file():
+        loaded = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict) and loaded.get("slug"):
+            return str(loaded["slug"])
+    return canvas_base_from_plan(path.name)
+
+
+def find_latest_snapshot(root: Path, slug: str) -> Path:
+    """Return the newest `.local/plans` snapshot matching *slug* (mtime)."""
+    validate_slug(slug)
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    plans_dir = root / lwp.LOCAL_PLANS_DIR
+    if not plans_dir.is_dir():
+        raise FileNotFoundError(f"no plan snapshot for slug {slug!r}")
+
+    matches: list[Path] = []
+    for path in plans_dir.glob("*.plan.md"):
+        if _snapshot_slug(path) == slug:
+            matches.append(path)
+    if not matches:
+        raise FileNotFoundError(f"no plan snapshot for slug {slug!r}")
+
+    return max(matches, key=lambda p: p.stat().st_mtime)
+
+
+def open_plan(root: Path, *, slug: str, force: bool = False) -> Path:
+    """Copy latest local snapshot to ``~/.cursor/plans/<slug>.plan.md`` (Build bridge)."""
+    validate_slug(slug)
+    src = find_latest_snapshot(root, slug)
+    dest = cursor_host_paths.cursor_plans_dir() / f"{slug}.plan.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.is_file() and not force:
+        raise ValueError(f"exists; pass --force ({dest})")
+    shutil.copy2(src, dest)
+    return dest
+
+
+def _append_plan_index(
+    root: Path,
+    *,
+    snapshot: str,
+    slug: str,
+    agent: str | None,
+    board_item: str | None,
+    source: str,
+) -> None:
+    lwp = _load_local_workflow_paths(root)
+    index_path = root / lwp.LOCAL_PLANS_INDEX
+    if not index_path.is_file():
+        return
+    row = f"| {snapshot}.plan.md | {slug} | {agent or '—'} | {board_item or '—'} | {source} |"
+    text = index_path.read_text(encoding="utf-8")
+    if snapshot in text:
+        return
+    index_path.write_text(text.rstrip() + "\n" + row + "\n", encoding="utf-8")

--- a/.ai_infra/install/cursor_workflow/project_atomics.py
+++ b/.ai_infra/install/cursor_workflow/project_atomics.py
@@ -84,9 +84,8 @@ def is_placeholder_section_content(text: str) -> bool:
     stripped = str(text or "").strip()
     if not stripped:
         return True
+    # After .strip(), every remaining line that survives ln.strip() is non-empty.
     lines = [ln.strip() for ln in stripped.splitlines() if ln.strip()]
-    if not lines:
-        return True
 
     def _line_is_tbd(line: str) -> bool:
         s = line.casefold()
@@ -594,7 +593,7 @@ def ensure_start_date_if_starting(
         return True, "skipped: fields.start_date.field_id missing", False
     snapshot = item
     if snapshot is None:
-        items, err = _cli().fetch_project_items(ssot, limit=100)
+        items, err = _cli().fetch_project_items(ssot, limit=200)
         if not err:
             snapshot = _cli().find_item_by_id(items, item_id)
     existing = item_start_date_value(snapshot if isinstance(snapshot, dict) else None)

--- a/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/.ai_infra/install/cursor_workflow/project_cli.py
@@ -376,7 +376,7 @@ def cmd_create_from_template(args: argparse.Namespace) -> int:
             guess_note = "Size/Estimate guessed (default s/1)"
             if agent:
                 n_ok, n_detail, _n_code = append_notes_helper(
-                    root, ssot, item_id, agent=agent, text=guess_note, limit=100
+                    root, ssot, item_id, agent=agent, text=guess_note, limit=200
                 )
                 if not n_ok:
                     print(
@@ -811,7 +811,7 @@ def cmd_set_status(args: argparse.Namespace) -> int:
             queue_payload["start_date"] = utc_today_iso()
     # Body gate before precheck/queue so EXIT_VALIDATION never enqueues a doomed close.
     if _normalize_status(str(args.to)) in BODY_GATE_STATUSES:
-        items, list_err = fetch_project_items(ssot, limit=100)
+        items, list_err = fetch_project_items(ssot, limit=200)
         if list_err:
             return fail("set-status", EXIT_GH, list_err)
         item = find_item_by_id(items, item_id)

--- a/.ai_infra/install/cursor_workflow/project_parser.py
+++ b/.ai_infra/install/cursor_workflow/project_parser.py
@@ -41,7 +41,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="Filter: backlog|ready|in_progress|in_review|done",
     )
-    list_cmd.add_argument("--limit", type=int, default=100)
+    list_cmd.add_argument("--limit", type=int, default=200)
     list_cmd.add_argument("--json", action="store_true")
     list_cmd.set_defaults(func=pc.cmd_list)
 
@@ -168,7 +168,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     get_cmd = project_sub.add_parser("get", help="Get one project item by id")
     get_cmd.add_argument("--directory", type=Path, default=".")
     _add_id_or_last(get_cmd)
-    get_cmd.add_argument("--limit", type=int, default=100)
+    get_cmd.add_argument("--limit", type=int, default=200)
     get_cmd.add_argument("--json", action="store_true")
     get_cmd.set_defaults(func=pc.cmd_get)
 
@@ -184,7 +184,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="Agent id for attribution (required when require_attribution_on_exit)",
     )
-    notes_cmd.add_argument("--limit", type=int, default=100)
+    notes_cmd.add_argument("--limit", type=int, default=200)
     notes_cmd.set_defaults(func=pc.cmd_append_notes)
 
     set_section = project_sub.add_parser(
@@ -208,7 +208,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="Optional: append Notes audit line set-section Acceptance|Rollback",
     )
-    set_section.add_argument("--limit", type=int, default=100)
+    set_section.add_argument("--limit", type=int, default=200)
     set_section.set_defaults(func=pc.cmd_set_section)
 
     claim_cmd = project_sub.add_parser(
@@ -219,7 +219,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     _add_id_or_last(claim_cmd)
     claim_cmd.add_argument("--agent", required=True, help="Agent id for @user/agent Notes")
     claim_cmd.add_argument("--text", default="claimed", help="Notes text after attribution")
-    claim_cmd.add_argument("--limit", type=int, default=100)
+    claim_cmd.add_argument("--limit", type=int, default=200)
     claim_cmd.set_defaults(func=pc.cmd_claim)
 
     mention_cmd = project_sub.add_parser(
@@ -230,7 +230,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     _add_id_or_last(mention_cmd)
     mention_cmd.add_argument("--pr", required=True, help="PR number or URL")
     mention_cmd.add_argument("--agent", required=True)
-    mention_cmd.add_argument("--limit", type=int, default=100)
+    mention_cmd.add_argument("--limit", type=int, default=200)
     mention_cmd.set_defaults(func=pc.cmd_mention_pr)
 
     promote_cmd = project_sub.add_parser(
@@ -245,7 +245,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="owner/repo (defaults to project_ssot.default_repo)",
     )
-    promote_cmd.add_argument("--limit", type=int, default=100)
+    promote_cmd.add_argument("--limit", type=int, default=200)
     promote_cmd.set_defaults(func=pc.cmd_promote_to_issue)
 
     handoff_cmd = project_sub.add_parser(
@@ -258,7 +258,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     handoff_cmd.add_argument("--next", required=True, help="Next agent name (no @user/ needed)")
     handoff_cmd.add_argument("--to", default="", help="Optional status: in_review|done|…")
     handoff_cmd.add_argument("--text", default="", help="Optional extra Notes text")
-    handoff_cmd.add_argument("--limit", type=int, default=100)
+    handoff_cmd.add_argument("--limit", type=int, default=200)
     handoff_cmd.set_defaults(func=pc.cmd_handoff)
 
     val_cmd = project_sub.add_parser(
@@ -267,7 +267,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     )
     val_cmd.add_argument("--directory", type=Path, default=".")
     _add_id_or_last(val_cmd)
-    val_cmd.add_argument("--limit", type=int, default=100)
+    val_cmd.add_argument("--limit", type=int, default=200)
     val_cmd.set_defaults(func=pc.cmd_validate_item)
 
     last_cmd = project_sub.add_parser("last", help="Print last saved item_id (after create/claim)")
@@ -366,7 +366,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     find_cmd.add_argument("--directory", type=Path, default=".")
     find_cmd.add_argument("--pr", required=True, help="PR number or URL")
     find_cmd.add_argument("--repo", default="", help="owner/repo (defaults to project_ssot.default_repo)")
-    find_cmd.add_argument("--limit", type=int, default=100)
+    find_cmd.add_argument("--limit", type=int, default=200)
     find_cmd.add_argument("--json", action="store_true")
     find_cmd.set_defaults(func=pc.cmd_find_by_pr)
 
@@ -380,7 +380,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Output path (default: .local/generated-data/project-board-snapshot.json)",
     )
-    export_cmd.add_argument("--limit", type=int, default=100)
+    export_cmd.add_argument("--limit", type=int, default=200)
     export_cmd.add_argument("--json", action="store_true", help="Also print JSON to stdout")
     export_cmd.add_argument("--stdout", action="store_true", help="Print JSON only (no file write)")
     export_cmd.set_defaults(func=pc.cmd_export)
@@ -429,5 +429,5 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Override max_flush_per_run from settings",
     )
-    ob_flush.add_argument("--limit", type=int, default=100)
+    ob_flush.add_argument("--limit", type=int, default=200)
     ob_flush.set_defaults(func=pc.cmd_outbox_flush)

--- a/.ai_infra/scripts/ci/seed_kit_workspace.py
+++ b/.ai_infra/scripts/ci/seed_kit_workspace.py
@@ -101,8 +101,11 @@ def seed_kit_workspace(root: Path, profile: str = "kit-dev") -> list[str]:
 
     lwp = _import_local_workflow_paths(root)
     lwp.ensure_workflow_artifacts_tree(root=root)
+    lwp.ensure_local_artifact_tree(root=root)
     for bucket in lwp.WORKFLOW_ARTIFACT_BUCKETS:
         log.append(f"mkdir {bucket}")
+    for directory in lwp.LOCAL_ARTIFACT_DIRS:
+        log.append(f"mkdir {directory}")
 
     _copy_artifact_readme_stubs(root, lwp.ARTIFACT_STUB_BUCKET_NAMES, log)
     _seed_dashboards(root, log)

--- a/.ai_infra/scripts/install/scaffold.py
+++ b/.ai_infra/scripts/install/scaffold.py
@@ -242,6 +242,41 @@ def _scaffold_artifact_readme_stubs(
                 _copy_file_if_missing(tab_src, tab_dst, dry_run, log)
 
 
+def _scaffold_local_canvas_plan_buckets(
+    ui_root: Path,
+    target: Path,
+    dry_run: bool,
+    log: list[str],
+    lwp: object,
+) -> None:
+    """Create .local/canvases and .local/plans with index stubs (ADR-010)."""
+    exemplars = ui_root / "exemplars"
+    stubs_root = ui_root / "artifact-stubs"
+    if dry_run:
+        for directory in lwp.LOCAL_ARTIFACT_DIRS:  # type: ignore[attr-defined]
+            _log(log, f"DRY-RUN mkdir {target / directory}")
+        _log(log, f"DRY-RUN mkdir {target / lwp.WORKFLOW_CANVAS_DIR}")  # type: ignore[attr-defined]
+        return
+    lwp.ensure_local_artifact_tree(root=target)  # type: ignore[attr-defined]
+    _copy_file_if_missing(
+        exemplars / "local-canvases-index.md",
+        target / lwp.LOCAL_CANVASES_INDEX,  # type: ignore[attr-defined]
+        dry_run,
+        log,
+    )
+    _copy_file_if_missing(
+        exemplars / "local-plans-index.md",
+        target / lwp.LOCAL_PLANS_INDEX,  # type: ignore[attr-defined]
+        dry_run,
+        log,
+    )
+    for bucket in ("canvases", "plans"):
+        src = stubs_root / bucket / "README.md"
+        dst = target / ".local" / bucket / "README.md"
+        if src.is_file():
+            _copy_file_if_missing(src, dst, dry_run, log)
+
+
 def _scaffold_dashboards(ui_root: Path, target: Path, dry_run: bool, log: list[str]) -> None:
     """Copy kit-managed dashboard shells; always refresh from templates on each scaffold/activate."""
     dash = target / ".local" / "agents-control-center" / "dashboards"
@@ -353,6 +388,7 @@ def _scaffold_local(source: Path, target: Path, dry_run: bool, log: list[str]) -
     _scaffold_artifact_readme_stubs(
         ui_root, target, dry_run, log, lwp.ARTIFACT_STUB_BUCKET_NAMES
     )
+    _scaffold_local_canvas_plan_buckets(ui_root, target, dry_run, log, lwp)
 
     for name in EXEMPLAR_TRACKERS:
         _copy_file_if_missing(exemplars / name, current / name, dry_run, log)

--- a/.ai_infra/scripts/integration/checks.py
+++ b/.ai_infra/scripts/integration/checks.py
@@ -25,7 +25,15 @@ REQUIRED_AGENT_MARKERS = (
     "## MCP integration",
     "workflow-kit",
     "mcp.registry.yaml",
+    "cursor_workflow mcp",
 )
+
+CANVAS_AGENT_MARKERS = (
+    "cursor_workflow canvas",
+    "canvas-artifacts",
+)
+
+CANVAS_AGENT_IDS = frozenset({"implementer", "integrator"})
 
 
 def agent_file_ids(agents_dir: Path) -> set[str]:
@@ -70,6 +78,18 @@ def check_all_agent_files(agents_dir: Path) -> list[str]:
         return violations
     for path in agents:
         violations.extend(check_agent_file(path))
+        if path.stem in CANVAS_AGENT_IDS:
+            violations.extend(check_canvas_agent_file(path))
+    return violations
+
+
+def check_canvas_agent_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    rel = path.name
+    violations: list[str] = []
+    for marker in CANVAS_AGENT_MARKERS:
+        if marker not in text:
+            violations.append(f"{rel}: missing canvas marker '{marker}'")
     return violations
 
 

--- a/.ai_infra/scripts/pr/local_workflow_paths.py
+++ b/.ai_infra/scripts/pr/local_workflow_paths.py
@@ -54,6 +54,19 @@ ARTIFACT_STUB_BUCKET_NAMES: tuple[str, ...] = tuple(p.name for p in WORKFLOW_ART
 # Default live planning trackers (index-and-planning/current/)
 PLANNING_CURRENT_DIR = Path(".local/index-and-planning/current")
 
+# Canvas / plan local evidence (ADR-010; gitignored Tier-2 runtime)
+LOCAL_CANVASES_DIR = Path(".local/canvases")
+LOCAL_PLANS_DIR = Path(".local/plans")
+LOCAL_CANVASES_INDEX = LOCAL_CANVASES_DIR / "index.md"
+LOCAL_PLANS_INDEX = LOCAL_PLANS_DIR / "index.md"
+REPO_CANVASES_DIR = Path("canvases")
+WORKFLOW_CANVAS_DIR = WORKFLOW_ARTIFACTS_DIR / "canvas"
+
+LOCAL_ARTIFACT_DIRS: tuple[Path, ...] = (
+    LOCAL_CANVASES_DIR,
+    LOCAL_PLANS_DIR,
+)
+
 # Fallback when `.local/user_settings/github.collaboration.yaml` is missing or incomplete.
 # Prefer resolve_github_user() from user_settings.py in PR scripts.
 DEFAULT_GITHUB_USER = "@YourGitHubHandle"
@@ -69,3 +82,11 @@ def ensure_workflow_artifacts_tree(*, root: Path | None = None) -> None:
 def ensure_workflow_artifacts_dir() -> None:
     """Create workflow artifact subdirectories if missing (cwd-relative)."""
     ensure_workflow_artifacts_tree()
+
+
+def ensure_local_artifact_tree(*, root: Path | None = None) -> None:
+    """Create `.local/canvases/` and `.local/plans/` if missing."""
+    base = Path(".") if root is None else root
+    for directory in LOCAL_ARTIFACT_DIRS:
+        (base / directory).mkdir(parents=True, exist_ok=True)
+    (base / WORKFLOW_CANVAS_DIR).mkdir(parents=True, exist_ok=True)

--- a/.ai_infra/scripts/workflow/drift_checks.py
+++ b/.ai_infra/scripts/workflow/drift_checks.py
@@ -863,6 +863,76 @@ def check_drift011(paths: DriftPaths) -> CheckResult:
     )
 
 
+def check_drift012(paths: DriftPaths) -> CheckResult:
+    """Advisory: .local/plans/ must not host live/current plan SSOT under board_only."""
+    collab = paths.root / ".local" / "user_settings" / "github.collaboration.yaml"
+    if not collab.is_file():
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="no github.collaboration.yaml — skipped",
+        )
+    try:
+        import yaml
+    except ImportError:
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="PyYAML missing — skipped",
+        )
+    try:
+        data = yaml.safe_load(collab.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=False,
+            detail=f"cannot parse collab YAML: {exc}",
+        )
+    ssot = data.get("project_ssot") if isinstance(data, dict) else None
+    if not isinstance(ssot, dict) or not ssot.get("enabled"):
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="project_ssot disabled — skipped",
+        )
+    if str(ssot.get("sync_policy") or "") != "board_only":
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="sync_policy not board_only — skipped",
+        )
+
+    plans_dir = paths.root / ".local" / "plans"
+    issues: list[str] = []
+    if plans_dir.is_dir():
+        for path in plans_dir.iterdir():
+            if path.is_file() and "current" in path.name.lower():
+                issues.append(f"live-plan filename: {path.name}")
+        index = plans_dir / "index.md"
+        if index.is_file():
+            for line in index.read_text(encoding="utf-8").splitlines():
+                lower = line.lower()
+                if lower.startswith("|") and " active " in f" {lower} ":
+                    issues.append("index row marks plan as active")
+
+    passed = not issues
+    return CheckResult(
+        check_id="DRIFT-012",
+        severity=Severity.P2,
+        passed=passed,
+        detail=(
+            "board_only: .local/plans/ is snapshot-only"
+            if passed
+            else "; ".join(issues)
+        ),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_drift001,
     check_drift002,
@@ -876,6 +946,7 @@ KIT_DEV_CHECKS = (
     check_drift009,
     check_drift010,
     check_drift011,
+    check_drift012,
 )
 
 CONSUMER_CHECKS = (
@@ -888,4 +959,5 @@ CONSUMER_BOARD_CHECKS = (
     check_drift008,
     check_drift009,
     check_drift010,
+    check_drift012,
 )

--- a/.ai_infra/templates/local-workspace/artifact-stubs/canvases/README.md
+++ b/.ai_infra/templates/local-workspace/artifact-stubs/canvases/README.md
@@ -1,0 +1,9 @@
+# `.local/canvases/` (session evidence)
+
+Gitignored ephemeral canvases saved from Cursor managed path or agent analysis.
+
+- **Product / onboarding canvases:** edit `canvases/*.canvas.tsx` in the repo (git SSOT).
+- **IDE preview:** `python3 -m cursor_workflow canvas sync --name <base>`
+- **Save ephemeral:** `python3 -m cursor_workflow canvas save --slug <slug>`
+
+See ADR-010 and `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.ai_infra/templates/local-workspace/artifact-stubs/plans/README.md
+++ b/.ai_infra/templates/local-workspace/artifact-stubs/plans/README.md
@@ -1,0 +1,11 @@
+# `.local/plans/` (plan snapshot history)
+
+Dated plan-mode snapshots — **not** live SSOT. Under `board_only`, active plan lives on the GitHub Project card body.
+
+No Build chrome when opening these files directly — agents read and execute from here; humans use `plan open` for IDE Build.
+
+- **Snapshot:** `python3 -m cursor_workflow plan snapshot --slug <slug>`
+- **List:** `python3 -m cursor_workflow plan list`
+- **Build bridge (human):** `python3 -m cursor_workflow plan open --slug <slug>` (`--force` to overwrite Cursor twin)
+
+See ADR-010 and `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.ai_infra/templates/local-workspace/exemplars/local-canvases-index.md
+++ b/.ai_infra/templates/local-workspace/exemplars/local-canvases-index.md
@@ -1,0 +1,18 @@
+<!--
+File: local-canvases-index.md
+Path: .ai_infra/templates/local-workspace/exemplars/local-canvases-index.md
+Role: Index for ephemeral session canvases under .local/canvases/
+Used By:
+ - scaffold.py → .local/canvases/index.md
+Notes:
+ - ADR-010. Product canvases stay in repo canvases/; this dir is gitignored evidence.
+-->
+
+# Local canvases index
+
+Ephemeral agent canvases (billing reviews, one-off analyses). **Not** git SSOT — use `canvases/` for product docs.
+
+| Slug | Saved (UTC) | Agent | Notes |
+|------|-------------|-------|-------|
+
+Sync to IDE preview: `python3 -m cursor_workflow canvas sync --from local --name <slug>`

--- a/.ai_infra/templates/local-workspace/exemplars/local-plans-index.md
+++ b/.ai_infra/templates/local-workspace/exemplars/local-plans-index.md
@@ -1,0 +1,18 @@
+<!--
+File: local-plans-index.md
+Path: .ai_infra/templates/local-workspace/exemplars/local-plans-index.md
+Role: Index for plan-mode snapshots under .local/plans/
+Used By:
+ - scaffold.py → .local/plans/index.md
+Notes:
+ - ADR-010. Live plan SSOT: board card (board_only) or plan.md offline — not this dir.
+-->
+
+# Local plan snapshots index
+
+Dated plan-mode history only. **Do not** treat rows here as active backlog or slice status.
+
+| Snapshot | Slug | Agent | Board item | Source |
+|----------|------|-------|------------|--------|
+
+List: `python3 -m cursor_workflow plan list` · Create: `python3 -m cursor_workflow plan snapshot --slug <slug>` · Human Build bridge: `python3 -m cursor_workflow plan open --slug <slug> [--force]`

--- a/.ai_infra/templates/plugin/skills/mcp-connect/SKILL.md
+++ b/.ai_infra/templates/plugin/skills/mcp-connect/SKILL.md
@@ -3,7 +3,7 @@ name: mcp-connect
 description: Connect external MCP servers to MAS Workflow Kit agents via mcp.user.json and mcp.registry.yaml.
 ---
 
-# Connect external MCP
+# MCP connect
 
 ## When
 
@@ -16,25 +16,45 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 3. Add server entry to `mcp.user.json` **or** run:
 
 ```bash
-cursor-workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
+python3 -m cursor_workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
 ```
 
 4. Map the server to agents in `mcp.registry.yaml`
 5. Merge and validate:
 
 ```bash
-cursor-workflow mcp validate
+python3 -m cursor_workflow mcp validate
+python3 -m cursor_workflow mcp doctor
 ```
 
-6. Enable MCP in Cursor settings for the workspace.
+6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
+
+**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+
+```bash
+python3 -m cursor_workflow mcp list-tools --server workflow-kit
+python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_TOKEN
+python3 -m cursor_workflow mcp smoke --server workflow-kit
+```
+
+**Fastest external smoke:** DeepWiki (zero-auth) — copy examples, validate, then:
+
+```bash
+python3 -m cursor_workflow mcp smoke --server deepwiki
+```
+
+Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `cursor-workflow mcp validate` exits 0
-- `workflow_list_mcp_registry` (workflow-kit MCP) lists external servers
+- `python3 -m cursor_workflow mcp validate` exits 0
+- `python3 -m cursor_workflow mcp doctor` shows configured vs host-loaded
+- `mcp list-tools` / `mcp call` work for allowlisted servers
 - Target agent markdown includes the server under **MCP integration**
 
 ## Reference
 
-- `.ai_infra/docs/operations/connect-external-mcp.md` (after install)
-- `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md` (after install)
+- `.ai_infra/docs/operations/connect-external-mcp.md`
+- `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
+- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`

--- a/.ai_infra/templates/user-settings/README.md
+++ b/.ai_infra/templates/user-settings/README.md
@@ -20,6 +20,7 @@ Notes:
 |----------|-----------|--------|
 | `exemplars/github.collaboration.yaml` | `.local/user_settings/github.collaboration.yaml` | Commit trailers, PR bodies, PR phase artifacts |
 | `exemplars/mcp.agents.yaml` | `.local/user_settings/mcp.agents.yaml` | `.cursor/mcp.user.json`, `.cursor/mcp.registry.yaml` |
+| `exemplars/mcp.secrets.yaml` | `.local/user_settings/mcp.secrets.yaml` | Pattern A `mcp auth` / `mcp call` secrets (gitignored; ADR-009) |
 | `exemplars/board-shell.schema.minimal.yaml` | `.local/user_settings/board-shell.schema.yaml` | Optional **2-view** bootstrap minimum ([Playground #3](https://github.com/users/SavinRazvan/projects/3)); manual copy; gitignored |
 
 **Agents:** Read completed files for attribution defaults and MCP intent. Wired integration:

--- a/.ai_infra/templates/user-settings/exemplars/mcp.secrets.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/mcp.secrets.yaml
@@ -1,0 +1,16 @@
+# mcp.secrets.yaml — exemplar (copy to .local/user_settings/mcp.secrets.yaml)
+# Role: Store MCP auth material locally (gitignored). Never commit real tokens.
+# Apply: python3 -m cursor_workflow mcp auth --server <id> --token-env MY_TOKEN
+# Canon: ADR-009
+#
+# Example shape (do not commit real values):
+# version: 1
+# servers:
+#   my-api:
+#     token: "..."
+#     header: Authorization
+#     env:
+#       API_KEY: "..."
+
+version: 1
+servers: {}

--- a/.cursor/agents/auditor.md
+++ b/.cursor/agents/auditor.md
@@ -70,8 +70,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** When producing audit or alignment artifacts, persist session evidence via `canvas save` / `plan snapshot` under `.local/canvases/` and `.local/plans/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/board.md
+++ b/.cursor/agents/board.md
@@ -97,5 +97,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Kit | `workflow-kit` | Trackers/gates if needed — prefer `cursor_workflow project` for board |
 | External | See `.cursor/mcp.registry.yaml` | Only if listed for `board` |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Live plan SSOT on the board card (`board_only`) or `plan.md` offline — `.local/plans/` is snapshot-only; `plan snapshot|list|open` for history / human Build bridge — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/drift-guard.md
+++ b/.cursor/agents/drift-guard.md
@@ -8,7 +8,7 @@ description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/do
 
 ## What we guard (continuous)
 
-**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…011 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
+**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…012 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
 
 **Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
 
@@ -29,7 +29,7 @@ description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/do
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when applicable; prefer a fresh `project export` snapshot for DRIFT-010).
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when applicable; prefer a fresh `project export` snapshot for DRIFT-010; **DRIFT-012** guards `.local/plans/` snapshot-only under `board_only`).
 3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
 4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
 5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
@@ -58,8 +58,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | Trackers/gates — prefer scripts |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for this agent |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
+| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Under `board_only`, `.local/plans/` is snapshot-only (**DRIFT-012**); live plan stays on the board card — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -77,5 +77,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Kit | `workflow-kit` | PR scripts, gates — prefer `cursor_workflow project` for board |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** `python3 -m cursor_workflow canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/integrator.md
+++ b/.cursor/agents/integrator.md
@@ -90,8 +90,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | `workflow_list_session_agents`, trackers, governance — prefer over shell |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator` |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
+| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** `python3 -m cursor_workflow canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -125,8 +125,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | `deepwiki` (worked example, zero-auth) — see `.cursor/mcp.registry.yaml` | GitHub repo docs/Q&A (`read_wiki_structure`, `read_wiki_contents`, `ask_question`); other listed servers only if connected for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`. Example: `mcp call --server deepwiki --tool ask_question --args-json '{"repo":"org/name","question":"..."}'`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Ephemeral analysis → persist via `canvas save`; not git SSOT — research packs stay under `_research_results/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -38,8 +38,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Test evidence stays under `.local/`; board/card Notes may pointer-only cite paths — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -42,8 +42,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Claims may cite `.local/plans/` snapshots and `.local/canvases/` evidence; live plan remains board card / `plan.md` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -10,6 +10,16 @@
         "WORKFLOW_KIT_ROOT": "${workspaceFolder}",
         "PYTHONPATH": "${workspaceFolder}/.ai_infra/mcp_servers"
       }
+    },
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "my-custom-server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-example"
+      ]
     }
   }
 }

--- a/.cursor/mcp.registry.yaml
+++ b/.cursor/mcp.registry.yaml
@@ -1,0 +1,18 @@
+version: 1
+servers:
+  workflow-kit:
+    tier: kit
+    description: PR workflow, trackers, gates
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    tools_hint: [workflow_run_prepare, workflow_get_tracker, workflow_list_mcp_registry, workflow_integrate_validate, workflow_drift_validate]
+  # User adds keys matching mcp.json mcpServers:
+  deepwiki:
+    tier: external
+    description: Public GitHub repo docs/Q&A (no auth) — Cognition DeepWiki
+    agents: [researcher, implementer, auditor]
+    tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
+  my-custom-server:
+    tier: external
+    description: "Fill in — e.g. database, Slack, GitHub"
+    agents: [implementer]
+    tools_hint: []

--- a/.cursor/rules/implementation-workflow-governance.mdc
+++ b/.cursor/rules/implementation-workflow-governance.mdc
@@ -27,6 +27,7 @@ alwaysApply: true
 - After substantive code change: `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when tests or risk change; `updates-log.md` (one line — see `.ai_infra/docs/operations/token-efficiency.md`).
 - Planning-only scope changes: update `plan.md` / `work-tracker.md` + at least one `updates-log.md` entry.
 - Blocked: mark blocker and unblock action in `work-tracker.md`.
+- **ADR-010:** `.local/plans/` is snapshot history only — live plan SSOT stays on the board card (`board_only`) or `plan.md` offline; see `canvas-artifacts` skill.
 - **Slice closure** (before handoff): regenerate `current/coverage-index.md` when coverage mattered; if a new tracker path is added, update `.local/agents-control-center/config/pages.json` and dashboard header **Depends On**; do not edit `.local/agents-control-center/audits/module-audit.html` unless refreshing that export.
 
 ## Merge gates

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
 - **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -34,6 +34,15 @@ When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Projec
 **Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
 **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
+## Two-tier plans (ADR-010)
+
+| Tier | Location | Role |
+|------|----------|------|
+| **Live** | Board card body (`board_only`) or `.local/index-and-planning/current/plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
+| **History** | `.local/plans/` (`plan snapshot`, `plan list`, `plan open` for human Build) | Dated snapshots + `index.md` — **never** competing Status or live plan under `board_only` (**DRIFT-012**) |
+
+Agents: `plan list` → read snapshot → execute. Exit: `plan snapshot --slug … --board-item …`. See `.cursor/skills/canvas-artifacts/SKILL.md`.
+
 ## First-run (board shell) — before day-to-day cards
 
 Day-0 requires the kit **default** shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Priority/Size/Estimate/Start date on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.

--- a/.cursor/skills/canvas-artifacts/SKILL.md
+++ b/.cursor/skills/canvas-artifacts/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: canvas-artifacts
+description: Three-tier canvas and plan snapshot workflow via cursor_workflow canvas/plan CLI (ADR-010).
+---
+
+# Canvas and plan artifacts (Pattern A)
+
+## When
+
+- Editing kit canvases in `canvases/` and needing IDE preview
+- Saving ephemeral analysis canvases for history
+- Exiting Plan mode and archiving a dated snapshot
+
+## Tiers (do not dual-write)
+
+| Tier | Path | Role |
+|------|------|------|
+| Git SSOT | `canvases/*.canvas.tsx` | Product / onboarding docs |
+| Cursor managed | `~/.cursor/projects/<workspace>/canvases/` | IDE render bridge only |
+| Local evidence | `.local/canvases/` | Session canvases (gitignored) |
+| Live plan | Board card body or `plan.md` (offline) | Writable SSOT |
+| Plan history | `.local/plans/<date>-<slug>.plan.md` | Snapshots only |
+
+## Canvas CLI
+
+```bash
+python3 -m cursor_workflow canvas doctor
+python3 -m cursor_workflow canvas list --tier all
+python3 -m cursor_workflow canvas sync --name mcp-onboarding
+python3 -m cursor_workflow canvas sync --missing
+python3 -m cursor_workflow canvas save --slug billing-review --agent implementer
+```
+
+- Use `export default function NameCanvas()` in `.canvas.tsx` files.
+- `sync --all` requires `--force` (avoid silent overwrite).
+
+## Plan CLI
+
+```bash
+python3 -m cursor_workflow plan snapshot --slug slice-170 --agent implementer --board-item PVTI_xxx
+python3 -m cursor_workflow plan list
+python3 -m cursor_workflow plan open --slug slice-170          # human Build bridge
+python3 -m cursor_workflow plan open --slug slice-170 --force  # overwrite Cursor twin
+python3 -m cursor_workflow plan snapshot --slug my-plan --from cursor-plan:my-plan.plan.md
+```
+
+Never treat `.local/plans/` as active backlog under `board_only`.
+
+## Agent rituals
+
+1. **Product canvas:** edit repo → `canvas sync --name …` → Open Canvas in IDE.
+2. **Ephemeral canvas:** write via Cursor canvas skill to managed path → `canvas save --slug …`.
+3. **Plan mode exit:** `plan snapshot --slug …` with board item id when known.
+
+### Consumer plans (agent build — Path A)
+
+Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
+
+1. `plan list` — discover slugs under `.local/plans/`
+2. Read `.local/plans/<latest>-<slug>.plan.md` (+ sibling `.meta.yaml`)
+3. Execute todos / acceptance as implementer (no Build required)
+4. **Human-only:** `plan open --slug …` → Plans UI → Build (copies latest snapshot to `~/.cursor/plans/<slug>.plan.md`)
+5. After plan-mode work in Cursor: `plan snapshot --from cursor-plan:…` to re-anchor history in `.local/plans/`
+
+`plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
+
+Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/.cursor/skills/drift-audit/SKILL.md
+++ b/.cursor/skills/drift-audit/SKILL.md
@@ -25,6 +25,7 @@ Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:
 - plan ↔ tracker ↔ session-pointer incoherence
 - **DRIFT-004b** session Board vs export; **DRIFT-009** dual-write; **DRIFT-010** board vs PRs
 - **DRIFT-011** `.cursor/agents` basenames == eight live kit agent ids
+- **DRIFT-012** `.local/plans/` snapshot-only under `board_only` (no live/current plan SSOT in that dir)
 - Prose goal pulse: board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards (flag gaps; hand off — do not rewrite architecture)
 
 Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
@@ -46,7 +47,7 @@ Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when kit-dev / board_only as applicable (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when kit-dev / board_only as applicable (ADR-007/008/010).
 3. Capture profile, check IDs, severities, and details from output.
 4. Add prose **Goal pulse** section in drift-audit.md (board/plan/AGENTS gaps). Fuzzy “vision mismatch” stays Probable — not CI.
 5. Write artifacts under `.local/workflow-artifacts/drift/` only.

--- a/.cursor/skills/implementer-loop/SKILL.md
+++ b/.cursor/skills/implementer-loop/SKILL.md
@@ -29,6 +29,8 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
 6. **Close (board-indexed):** when a PR exists → `mention-pr --pr N`; ensure Assignee via claim/`set-assignee --login` (Issue-at-create); `set-status --to in_review|done`; print `item_id=… · Status=… · Priority=p? · Size=? · Estimate=? · next=…` and `Tasks: [P…]…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
+**Plan mode / ADR-010:** Agents execute from `.local/plans/` via `plan list` → read latest snapshot; on slice exit use `plan snapshot --slug <kebab> --agent implementer --board-item <PVTI_>`. Live plan SSOT stays on the board card (`board_only`) or `plan.md` offline — never Status dual-write into `.local/plans/`. Humans bridge IDE Build with `plan open --slug <kebab>`. Canvas evidence: `canvas doctor|sync|save` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+
 ## Output
 
 Slice • item_id • Status before→after • Priority · Size · Estimate • modules/files • gates outcome • blockers • next agent · Tasks `[P…]`

--- a/.cursor/skills/integrator-protocol/SKILL.md
+++ b/.cursor/skills/integrator-protocol/SKILL.md
@@ -114,7 +114,16 @@ Follow `.ai_infra/docs/operations/connect-external-mcp.md` plus:
 3. Keys in `.cursor/mcp.registry.yaml` — `agents: [...]` per server
 4. `python -m cursor_workflow mcp validate`
 
-### D. New maintainer script
+### D. Canvases / plans (ADR-010)
+
+When touching `canvases/`, `.local/canvases/`, or `.local/plans/`:
+
+1. Read `.cursor/skills/canvas-artifacts/SKILL.md` and [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md).
+2. Repo `canvases/` = git SSOT → `canvas sync` → optional `canvas save` to `.local/canvases/`.
+3. `.local/plans/` = snapshot history only; live plan stays on board card / `plan.md` — wire `plan snapshot|list|open` in docs/agent cards as needed.
+4. After canvas edits: `python3 -m cursor_workflow canvas sync --name <stem>` (+ `canvas doctor` smoke).
+
+### E. New maintainer script
 
 - Lives under `.ai_infra/scripts/` — never duplicate `GATES` outside `prepare.py`
 - File header per `file-docstring-header-relations.mdc`

--- a/.cursor/skills/mcp-connect/SKILL.md
+++ b/.cursor/skills/mcp-connect/SKILL.md
@@ -16,30 +16,45 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 3. Add server entry to `mcp.user.json` **or** run:
 
 ```bash
-cursor-workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
+python3 -m cursor_workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
 ```
 
 4. Map the server to agents in `mcp.registry.yaml`
 5. Merge and validate:
 
 ```bash
-cursor-workflow mcp validate
+python3 -m cursor_workflow mcp validate
+python3 -m cursor_workflow mcp doctor
 ```
 
-6. Enable MCP in Cursor settings for the workspace.
+6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
 
-**Fastest way to validate this end-to-end:** the `deepwiki` entry already shipped in both
-example files is a free, zero-auth, remote server — copy the examples as-is (no secrets to
-fill in) and skip straight to step 5. Full walkthrough:
-`.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki.
+**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+
+```bash
+python3 -m cursor_workflow mcp list-tools --server workflow-kit
+python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_TOKEN
+python3 -m cursor_workflow mcp smoke --server workflow-kit
+```
+
+**Fastest external smoke:** DeepWiki (zero-auth) — copy examples, validate, then:
+
+```bash
+python3 -m cursor_workflow mcp smoke --server deepwiki
+```
+
+Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `cursor-workflow mcp validate` exits 0
-- `workflow_list_mcp_registry` (workflow-kit MCP) lists external servers
+- `python3 -m cursor_workflow mcp validate` exits 0
+- `python3 -m cursor_workflow mcp doctor` shows configured vs host-loaded
+- `mcp list-tools` / `mcp call` work for allowlisted servers
 - Target agent markdown includes the server under **MCP integration**
 
 ## Reference
 
 - `.ai_infra/docs/operations/connect-external-mcp.md`
 - `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
+- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -94,7 +94,7 @@ See [consumer-quickstart.md](../../.ai_infra/docs/operations/consumer-quickstart
 |-------|-----------------|---------------|
 | Cursor contract | `.cursor/`, `.agents/`, `AGENTS.md` | Yes |
 | Infrastructure | `.ai_infra/`, `cursor_workflow/` | No — scripts/CLI |
-| Runtime | `.local/` Tier 1 scaffold: trackers, six `workflow-artifacts/*` buckets + README stubs, `pages.json`, dashboards; `user_settings/` exemplars | No — gitignored |
+| Runtime | `.local/` Tier 1 scaffold: trackers, six `workflow-artifacts/*` buckets + README stubs, `.local/canvases/` + `.local/plans/` index stubs (ADR-010), `pages.json`, dashboards; `user_settings/` exemplars | No — gitignored |
 
 Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear when agents/scripts run. See [local-workspace-layout.md](../../.ai_infra/docs/operations/local-workspace-layout.md) § Artifact tiers. Re-activate does not overwrite existing trackers, `user_settings/`, or `AGENTS.md`. Kit-managed dashboard HTML, JS/CSS assets, `module-audit.html`, and `pages.json` are refreshed from the activate source (plugin `payload/` when resolved) or embedded `.ai_infra/templates/local-workspace/` when not.
 
@@ -116,7 +116,7 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 **Dashboards (optional):** from project root run `source .venv/bin/activate && python3 -m http.server 8000`, then open
 http://localhost:8000/.local/agents-control-center/dashboards/index.html (not `file://`).
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
+Optional: `integrate validate`, `health`, `canvas doctor` (ADR-010 three-tier canvases). Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ _temp_kit_installation/**
 
 # Editor
 .DS_Store
+.cursor/mcp.user.json
+.local/user_settings/mcp.secrets.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Required in every commit message (see **`.cursor/rules/commit-trailer-format.mdc
 | Root | Role |
 |------|------|
 | `.cursor/agents/` | Subagent cards (8) — Task delegation; **`model: auto`**; audit agents write `.local/` artifacts only |
-| `.cursor/skills/` | **Canonical protocols** (12 folders: `auditor-protocol`, `audit-orchestration`, `audit-module-map`, `board-ssot`, `board-shell`, `drift-audit`, `implementer-loop`, `integrator-protocol`, `mcp-connect`, `research-corpus`, `test-coverage`, `workflow-activate`) — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
+| `.cursor/skills/` | **Canonical protocols** (13 folders: `auditor-protocol`, `audit-orchestration`, `audit-module-map`, `board-ssot`, `board-shell`, `canvas-artifacts`, `drift-audit`, `implementer-loop`, `integrator-protocol`, `mcp-connect`, `research-corpus`, `test-coverage`, `workflow-activate`) — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
 | `.agents/skills/` | **Maintainer slash skills** (6 folders: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` stub → `auditor`) — additive in plugin sync |
 | `.cursor/rules/` | **7** `alwaysApply` rules in this product repo (6 kit + `project-ssot-precedence`) — high context cost by design |
 
@@ -148,13 +148,14 @@ Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. Staged `/
 | Integrate infrastructure | `.cursor/agents/integrator.md` + `.cursor/skills/integrator-protocol/SKILL.md` — validate with `python3 -m cursor_workflow integrate validate` |
 | Tests / coverage | `.cursor/agents/test-runner.md` + `.cursor/skills/test-coverage/SKILL.md` |
 | Verify claims | `.cursor/agents/verifier.md` |
-| Continuous goal/plan/agent-doctrine coherence + DRIFT scripts | **`drift-guard`** — `.cursor/agents/drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — `python3 -m cursor_workflow drift validate` (incl. DRIFT-011) |
+| Continuous goal/plan/agent-doctrine coherence + DRIFT scripts | **`drift-guard`** — `.cursor/agents/drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — `python3 -m cursor_workflow drift validate` (incl. DRIFT-011, DRIFT-012) |
 | Deep / periodic architecture + CHK-* (security/perf/granularity/docs) | **`auditor`** — `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md` — not continuous plan pulse |
 | Audit orchestration | `.cursor/skills/audit-orchestration/SKILL.md` — parent runs verify-all + Task delegation (no dedicated agent) |
 | Audit module map | `.cursor/skills/audit-module-map/SKILL.md` — optional deep map; invoke via **`auditor`** |
 | Maintainer PR | `.agents/skills/pr-workflow/SKILL.md` → `review-pr` → `prepare-pr` → `merge-pr` (staged) → `full-pr-workflow` → `finalize.py` (cleanup + `finalize.md` evidence) |
 | Research corpus (shipped; opt-in packs) | `.cursor/agents/researcher.md` — adaptive Brief from chat/agents; HTTPS/`github:`/`path:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/`; live E2E proven 2026-07-19 |
 | MCP | `.ai_infra/mcp_servers/workflow_mcp/` — `python -m workflow_mcp`; [`.cursor/mcp.json.kit.example`](.cursor/mcp.json.kit.example) + [mcp-connect](.ai_infra/docs/operations/connect-external-mcp.md) |
+| Canvas / plan artifacts | [canvas-artifacts](.cursor/skills/canvas-artifacts/SKILL.md) — `python3 -m cursor_workflow canvas …` / `plan snapshot|list|open` (ADR-010) |
 
 Scripts:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1218 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1411 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 
@@ -305,7 +305,7 @@ python3 -m cursor_workflow project list --status ready
 # create / claim — see: python3 -m cursor_workflow project guide
 ```
 
-Maintainer gates: `make gates` · `make drift-validate` · `make doc-validate` · shipped matrix: [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md). Kit canvases: **15** files under `canvases/` (**11** agent/roster hubs + 4 concept hubs — see IMPLEMENTATION-STATUS § Kit canvases).
+Maintainer gates: `make gates` · `make drift-validate` · `make doc-validate` · shipped matrix: [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md). Kit canvases: **15** files under `canvases/` (**11** agent/roster hubs + 4 concept hubs — see IMPLEMENTATION-STATUS § Kit canvases). Canvas/plan local artifacts: [ADR-010](.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md) · [canvas-artifacts](.cursor/skills/canvas-artifacts/SKILL.md).
 
 ---
 

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -70,8 +70,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** When producing audit or alignment artifacts, persist session evidence via `canvas save` / `plan snapshot` under `.local/canvases/` and `.local/plans/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/board.md
+++ b/agents/board.md
@@ -97,5 +97,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Kit | `workflow-kit` | Trackers/gates if needed — prefer `cursor_workflow project` for board |
 | External | See `.cursor/mcp.registry.yaml` | Only if listed for `board` |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Live plan SSOT on the board card (`board_only`) or `plan.md` offline — `.local/plans/` is snapshot-only; `plan snapshot|list|open` for history / human Build bridge — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/drift-guard.md
+++ b/agents/drift-guard.md
@@ -8,7 +8,7 @@ description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/do
 
 ## What we guard (continuous)
 
-**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…011 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
+**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…012 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
 
 **Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
 
@@ -29,7 +29,7 @@ description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/do
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when applicable; prefer a fresh `project export` snapshot for DRIFT-010).
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when applicable; prefer a fresh `project export` snapshot for DRIFT-010; **DRIFT-012** guards `.local/plans/` snapshot-only under `board_only`).
 3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
 4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
 5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
@@ -58,8 +58,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | Trackers/gates — prefer scripts |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for this agent |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
+| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Under `board_only`, `.local/plans/` is snapshot-only (**DRIFT-012**); live plan stays on the board card — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -77,5 +77,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Kit | `workflow-kit` | PR scripts, gates — prefer `cursor_workflow project` for board |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** `python3 -m cursor_workflow canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/integrator.md
+++ b/agents/integrator.md
@@ -90,8 +90,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | `workflow_list_session_agents`, trackers, governance — prefer over shell |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator` |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
+| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** `python3 -m cursor_workflow canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -125,8 +125,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | `deepwiki` (worked example, zero-auth) — see `.cursor/mcp.registry.yaml` | GitHub repo docs/Q&A (`read_wiki_structure`, `read_wiki_contents`, `ask_question`); other listed servers only if connected for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`. Example: `mcp call --server deepwiki --tool ask_question --args-json '{"repo":"org/name","question":"..."}'`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Ephemeral analysis → persist via `canvas save`; not git SSOT — research packs stay under `_research_results/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -38,8 +38,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Test evidence stays under `.local/`; board/card Notes may pointer-only cite paths — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -42,8 +42,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Claims may cite `.local/plans/` snapshots and `.local/canvases/` evidence; live plan remains board card / `plan.md` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/canvases/agent-auditor.canvas.tsx
+++ b/canvases/agent-auditor.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/auditor.md · auditor-protocol/SKILL.md · board-ssot/SKILL.md";
 
@@ -88,6 +88,7 @@ const READ_FIRST = [
   [".cursor/skills/audit-orchestration/SKILL.md", "Quarterly vs PR cadence"],
   [".cursor/skills/board-ssot/SKILL.md", "When project_ssot.enabled"],
   [".ai_infra/docs/roadmap/alignment-audit-schema.md", "Alignment schema"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
 ];
 
 const PATTERNS = [
@@ -129,6 +130,16 @@ const ARTIFACTS = [
     "Deprecated HTML ICC (EA-010) — offline only; prefer board + Open Canvas",
   ],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+  [
+    ".local/plans/",
+    "plan snapshot|list (history)",
+    "Agents execute; humans plan open",
+  ],
+  [
+    ".local/canvases/",
+    "canvas save (session evidence)",
+    "canvas-artifacts skill",
+  ],
 ];
 
 const PEERS = [

--- a/canvases/agent-board-collaboration.canvas.tsx
+++ b/canvases/agent-board-collaboration.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type FlowMode = "slice" | "side";
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   "project-board-collaboration.md · board-ssot/SKILL.md · board-shell/SKILL.md · agent-relations · agent-roster · .cursor/agents/*.md · ADR-007";
 
@@ -105,7 +105,7 @@ const PER_AGENT_ENTRY_EXIT = [
   [
     "drift-guard",
     "Must status + list In progress",
-    "Drift card →Done; goal pulse + DRIFT-001…011; remediation via Notes/Ready — no silent tracker edits",
+    "Drift card →Done; goal pulse + DRIFT-001…012; remediation via Notes/Ready — no silent tracker edits",
   ],
   [
     "researcher",
@@ -250,7 +250,7 @@ const SLICE_FLOW = [
 const SIDE_FLOW = [
   "auditor: audit card → CHK-* / enterprise-architecture-audit/ + alignment/ → Notes paths → implementer (Phase 3: drift-guard goal pulse / verifier)",
   "implementer: make drift-validate → P0/P1 or goal-pulse gaps → hand off drift-guard",
-  "drift-guard: board In progress + Acceptance/Notes → drift validate (DRIFT-001…011 kit-dev) → .local/workflow-artifacts/drift/ → card done; remediation via Notes/Ready",
+  "drift-guard: board In progress + Acceptance/Notes → drift validate (DRIFT-001…012 kit-dev) → .local/workflow-artifacts/drift/ → card done; remediation via Notes/Ready",
   "integrator: integration card → integrate validate → escalate to implementer | test-runner | auditor",
 ];
 

--- a/canvases/agent-board.canvas.tsx
+++ b/canvases/agent-board.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/board.md · board-ssot/SKILL.md · board-shell/SKILL.md · ADR-006 · ADR-008";
 
@@ -91,6 +91,7 @@ const READ_FIRST = [
   [".ai_infra/templates/project-board/README.md", "Card templates"],
   ["ADR-006", "Independent-governed agent"],
   ["ADR-008", "Project board SSOT (board_only)"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
 ];
 
 const PATTERNS = [
@@ -108,6 +109,16 @@ const ARTIFACTS = [
   ["history/updates-log.md", "Exit", "Continuity readers"],
   ["Board Status + Notes", "Every triage", "implementer / next agent"],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+  [
+    ".local/plans/",
+    "plan snapshot|list (history)",
+    "Agents execute; humans plan open",
+  ],
+  [
+    ".local/canvases/",
+    "canvas save (session evidence)",
+    "canvas-artifacts skill",
+  ],
 ];
 
 const PEERS = [

--- a/canvases/agent-drift-guard.canvas.tsx
+++ b/canvases/agent-drift-guard.canvas.tsx
@@ -23,13 +23,13 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/drift-guard.md · drift-audit/SKILL.md · board-ssot/SKILL.md · ADR-007";
 
 const GOALS = [
   "Continuous goal/plan/agent-doctrine/docs coherence (+ DRIFT scripts)",
-  "DRIFT-001…011 script-first; goal pulse prose in drift artifacts",
+  "DRIFT-001…012 script-first; goal pulse prose in drift artifacts",
   "Write drift/ only — no product code; remediations via Notes/Ready",
 ];
 
@@ -89,8 +89,10 @@ const READ_FIRST = [
   [".cursor/skills/drift-audit/SKILL.md", "Drift audit + goal pulse"],
   [".cursor/skills/board-ssot/SKILL.md", "Board SSOT when enabled"],
   ["python3 -m cursor_workflow drift validate", "CLI entry"],
-  ["DRIFT-009 / 010 / 011", "Board + agent roster pulse"],
+  ["DRIFT-009 / 010 / 011 / 012", "Board + agent roster pulse"],
   ["project export", "DRIFT-010 evidence"],
+  [".local/plans/", "DRIFT-012 snapshot-only under board_only"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
 ];
 
 const PATTERNS = [
@@ -206,7 +208,7 @@ export default function AgentDriftGuardCanvas() {
         </Row>
         <Text tone="secondary">
           drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/docs
-          coherence + DRIFT-001…011; remediations via Notes/Ready (not auditor
+          coherence + DRIFT-001…012; remediations via Notes/Ready (not auditor
           deep scorecard).
         </Text>
         <Text tone="tertiary" size="small">
@@ -216,7 +218,7 @@ export default function AgentDriftGuardCanvas() {
 
       <Grid columns={3} gap={12}>
         <Stat value="MUST status" label="Entry when board on" />
-        <Stat value="DRIFT-009…011" label="Board + roster pulse" />
+        <Stat value="DRIFT-009…012" label="Board + roster pulse" />
         <Stat value="EXIT_QUEUED" label="Outbox on rate-limit" tone="warning" />
       </Grid>
 
@@ -252,7 +254,7 @@ export default function AgentDriftGuardCanvas() {
       <CollapsibleSection title="Loop steps (canon)" defaultOpen>
         <Stack gap={6}>
           <Text>1. project status + list in_progress (board required when on).</Text>
-          <Text>2. Run drift validate; check DRIFT-009 / 010 / 011 (kit-dev).</Text>
+          <Text>2. Run drift validate; check DRIFT-009 / 010 / 011 / 012 (kit-dev).</Text>
           <Text>3. Goal pulse: board Acceptance/Notes + plan pointers + roster.</Text>
           <Text>4. project export for DRIFT-010 evidence when needed.</Text>
           <Text>

--- a/canvases/agent-implementer.canvas.tsx
+++ b/canvases/agent-implementer.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/implementer.md · implementer-loop/SKILL.md · board-shell · board-ssot § Continuation";
 
@@ -111,6 +111,9 @@ const READ_FIRST = [
   [".local/index-and-planning/current/architecture.md", "Architecture stub"],
   ["session-pointer / plan / work-tracker", "Fallback only"],
   ["test-plan.md / test-index.md", "When tests or ownership change"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
+  [".local/plans/", "Agent Path A — plan list → execute"],
+  [".local/canvases/", "canvas save session evidence"],
 ];
 
 const ARTIFACTS = [
@@ -143,6 +146,16 @@ const ARTIFACTS = [
     ".local/generated-data/board-outbox.jsonl",
     "EXIT_QUEUED (6)",
     "Later flush (any agent/human)",
+  ],
+  [
+    ".local/plans/",
+    "Exit — plan snapshot",
+    "Agents + verifier",
+  ],
+  [
+    ".local/canvases/",
+    "canvas save when used",
+    "Session evidence (ADR-010)",
   ],
 ];
 

--- a/canvases/agent-integrator.canvas.tsx
+++ b/canvases/agent-integrator.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/integrator.md · integrator-protocol/SKILL.md · board-ssot/SKILL.md";
 
@@ -91,6 +91,9 @@ const READ_FIRST = [
   ["python3 -m cursor_workflow integrate validate", "Wire verification"],
   ["prepare.py resolve_gates()", "PR / kit-dev gate SSOT"],
   ["check_governance_consistency.py", "When policy docs change"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
+  [".local/plans/", "Snapshot history when touching plans"],
+  [".local/canvases/", "canvas sync/save when touching canvases"],
 ];
 
 const PATTERNS = [
@@ -108,6 +111,8 @@ const ARTIFACTS = [
   ["history/updates-log.md", "Exit", "Continuity readers"],
   ["Board Status + Notes", "Exit (validate outcomes)", "implementer / escalations"],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+  [".local/plans/", "plan snapshot when touching plans", "History only (DRIFT-012)"],
+  [".local/canvases/", "canvas save / sync", "Session evidence (ADR-010)"],
 ];
 
 const PEERS = [

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -20,7 +20,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   "agent-relations edges · audit-orchestration (quarterly CHK-* vs PR focused) · board-ssot § Continuation · per-agent canvas PEERS";
 
@@ -71,7 +71,7 @@ const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   },
   {
     id: "drift-guard",
-    role: "drift-guard MAS-SSOT-KIT · drift-audit (goal pulse + DRIFT-001…011)",
+    role: "drift-guard MAS-SSOT-KIT · drift-audit (goal pulse + DRIFT-001…012)",
     lane: "Quality",
   },
   {

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/researcher.md · research-corpus/SKILL.md · research_cli.py · .agents/skills/RESEARCH_WORKFLOW.md · live pack flexiai-toolsmith + verifier";
 
@@ -104,6 +104,7 @@ const READ_FIRST = [
   [".cursor/skills/research-corpus/SKILL.md", "Intake + rounds canon"],
   ["_research_results/RESEARCH_BOUNDARIES.md", "Hard-stop boundaries"],
   [".cursor/skills/board-ssot/SKILL.md", "When project_ssot.enabled"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
 ];
 
 const PATTERNS = [
@@ -122,6 +123,16 @@ const ARTIFACTS = [
   ["_research_results/sources/<slug>/", "Pack + AGENT_BRIEF", "implementer / integrator"],
   ["Board Status + Notes", "Research card done + pack paths", "Next / requesting agent"],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+  [
+    ".local/plans/",
+    "plan snapshot|list (history)",
+    "Agents execute; humans plan open",
+  ],
+  [
+    ".local/canvases/",
+    "canvas save (session evidence)",
+    "canvas-artifacts skill",
+  ],
 ];
 
 const PEERS = [

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -16,7 +16,7 @@ import {
   useHostTheme,
 } from "cursor/canvas";
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 const SOURCES = "Aggregated from .cursor/agents/*.md (post goal-pulse / CHK-*)";
 
 const AGENTS = [
@@ -214,7 +214,7 @@ export default function AgentRosterCanvas() {
           auditor · board · drift-guard · implementer · integrator · researcher ·
           test-runner · verifier — skills: board-ssot, implementer-loop,
           test-coverage, auditor-protocol (CHK-*), drift-audit (goal pulse +
-          DRIFT-001…011), integrator-protocol, …
+          DRIFT-001…012), integrator-protocol, …
         </Callout>
         <Callout tone="neutral" title="Quality lane split (2026-08-04)">
           Continuous plan/agent/docs coherence → drift-guard. Deep

--- a/canvases/agent-test-runner.canvas.tsx
+++ b/canvases/agent-test-runner.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-05";
 const SOURCES =
   ".cursor/agents/test-runner.md · test-coverage/SKILL.md · board-ssot/SKILL.md";
 
@@ -98,6 +98,7 @@ const READ_FIRST = [
   [".local/index-and-planning/current/test-index.md", "When tests change"],
   [".local/index-and-planning/current/test-plan.md", "When tests change"],
   ["check_testing_artifacts.py", "Before PR path"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
 ];
 
 const PATTERNS = [
@@ -122,6 +123,16 @@ const ARTIFACTS = [
   ["change-index.md", "Exit", "Next agents / humans"],
   ["Board Status + Notes", "Exit", "Next agent"],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+  [
+    ".local/plans/",
+    "plan snapshot|list (history)",
+    "Agents execute; humans plan open",
+  ],
+  [
+    ".local/canvases/",
+    "canvas save (session evidence)",
+    "canvas-artifacts skill",
+  ],
 ];
 
 const PEERS = [

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -23,7 +23,7 @@ import {
 
 type SsotMode = "board" | "fallback";
 
-const VERIFIED = "2026-08-03";
+const VERIFIED = "2026-08-05";
 const SOURCES = ".cursor/agents/verifier.md · board-ssot/SKILL.md § Continuation";
 
 const GOALS = [
@@ -92,6 +92,7 @@ const READ_FIRST = [
   [".cursor/skills/board-ssot/SKILL.md", "When project_ssot.enabled"],
   [".local/index-and-planning/current/session-pointer.md", "Fallback Entry"],
   [".local/workflow-artifacts/pr/", "When maintainer workflow in play"],
+  [".cursor/skills/canvas-artifacts/SKILL.md", "ADR-010 canvas/plan tiers"],
 ];
 
 const PATTERNS = [
@@ -108,6 +109,16 @@ const ARTIFACTS = [
   ["change-index.md", "If findings change status", "Next agents / humans"],
   ["Board Status + Notes", "Exit (done or in_review + failure Notes)", "Next agent"],
   [".local/generated-data/board-outbox.jsonl", "EXIT_QUEUED (6)", "Later flush"],
+  [
+    ".local/plans/",
+    "plan snapshot|list (history)",
+    "Agents execute; humans plan open",
+  ],
+  [
+    ".local/canvases/",
+    "canvas save (session evidence)",
+    "canvas-artifacts skill",
+  ],
 ];
 
 const PEERS = [

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -26,9 +26,9 @@ import {
  * Not an agent-* canvas — excluded from DOC-008 roster scan (same as board-ssot-vs-kit).
  */
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 const SOURCES =
-  "ADR-008 · ADR-007 · board-ssot/SKILL.md · project-board-collaboration.md · agent cards · drift/auditor quality split";
+  "ADR-008 · ADR-010 · ADR-007 · board-ssot/SKILL.md · canvas-artifacts/SKILL.md · project-board-collaboration.md · agent cards · drift/auditor quality split";
 
 const NODE_W = 118;
 const NODE_H = 36;
@@ -91,8 +91,8 @@ const WHO_WRITES: string[][] = [
   [
     "implementer",
     "claim · handoff · promote · mention-pr",
-    "session/plan/change-index (offline mirror)",
-    "Ships code; PR path",
+    "change-index; live plan on board card (board_only)",
+    "Ships code; PR path; plan snapshot on exit",
   ],
   [
     "test-runner",
@@ -161,7 +161,7 @@ const ARTIFACT_LANES: string[][] = [
     "Drift",
     ".local/workflow-artifacts/drift/",
     "drift-guard",
-    "Goal pulse + DRIFT-009…011 (011 kit-dev roster)",
+    "Goal pulse + DRIFT-009…012 (011 roster; 012 plan snapshots)",
   ],
   [
     "Release / smoke",
@@ -181,6 +181,18 @@ const ARTIFACT_LANES: string[][] = [
     "Any agent on EXIT_QUEUED (6)",
     "Flush later — not a second SSOT",
   ],
+  [
+    "Session canvases (local evidence)",
+    ".local/canvases/",
+    "Any agent via canvas save",
+    "ADR-010 — sync to IDE with canvas sync",
+  ],
+  [
+    "Plan snapshots (history only)",
+    ".local/plans/",
+    "plan snapshot · plan list (agents); plan open (human Build)",
+    "Live plan = board card under board_only — DRIFT-012",
+  ],
 ];
 
 const HAPPY_PATH = [
@@ -188,7 +200,8 @@ const HAPPY_PATH = [
   "2. claim --last --agent <name> (Start date on In progress when configured)",
   "3. Work — code/tests and/or write .local artifacts",
   "4. Exit — handoff --to in_review|done + Notes (@user/agent · UTC · …)",
-  "5. PR — mention-pr; merge.py can set card Done",
+  "5. Plan — agents: plan list → read .local/plans/; humans: plan open for Build",
+  "6. PR — mention-pr; merge.py can set card Done",
 ];
 
 function LoopDag({
@@ -353,6 +366,9 @@ export default function AgentsArtifactsBoardCanvas() {
           <Pill size="sm" tone="neutral" active>
             ADR-008
           </Pill>
+          <Pill size="sm" tone="neutral" active>
+            ADR-010
+          </Pill>
           <Pill size="sm" tone="neutral">
             8 agents
           </Pill>
@@ -447,7 +463,7 @@ export default function AgentsArtifactsBoardCanvas() {
           </Text>
           <Text size="small">
             implementer makes drift-validate → P0/P1 or goal-pulse gaps →
-            drift-guard writes drift artifacts (DRIFT-001…011 kit-dev) →
+            drift-guard writes drift artifacts (DRIFT-001…012 kit-dev) →
             remediation via Notes/Ready (never silent tracker Status).
           </Text>
           <Text size="small">

--- a/canvases/board-ssot-vs-kit.canvas.tsx
+++ b/canvases/board-ssot-vs-kit.canvas.tsx
@@ -26,7 +26,7 @@ import {
 
 type Mode = "classic" | "shipped" | "compare";
 
-const VERIFIED = "2026-08-04";
+const VERIFIED = "2026-08-05";
 
 const CLASSIC_NODES = [
   { id: "agent" },
@@ -122,6 +122,16 @@ const ABC_SLICES = [
       "Deprecated HTML ICC Project Board tab (EA-010) — offline export only; prefer live board + Open Canvas",
     ],
   },
+];
+
+
+const CANVAS_PLAN_TIERS: string[][] = [
+  ["Repo canvases/", "git SSOT", "canvases/*.canvas.tsx"],
+  ["canvas sync", "IDE managed preview", "~/.cursor/projects/.../canvases/"],
+  [".local/canvases/", "session evidence", "canvas save (ADR-010)"],
+  ["Board card body", "live plan SSOT", "board_only Acceptance/scope"],
+  [".local/plans/", "snapshot history", "plan snapshot|list; agents execute; humans plan open"],
+  ["DRIFT-012", "guard", ".local/plans/ must not host live plan under board_only"],
 ];
 
 const FOLLOWUP_SLICES = [
@@ -551,6 +561,18 @@ export default function BoardSsotVsKitCanvas() {
         </Card>
       </Grid>
 
+      <Divider />
+      <H2>Canvas / plan tiers (ADR-010)</H2>
+      <Text size="small" tone="secondary">
+        Shipped three-tier canvases + two-tier plans. Live plan stays on the board under board_only.
+      </Text>
+      <Spacer height={8} />
+      <Table
+        headers={["Tier", "Role", "Path / CLI"]}
+        rows={CANVAS_PLAN_TIERS}
+        columnAlign={["left", "left", "left"]}
+      />
+
       <H2>Classic vs shipped</H2>
       <Table
         headers={["Concern", "Classic kit", "STANDALONE product"]}
@@ -576,6 +598,7 @@ export default function BoardSsotVsKitCanvas() {
           ["Dual writers", "Single (markdown)", "Forbidden — DRIFT-009"],
           ["Stale PR detection", "N/A", "DRIFT-010 + export snapshot"],
           ["Agent roster pulse", "N/A", "DRIFT-011 kit-dev (.cursor/agents)"],
+          ["Plan snapshot guard", "N/A", "DRIFT-012 .local/plans snapshot-only"],
           [
             "PR merge gates",
             "prepare.py resolve_gates()",

--- a/canvases/mcp-onboarding.canvas.tsx
+++ b/canvases/mcp-onboarding.canvas.tsx
@@ -1,0 +1,202 @@
+import {
+  Callout,
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  H1,
+  Pill,
+  Stack,
+  Table,
+  Text,
+} from "cursor/canvas";
+
+const VERIFIED = "2026-08-05";
+
+const REGISTRY_SNAPSHOT = {
+  workflowKit: {
+    serverId: "workflow-kit",
+    tier: "kit",
+    agents: [
+      "implementer",
+      "test-runner",
+      "verifier",
+      "auditor",
+      "researcher",
+      "integrator",
+      "drift-guard",
+    ],
+  },
+  deepwiki: {
+    serverId: "deepwiki",
+    tier: "external",
+    agents: ["researcher", "implementer", "auditor"],
+    tools: ["read_wiki_structure", "read_wiki_contents", "ask_question"],
+  },
+};
+
+const FLOW_COMMANDS: Array<[string, string]> = [
+  [
+    "1) Merge + sanity check",
+    "python3 -m cursor_workflow mcp validate",
+  ],
+  [
+    "2) Doctor (config vs Cursor host)",
+    "python3 -m cursor_workflow mcp doctor",
+  ],
+  [
+    "3) Discover tools",
+    "python3 -m cursor_workflow mcp list-tools --server workflow-kit",
+  ],
+  [
+    "4) Call a tool (kit stdio example)",
+    "python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count",
+  ],
+];
+
+const DEEPWIKI_DEMO_COMMANDS: Array<[string, string]> = [
+  [
+    "A) Smoke DeepWiki server",
+    "python3 -m cursor_workflow mcp smoke --server deepwiki",
+  ],
+  [
+    "B) List wiki topics for a repo",
+    "python3 -m cursor_workflow mcp call --server deepwiki --tool read_wiki_structure --args-json '{\"repoName\":\"cloudflare/workers-sdk\"}'",
+  ],
+  [
+    "C) Ask a factual question",
+    "python3 -m cursor_workflow mcp call --server deepwiki --tool ask_question --args-json '{\"repoName\":\"cloudflare/workers-sdk\",\"question\":\"What are the Workers KV limits (key size, value size, TTL/cache TTL)?\"}'",
+  ],
+];
+
+const CONFIG_LOCATIONS = [
+  {
+    path: ".cursor/mcp.registry.yaml",
+    role: "Allowlist mapping: which server id is allowed for which agent ids.",
+  },
+  {
+    path: ".cursor/mcp.user.json",
+    role: "Transport config (command/args or url) for user servers; gitignored.",
+  },
+  {
+    path: ".local/user_settings/mcp.secrets.yaml",
+    role: "Secrets/tokens for MCP auth; gitignored.",
+  },
+];
+
+const TROUBLESHOOTING = [
+  {
+    issue: "DeepWiki says “Repository Not Indexed”",
+    fix: "Wait for DeepWiki indexing to complete, or pick an indexed repo (example: cloudflare/workers-sdk).",
+  },
+  {
+    issue: "No module named 'mcp'",
+    fix: "Run via the venv (activate `.venv` or use `.venv/bin/python -m cursor_workflow ...`).",
+  },
+  {
+    issue: "Strict validate fails without live registry",
+    fix: "Use `mcp validate` (non-strict) for kit-only installs, or copy `.cursor/mcp.registry.yaml.example` into a live `.cursor/mcp.registry.yaml`.",
+  },
+];
+
+export default function MCPOnboardingCanvas() {
+  return (
+    <Stack gap={10}>
+      <H1>MCP onboarding (Pattern A)</H1>
+      <Text tone="tertiary">
+        Canonical portable path for agents + CI: use <Pill>cursor_workflow mcp</Pill> commands.
+        Cursor IDE MCP loading is optional. Verified {VERIFIED}.
+      </Text>
+
+      <Callout tone="neutral" title="Key idea: CLI is canonical">
+        Agents should follow the same “universal” sequence regardless of whether Cursor host MCP
+        is loaded: validate → list → call → smoke.
+      </Callout>
+
+      <Card>
+        <CardHeader>Quick start (kit: workflow-kit)</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Table
+              headers={["Step", "Command"]}
+              rows={FLOW_COMMANDS.map(([step, cmd]) => [step, cmd])}
+            />
+            <Text tone="tertiary" size="small">
+              Tip: if you see “configured but NOT host-loaded” in <Pill>mcp doctor</Pill>, that’s normal—
+              the CLI still works.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>DeepWiki demo (external: deepwiki)</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              In your current registry snapshot, <Pill>deepwiki</Pill> is mapped to agents:
+              {" "}
+              <Pill>{REGISTRY_SNAPSHOT.deepwiki.agents.join(", ")}</Pill>.
+            </Text>
+            <Table
+              headers={["Demo step", "Command"]}
+              rows={DEEPWIKI_DEMO_COMMANDS.map(([step, cmd]) => [step, cmd])}
+            />
+            <Text tone="tertiary" size="small">
+              Note: DeepWiki tool args use <Pill>repoName</Pill> (not <Pill>repo</Pill>).
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Divider />
+
+      <Card>
+        <CardHeader>Where to configure servers</CardHeader>
+        <CardBody>
+          <Table
+            headers={["Path", "Role"]}
+            rows={CONFIG_LOCATIONS.map((r) => [r.path, r.role])}
+          />
+        </CardBody>
+      </Card>
+
+      <Divider />
+
+      <Card>
+        <CardHeader>Agent usage template (what to tell an agent)</CardHeader>
+        <CardBody>
+          <Stack gap={6}>
+            <Text>
+              Use DeepWiki only when the server is mapped to your agent id in{" "}
+              <Pill>.cursor/mcp.registry.yaml</Pill>.
+            </Text>
+            <Text>
+              For a typical doc help flow:
+            </Text>
+            <Text>
+              1) call <Pill>read_wiki_structure</Pill> → find relevant section/pages
+            </Text>
+            <Text>
+              2) call <Pill>ask_question</Pill> (or <Pill>read_wiki_contents</Pill>) → extract facts
+            </Text>
+            <Text tone="tertiary" size="small">
+              Output should be: answer + short pointers (wiki topic/page) + caveat if DeepWiki indexing is incomplete.
+            </Text>
+          </Stack>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>Troubleshooting</CardHeader>
+        <CardBody>
+          <Table
+            headers={["Issue", "Fix"]}
+            rows={TROUBLESHOOTING.map((r) => [r.issue, r.fix])}
+          />
+        </CardBody>
+      </Card>
+    </Stack>
+  );
+}
+

--- a/overlays/rules/project-ssot-precedence.mdc
+++ b/overlays/rules/project-ssot-precedence.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
 - **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -68,9 +68,11 @@ Drift validation: `make drift-validate` — see [gate-matrix.md](../operations/g
 
 | Root | Contents |
 |------|----------|
-| `.cursor/skills/` | Canonical protocols (**12**): `workflow-activate`, `board-ssot`, `board-shell`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
+| `.cursor/skills/` | Canonical protocols (**13**): `workflow-activate`, `board-ssot`, `board-shell`, `canvas-artifacts`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
 | `.agents/skills/` | Maintainer slash skills: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` (redirect) |
 
 Plugin bundle copies `.cursor/skills/` first; maintainer skills are **additive only** (no overwrite).
+
+Canvas/plan local artifacts: [ADR-010](../decisions/ADR-010-canvas-plan-local-artifacts.md) · skill `canvas-artifacts`.
 
 See [folder-charter.md](../governance/folder-charter.md) and [decisions/README.md](../decisions/README.md).

--- a/payload/.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md
+++ b/payload/.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md
@@ -21,8 +21,9 @@ Registry maps agent ids → server keys → tool hints. Agents read registry bef
 ## Consequences
 
 - `cursor_workflow mcp link` / `mcp validate` CLI (Phase 5b)
+- Pattern A transport: `mcp doctor|list-tools|call|auth|smoke` — see [ADR-009](ADR-009-mcp-pattern-a-cli.md)
 - `mcp-connect` skill and ops doc
-- Secrets in `.cursor/mcp.user.json` (gitignored)
+- Transport in `.cursor/mcp.user.json` (gitignored); auth secrets in `.local/user_settings/mcp.secrets.yaml`
 
 ## Reference implementation
 

--- a/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
+++ b/payload/.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md
@@ -58,6 +58,7 @@ Auto-detect profile from `work-tracker.md` unless `--profile` overrides.
 | DRIFT-009 | P1 | kit-dev | When `project_ssot.sync_policy: board_only`, no competing `in_progress` in work-tracker Active (ADR-008) |
 | DRIFT-010 | P1 | kit-dev | When `board_only`, board Status vs open PRs / stale In progress / merged-but-not-Done (uses read-only `project export` snapshot; skips offline) |
 | DRIFT-011 | P1 | kit-dev | Agent roster coherence: `.cursor/agents/*.md` basenames match the eight live kit agent ids (goal/doctrine pulse — falsifiable) |
+| DRIFT-012 | P2 | kit-dev | When `board_only`, `.local/plans/` is snapshot-only — no live/current plan SSOT in that dir (ADR-010) |
 
 **Exit policy:** exit code 1 on any P0 failure; P1/P2 advisory in output (same as `integrate validate`). Pending `project_ssot.outbox` ops are **not** a drift failure — cite `project outbox status` in artifacts when relevant.
 

--- a/payload/.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md
+++ b/payload/.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md
@@ -1,0 +1,30 @@
+# ADR-009: MCP Pattern A CLI (universal agent transport)
+
+**Status:** accepted  
+**Date:** 2026-08-05
+
+## Context
+
+ADR-003/004 define kit + user MCP tiers and a registry. Cursor agent sessions often load only plugin MCPs, not project `.cursor/mcp.json` servers (`workflow-kit`, DeepWiki). Agents need a transport that works in shell, CI, and chat without depending on Cursor host loading.
+
+## Decision
+
+1. **CLI is canonical:** `python3 -m cursor_workflow mcp doctor|list-tools|call|auth|smoke` (plus existing `validate` / `link`).
+2. **Registry allowlist:** `mcp call` / `list-tools` only target servers present in `.cursor/mcp.registry.yaml` (when that file exists); `--agent` filters to servers that list the agent.
+3. **Secrets:** `.local/user_settings/mcp.secrets.yaml` (gitignored); `mcp.user.json` stays transport-only.
+4. **Cursor `CallMcpTool` is optional** when the IDE host loads the same server; docs/skills must not require it.
+5. **Kit `workflow-kit` stdio server unchanged** — still wraps `.ai_infra/scripts/`; CLI client talks to it over MCP stdio.
+6. **Exit codes:** align with project CLI (`0/2/3/4/5`); remote outbox / `EXIT_QUEUED=6` deferred.
+
+## Consequences
+
+- Modules: `mcp_cli.py`, `mcp_client.py`, `mcp_secrets.py` beside `mcp_manage.py`
+- Evidence under `.local/workflow-artifacts/mcp/`
+- Agent MCP sections prefer CLI recipes
+- Extends ADR-004; does not replace ADR-003 boundaries
+
+## References
+
+- [ADR-003](ADR-003-plugin-mcp-boundaries.md), [ADR-004](ADR-004-user-mcp-registry.md)
+- Ops: `.ai_infra/docs/operations/connect-external-mcp.md`
+- Skill: `.cursor/skills/mcp-connect/SKILL.md`

--- a/payload/.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md
+++ b/payload/.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md
@@ -1,0 +1,30 @@
+# ADR-010: Canvas and plan local artifacts (Pattern A)
+
+**Status:** accepted  
+**Date:** 2026-08-05
+
+## Context
+
+Kit canvases live in git under `canvases/*.canvas.tsx`, but Cursor IDE only compiles canvases from `~/.cursor/projects/<workspace>/canvases/`. Plan-mode output lands in global `~/.cursor/plans/`, while live slice plans under `board_only` belong on the GitHub Project card (ADR-008). Agents need durable, project-scoped history for ephemeral canvases and plan snapshots without creating a second writable SSOT.
+
+## Decision
+
+1. **Three canvas tiers:** repo `canvases/` (git SSOT for product docs), Cursor managed path (render bridge only), `.local/canvases/` (session evidence, gitignored).
+2. **Two plan tiers:** live plan on board card body (or `plan.md` offline fallback); `.local/plans/` holds dated **snapshots only** — never competing backlog/status.
+3. **CLI is canonical:** `python3 -m cursor_workflow canvas doctor|list|sync|save` and `plan snapshot|list|open`.
+4. **Explicit sync:** no silent overwrite of Cursor managed canvases on activate; `canvas sync --all` requires `--force`; `--missing` copies only absent managed files.
+5. **Evidence:** optional doctor reports under `.local/workflow-artifacts/canvas/`.
+
+## Consequences
+
+- Modules: `cursor_host_paths.py`, `canvas_manage.py`, `canvas_cli.py`, `plan_manage.py`, `plan_cli.py`
+- Skill: `.cursor/skills/canvas-artifacts/SKILL.md`
+- **`plan open`** copies the latest `.local/plans/<date>-<slug>.plan.md` snapshot to `~/.cursor/plans/<slug>.plan.md` so humans get IDE Build; requires `--force` when the Cursor twin already exists (same safety model as `canvas sync --all`)
+- **Agents build from `.local/plans/`** via `plan list` + read snapshot — never depend on Build or the global Cursor plan store
+- Extends ADR-008 (no dual-write); complements Cursor global canvas/plan skills
+
+## References
+
+- [ADR-008](ADR-008-project-board-ssot.md)
+- Ops: `.ai_infra/docs/operations/local-workspace-layout.md`, `PLUGIN-USER-GUIDE.md`
+- Skill: `.cursor/skills/canvas-artifacts/SKILL.md`

--- a/payload/.ai_infra/docs/decisions/README.md
+++ b/payload/.ai_infra/docs/decisions/README.md
@@ -10,5 +10,7 @@
 | [ADR-006](ADR-006-agent-integration-model.md) | Agent integration model (MAS vs independent) | accepted |
 | [ADR-007](ADR-007-workflow-drift-guard.md) | Workflow drift guard (operational drift detection) | accepted |
 | [ADR-008](ADR-008-project-board-ssot.md) | GitHub Project board as agent SSOT (product doctrine) | accepted |
+| [ADR-009](ADR-009-mcp-pattern-a-cli.md) | MCP Pattern A CLI (universal agent transport) | accepted |
+| [ADR-010](ADR-010-canvas-plan-local-artifacts.md) | Canvas and plan local artifacts (Pattern A) | accepted |
 
 New decisions: add `ADR-NNN-short-title.md` and update this index.

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -296,6 +296,21 @@ Versioned under repo `canvases/*.canvas.tsx` (git SSOT). **Rendering** uses Curs
 
 Clicking a file in the repo explorer opens **source**, not the visualization. To view diagrams: **Ctrl+Shift+P → Open Canvas** (pick e.g. `agents-artifacts-board` or an `agent-*` canvas). See hub canvas `canvases/agents-artifacts-board.canvas.tsx` for the same note.
 
+**Three-tier model (ADR-010):** repo `canvases/` (git SSOT) → sync → Cursor managed path (preview) → optional save → `.local/canvases/` (session evidence). Plan snapshots: `.local/plans/` (history only; live plan stays on board or `plan.md`). Agents execute plans from `.local/plans/`; humans bridge to IDE Build with `plan open --slug <slug>` (requires `--force` if a Cursor twin already exists).
+
+```bash
+python3 -m cursor_workflow canvas doctor
+python3 -m cursor_workflow canvas list
+python3 -m cursor_workflow canvas sync --name mcp-onboarding
+python3 -m cursor_workflow canvas save --name <stem>
+python3 -m cursor_workflow canvas sync --missing
+python3 -m cursor_workflow plan snapshot --slug my-slice
+python3 -m cursor_workflow plan list
+python3 -m cursor_workflow plan open --slug my-slice
+```
+
+Skill: `.cursor/skills/canvas-artifacts/SKILL.md`
+
 Legacy browser UI still ships on activate. **Do not open HTML via `file://`**. From project root:
 
 ```bash

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -82,7 +82,9 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
 | P0 / P1 / P2 / P3 | Priority — board uses `p0\|p1\|p2`; chat P3 → board `p2` + Notes `deferred` | `board-ssot` skill |
 | xs…xl | Size options on the board (Tier-1) | Size↔Estimate table in skill |
 
-High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`), **DRIFT-011** (`.cursor/agents` basenames == eight live kit agent ids — goal/doctrine pulse).
+High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `in_progress` under `board_only`), **DRIFT-010** (board Status vs PRs / stale In progress; uses read-only `project export`), **DRIFT-011** (`.cursor/agents` basenames == eight live kit agent ids — goal/doctrine pulse), **DRIFT-012** (`.local/plans/` snapshot-only under `board_only`).
+
+**Canvas / plan (ADR-010):** repo `canvases/` → `canvas sync` → IDE preview → optional `canvas save` → `.local/canvases/`; plan history in `.local/plans/` via `plan snapshot|list|open` (live plan on board card).
 
 ## Planes
 

--- a/payload/.ai_infra/docs/operations/agent-workflow-procedures.md
+++ b/payload/.ai_infra/docs/operations/agent-workflow-procedures.md
@@ -70,6 +70,7 @@ When **`resolve_gates()`** / **`GATES`** in `prepare.py` change, update in the *
 | Always-applied rule | `.cursor/rules/pr-workflow-enforcement.mdc` |
 | Onboarding | `README.md`, `AGENTS.md` |
 | Checklist | `.ai_infra/docs/operations/workflow-complete.md` |
+| Canvas / plan artifacts | `.cursor/skills/canvas-artifacts/SKILL.md` (ADR-010) |
 | Maintainer skills | `.agents/skills/pr-workflow/SKILL.md`, `prepare-pr/SKILL.md`, `review-pr/SKILL.md`, `merge-pr/SKILL.md`, `full-pr-workflow/SKILL.md` |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` (via `full-pr-workflow`) |
 

--- a/payload/.ai_infra/docs/operations/connect-external-mcp.md
+++ b/payload/.ai_infra/docs/operations/connect-external-mcp.md
@@ -45,7 +45,20 @@ cursor-workflow mcp validate
 | Kit | `mcp.json.kit.example` → merged into `mcp.json` | `workflow-kit` tools (PR, trackers, gates) |
 | User | `mcp.user.json` + registry YAML | External servers per agent |
 
-See [ADR-004](../decisions/ADR-004-user-mcp-registry.md).
+See [ADR-004](../decisions/ADR-004-user-mcp-registry.md) and [ADR-009](../decisions/ADR-009-mcp-pattern-a-cli.md) (Pattern A CLI).
+
+## Pattern A CLI (canonical agent transport)
+
+```bash
+python3 -m cursor_workflow mcp doctor
+python3 -m cursor_workflow mcp validate [--strict]
+python3 -m cursor_workflow mcp list-tools --server workflow-kit
+python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_TOKEN
+python3 -m cursor_workflow mcp smoke --server workflow-kit
+```
+
+Cursor IDE MCP loading is optional. Registry YAML is the allowlist for `call` / `list-tools`.
 
 ## Worked example: DeepWiki (zero auth)
 
@@ -74,29 +87,44 @@ servers:
     tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
 ```
 
-3. **Merge + validate, then reload Cursor MCP:**
+4. **Pattern A smoke (preferred — no Cursor host required):**
 
 ```bash
-cursor-workflow mcp validate
+python3 -m cursor_workflow mcp doctor
+python3 -m cursor_workflow mcp smoke --server deepwiki
+python3 -m cursor_workflow mcp call --server deepwiki --tool ask_question \
+  --args-json '{"repo":"cloudflare/workers-sdk","question":"What are Workers KV limits?"}'
 ```
 
-4. **Try it** — ask an agent (e.g. `researcher`) to read the wiki structure or ask a question
-   about any public GitHub repo; no secrets, no local process, no `secrets_checklist` entry
-   needed in `.local/user_settings/mcp.agents.yaml`.
+Optional: reload Cursor MCP so `CallMcpTool` also works when the IDE host loads the server.
+
+5. **Try it in chat** — ask an agent (e.g. `researcher`) to use Pattern A CLI or CallMcpTool;
+   no secrets, no local process, no `secrets_checklist` entry needed in
+   `.local/user_settings/mcp.agents.yaml` for DeepWiki.
 
 Both example files (`.cursor/mcp.registry.yaml.example`, `.cursor/mcp.user.example.json`) already
 ship this entry alongside the command-based `my-custom-server` example, so you can see the
 URL-based and command-based transport shapes side by side.
+
+### Auth (Pattern A)
+
+```bash
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_API_TOKEN
+# stores under .local/user_settings/mcp.secrets.yaml (gitignored)
+```
+
+See [ADR-009](../decisions/ADR-009-mcp-pattern-a-cli.md).
 
 ### Stretch: GitHub official remote MCP
 
 GitHub's official remote MCP server (`https://api.githubcopilot.com/mcp/`) is documented as a
 secondary/stretch example in `.local/user_settings/mcp.agents.yaml` (commented `github-remote`
 block). It is **not** zero-auth: it requires either a Copilot seat (OAuth) or a personal access
-token sent as a `Bearer` header, so it is not wired live in the kit demo to avoid auth friction —
-uncomment and fill in a token to try it yourself.
+token sent as a `Bearer` header — use `mcp auth --server github-remote --token-env GITHUB_TOKEN`.
 
 ## Troubleshooting
 
 - `mcp validate` fails: ensure every registry `servers` key exists in merged `mcp.json` `mcpServers`
-- Secrets: never commit `mcp.user.json` — scaffold adds it to `.gitignore`
+- `mcp validate --strict` fails without a live `.cursor/mcp.registry.yaml` — copy the example when enforcing user tier
+- `mcp doctor` shows configured but NOT host-loaded: expected until Cursor enables project `mcp.json`; use Pattern A CLI anyway
+- Secrets: never commit `mcp.user.json` or `.local/user_settings/mcp.secrets.yaml` — `mcp link` / `mcp auth` update `.gitignore`

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -260,7 +260,8 @@ python3 -m cursor_workflow project status
 2. Claim/update the board card (Status + Notes `@user/agent · <ISO-8601-UTC> · …`); local `plan.md` / `work-tracker.md` only as offline fallback under `board_only`; optional `history/continuity-index.md` (≥3-day local rollup)
 3. If board writes hit GraphQL rate-limit (EXIT_QUEUED): `project outbox status` / later `outbox flush` — enable `project_ssot.outbox` defaults after activate
 4. **`/implementer`** (or `/test-runner`, `/verifier`; `/auditor` only for architecture-impacting / pre-merge audits — not day-0 onboarding)
-5. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
+5. Canvas/plan (ADR-010): `canvas doctor` · `canvas sync --name <stem>` · `plan snapshot|list|open` — see [canvas-artifacts](../../.cursor/skills/canvas-artifacts/SKILL.md)
+6. Dashboard (optional, **deprecated**): see [Control Center dashboards](#control-center-dashboards-deprecated) below
 
 **Add your own agent/skill/MCP:** **`/integrator`** + **`/integrator-protocol`**
 

--- a/payload/.ai_infra/docs/operations/local-workspace-layout.md
+++ b/payload/.ai_infra/docs/operations/local-workspace-layout.md
@@ -55,6 +55,9 @@ The `.local/` directory is **gitignored**. This document is the **versioned cont
 | `workflow-artifacts/audit/` | `preflight.json`, `doc-facts-preflight.json` (verify-all / doc validate) |
 | `user_settings/` | Gitignored YAML worksheets: GitHub collaboration + MCP agent wiring (from kit exemplars) |
 | `generated-data/` | Coverage JSON, `project-board-snapshot.json` (read-only board export for ICC), and similar machine output |
+| `canvases/` | Ephemeral session canvases (gitignored); index at `index.md`; sync via `cursor_workflow canvas` |
+| `plans/` | Dated plan-mode snapshots only (not live SSOT under `board_only`); index at `index.md` |
+| `workflow-artifacts/canvas/` | Optional `canvas doctor` reports (ADR-010) |
 
 ## Git commits vs `.local` markdown
 

--- a/payload/.ai_infra/docs/operations/workflow-complete.md
+++ b/payload/.ai_infra/docs/operations/workflow-complete.md
@@ -95,7 +95,8 @@ This is the **implementation agent** end-of-loop on top of sections **C** and **
 3. **`change-index.md`** — one row; do **not** dual-write tracker `in_progress` under `board_only`.
 4. **`test-plan.md` / `test-index.md`** — when tests changed.
 5. After merge: **`merge.py --merge-sha`** is the sole Pattern A writer that sets the card → **Done** + Notes (PR URL + SHA); `find-by-pr` resolves from the PR body, or pass `--item-id` when known. Prefer `- Board-Item: <id>` in the PR Collaboration section (never paste docs placeholders).
-6. **`make drift-validate`** — on P0/P1, hand off to **`drift-guard`** (reads + updates the board; DRIFT-009/010).
+6. When plan-mode was used: `plan snapshot --slug <kebab> --agent <name> --board-item <PVTI_>` (`.local/plans/` history only under `board_only`).
+7. **`make drift-validate`** — on P0/P1, hand off to **`drift-guard`** (reads + updates the board; DRIFT-009/010/012).
 
 **Offline fallback (project_ssot disabled / no gh):**
 

--- a/payload/.ai_infra/install/cursor_workflow/activate_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/activate_cli.py
@@ -107,6 +107,8 @@ def _print_post_activate_hints(root: Path) -> None:
         print("     Until shell green (2-view overlay or six-view default; Tier-1 columns on both primary views).")
         print("  9. Run: source .venv/bin/activate && python3 -m cursor_workflow project status")
         print(" 10. In Agent chat: /implementer — local trackers are offline fallback under board_only.")
+        print(" 11. Canvas preview: python3 -m cursor_workflow canvas doctor")
+        print("     (sync repo canvases: canvas sync --missing)")
     else:
         print("\nYou're almost done — 3 quick steps:")
         print(f"  1. Edit {yaml_path}")
@@ -116,6 +118,7 @@ def _print_post_activate_hints(root: Path) -> None:
         print("\nOptional:")
         print("  source .venv/bin/activate && python3 -m cursor_workflow integrate validate")
         print("  source .venv/bin/activate && python3 -m cursor_workflow health")
+        print("  source .venv/bin/activate && python3 -m cursor_workflow canvas doctor")
         print("Add agents/skills later: /integrator (subagent, not a shell command).")
 
 

--- a/payload/.ai_infra/install/cursor_workflow/canvas_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/canvas_cli.py
@@ -1,0 +1,147 @@
+"""
+File: canvas_cli.py
+Path: .ai_infra/install/cursor_workflow/canvas_cli.py
+Role: Pattern A canvas CLI — doctor, list, sync, save (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/cli.py
+Depends On:
+ - canvas_manage, cursor_host_paths
+Notes:
+ - Exit codes align with project CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import canvas_manage
+
+
+def _artifact_dir(root: Path) -> Path:
+    path = root / ".local" / "workflow-artifacts" / "canvas"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_artifact(root: Path, prefix: str, body: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = _artifact_dir(root) / f"{prefix}-{stamp}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def cmd_canvas_doctor(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    report = canvas_manage.build_doctor_report(root)
+    body = canvas_manage.format_doctor_markdown(report)
+    print(body)
+    art = _write_artifact(root, "doctor", body)
+    print(f"artifact: {art}")
+    return canvas_manage.EXIT_OK
+
+
+def cmd_canvas_list(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    tier = args.tier
+    by_tier = canvas_manage.list_by_tier(root, tier)  # type: ignore[arg-type]
+    for name, files in by_tier.items():
+        print(f"[{name}]")
+        for filename in files:
+            print(f"  {filename}")
+        if not files:
+            print("  (none)")
+    return canvas_manage.EXIT_OK
+
+
+def cmd_canvas_sync(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        copied = canvas_manage.sync_canvas(
+            root,
+            name=args.name,
+            missing=bool(args.missing),
+            sync_all=bool(args.all),
+            force=bool(args.force),
+            source=args.from_tier,  # type: ignore[arg-type]
+        )
+    except FileNotFoundError as exc:
+        print(f"canvas sync: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"canvas sync: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_USAGE
+    if not copied:
+        print("canvas sync: nothing to copy")
+    else:
+        print(f"canvas sync: copied {len(copied)} file(s)")
+        for name in copied:
+            print(f" - {name}")
+    return canvas_manage.EXIT_OK
+
+
+def cmd_canvas_save(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        dst = canvas_manage.save_canvas(
+            root,
+            slug=args.slug,
+            source=args.from_tier,  # type: ignore[arg-type]
+            agent=args.agent,
+        )
+    except FileNotFoundError as exc:
+        print(f"canvas save: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"canvas save: FAIL — {exc}", file=sys.stderr)
+        return canvas_manage.EXIT_VALIDATION
+    text = dst.read_text(encoding="utf-8")
+    for warning in canvas_manage.validate_canvas_source(text):
+        print(f"canvas save: WARN — {warning}", file=sys.stderr)
+    print(f"canvas save: {dst}")
+    return canvas_manage.EXIT_OK
+
+
+def register_canvas_subcommands(sub: Any) -> None:
+    """Attach canvas subcommands to the root parser group."""
+    doctor = sub.add_parser("doctor", help="Report repo vs managed vs local canvas drift")
+    doctor.add_argument("--directory", type=Path, default=".")
+    doctor.set_defaults(func=cmd_canvas_doctor)
+
+    list_p = sub.add_parser("list", help="List canvases by tier")
+    list_p.add_argument("--directory", type=Path, default=".")
+    list_p.add_argument(
+        "--tier",
+        choices=("repo", "managed", "local", "all"),
+        default="all",
+    )
+    list_p.set_defaults(func=cmd_canvas_list)
+
+    sync = sub.add_parser("sync", help="Copy canvases to Cursor managed render path")
+    sync.add_argument("--directory", type=Path, default=".")
+    sync.add_argument("--name", default=None, help="Canvas base name (no .canvas.tsx)")
+    sync.add_argument("--missing", action="store_true", help="Copy only absent managed files")
+    sync.add_argument("--all", action="store_true", help="Copy all from source (requires --force)")
+    sync.add_argument("--force", action="store_true", help="Allow --all overwrite")
+    sync.add_argument(
+        "--from",
+        dest="from_tier",
+        choices=("repo", "local"),
+        default="repo",
+    )
+    sync.set_defaults(func=cmd_canvas_sync)
+
+    save = sub.add_parser("save", help="Save canvas to .local/canvases/")
+    save.add_argument("--directory", type=Path, default=".")
+    save.add_argument("--slug", required=True, help="Canvas base name (kebab-case)")
+    save.add_argument("--agent", default=None)
+    save.add_argument(
+        "--from",
+        dest="from_tier",
+        choices=("managed", "repo", "local"),
+        default="managed",
+    )
+    save.set_defaults(func=cmd_canvas_save)

--- a/payload/.ai_infra/install/cursor_workflow/canvas_manage.py
+++ b/payload/.ai_infra/install/cursor_workflow/canvas_manage.py
@@ -1,0 +1,253 @@
+"""
+File: canvas_manage.py
+Path: .ai_infra/install/cursor_workflow/canvas_manage.py
+Role: Canvas tier paths, list/sync/save, doctor drift detection (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/canvas_cli.py
+Depends On:
+ - cursor_host_paths
+Notes:
+ - Repo canvases/ is git SSOT; Cursor managed path is render bridge only.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import cursor_host_paths
+
+CANVAS_SUFFIX = ".canvas.tsx"
+CANVAS_NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+
+Tier = Literal["repo", "managed", "local", "all"]
+SourceTier = Literal["repo", "local"]
+
+
+def _load_local_workflow_paths(root: Path):
+    pr_scripts = root / ".ai_infra" / "scripts" / "pr"
+    pr_str = str(pr_scripts)
+    if pr_str not in sys.path:
+        sys.path.insert(0, pr_str)
+    import local_workflow_paths
+
+    return local_workflow_paths
+
+
+def canvas_filename(base: str) -> str:
+    if not CANVAS_NAME_RE.match(base):
+        raise ValueError(f"invalid canvas base name: {base!r} (use kebab-case)")
+    return f"{base}{CANVAS_SUFFIX}"
+
+
+def list_canvases_in_dir(directory: Path | None) -> list[str]:
+    if directory is None or not directory.is_dir():
+        return []
+    return sorted(p.name for p in directory.glob(f"*{CANVAS_SUFFIX}") if p.is_file())
+
+
+def canvas_base(name: str) -> str:
+    if name.endswith(CANVAS_SUFFIX):
+        return name[: -len(CANVAS_SUFFIX)]
+    return name
+
+
+def tier_dir(root: Path, tier: SourceTier | Literal["managed"]) -> Path | None:
+    lwp = _load_local_workflow_paths(root)
+    if tier == "repo":
+        path = root / lwp.REPO_CANVASES_DIR
+        return path if path.is_dir() else None
+    if tier == "local":
+        path = root / lwp.LOCAL_CANVASES_DIR
+        return path if path.is_dir() else None
+    return cursor_host_paths.cursor_canvases_dir(root)
+
+
+def list_by_tier(root: Path, tier: Tier) -> dict[str, list[str]]:
+    tiers: dict[str, list[str]] = {}
+    if tier in ("repo", "all"):
+        tiers["repo"] = list_canvases_in_dir(tier_dir(root, "repo"))
+    if tier in ("managed", "all"):
+        tiers["managed"] = list_canvases_in_dir(tier_dir(root, "managed"))
+    if tier in ("local", "all"):
+        tiers["local"] = list_canvases_in_dir(tier_dir(root, "local"))
+    return tiers
+
+
+def validate_canvas_source(text: str) -> list[str]:
+    warnings: list[str] = []
+    if "export default function" not in text:
+        if re.search(r"export\s+default\s+\w+\s*;", text):
+            warnings.append(
+                "uses separate `export default Name` — prefer `export default function …()` "
+                "for Cursor canvas indexing"
+            )
+        else:
+            warnings.append("missing `export default function` export")
+    return warnings
+
+
+def build_doctor_report(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    by_tier = list_by_tier(root, "all")
+    repo_set = {canvas_base(n) for n in by_tier.get("repo", [])}
+    managed_set = {canvas_base(n) for n in by_tier.get("managed", [])}
+    local_set = {canvas_base(n) for n in by_tier.get("local", [])}
+
+    repo_dir = tier_dir(root, "repo")
+    managed_dir = tier_dir(root, "managed")
+    stale: list[str] = []
+    for base in sorted(repo_set & managed_set):
+        assert repo_dir is not None and managed_dir is not None
+        repo_file = repo_dir / canvas_filename(base)
+        managed_file = managed_dir / canvas_filename(base)
+        if repo_file.stat().st_mtime > managed_file.stat().st_mtime:
+            stale.append(base)
+
+    return {
+        "root": str(root),
+        "repo_dir": str(repo_dir) if repo_dir else None,
+        "managed_dir": str(managed_dir) if managed_dir else None,
+        "local_dir": str(tier_dir(root, "local")),
+        "repo": by_tier.get("repo", []),
+        "managed": by_tier.get("managed", []),
+        "local": by_tier.get("local", []),
+        "repo_not_managed": sorted(repo_set - managed_set),
+        "managed_not_repo": sorted(managed_set - repo_set),
+        "stale_managed": stale,
+        "local_only": sorted(local_set - repo_set - managed_set),
+    }
+
+
+def format_doctor_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Canvas doctor",
+        "",
+        f"- root: `{report['root']}`",
+        f"- repo: `{report['repo_dir'] or '(missing)'}`",
+        f"- managed: `{report['managed_dir'] or '(not found)'}`",
+        f"- local: `{report['local_dir'] or '(missing)'}`",
+        "",
+        "## Counts",
+        "",
+        f"- repo: {len(report['repo'])}",
+        f"- managed: {len(report['managed'])}",
+        f"- local: {len(report['local'])}",
+        "",
+        "## Drift",
+        "",
+        f"- repo not in managed: {', '.join(report['repo_not_managed']) or '(none)'}",
+        f"- managed not in repo: {', '.join(report['managed_not_repo']) or '(none)'}",
+        f"- stale managed (repo newer): {', '.join(report['stale_managed']) or '(none)'}",
+        f"- local-only slugs: {', '.join(report['local_only']) or '(none)'}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _copy_canvas(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def sync_canvas(
+    root: Path,
+    *,
+    name: str | None = None,
+    missing: bool = False,
+    sync_all: bool = False,
+    force: bool = False,
+    source: SourceTier = "repo",
+) -> list[str]:
+    root = root.resolve()
+    src_dir = tier_dir(root, source)
+    dst_dir = tier_dir(root, "managed")
+    if src_dir is None:
+        raise FileNotFoundError(f"source tier {source!r} directory missing")
+    if dst_dir is None:
+        project = cursor_host_paths.cursor_project_dir(root)
+        if project is None:
+            raise FileNotFoundError("Cursor managed project dir not found")
+        dst_dir = project / "canvases"
+        dst_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    if sync_all:
+        if not force:
+            raise ValueError("sync --all requires --force")
+        for filename in list_canvases_in_dir(src_dir):
+            _copy_canvas(src_dir / filename, dst_dir / filename)
+            copied.append(filename)
+        return copied
+
+    if missing:
+        for filename in list_canvases_in_dir(src_dir):
+            dst = dst_dir / filename
+            if not dst.is_file():
+                _copy_canvas(src_dir / filename, dst)
+                copied.append(filename)
+        return copied
+
+    if not name:
+        raise ValueError("pass --name, --missing, or --all")
+    filename = canvas_filename(name)
+    src = src_dir / filename
+    if not src.is_file():
+        raise FileNotFoundError(f"missing source canvas: {src}")
+    _copy_canvas(src, dst_dir / filename)
+    copied.append(filename)
+    return copied
+
+
+def save_canvas(
+    root: Path,
+    *,
+    slug: str,
+    source: Literal["managed", "repo", "local"] = "managed",
+    agent: str | None = None,
+) -> Path:
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    lwp.ensure_local_artifact_tree(root=root)
+
+    if source == "managed":
+        src_dir = tier_dir(root, "managed")
+    elif source == "repo":
+        src_dir = tier_dir(root, "repo")
+    else:
+        src_dir = tier_dir(root, "local")
+    if src_dir is None:
+        raise FileNotFoundError(f"source tier {source!r} directory missing")
+
+    filename = canvas_filename(slug)
+    src = src_dir / filename
+    if not src.is_file():
+        raise FileNotFoundError(f"missing canvas to save: {src}")
+
+    dst = root / lwp.LOCAL_CANVASES_DIR / filename
+    _copy_canvas(src, dst)
+    _append_canvas_index(root, slug=slug, agent=agent)
+    return dst
+
+
+def _append_canvas_index(root: Path, *, slug: str, agent: str | None) -> None:
+    lwp = _load_local_workflow_paths(root)
+    index_path = root / lwp.LOCAL_CANVASES_INDEX
+    if not index_path.is_file():
+        return
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    agent_col = agent or "—"
+    row = f"| {slug} | {stamp} | {agent_col} | saved via canvas save |"
+    text = index_path.read_text(encoding="utf-8")
+    if slug in text:
+        return
+    index_path.write_text(text.rstrip() + "\n" + row + "\n", encoding="utf-8")

--- a/payload/.ai_infra/install/cursor_workflow/cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/cli.py
@@ -8,8 +8,10 @@ Depends On:
  - .ai_infra/bootstrap.py
  - .ai_infra/scripts/install/scaffold.py
  - .ai_infra/install/cursor_workflow/mcp_manage.py
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
 Notes:
  - install forwards to scaffold.py; gates runs prepare-aligned checks.
+ - ADR-009 MCP; ADR-010 canvas/plan Pattern A CLI.
 """
 
 from __future__ import annotations
@@ -39,6 +41,9 @@ _MCP_PKG = Path(__file__).resolve().parent
 if str(_MCP_PKG) not in sys.path:
     sys.path.insert(0, str(_MCP_PKG))
 import mcp_manage  # noqa: E402
+import mcp_cli  # noqa: E402
+import canvas_cli  # noqa: E402
+import plan_cli  # noqa: E402
 import contributors_cli  # noqa: E402
 import integrate_cli  # noqa: E402
 import drift_cli  # noqa: E402
@@ -189,35 +194,6 @@ def cmd_health(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_mcp_validate(args: argparse.Namespace) -> int:
-    root = Path(args.directory).resolve()
-    try:
-        mcp_manage.write_merged_mcp(root)
-        errors = mcp_manage.validate_registry(root)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"mcp validate: FAIL — {exc}", file=sys.stderr)
-        return 1
-    if errors:
-        print("mcp validate: FAIL")
-        for err in errors:
-            print(f" - {err}")
-        return 1
-    print("mcp validate: PASS")
-    return 0
-
-
-def cmd_mcp_link(args: argparse.Namespace) -> int:
-    root = Path(args.directory).resolve()
-    try:
-        mcp_manage.link_user_server(root, args.name, args.file.resolve())
-        mcp_manage.ensure_mcp_gitignore(root)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"mcp link: FAIL — {exc}", file=sys.stderr)
-        return 1
-    print(f"mcp link: linked '{args.name}' from {args.file}")
-    return 0
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="cursor-workflow",
@@ -266,18 +242,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     health.set_defaults(func=cmd_health)
 
-    mcp = sub.add_parser("mcp", help="MCP config merge and registry validation")
+    mcp = sub.add_parser(
+        "mcp",
+        help="Pattern A MCP: validate, link, doctor, list-tools, call, auth, smoke",
+    )
     mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+    mcp_cli.register_mcp_subcommands(mcp_sub)
 
-    mcp_validate = mcp_sub.add_parser("validate", help="Merge kit+user MCP and validate registry")
-    mcp_validate.add_argument("--directory", type=Path, default=".")
-    mcp_validate.set_defaults(func=cmd_mcp_validate)
+    canvas = sub.add_parser(
+        "canvas",
+        help="Pattern A canvas: doctor, list, sync, save (ADR-010)",
+    )
+    canvas_sub = canvas.add_subparsers(dest="canvas_command", required=True)
+    canvas_cli.register_canvas_subcommands(canvas_sub)
 
-    mcp_link = mcp_sub.add_parser("link", help="Link external MCP server fragment into mcp.user.json")
-    mcp_link.add_argument("--name", required=True, help="Server name in mcp.user.json")
-    mcp_link.add_argument("--file", required=True, type=Path, help="JSON fragment with mcpServers")
-    mcp_link.add_argument("--directory", type=Path, default=".")
-    mcp_link.set_defaults(func=cmd_mcp_link)
+    plan = sub.add_parser(
+        "plan",
+        help="Pattern A plan snapshots: snapshot, list, open (ADR-010)",
+    )
+    plan_sub = plan.add_subparsers(dest="plan_command", required=True)
+    plan_cli.register_plan_subcommands(plan_sub)
 
     contributors_cli.register_contributors_subparser(sub)
     integrate_cli.register_integrate_subparser(sub)

--- a/payload/.ai_infra/install/cursor_workflow/cursor_host_paths.py
+++ b/payload/.ai_infra/install/cursor_workflow/cursor_host_paths.py
@@ -1,0 +1,65 @@
+"""
+File: cursor_host_paths.py
+Path: .ai_infra/install/cursor_workflow/cursor_host_paths.py
+Role: Resolve Cursor IDE managed paths for workspace (canvases, mcps, global plans).
+Used By:
+ - .ai_infra/install/cursor_workflow/mcp_manage.py
+ - .ai_infra/install/cursor_workflow/canvas_manage.py
+Depends On:
+ - pathlib, re
+Notes:
+ - Best-effort fuzzy match for WSL/Linux workspace slugs. ADR-010.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def cursor_projects_home() -> Path:
+    return Path.home() / ".cursor" / "projects"
+
+
+def cursor_plans_dir() -> Path:
+    """Global Cursor plan-mode store (not project-scoped)."""
+    return Path.home() / ".cursor" / "plans"
+
+
+def cursor_project_dir(root: Path) -> Path | None:
+    """Best-effort path to Cursor's per-project cache for this workspace."""
+    home = cursor_projects_home()
+    if not home.is_dir():
+        return None
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", str(root).strip("/")).strip("-")
+    candidates = [
+        home / f"home-{slug}" if not str(root).startswith("/home/") else None,
+        home / ("home-" + str(root).lstrip("/").replace("/", "-")),
+    ]
+    rel = str(root)
+    if rel.startswith("/"):
+        candidates.append(home / ("home-" + rel[1:].replace("/", "-")))
+    for candidate in candidates:
+        if candidate is not None and candidate.is_dir():
+            return candidate
+    name = root.name
+    for path in sorted(home.iterdir()):
+        if path.is_dir() and path.name.endswith(name):
+            return path
+    return None
+
+
+def cursor_canvases_dir(root: Path) -> Path | None:
+    project = cursor_project_dir(root)
+    if project is None:
+        return None
+    canvases = project / "canvases"
+    return canvases if canvases.is_dir() else None
+
+
+def cursor_project_mcps_dir(root: Path) -> Path | None:
+    project = cursor_project_dir(root)
+    if project is None:
+        return None
+    mcps = project / "mcps"
+    return mcps if mcps.is_dir() else None

--- a/payload/.ai_infra/install/cursor_workflow/mcp_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/mcp_cli.py
@@ -1,0 +1,338 @@
+"""
+File: mcp_cli.py
+Path: .ai_infra/install/cursor_workflow/mcp_cli.py
+Role: Pattern A MCP CLI handlers — doctor, list-tools, call, auth, smoke.
+Used By:
+ - .ai_infra/install/cursor_workflow/cli.py
+Depends On:
+ - mcp_manage, mcp_client, mcp_secrets
+Notes:
+ - ADR-009. Exit codes align with project CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import mcp_client
+import mcp_manage
+import mcp_secrets
+
+
+def _artifact_dir(root: Path) -> Path:
+    path = root / ".local" / "workflow-artifacts" / "mcp"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_artifact(root: Path, prefix: str, body: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = _artifact_dir(root) / f"{prefix}-{stamp}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def build_doctor_report(root: Path) -> dict[str, Any]:
+    try:
+        merged = mcp_manage.load_merged_servers(root, write=False)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        merged = {}
+        merge_error = str(exc)
+    else:
+        merge_error = None
+
+    reg_path = mcp_manage.registry_path_used(root)
+    reg_live = (root / mcp_manage.REGISTRY).is_file()
+    user_live = (root / mcp_manage.USER_FRAGMENT).is_file()
+    servers_reg = mcp_manage.registry_servers(root)
+
+    agent_map: dict[str, list[str]] = {}
+    for name, spec in servers_reg.items():
+        if not isinstance(spec, dict):
+            continue
+        agents = spec.get("agents") or []
+        if isinstance(agents, list):
+            for agent in agents:
+                if isinstance(agent, str) and agent:
+                    agent_map.setdefault(agent, []).append(name)
+
+    mcps_dir = mcp_manage.cursor_project_mcps_dir(root)
+    host_loaded = mcp_manage.list_cursor_host_servers(mcps_dir)
+    configured = sorted(merged.keys())
+    host_set = set(host_loaded)
+    cfg_set = set(configured)
+
+    import_info = mcp_manage.check_workflow_mcp_import(root)
+
+    return {
+        "root": str(root),
+        "merged_servers": configured,
+        "merge_error": merge_error,
+        "user_fragment_present": user_live,
+        "registry_path": str(reg_path) if reg_path else None,
+        "registry_live": reg_live,
+        "registry_servers": sorted(servers_reg.keys()),
+        "agent_mappings": {k: sorted(v) for k, v in sorted(agent_map.items())},
+        "workflow_mcp": import_info,
+        "cursor_mcps_dir": str(mcps_dir) if mcps_dir else None,
+        "cursor_host_loaded": host_loaded,
+        "configured_not_host_loaded": sorted(cfg_set - host_set),
+        "host_loaded_not_configured": sorted(host_set - cfg_set),
+    }
+
+
+def format_doctor_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# MCP doctor",
+        "",
+        f"- root: `{report['root']}`",
+        f"- user fragment (mcp.user.json): {'yes' if report['user_fragment_present'] else 'no'}",
+        f"- registry: `{report['registry_path']}` "
+        f"({'live' if report['registry_live'] else 'example/fallback'})",
+        f"- merged servers: {', '.join(report['merged_servers']) or '(none)'}",
+        f"- registry servers: {', '.join(report['registry_servers']) or '(none)'}",
+        "",
+        "## Configured vs Cursor host",
+        "",
+        f"- cursor mcps dir: `{report['cursor_mcps_dir'] or '(not found)'}`",
+        f"- host-loaded: {', '.join(report['cursor_host_loaded']) or '(none)'}",
+        f"- configured but NOT host-loaded: "
+        f"{', '.join(report['configured_not_host_loaded']) or '(none)'}",
+        f"- host-loaded but not in mcp.json: "
+        f"{', '.join(report['host_loaded_not_configured']) or '(none)'}",
+        "",
+        "## workflow_mcp import",
+        "",
+        f"- venv: `{report['workflow_mcp'].get('venv_python')}`",
+        f"- import_ok: {report['workflow_mcp'].get('import_ok')}",
+    ]
+    if report["workflow_mcp"].get("error"):
+        lines.append(f"- error: {report['workflow_mcp']['error']}")
+    if report.get("merge_error"):
+        lines.extend(["", f"**merge error:** {report['merge_error']}"])
+    lines.extend(["", "## Agent mappings", ""])
+    mappings = report.get("agent_mappings") or {}
+    if not mappings:
+        lines.append("(none)")
+    else:
+        for agent, servers in mappings.items():
+            lines.append(f"- `{agent}`: {', '.join(servers)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def cmd_mcp_doctor(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.write_merged_mcp(root)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp doctor: WARN — merge failed: {exc}", file=sys.stderr)
+    report = build_doctor_report(root)
+    body = format_doctor_markdown(report)
+    print(body)
+    art = _write_artifact(root, "doctor", body)
+    print(f"artifact: {art}")
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_validate(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    strict = bool(getattr(args, "strict", False))
+    try:
+        mcp_manage.write_merged_mcp(root)
+        errors = mcp_manage.validate_registry(root, strict=strict)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp validate: FAIL — {exc}", file=sys.stderr)
+        return 1
+    if errors:
+        print("mcp validate: FAIL")
+        for err in errors:
+            print(f" - {err}")
+        return 1
+    print("mcp validate: PASS" + (" (strict)" if strict else ""))
+    return 0
+
+
+def cmd_mcp_link(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.link_user_server(root, args.name, args.file.resolve())
+        mcp_manage.ensure_mcp_gitignore(root)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp link: FAIL — {exc}", file=sys.stderr)
+        return 1
+    print(f"mcp link: linked '{args.name}' from {args.file}")
+    return 0
+
+
+def cmd_mcp_list_tools(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.write_merged_mcp(root)
+        tools = mcp_client.list_tools(root, args.server, agent=args.agent)
+    except mcp_client.McpClientError as exc:
+        print(f"mcp list-tools: FAIL — {exc}", file=sys.stderr)
+        return int(exc.code)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp list-tools: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    for tool in tools:
+        desc = (tool.get("description") or "").replace("\n", " ")
+        print(f"{tool['name']}\t{desc}")
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_call(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        mcp_manage.write_merged_mcp(root)
+        arguments = mcp_client.parse_args_json(args.args_json)
+        result = mcp_client.call_tool(
+            root,
+            args.server,
+            args.tool,
+            arguments,
+            agent=args.agent,
+        )
+    except mcp_client.McpClientError as exc:
+        print(f"mcp call: FAIL — {exc}", file=sys.stderr)
+        return int(exc.code)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp call: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    if isinstance(result, (dict, list)):
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(result)
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_auth(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    token = args.token
+    if not token and args.token_env:
+        import os
+
+        token = os.environ.get(args.token_env)
+        if not token:
+            print(
+                f"mcp auth: FAIL — env {args.token_env} empty",
+                file=sys.stderr,
+            )
+            return mcp_manage.EXIT_USAGE
+    if not token and not args.env_pair:
+        print(
+            "mcp auth: FAIL — pass --token, --token-env, or --env KEY=VALUE",
+            file=sys.stderr,
+        )
+        return mcp_manage.EXIT_USAGE
+    env_map: dict[str, str] = {}
+    for pair in args.env_pair or []:
+        if "=" not in pair:
+            print(f"mcp auth: FAIL — bad --env {pair}", file=sys.stderr)
+            return mcp_manage.EXIT_USAGE
+        k, v = pair.split("=", 1)
+        env_map[k] = v
+    try:
+        path = mcp_secrets.set_server_secret(
+            root,
+            args.server,
+            token=token,
+            header_name=args.header,
+            env=env_map or None,
+        )
+        mcp_manage.ensure_mcp_gitignore(root)
+    except (OSError, ValueError) as exc:
+        print(f"mcp auth: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    print(f"mcp auth: stored secrets for '{args.server}' at {path} (values not printed)")
+    return mcp_manage.EXIT_OK
+
+
+def cmd_mcp_smoke(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    server = args.server
+    try:
+        mcp_manage.write_merged_mcp(root)
+        result = mcp_client.smoke_server(root, server, agent=args.agent)
+    except mcp_client.McpClientError as exc:
+        print(f"mcp smoke: FAIL — {exc}", file=sys.stderr)
+        body = f"# MCP smoke FAIL\n\n- server: `{server}`\n- error: {exc}\n"
+        art = _write_artifact(root, "smoke", body)
+        print(f"artifact: {art}", file=sys.stderr)
+        return int(exc.code)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mcp smoke: FAIL — {exc}", file=sys.stderr)
+        return mcp_manage.EXIT_VALIDATION
+    body = (
+        f"# MCP smoke OK\n\n"
+        f"- server: `{server}`\n"
+        f"- tool_count: {result['tool_count']}\n"
+        f"- tools: {', '.join(result['tools'])}\n"
+    )
+    print(body)
+    art = _write_artifact(root, "smoke", body)
+    print(f"artifact: {art}")
+    return mcp_manage.EXIT_OK
+
+
+def register_mcp_subcommands(mcp_sub: Any) -> None:
+    """Attach Pattern A MCP subparsers to an existing `mcp` subparser group."""
+    mcp_validate = mcp_sub.add_parser("validate", help="Merge kit+user MCP and validate registry")
+    mcp_validate.add_argument("--directory", type=Path, default=".")
+    mcp_validate.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail when live registry is missing or external entries absent from mcp.json",
+    )
+    mcp_validate.set_defaults(func=cmd_mcp_validate)
+
+    mcp_link = mcp_sub.add_parser("link", help="Link external MCP server fragment into mcp.user.json")
+    mcp_link.add_argument("--name", required=True, help="Server name in mcp.user.json")
+    mcp_link.add_argument("--file", required=True, type=Path, help="JSON fragment with mcpServers")
+    mcp_link.add_argument("--directory", type=Path, default=".")
+    mcp_link.set_defaults(func=cmd_mcp_link)
+
+    doctor = mcp_sub.add_parser("doctor", help="Report MCP config vs Cursor host load status")
+    doctor.add_argument("--directory", type=Path, default=".")
+    doctor.set_defaults(func=cmd_mcp_doctor)
+
+    list_tools = mcp_sub.add_parser("list-tools", help="List tools for an allowlisted MCP server")
+    list_tools.add_argument("--directory", type=Path, default=".")
+    list_tools.add_argument("--server", required=True)
+    list_tools.add_argument("--agent", default=None, help="Filter by registry agent mapping")
+    list_tools.set_defaults(func=cmd_mcp_list_tools)
+
+    call = mcp_sub.add_parser("call", help="Call a tool on an allowlisted MCP server")
+    call.add_argument("--directory", type=Path, default=".")
+    call.add_argument("--server", required=True)
+    call.add_argument("--tool", required=True)
+    call.add_argument("--args-json", default=None, help='JSON object, e.g. \'{"repo":"org/name"}\'')
+    call.add_argument("--agent", default=None)
+    call.set_defaults(func=cmd_mcp_call)
+
+    auth = mcp_sub.add_parser("auth", help="Store MCP secrets under .local/user_settings")
+    auth.add_argument("--directory", type=Path, default=".")
+    auth.add_argument("--server", required=True)
+    auth.add_argument("--token", default=None, help="Bearer/token value (not echoed later)")
+    auth.add_argument("--token-env", default=None, help="Read token from environment variable")
+    auth.add_argument("--header", default=None, help="HTTP header name (default Authorization)")
+    auth.add_argument(
+        "--env",
+        dest="env_pair",
+        action="append",
+        default=[],
+        help="KEY=VALUE env injected for stdio servers (repeatable)",
+    )
+    auth.set_defaults(func=cmd_mcp_auth)
+
+    smoke = mcp_sub.add_parser("smoke", help="Initialize server and list tools; write evidence")
+    smoke.add_argument("--directory", type=Path, default=".")
+    smoke.add_argument("--server", required=True)
+    smoke.add_argument("--agent", default=None)
+    smoke.set_defaults(func=cmd_mcp_smoke)

--- a/payload/.ai_infra/install/cursor_workflow/mcp_client.py
+++ b/payload/.ai_infra/install/cursor_workflow/mcp_client.py
@@ -1,0 +1,200 @@
+"""
+File: mcp_client.py
+Path: .ai_infra/install/cursor_workflow/mcp_client.py
+Role: Pattern A MCP client — stdio + URL transports for list-tools/call/smoke.
+Used By:
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
+Depends On:
+ - mcp (SDK), mcp_manage, mcp_secrets
+Notes:
+ - ADR-009. Does not print secrets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import mcp_manage
+import mcp_secrets
+
+EXIT_OK = mcp_manage.EXIT_OK
+EXIT_USAGE = mcp_manage.EXIT_USAGE
+EXIT_GH = mcp_manage.EXIT_GH
+EXIT_NOT_FOUND = mcp_manage.EXIT_NOT_FOUND
+EXIT_VALIDATION = mcp_manage.EXIT_VALIDATION
+
+
+class McpClientError(Exception):
+    def __init__(self, message: str, *, code: int = EXIT_GH) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _resolve_spec(root: Path, server: str) -> dict[str, Any]:
+    err = mcp_manage.assert_server_allowed(root, server)
+    if err:
+        raise McpClientError(err, code=EXIT_VALIDATION)
+    merged = mcp_manage.load_merged_servers(root)
+    raw = merged[server]
+    return mcp_manage.expand_server_env(raw, root)
+
+
+@asynccontextmanager
+async def _open_session(
+    root: Path,
+    server: str,
+    *,
+    agent: str | None = None,
+) -> AsyncIterator[Any]:
+    err = mcp_manage.assert_server_allowed(root, server, agent=agent)
+    if err:
+        raise McpClientError(err, code=EXIT_VALIDATION)
+
+    from mcp import ClientSession
+
+    spec = _resolve_spec(root, server)
+    secret = mcp_secrets.secrets_for_server(root, server)
+
+    if "url" in spec and isinstance(spec["url"], str):
+        url = spec["url"]
+        headers = mcp_secrets.http_headers_from_secrets(secret)
+        try:
+            from mcp.client.streamable_http import streamable_http_client
+            from mcp.client.streamable_http import create_mcp_http_client
+        except ImportError as exc:  # pragma: no cover
+            raise McpClientError(f"streamable HTTP transport unavailable: {exc}") from exc
+
+        if headers:
+            async with create_mcp_http_client(headers=headers) as http_client:
+                async with streamable_http_client(url, http_client=http_client) as streams:
+                    read, write = streams[0], streams[1]
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        yield session
+        else:
+            async with streamable_http_client(url) as streams:
+                read, write = streams[0], streams[1]
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    yield session
+        return
+
+    command = spec.get("command")
+    if not isinstance(command, str) or not command:
+        raise McpClientError(
+            f"server '{server}' needs 'command' (stdio) or 'url' (HTTP)",
+            code=EXIT_VALIDATION,
+        )
+
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    args = spec.get("args") or []
+    if not isinstance(args, list):
+        raise McpClientError(f"server '{server}' args must be a list", code=EXIT_VALIDATION)
+    env_spec = spec.get("env") if isinstance(spec.get("env"), dict) else {}
+    env = {**os.environ, **{str(k): str(v) for k, v in env_spec.items()}}
+    env.update(mcp_secrets.env_from_secrets(secret))
+    params = StdioServerParameters(
+        command=command,
+        args=[str(a) for a in args],
+        env=env,
+        cwd=str(root),
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+async def _list_tools_async(root: Path, server: str, *, agent: str | None) -> list[dict[str, Any]]:
+    async with _open_session(root, server, agent=agent) as session:
+        result = await session.list_tools()
+        out: list[dict[str, Any]] = []
+        for tool in result.tools:
+            out.append(
+                {
+                    "name": tool.name,
+                    "description": getattr(tool, "description", None) or "",
+                }
+            )
+        return out
+
+
+async def _call_tool_async(
+    root: Path,
+    server: str,
+    tool: str,
+    arguments: dict[str, Any],
+    *,
+    agent: str | None,
+) -> Any:
+    async with _open_session(root, server, agent=agent) as session:
+        result = await session.call_tool(tool, arguments=arguments)
+        # Prefer structured content when present
+        if getattr(result, "structuredContent", None) is not None:
+            return result.structuredContent
+        texts: list[str] = []
+        for block in getattr(result, "content", None) or []:
+            text = getattr(block, "text", None)
+            if text is not None:
+                texts.append(str(text))
+            else:
+                texts.append(str(block))
+        if len(texts) == 1:
+            return texts[0]
+        return texts
+
+
+def list_tools(root: Path, server: str, *, agent: str | None = None) -> list[dict[str, Any]]:
+    try:
+        return asyncio.run(_list_tools_async(root, server, agent=agent))
+    except McpClientError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise McpClientError(str(exc), code=EXIT_GH) from exc
+
+
+def call_tool(
+    root: Path,
+    server: str,
+    tool: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    agent: str | None = None,
+) -> Any:
+    try:
+        return asyncio.run(
+            _call_tool_async(root, server, tool, arguments or {}, agent=agent)
+        )
+    except McpClientError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise McpClientError(str(exc), code=EXIT_GH) from exc
+
+
+def smoke_server(root: Path, server: str, *, agent: str | None = None) -> dict[str, Any]:
+    tools = list_tools(root, server, agent=agent)
+    return {
+        "server": server,
+        "ok": True,
+        "tool_count": len(tools),
+        "tools": [t["name"] for t in tools],
+    }
+
+
+def parse_args_json(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise McpClientError(f"invalid --args-json: {exc}", code=EXIT_USAGE) from exc
+    if not isinstance(data, dict):
+        raise McpClientError("--args-json must be a JSON object", code=EXIT_USAGE)
+    return data

--- a/payload/.ai_infra/install/cursor_workflow/mcp_manage.py
+++ b/payload/.ai_infra/install/cursor_workflow/mcp_manage.py
@@ -1,24 +1,28 @@
 """
 File: mcp_manage.py
 Path: .ai_infra/install/cursor_workflow/mcp_manage.py
-Role: Merge kit + user MCP JSON; validate registry against mcp.json.
+Role: Merge kit + user MCP JSON; validate registry against mcp.json; doctor helpers.
 Used By:
  - .ai_infra/install/cursor_workflow/cli.py
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
  - .ai_infra/scripts/install/scaffold.py
 Depends On:
  - json, yaml (PyYAML)
 Notes:
  - Never overwrites existing mcp.user.json on install.
+ - Pattern A CLI: ADR-009.
 """
 
 from __future__ import annotations
 
 import json
-import shutil
+import os
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+import cursor_host_paths
 
 KIT_FRAGMENT = Path(".cursor") / "mcp.json.kit.example"
 USER_FRAGMENT = Path(".cursor") / "mcp.user.json"
@@ -26,6 +30,13 @@ USER_EXAMPLE = Path(".cursor") / "mcp.user.example.json"
 REGISTRY = Path(".cursor") / "mcp.registry.yaml"
 REGISTRY_EXAMPLE = Path(".cursor") / "mcp.registry.yaml.example"
 MCP_JSON = Path(".cursor") / "mcp.json"
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_GH = 3
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+EXIT_QUEUED = 6
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -94,11 +105,16 @@ def load_registry(root: Path) -> dict[str, Any]:
     return data
 
 
-def validate_registry(root: Path) -> list[str]:
+def validate_registry(root: Path, *, strict: bool = False) -> list[str]:
     errors: list[str] = []
     registry_path = root / REGISTRY
     if not registry_path.is_file():
-        return []
+        if strict:
+            errors.append(
+                f"strict: missing live registry {registry_path} "
+                f"(copy from {REGISTRY_EXAMPLE})"
+            )
+        return errors
     try:
         registry = load_registry(root)
     except (FileNotFoundError, ValueError) as exc:
@@ -126,8 +142,157 @@ def validate_registry(root: Path) -> list[str]:
         agents = spec.get("agents", [])
         if agents is not None and not isinstance(agents, list):
             errors.append(f"registry server '{name}' agents must be a list")
+        if strict and isinstance(spec, dict):
+            tier = str(spec.get("tier") or "")
+            if tier == "external" and name not in mcp_servers:
+                # already covered above; keep for clarity
+                pass
+
+    if strict and not (root / USER_FRAGMENT).is_file():
+        # Kit-only is OK unless registry lists external servers missing from merge
+        for name, spec in servers.items():
+            if not isinstance(spec, dict):
+                continue
+            if str(spec.get("tier") or "") == "external" and name not in mcp_servers:
+                errors.append(
+                    f"strict: external registry server '{name}' missing from mcp.json "
+                    f"(add to {USER_FRAGMENT} and re-validate)"
+                )
 
     return errors
+
+
+def load_merged_servers(root: Path, *, write: bool = False) -> dict[str, Any]:
+    """Return mcpServers from merged kit+user (optionally rewrite mcp.json)."""
+    if write:
+        write_merged_mcp(root)
+    mcp_path = root / MCP_JSON
+    if not mcp_path.is_file():
+        write_merged_mcp(root)
+    mcp = _read_json(root / MCP_JSON)
+    servers = mcp.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("mcp.json mcpServers must be an object")
+    return {k: v for k, v in servers.items() if isinstance(v, dict)}
+
+
+def registry_path_used(root: Path) -> Path | None:
+    live = root / REGISTRY
+    if live.is_file():
+        return live
+    example = root / REGISTRY_EXAMPLE
+    if example.is_file():
+        return example
+    return None
+
+
+def registry_servers(root: Path) -> dict[str, Any]:
+    try:
+        data = load_registry(root)
+    except FileNotFoundError:
+        return {}
+    servers = data.get("servers") or {}
+    return servers if isinstance(servers, dict) else {}
+
+
+def servers_for_agent(root: Path, agent: str | None) -> set[str] | None:
+    """
+    If agent is None, return None (no filter).
+    If agent set, return allowlisted server names for that agent from registry.
+    """
+    if not agent:
+        return None
+    servers = registry_servers(root)
+    allowed: set[str] = set()
+    for name, spec in servers.items():
+        if not isinstance(spec, dict):
+            continue
+        agents = spec.get("agents") or []
+        if isinstance(agents, list) and agent in agents:
+            allowed.add(name)
+    return allowed
+
+
+def assert_server_allowed(
+    root: Path,
+    server: str,
+    *,
+    agent: str | None = None,
+) -> str | None:
+    """Return error message if server not allowlisted; None if OK."""
+    reg_live = root / REGISTRY
+    if reg_live.is_file():
+        servers = registry_servers(root)
+        if server not in servers:
+            return f"server '{server}' not in registry {reg_live}"
+        if agent:
+            allowed = servers_for_agent(root, agent)
+            if allowed is not None and server not in allowed:
+                return f"server '{server}' not mapped to agent '{agent}' in registry"
+    merged = load_merged_servers(root)
+    if server not in merged:
+        return f"server '{server}' not in merged mcp.json mcpServers"
+    return None
+
+
+def expand_server_env(spec: dict[str, Any], root: Path) -> dict[str, Any]:
+    """Expand ${workspaceFolder} in command/args/env for local spawn."""
+    root_s = str(root)
+    out = dict(spec)
+
+    def _expand(val: Any) -> Any:
+        if isinstance(val, str):
+            return val.replace("${workspaceFolder}", root_s)
+        if isinstance(val, list):
+            return [_expand(v) for v in val]
+        if isinstance(val, dict):
+            return {k: _expand(v) for k, v in val.items()}
+        return val
+
+    return _expand(out)  # type: ignore[return-value]
+
+
+def cursor_project_mcps_dir(root: Path) -> Path | None:
+    """Best-effort path to Cursor's per-project mcps cache for this workspace."""
+    return cursor_host_paths.cursor_project_mcps_dir(root)
+
+
+def list_cursor_host_servers(mcps_dir: Path | None) -> list[str]:
+    if mcps_dir is None or not mcps_dir.is_dir():
+        return []
+    return sorted(p.name for p in mcps_dir.iterdir() if p.is_dir() and not p.name.startswith("."))
+
+
+def check_workflow_mcp_import(root: Path) -> dict[str, Any]:
+    """Report venv python + whether workflow_mcp is importable with kit PYTHONPATH."""
+    venv_py = root / ".venv" / "bin" / "python"
+    servers_path = root / ".ai_infra" / "mcp_servers"
+    result: dict[str, Any] = {
+        "venv_python": str(venv_py) if venv_py.is_file() else None,
+        "mcp_servers_path": str(servers_path) if servers_path.is_dir() else None,
+        "import_ok": False,
+        "error": None,
+    }
+    if not venv_py.is_file() or not servers_path.is_dir():
+        result["error"] = "missing .venv/bin/python or .ai_infra/mcp_servers"
+        return result
+    import subprocess
+
+    env = {**os.environ, "PYTHONPATH": str(servers_path)}
+    proc = subprocess.run(
+        [str(venv_py), "-c", "import workflow_mcp; print(workflow_mcp.__file__)"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode == 0:
+        result["import_ok"] = True
+        result["module_file"] = proc.stdout.strip()
+    else:
+        result["error"] = (proc.stderr or proc.stdout or "import failed").strip()
+    return result
 
 
 def link_user_server(root: Path, name: str, fragment_file: Path) -> None:
@@ -165,10 +330,14 @@ def link_user_server(root: Path, name: str, fragment_file: Path) -> None:
 
 def ensure_mcp_gitignore(root: Path) -> None:
     gitignore = root / ".gitignore"
-    line = ".cursor/mcp.user.json"
+    lines = [
+        ".cursor/mcp.user.json",
+        ".local/user_settings/mcp.secrets.yaml",
+    ]
     if gitignore.is_file():
         text = gitignore.read_text(encoding="utf-8")
-        if line not in text:
-            gitignore.write_text(text.rstrip() + f"\n{line}\n", encoding="utf-8")
+        additions = [ln for ln in lines if ln not in text]
+        if additions:
+            gitignore.write_text(text.rstrip() + "\n" + "\n".join(additions) + "\n", encoding="utf-8")
     else:
-        gitignore.write_text(f"# MCP secrets\n{line}\n", encoding="utf-8")
+        gitignore.write_text("# MCP secrets\n" + "\n".join(lines) + "\n", encoding="utf-8")

--- a/payload/.ai_infra/install/cursor_workflow/mcp_secrets.py
+++ b/payload/.ai_infra/install/cursor_workflow/mcp_secrets.py
@@ -1,0 +1,113 @@
+"""
+File: mcp_secrets.py
+Path: .ai_infra/install/cursor_workflow/mcp_secrets.py
+Role: Read/write MCP secrets under .local/user_settings (gitignored).
+Used By:
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
+ - .ai_infra/install/cursor_workflow/mcp_client.py
+Depends On:
+ - yaml
+Notes:
+ - Never print secret values. ADR-009.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SECRETS_REL = Path(".local") / "user_settings" / "mcp.secrets.yaml"
+SECRETS_EXEMPLAR_REL = (
+    Path(".ai_infra") / "templates" / "user-settings" / "exemplars" / "mcp.secrets.yaml"
+)
+
+
+def secrets_path(root: Path) -> Path:
+    return root / SECRETS_REL
+
+
+def load_secrets(root: Path) -> dict[str, Any]:
+    path = secrets_path(root)
+    if not path.is_file():
+        return {"version": 1, "servers": {}}
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"invalid secrets file: {path}")
+    servers = data.get("servers")
+    if servers is None:
+        data["servers"] = {}
+    elif not isinstance(servers, dict):
+        raise ValueError("secrets servers must be a mapping")
+    return data
+
+
+def save_secrets(root: Path, data: dict[str, Any]) -> Path:
+    path = secrets_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def set_server_secret(
+    root: Path,
+    server: str,
+    *,
+    token: str | None = None,
+    header_name: str | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    data = load_secrets(root)
+    servers = data.setdefault("servers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("secrets servers must be a mapping")
+    entry: dict[str, Any] = {}
+    if token is not None:
+        entry["token"] = token
+    if header_name:
+        entry["header"] = header_name
+    if env:
+        entry["env"] = dict(env)
+    existing = servers.get(server)
+    if isinstance(existing, dict):
+        existing.update(entry)
+        servers[server] = existing
+    else:
+        servers[server] = entry
+    data["version"] = int(data.get("version") or 1)
+    return save_secrets(root, data)
+
+
+def secrets_for_server(root: Path, server: str) -> dict[str, Any]:
+    data = load_secrets(root)
+    servers = data.get("servers") or {}
+    if not isinstance(servers, dict):
+        return {}
+    entry = servers.get(server)
+    return dict(entry) if isinstance(entry, dict) else {}
+
+
+def http_headers_from_secrets(entry: dict[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    token = entry.get("token")
+    if isinstance(token, str) and token:
+        header = entry.get("header")
+        name = header if isinstance(header, str) and header else "Authorization"
+        if name.lower() == "authorization" and not token.lower().startswith("bearer "):
+            headers[name] = f"Bearer {token}"
+        else:
+            headers[name] = token
+    extra = entry.get("headers")
+    if isinstance(extra, dict):
+        for k, v in extra.items():
+            if isinstance(k, str) and isinstance(v, str):
+                headers[k] = v
+    return headers
+
+
+def env_from_secrets(entry: dict[str, Any]) -> dict[str, str]:
+    env = entry.get("env")
+    if not isinstance(env, dict):
+        return {}
+    return {str(k): str(v) for k, v in env.items()}

--- a/payload/.ai_infra/install/cursor_workflow/plan_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/plan_cli.py
@@ -1,0 +1,124 @@
+"""
+File: plan_cli.py
+Path: .ai_infra/install/cursor_workflow/plan_cli.py
+Role: Pattern A plan snapshot CLI (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/cli.py
+Depends On:
+ - plan_manage
+Notes:
+ - History snapshots only; live SSOT remains board/plan.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import plan_manage
+
+
+def cmd_plan_snapshot(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        dst, meta = plan_manage.snapshot_plan(
+            root,
+            slug=args.slug,
+            from_spec=args.from_spec,
+            agent=args.agent,
+            board_item=args.board_item,
+            parent_chat=args.parent_chat,
+        )
+    except FileNotFoundError as exc:
+        print(f"plan snapshot: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"plan snapshot: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_VALIDATION
+    print(f"plan snapshot: {dst}")
+    if meta:
+        print(f"meta: {meta}")
+    return plan_manage.EXIT_OK
+
+
+def cmd_plan_list(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    rows = plan_manage.list_snapshots(root)
+    if not rows:
+        print("plan list: (none)")
+        return plan_manage.EXIT_OK
+    print("snapshot\tslug\tagent\tboard_item\tsource")
+    seen_slugs: set[str] = set()
+    for row in rows:
+        slug = row.get("slug") or "—"
+        if slug != "—":
+            seen_slugs.add(slug)
+        print(
+            f"{row['file']}\t{slug}\t"
+            f"{row.get('agent') or '—'}\t{row.get('board_item') or '—'}\t"
+            f"{row.get('source') or '—'}"
+        )
+        if args.verbose and slug != "—":
+            local_path = root / ".local" / "plans" / row["file"]
+            print(f"# local: {local_path}")
+            print(f"# build_bridge: plan open --slug {slug}")
+    if seen_slugs and not args.verbose:
+        for slug in sorted(seen_slugs):
+            print(f"build_bridge: plan open --slug {slug}")
+    return plan_manage.EXIT_OK
+
+
+def cmd_plan_open(args: argparse.Namespace) -> int:
+    root = Path(args.directory).resolve()
+    try:
+        dest = plan_manage.open_plan(root, slug=args.slug, force=args.force)
+    except FileNotFoundError as exc:
+        print(f"plan open: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(f"plan open: FAIL — {exc}", file=sys.stderr)
+        return plan_manage.EXIT_VALIDATION
+    print(f"plan open: {dest}")
+    print("hint: Open in Plans UI for Build; agents build from .local/plans")
+    return plan_manage.EXIT_OK
+
+
+def register_plan_subcommands(sub: Any) -> None:
+    """Attach plan subcommands to the root parser group."""
+    snapshot = sub.add_parser("snapshot", help="Save dated plan snapshot under .local/plans/")
+    snapshot.add_argument("--directory", type=Path, default=".")
+    snapshot.add_argument("--slug", required=True, help="Kebab-case slug for this plan")
+    snapshot.add_argument(
+        "--from",
+        dest="from_spec",
+        default="plan.md",
+        help="Source: plan.md, path, or cursor-plan:<basename>",
+    )
+    snapshot.add_argument("--agent", default=None)
+    snapshot.add_argument("--board-item", default=None)
+    snapshot.add_argument("--parent-chat", default=None)
+    snapshot.set_defaults(func=cmd_plan_snapshot)
+
+    list_p = sub.add_parser("list", help="List plan snapshots")
+    list_p.add_argument("--directory", type=Path, default=".")
+    list_p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print local path and build_bridge hint per row",
+    )
+    list_p.set_defaults(func=cmd_plan_list)
+
+    open_p = sub.add_parser(
+        "open",
+        help="Copy latest local snapshot to ~/.cursor/plans/ for IDE Build",
+    )
+    open_p.add_argument("--directory", type=Path, default=".")
+    open_p.add_argument("--slug", required=True, help="Kebab-case slug for this plan")
+    open_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing Cursor plan twin",
+    )
+    open_p.set_defaults(func=cmd_plan_open)

--- a/payload/.ai_infra/install/cursor_workflow/plan_manage.py
+++ b/payload/.ai_infra/install/cursor_workflow/plan_manage.py
@@ -1,0 +1,202 @@
+"""
+File: plan_manage.py
+Path: .ai_infra/install/cursor_workflow/plan_manage.py
+Role: Plan snapshot paths and copy logic (ADR-010).
+Used By:
+ - .ai_infra/install/cursor_workflow/plan_cli.py
+Depends On:
+ - cursor_host_paths
+Notes:
+ - Snapshots only; never mutates live plan.md or board SSOT.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import cursor_host_paths
+import yaml
+
+SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 4
+EXIT_VALIDATION = 5
+
+
+def _load_local_workflow_paths(root: Path):
+    pr_scripts = root / ".ai_infra" / "scripts" / "pr"
+    pr_str = str(pr_scripts)
+    if pr_str not in sys.path:
+        sys.path.insert(0, pr_str)
+    import local_workflow_paths
+
+    return local_workflow_paths
+
+
+def validate_slug(slug: str) -> None:
+    if not SLUG_RE.match(slug):
+        raise ValueError(f"invalid slug: {slug!r} (use kebab-case)")
+
+
+def resolve_plan_source(root: Path, from_spec: str) -> Path:
+    root = root.resolve()
+    if from_spec == "plan.md":
+        lwp = _load_local_workflow_paths(root)
+        return root / lwp.PLANNING_CURRENT_DIR / "plan.md"
+    if from_spec.startswith("cursor-plan:"):
+        basename = from_spec.split(":", 1)[1].strip()
+        if not basename.endswith(".plan.md"):
+            basename = f"{basename}.plan.md"
+        path = cursor_host_paths.cursor_plans_dir() / basename
+        return path
+    path = Path(from_spec)
+    if not path.is_absolute():
+        path = root / path
+    return path
+
+
+def snapshot_plan(
+    root: Path,
+    *,
+    slug: str,
+    from_spec: str = "plan.md",
+    agent: str | None = None,
+    board_item: str | None = None,
+    parent_chat: str | None = None,
+) -> tuple[Path, Path | None]:
+    validate_slug(slug)
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    lwp.ensure_local_artifact_tree(root=root)
+
+    src = resolve_plan_source(root, from_spec)
+    if not src.is_file():
+        raise FileNotFoundError(f"plan source missing: {src}")
+
+    today = date.today().isoformat()
+    base = f"{today}-{slug}"
+    dst = root / lwp.LOCAL_PLANS_DIR / f"{base}.plan.md"
+    if dst.is_file():
+        stamp = datetime.now(timezone.utc).strftime("%H%M%S")
+        base = f"{today}-{slug}-{stamp}"
+        dst = root / lwp.LOCAL_PLANS_DIR / f"{base}.plan.md"
+
+    shutil.copy2(src, dst)
+
+    meta_path: Path | None = None
+    meta = {
+        "slug": slug,
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "source": str(src),
+        "agent": agent,
+        "board_item": board_item,
+        "parent_chat": parent_chat,
+    }
+    meta_path = dst.parent / f"{base}.meta.yaml"
+    meta_path.write_text(yaml.safe_dump(meta, sort_keys=False), encoding="utf-8")
+
+    _append_plan_index(root, snapshot=base, slug=slug, agent=agent, board_item=board_item, source=from_spec)
+    return dst, meta_path
+
+
+def list_snapshots(root: Path) -> list[dict[str, Any]]:
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    plans_dir = root / lwp.LOCAL_PLANS_DIR
+    if not plans_dir.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for path in sorted(plans_dir.glob("*.plan.md")):
+        # Snapshot files are `<base>.plan.md`; meta is sibling `<base>.meta.yaml`
+        # (not Path.with_suffix(".meta.yaml"), which yields `<base>.plan.meta.yaml`).
+        meta_path = path.parent / f"{path.name.removesuffix('.plan.md')}.meta.yaml"
+        meta: dict[str, Any] = {}
+        if meta_path.is_file():
+            loaded = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                meta = loaded
+        rows.append(
+            {
+                "file": path.name,
+                "slug": meta.get("slug", canvas_base_from_plan(path.name)),
+                "agent": meta.get("agent"),
+                "board_item": meta.get("board_item"),
+                "source": meta.get("source"),
+            }
+        )
+    return rows
+
+
+def canvas_base_from_plan(filename: str) -> str:
+    name = filename.removesuffix(".plan.md")
+    parts = name.split("-", 3)
+    if len(parts) >= 4 and parts[0].isdigit() and parts[1].isdigit() and parts[2].isdigit():
+        return "-".join(parts[3:])
+    return name
+
+
+def _snapshot_slug(path: Path) -> str:
+    meta_path = path.parent / f"{path.name.removesuffix('.plan.md')}.meta.yaml"
+    if meta_path.is_file():
+        loaded = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict) and loaded.get("slug"):
+            return str(loaded["slug"])
+    return canvas_base_from_plan(path.name)
+
+
+def find_latest_snapshot(root: Path, slug: str) -> Path:
+    """Return the newest `.local/plans` snapshot matching *slug* (mtime)."""
+    validate_slug(slug)
+    root = root.resolve()
+    lwp = _load_local_workflow_paths(root)
+    plans_dir = root / lwp.LOCAL_PLANS_DIR
+    if not plans_dir.is_dir():
+        raise FileNotFoundError(f"no plan snapshot for slug {slug!r}")
+
+    matches: list[Path] = []
+    for path in plans_dir.glob("*.plan.md"):
+        if _snapshot_slug(path) == slug:
+            matches.append(path)
+    if not matches:
+        raise FileNotFoundError(f"no plan snapshot for slug {slug!r}")
+
+    return max(matches, key=lambda p: p.stat().st_mtime)
+
+
+def open_plan(root: Path, *, slug: str, force: bool = False) -> Path:
+    """Copy latest local snapshot to ``~/.cursor/plans/<slug>.plan.md`` (Build bridge)."""
+    validate_slug(slug)
+    src = find_latest_snapshot(root, slug)
+    dest = cursor_host_paths.cursor_plans_dir() / f"{slug}.plan.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.is_file() and not force:
+        raise ValueError(f"exists; pass --force ({dest})")
+    shutil.copy2(src, dest)
+    return dest
+
+
+def _append_plan_index(
+    root: Path,
+    *,
+    snapshot: str,
+    slug: str,
+    agent: str | None,
+    board_item: str | None,
+    source: str,
+) -> None:
+    lwp = _load_local_workflow_paths(root)
+    index_path = root / lwp.LOCAL_PLANS_INDEX
+    if not index_path.is_file():
+        return
+    row = f"| {snapshot}.plan.md | {slug} | {agent or '—'} | {board_item or '—'} | {source} |"
+    text = index_path.read_text(encoding="utf-8")
+    if snapshot in text:
+        return
+    index_path.write_text(text.rstrip() + "\n" + row + "\n", encoding="utf-8")

--- a/payload/.ai_infra/install/cursor_workflow/project_atomics.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_atomics.py
@@ -84,9 +84,8 @@ def is_placeholder_section_content(text: str) -> bool:
     stripped = str(text or "").strip()
     if not stripped:
         return True
+    # After .strip(), every remaining line that survives ln.strip() is non-empty.
     lines = [ln.strip() for ln in stripped.splitlines() if ln.strip()]
-    if not lines:
-        return True
 
     def _line_is_tbd(line: str) -> bool:
         s = line.casefold()
@@ -594,7 +593,7 @@ def ensure_start_date_if_starting(
         return True, "skipped: fields.start_date.field_id missing", False
     snapshot = item
     if snapshot is None:
-        items, err = _cli().fetch_project_items(ssot, limit=100)
+        items, err = _cli().fetch_project_items(ssot, limit=200)
         if not err:
             snapshot = _cli().find_item_by_id(items, item_id)
     existing = item_start_date_value(snapshot if isinstance(snapshot, dict) else None)

--- a/payload/.ai_infra/install/cursor_workflow/project_cli.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_cli.py
@@ -376,7 +376,7 @@ def cmd_create_from_template(args: argparse.Namespace) -> int:
             guess_note = "Size/Estimate guessed (default s/1)"
             if agent:
                 n_ok, n_detail, _n_code = append_notes_helper(
-                    root, ssot, item_id, agent=agent, text=guess_note, limit=100
+                    root, ssot, item_id, agent=agent, text=guess_note, limit=200
                 )
                 if not n_ok:
                     print(
@@ -811,7 +811,7 @@ def cmd_set_status(args: argparse.Namespace) -> int:
             queue_payload["start_date"] = utc_today_iso()
     # Body gate before precheck/queue so EXIT_VALIDATION never enqueues a doomed close.
     if _normalize_status(str(args.to)) in BODY_GATE_STATUSES:
-        items, list_err = fetch_project_items(ssot, limit=100)
+        items, list_err = fetch_project_items(ssot, limit=200)
         if list_err:
             return fail("set-status", EXIT_GH, list_err)
         item = find_item_by_id(items, item_id)

--- a/payload/.ai_infra/install/cursor_workflow/project_parser.py
+++ b/payload/.ai_infra/install/cursor_workflow/project_parser.py
@@ -41,7 +41,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="Filter: backlog|ready|in_progress|in_review|done",
     )
-    list_cmd.add_argument("--limit", type=int, default=100)
+    list_cmd.add_argument("--limit", type=int, default=200)
     list_cmd.add_argument("--json", action="store_true")
     list_cmd.set_defaults(func=pc.cmd_list)
 
@@ -168,7 +168,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     get_cmd = project_sub.add_parser("get", help="Get one project item by id")
     get_cmd.add_argument("--directory", type=Path, default=".")
     _add_id_or_last(get_cmd)
-    get_cmd.add_argument("--limit", type=int, default=100)
+    get_cmd.add_argument("--limit", type=int, default=200)
     get_cmd.add_argument("--json", action="store_true")
     get_cmd.set_defaults(func=pc.cmd_get)
 
@@ -184,7 +184,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="Agent id for attribution (required when require_attribution_on_exit)",
     )
-    notes_cmd.add_argument("--limit", type=int, default=100)
+    notes_cmd.add_argument("--limit", type=int, default=200)
     notes_cmd.set_defaults(func=pc.cmd_append_notes)
 
     set_section = project_sub.add_parser(
@@ -208,7 +208,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="Optional: append Notes audit line set-section Acceptance|Rollback",
     )
-    set_section.add_argument("--limit", type=int, default=100)
+    set_section.add_argument("--limit", type=int, default=200)
     set_section.set_defaults(func=pc.cmd_set_section)
 
     claim_cmd = project_sub.add_parser(
@@ -219,7 +219,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     _add_id_or_last(claim_cmd)
     claim_cmd.add_argument("--agent", required=True, help="Agent id for @user/agent Notes")
     claim_cmd.add_argument("--text", default="claimed", help="Notes text after attribution")
-    claim_cmd.add_argument("--limit", type=int, default=100)
+    claim_cmd.add_argument("--limit", type=int, default=200)
     claim_cmd.set_defaults(func=pc.cmd_claim)
 
     mention_cmd = project_sub.add_parser(
@@ -230,7 +230,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     _add_id_or_last(mention_cmd)
     mention_cmd.add_argument("--pr", required=True, help="PR number or URL")
     mention_cmd.add_argument("--agent", required=True)
-    mention_cmd.add_argument("--limit", type=int, default=100)
+    mention_cmd.add_argument("--limit", type=int, default=200)
     mention_cmd.set_defaults(func=pc.cmd_mention_pr)
 
     promote_cmd = project_sub.add_parser(
@@ -245,7 +245,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default="",
         help="owner/repo (defaults to project_ssot.default_repo)",
     )
-    promote_cmd.add_argument("--limit", type=int, default=100)
+    promote_cmd.add_argument("--limit", type=int, default=200)
     promote_cmd.set_defaults(func=pc.cmd_promote_to_issue)
 
     handoff_cmd = project_sub.add_parser(
@@ -258,7 +258,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     handoff_cmd.add_argument("--next", required=True, help="Next agent name (no @user/ needed)")
     handoff_cmd.add_argument("--to", default="", help="Optional status: in_review|done|…")
     handoff_cmd.add_argument("--text", default="", help="Optional extra Notes text")
-    handoff_cmd.add_argument("--limit", type=int, default=100)
+    handoff_cmd.add_argument("--limit", type=int, default=200)
     handoff_cmd.set_defaults(func=pc.cmd_handoff)
 
     val_cmd = project_sub.add_parser(
@@ -267,7 +267,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     )
     val_cmd.add_argument("--directory", type=Path, default=".")
     _add_id_or_last(val_cmd)
-    val_cmd.add_argument("--limit", type=int, default=100)
+    val_cmd.add_argument("--limit", type=int, default=200)
     val_cmd.set_defaults(func=pc.cmd_validate_item)
 
     last_cmd = project_sub.add_parser("last", help="Print last saved item_id (after create/claim)")
@@ -366,7 +366,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
     find_cmd.add_argument("--directory", type=Path, default=".")
     find_cmd.add_argument("--pr", required=True, help="PR number or URL")
     find_cmd.add_argument("--repo", default="", help="owner/repo (defaults to project_ssot.default_repo)")
-    find_cmd.add_argument("--limit", type=int, default=100)
+    find_cmd.add_argument("--limit", type=int, default=200)
     find_cmd.add_argument("--json", action="store_true")
     find_cmd.set_defaults(func=pc.cmd_find_by_pr)
 
@@ -380,7 +380,7 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Output path (default: .local/generated-data/project-board-snapshot.json)",
     )
-    export_cmd.add_argument("--limit", type=int, default=100)
+    export_cmd.add_argument("--limit", type=int, default=200)
     export_cmd.add_argument("--json", action="store_true", help="Also print JSON to stdout")
     export_cmd.add_argument("--stdout", action="store_true", help="Print JSON only (no file write)")
     export_cmd.set_defaults(func=pc.cmd_export)
@@ -429,5 +429,5 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Override max_flush_per_run from settings",
     )
-    ob_flush.add_argument("--limit", type=int, default=100)
+    ob_flush.add_argument("--limit", type=int, default=200)
     ob_flush.set_defaults(func=pc.cmd_outbox_flush)

--- a/payload/.ai_infra/scripts/install/scaffold.py
+++ b/payload/.ai_infra/scripts/install/scaffold.py
@@ -242,6 +242,41 @@ def _scaffold_artifact_readme_stubs(
                 _copy_file_if_missing(tab_src, tab_dst, dry_run, log)
 
 
+def _scaffold_local_canvas_plan_buckets(
+    ui_root: Path,
+    target: Path,
+    dry_run: bool,
+    log: list[str],
+    lwp: object,
+) -> None:
+    """Create .local/canvases and .local/plans with index stubs (ADR-010)."""
+    exemplars = ui_root / "exemplars"
+    stubs_root = ui_root / "artifact-stubs"
+    if dry_run:
+        for directory in lwp.LOCAL_ARTIFACT_DIRS:  # type: ignore[attr-defined]
+            _log(log, f"DRY-RUN mkdir {target / directory}")
+        _log(log, f"DRY-RUN mkdir {target / lwp.WORKFLOW_CANVAS_DIR}")  # type: ignore[attr-defined]
+        return
+    lwp.ensure_local_artifact_tree(root=target)  # type: ignore[attr-defined]
+    _copy_file_if_missing(
+        exemplars / "local-canvases-index.md",
+        target / lwp.LOCAL_CANVASES_INDEX,  # type: ignore[attr-defined]
+        dry_run,
+        log,
+    )
+    _copy_file_if_missing(
+        exemplars / "local-plans-index.md",
+        target / lwp.LOCAL_PLANS_INDEX,  # type: ignore[attr-defined]
+        dry_run,
+        log,
+    )
+    for bucket in ("canvases", "plans"):
+        src = stubs_root / bucket / "README.md"
+        dst = target / ".local" / bucket / "README.md"
+        if src.is_file():
+            _copy_file_if_missing(src, dst, dry_run, log)
+
+
 def _scaffold_dashboards(ui_root: Path, target: Path, dry_run: bool, log: list[str]) -> None:
     """Copy kit-managed dashboard shells; always refresh from templates on each scaffold/activate."""
     dash = target / ".local" / "agents-control-center" / "dashboards"
@@ -353,6 +388,7 @@ def _scaffold_local(source: Path, target: Path, dry_run: bool, log: list[str]) -
     _scaffold_artifact_readme_stubs(
         ui_root, target, dry_run, log, lwp.ARTIFACT_STUB_BUCKET_NAMES
     )
+    _scaffold_local_canvas_plan_buckets(ui_root, target, dry_run, log, lwp)
 
     for name in EXEMPLAR_TRACKERS:
         _copy_file_if_missing(exemplars / name, current / name, dry_run, log)

--- a/payload/.ai_infra/scripts/integration/checks.py
+++ b/payload/.ai_infra/scripts/integration/checks.py
@@ -25,7 +25,15 @@ REQUIRED_AGENT_MARKERS = (
     "## MCP integration",
     "workflow-kit",
     "mcp.registry.yaml",
+    "cursor_workflow mcp",
 )
+
+CANVAS_AGENT_MARKERS = (
+    "cursor_workflow canvas",
+    "canvas-artifacts",
+)
+
+CANVAS_AGENT_IDS = frozenset({"implementer", "integrator"})
 
 
 def agent_file_ids(agents_dir: Path) -> set[str]:
@@ -70,6 +78,18 @@ def check_all_agent_files(agents_dir: Path) -> list[str]:
         return violations
     for path in agents:
         violations.extend(check_agent_file(path))
+        if path.stem in CANVAS_AGENT_IDS:
+            violations.extend(check_canvas_agent_file(path))
+    return violations
+
+
+def check_canvas_agent_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    rel = path.name
+    violations: list[str] = []
+    for marker in CANVAS_AGENT_MARKERS:
+        if marker not in text:
+            violations.append(f"{rel}: missing canvas marker '{marker}'")
     return violations
 
 

--- a/payload/.ai_infra/scripts/pr/local_workflow_paths.py
+++ b/payload/.ai_infra/scripts/pr/local_workflow_paths.py
@@ -54,6 +54,19 @@ ARTIFACT_STUB_BUCKET_NAMES: tuple[str, ...] = tuple(p.name for p in WORKFLOW_ART
 # Default live planning trackers (index-and-planning/current/)
 PLANNING_CURRENT_DIR = Path(".local/index-and-planning/current")
 
+# Canvas / plan local evidence (ADR-010; gitignored Tier-2 runtime)
+LOCAL_CANVASES_DIR = Path(".local/canvases")
+LOCAL_PLANS_DIR = Path(".local/plans")
+LOCAL_CANVASES_INDEX = LOCAL_CANVASES_DIR / "index.md"
+LOCAL_PLANS_INDEX = LOCAL_PLANS_DIR / "index.md"
+REPO_CANVASES_DIR = Path("canvases")
+WORKFLOW_CANVAS_DIR = WORKFLOW_ARTIFACTS_DIR / "canvas"
+
+LOCAL_ARTIFACT_DIRS: tuple[Path, ...] = (
+    LOCAL_CANVASES_DIR,
+    LOCAL_PLANS_DIR,
+)
+
 # Fallback when `.local/user_settings/github.collaboration.yaml` is missing or incomplete.
 # Prefer resolve_github_user() from user_settings.py in PR scripts.
 DEFAULT_GITHUB_USER = "@YourGitHubHandle"
@@ -69,3 +82,11 @@ def ensure_workflow_artifacts_tree(*, root: Path | None = None) -> None:
 def ensure_workflow_artifacts_dir() -> None:
     """Create workflow artifact subdirectories if missing (cwd-relative)."""
     ensure_workflow_artifacts_tree()
+
+
+def ensure_local_artifact_tree(*, root: Path | None = None) -> None:
+    """Create `.local/canvases/` and `.local/plans/` if missing."""
+    base = Path(".") if root is None else root
+    for directory in LOCAL_ARTIFACT_DIRS:
+        (base / directory).mkdir(parents=True, exist_ok=True)
+    (base / WORKFLOW_CANVAS_DIR).mkdir(parents=True, exist_ok=True)

--- a/payload/.ai_infra/scripts/workflow/drift_checks.py
+++ b/payload/.ai_infra/scripts/workflow/drift_checks.py
@@ -863,6 +863,76 @@ def check_drift011(paths: DriftPaths) -> CheckResult:
     )
 
 
+def check_drift012(paths: DriftPaths) -> CheckResult:
+    """Advisory: .local/plans/ must not host live/current plan SSOT under board_only."""
+    collab = paths.root / ".local" / "user_settings" / "github.collaboration.yaml"
+    if not collab.is_file():
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="no github.collaboration.yaml — skipped",
+        )
+    try:
+        import yaml
+    except ImportError:
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="PyYAML missing — skipped",
+        )
+    try:
+        data = yaml.safe_load(collab.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=False,
+            detail=f"cannot parse collab YAML: {exc}",
+        )
+    ssot = data.get("project_ssot") if isinstance(data, dict) else None
+    if not isinstance(ssot, dict) or not ssot.get("enabled"):
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="project_ssot disabled — skipped",
+        )
+    if str(ssot.get("sync_policy") or "") != "board_only":
+        return CheckResult(
+            check_id="DRIFT-012",
+            severity=Severity.P2,
+            passed=True,
+            detail="sync_policy not board_only — skipped",
+        )
+
+    plans_dir = paths.root / ".local" / "plans"
+    issues: list[str] = []
+    if plans_dir.is_dir():
+        for path in plans_dir.iterdir():
+            if path.is_file() and "current" in path.name.lower():
+                issues.append(f"live-plan filename: {path.name}")
+        index = plans_dir / "index.md"
+        if index.is_file():
+            for line in index.read_text(encoding="utf-8").splitlines():
+                lower = line.lower()
+                if lower.startswith("|") and " active " in f" {lower} ":
+                    issues.append("index row marks plan as active")
+
+    passed = not issues
+    return CheckResult(
+        check_id="DRIFT-012",
+        severity=Severity.P2,
+        passed=passed,
+        detail=(
+            "board_only: .local/plans/ is snapshot-only"
+            if passed
+            else "; ".join(issues)
+        ),
+    )
+
+
 KIT_DEV_CHECKS = (
     check_drift001,
     check_drift002,
@@ -876,6 +946,7 @@ KIT_DEV_CHECKS = (
     check_drift009,
     check_drift010,
     check_drift011,
+    check_drift012,
 )
 
 CONSUMER_CHECKS = (
@@ -888,4 +959,5 @@ CONSUMER_BOARD_CHECKS = (
     check_drift008,
     check_drift009,
     check_drift010,
+    check_drift012,
 )

--- a/payload/.ai_infra/templates/local-workspace/artifact-stubs/canvases/README.md
+++ b/payload/.ai_infra/templates/local-workspace/artifact-stubs/canvases/README.md
@@ -1,0 +1,9 @@
+# `.local/canvases/` (session evidence)
+
+Gitignored ephemeral canvases saved from Cursor managed path or agent analysis.
+
+- **Product / onboarding canvases:** edit `canvases/*.canvas.tsx` in the repo (git SSOT).
+- **IDE preview:** `python3 -m cursor_workflow canvas sync --name <base>`
+- **Save ephemeral:** `python3 -m cursor_workflow canvas save --slug <slug>`
+
+See ADR-010 and `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.ai_infra/templates/local-workspace/artifact-stubs/plans/README.md
+++ b/payload/.ai_infra/templates/local-workspace/artifact-stubs/plans/README.md
@@ -1,0 +1,11 @@
+# `.local/plans/` (plan snapshot history)
+
+Dated plan-mode snapshots — **not** live SSOT. Under `board_only`, active plan lives on the GitHub Project card body.
+
+No Build chrome when opening these files directly — agents read and execute from here; humans use `plan open` for IDE Build.
+
+- **Snapshot:** `python3 -m cursor_workflow plan snapshot --slug <slug>`
+- **List:** `python3 -m cursor_workflow plan list`
+- **Build bridge (human):** `python3 -m cursor_workflow plan open --slug <slug>` (`--force` to overwrite Cursor twin)
+
+See ADR-010 and `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.ai_infra/templates/local-workspace/exemplars/local-canvases-index.md
+++ b/payload/.ai_infra/templates/local-workspace/exemplars/local-canvases-index.md
@@ -1,0 +1,18 @@
+<!--
+File: local-canvases-index.md
+Path: .ai_infra/templates/local-workspace/exemplars/local-canvases-index.md
+Role: Index for ephemeral session canvases under .local/canvases/
+Used By:
+ - scaffold.py → .local/canvases/index.md
+Notes:
+ - ADR-010. Product canvases stay in repo canvases/; this dir is gitignored evidence.
+-->
+
+# Local canvases index
+
+Ephemeral agent canvases (billing reviews, one-off analyses). **Not** git SSOT — use `canvases/` for product docs.
+
+| Slug | Saved (UTC) | Agent | Notes |
+|------|-------------|-------|-------|
+
+Sync to IDE preview: `python3 -m cursor_workflow canvas sync --from local --name <slug>`

--- a/payload/.ai_infra/templates/local-workspace/exemplars/local-plans-index.md
+++ b/payload/.ai_infra/templates/local-workspace/exemplars/local-plans-index.md
@@ -1,0 +1,18 @@
+<!--
+File: local-plans-index.md
+Path: .ai_infra/templates/local-workspace/exemplars/local-plans-index.md
+Role: Index for plan-mode snapshots under .local/plans/
+Used By:
+ - scaffold.py → .local/plans/index.md
+Notes:
+ - ADR-010. Live plan SSOT: board card (board_only) or plan.md offline — not this dir.
+-->
+
+# Local plan snapshots index
+
+Dated plan-mode history only. **Do not** treat rows here as active backlog or slice status.
+
+| Snapshot | Slug | Agent | Board item | Source |
+|----------|------|-------|------------|--------|
+
+List: `python3 -m cursor_workflow plan list` · Create: `python3 -m cursor_workflow plan snapshot --slug <slug>` · Human Build bridge: `python3 -m cursor_workflow plan open --slug <slug> [--force]`

--- a/payload/.ai_infra/templates/user-settings/README.md
+++ b/payload/.ai_infra/templates/user-settings/README.md
@@ -20,6 +20,7 @@ Notes:
 |----------|-----------|--------|
 | `exemplars/github.collaboration.yaml` | `.local/user_settings/github.collaboration.yaml` | Commit trailers, PR bodies, PR phase artifacts |
 | `exemplars/mcp.agents.yaml` | `.local/user_settings/mcp.agents.yaml` | `.cursor/mcp.user.json`, `.cursor/mcp.registry.yaml` |
+| `exemplars/mcp.secrets.yaml` | `.local/user_settings/mcp.secrets.yaml` | Pattern A `mcp auth` / `mcp call` secrets (gitignored; ADR-009) |
 | `exemplars/board-shell.schema.minimal.yaml` | `.local/user_settings/board-shell.schema.yaml` | Optional **2-view** bootstrap minimum ([Playground #3](https://github.com/users/SavinRazvan/projects/3)); manual copy; gitignored |
 
 **Agents:** Read completed files for attribution defaults and MCP intent. Wired integration:

--- a/payload/.ai_infra/templates/user-settings/exemplars/mcp.secrets.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/mcp.secrets.yaml
@@ -1,0 +1,16 @@
+# mcp.secrets.yaml — exemplar (copy to .local/user_settings/mcp.secrets.yaml)
+# Role: Store MCP auth material locally (gitignored). Never commit real tokens.
+# Apply: python3 -m cursor_workflow mcp auth --server <id> --token-env MY_TOKEN
+# Canon: ADR-009
+#
+# Example shape (do not commit real values):
+# version: 1
+# servers:
+#   my-api:
+#     token: "..."
+#     header: Authorization
+#     env:
+#       API_KEY: "..."
+
+version: 1
+servers: {}

--- a/payload/.cursor/agents/auditor.md
+++ b/payload/.cursor/agents/auditor.md
@@ -70,8 +70,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** When producing audit or alignment artifacts, persist session evidence via `canvas save` / `plan snapshot` under `.local/canvases/` and `.local/plans/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/board.md
+++ b/payload/.cursor/agents/board.md
@@ -97,5 +97,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Kit | `workflow-kit` | Trackers/gates if needed — prefer `cursor_workflow project` for board |
 | External | See `.cursor/mcp.registry.yaml` | Only if listed for `board` |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Live plan SSOT on the board card (`board_only`) or `plan.md` offline — `.local/plans/` is snapshot-only; `plan snapshot|list|open` for history / human Build bridge — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/drift-guard.md
+++ b/payload/.cursor/agents/drift-guard.md
@@ -8,7 +8,7 @@ description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/do
 
 ## What we guard (continuous)
 
-**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…011 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
+**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…012 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
 
 **Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
 
@@ -29,7 +29,7 @@ description: drift-guard MAS-SSOT-KIT — Continuous goal/plan/agent-doctrine/do
 **Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
 
 1. Run `python -m cursor_workflow drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when applicable; prefer a fresh `project export` snapshot for DRIFT-010).
+2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when applicable; prefer a fresh `project export` snapshot for DRIFT-010; **DRIFT-012** guards `.local/plans/` snapshot-only under `board_only`).
 3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
 4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
 5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
@@ -58,8 +58,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | Trackers/gates — prefer scripts |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for this agent |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
+| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Under `board_only`, `.local/plans/` is snapshot-only (**DRIFT-012**); live plan stays on the board card — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -77,5 +77,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 | Kit | `workflow-kit` | PR scripts, gates — prefer `cursor_workflow project` for board |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** `python3 -m cursor_workflow canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/integrator.md
+++ b/payload/.cursor/agents/integrator.md
@@ -90,8 +90,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | `workflow_list_session_agents`, trackers, governance — prefer over shell |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `integrator` |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
+| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** `python3 -m cursor_workflow canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -125,8 +125,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | `deepwiki` (worked example, zero-auth) — see `.cursor/mcp.registry.yaml` | GitHub repo docs/Q&A (`read_wiki_structure`, `read_wiki_contents`, `ask_question`); other listed servers only if connected for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`. Example: `mcp call --server deepwiki --tool ask_question --args-json '{"repo":"org/name","question":"..."}'`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Ephemeral analysis → persist via `canvas save`; not git SSOT — research packs stay under `_research_results/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -38,8 +38,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Test evidence stays under `.local/`; board/card Notes may pointer-only cite paths — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -42,8 +42,12 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer over re-running shell |
+| Kit | `workflow-kit` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
 | External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
 
-Before **CallMcpTool**: read tool descriptor schema. Do not invent tool names.
+**Pattern A (preferred):** `python3 -m cursor_workflow mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+
+Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
 User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
+
+**Canvas / plan (ADR-010):** Claims may cite `.local/plans/` snapshots and `.local/canvases/` evidence; live plan remains board card / `plan.md` — see `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/rules/implementation-workflow-governance.mdc
+++ b/payload/.cursor/rules/implementation-workflow-governance.mdc
@@ -27,6 +27,7 @@ alwaysApply: true
 - After substantive code change: `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when tests or risk change; `updates-log.md` (one line — see `.ai_infra/docs/operations/token-efficiency.md`).
 - Planning-only scope changes: update `plan.md` / `work-tracker.md` + at least one `updates-log.md` entry.
 - Blocked: mark blocker and unblock action in `work-tracker.md`.
+- **ADR-010:** `.local/plans/` is snapshot history only — live plan SSOT stays on the board card (`board_only`) or `plan.md` offline; see `canvas-artifacts` skill.
 - **Slice closure** (before handoff): regenerate `current/coverage-index.md` when coverage mattered; if a new tracker path is added, update `.local/agents-control-center/config/pages.json` and dashboard header **Depends On**; do not edit `.local/agents-control-center/audits/module-audit.html` unless refreshing that export.
 
 ## Merge gates

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
 - **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -34,6 +34,15 @@ When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Projec
 **Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
 **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
+## Two-tier plans (ADR-010)
+
+| Tier | Location | Role |
+|------|----------|------|
+| **Live** | Board card body (`board_only`) or `.local/index-and-planning/current/plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
+| **History** | `.local/plans/` (`plan snapshot`, `plan list`, `plan open` for human Build) | Dated snapshots + `index.md` — **never** competing Status or live plan under `board_only` (**DRIFT-012**) |
+
+Agents: `plan list` → read snapshot → execute. Exit: `plan snapshot --slug … --board-item …`. See `.cursor/skills/canvas-artifacts/SKILL.md`.
+
 ## First-run (board shell) — before day-to-day cards
 
 Day-0 requires the kit **default** shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Priority/Size/Estimate/Start date on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.

--- a/payload/.cursor/skills/canvas-artifacts/SKILL.md
+++ b/payload/.cursor/skills/canvas-artifacts/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: canvas-artifacts
+description: Three-tier canvas and plan snapshot workflow via cursor_workflow canvas/plan CLI (ADR-010).
+---
+
+# Canvas and plan artifacts (Pattern A)
+
+## When
+
+- Editing kit canvases in `canvases/` and needing IDE preview
+- Saving ephemeral analysis canvases for history
+- Exiting Plan mode and archiving a dated snapshot
+
+## Tiers (do not dual-write)
+
+| Tier | Path | Role |
+|------|------|------|
+| Git SSOT | `canvases/*.canvas.tsx` | Product / onboarding docs |
+| Cursor managed | `~/.cursor/projects/<workspace>/canvases/` | IDE render bridge only |
+| Local evidence | `.local/canvases/` | Session canvases (gitignored) |
+| Live plan | Board card body or `plan.md` (offline) | Writable SSOT |
+| Plan history | `.local/plans/<date>-<slug>.plan.md` | Snapshots only |
+
+## Canvas CLI
+
+```bash
+python3 -m cursor_workflow canvas doctor
+python3 -m cursor_workflow canvas list --tier all
+python3 -m cursor_workflow canvas sync --name mcp-onboarding
+python3 -m cursor_workflow canvas sync --missing
+python3 -m cursor_workflow canvas save --slug billing-review --agent implementer
+```
+
+- Use `export default function NameCanvas()` in `.canvas.tsx` files.
+- `sync --all` requires `--force` (avoid silent overwrite).
+
+## Plan CLI
+
+```bash
+python3 -m cursor_workflow plan snapshot --slug slice-170 --agent implementer --board-item PVTI_xxx
+python3 -m cursor_workflow plan list
+python3 -m cursor_workflow plan open --slug slice-170          # human Build bridge
+python3 -m cursor_workflow plan open --slug slice-170 --force  # overwrite Cursor twin
+python3 -m cursor_workflow plan snapshot --slug my-plan --from cursor-plan:my-plan.plan.md
+```
+
+Never treat `.local/plans/` as active backlog under `board_only`.
+
+## Agent rituals
+
+1. **Product canvas:** edit repo → `canvas sync --name …` → Open Canvas in IDE.
+2. **Ephemeral canvas:** write via Cursor canvas skill to managed path → `canvas save --slug …`.
+3. **Plan mode exit:** `plan snapshot --slug …` with board item id when known.
+
+### Consumer plans (agent build — Path A)
+
+Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
+
+1. `plan list` — discover slugs under `.local/plans/`
+2. Read `.local/plans/<latest>-<slug>.plan.md` (+ sibling `.meta.yaml`)
+3. Execute todos / acceptance as implementer (no Build required)
+4. **Human-only:** `plan open --slug …` → Plans UI → Build (copies latest snapshot to `~/.cursor/plans/<slug>.plan.md`)
+5. After plan-mode work in Cursor: `plan snapshot --from cursor-plan:…` to re-anchor history in `.local/plans/`
+
+`plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
+
+Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/payload/.cursor/skills/drift-audit/SKILL.md
+++ b/payload/.cursor/skills/drift-audit/SKILL.md
@@ -25,6 +25,7 @@ Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:
 - plan ↔ tracker ↔ session-pointer incoherence
 - **DRIFT-004b** session Board vs export; **DRIFT-009** dual-write; **DRIFT-010** board vs PRs
 - **DRIFT-011** `.cursor/agents` basenames == eight live kit agent ids
+- **DRIFT-012** `.local/plans/` snapshot-only under `board_only` (no live/current plan SSOT in that dir)
 - Prose goal pulse: board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards (flag gaps; hand off — do not rewrite architecture)
 
 Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
@@ -46,7 +47,7 @@ Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when kit-dev / board_only as applicable (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when kit-dev / board_only as applicable (ADR-007/008/010).
 3. Capture profile, check IDs, severities, and details from output.
 4. Add prose **Goal pulse** section in drift-audit.md (board/plan/AGENTS gaps). Fuzzy “vision mismatch” stays Probable — not CI.
 5. Write artifacts under `.local/workflow-artifacts/drift/` only.

--- a/payload/.cursor/skills/implementer-loop/SKILL.md
+++ b/payload/.cursor/skills/implementer-loop/SKILL.md
@@ -29,6 +29,8 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
 6. **Close (board-indexed):** when a PR exists → `mention-pr --pr N`; ensure Assignee via claim/`set-assignee --login` (Issue-at-create); `set-status --to in_review|done`; print `item_id=… · Status=… · Priority=p? · Size=? · Estimate=? · next=…` and `Tasks: [P…]…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
+**Plan mode / ADR-010:** Agents execute from `.local/plans/` via `plan list` → read latest snapshot; on slice exit use `plan snapshot --slug <kebab> --agent implementer --board-item <PVTI_>`. Live plan SSOT stays on the board card (`board_only`) or `plan.md` offline — never Status dual-write into `.local/plans/`. Humans bridge IDE Build with `plan open --slug <kebab>`. Canvas evidence: `canvas doctor|sync|save` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+
 ## Output
 
 Slice • item_id • Status before→after • Priority · Size · Estimate • modules/files • gates outcome • blockers • next agent · Tasks `[P…]`

--- a/payload/.cursor/skills/integrator-protocol/SKILL.md
+++ b/payload/.cursor/skills/integrator-protocol/SKILL.md
@@ -114,7 +114,16 @@ Follow `.ai_infra/docs/operations/connect-external-mcp.md` plus:
 3. Keys in `.cursor/mcp.registry.yaml` — `agents: [...]` per server
 4. `python -m cursor_workflow mcp validate`
 
-### D. New maintainer script
+### D. Canvases / plans (ADR-010)
+
+When touching `canvases/`, `.local/canvases/`, or `.local/plans/`:
+
+1. Read `.cursor/skills/canvas-artifacts/SKILL.md` and [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md).
+2. Repo `canvases/` = git SSOT → `canvas sync` → optional `canvas save` to `.local/canvases/`.
+3. `.local/plans/` = snapshot history only; live plan stays on board card / `plan.md` — wire `plan snapshot|list|open` in docs/agent cards as needed.
+4. After canvas edits: `python3 -m cursor_workflow canvas sync --name <stem>` (+ `canvas doctor` smoke).
+
+### E. New maintainer script
 
 - Lives under `.ai_infra/scripts/` — never duplicate `GATES` outside `prepare.py`
 - File header per `file-docstring-header-relations.mdc`

--- a/payload/.cursor/skills/mcp-connect/SKILL.md
+++ b/payload/.cursor/skills/mcp-connect/SKILL.md
@@ -16,30 +16,45 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 3. Add server entry to `mcp.user.json` **or** run:
 
 ```bash
-cursor-workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
+python3 -m cursor_workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
 ```
 
 4. Map the server to agents in `mcp.registry.yaml`
 5. Merge and validate:
 
 ```bash
-cursor-workflow mcp validate
+python3 -m cursor_workflow mcp validate
+python3 -m cursor_workflow mcp doctor
 ```
 
-6. Enable MCP in Cursor settings for the workspace.
+6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
 
-**Fastest way to validate this end-to-end:** the `deepwiki` entry already shipped in both
-example files is a free, zero-auth, remote server — copy the examples as-is (no secrets to
-fill in) and skip straight to step 5. Full walkthrough:
-`.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki.
+**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+
+```bash
+python3 -m cursor_workflow mcp list-tools --server workflow-kit
+python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_TOKEN
+python3 -m cursor_workflow mcp smoke --server workflow-kit
+```
+
+**Fastest external smoke:** DeepWiki (zero-auth) — copy examples, validate, then:
+
+```bash
+python3 -m cursor_workflow mcp smoke --server deepwiki
+```
+
+Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `cursor-workflow mcp validate` exits 0
-- `workflow_list_mcp_registry` (workflow-kit MCP) lists external servers
+- `python3 -m cursor_workflow mcp validate` exits 0
+- `python3 -m cursor_workflow mcp doctor` shows configured vs host-loaded
+- `mcp list-tools` / `mcp call` work for allowlisted servers
 - Target agent markdown includes the server under **MCP integration**
 
 ## Reference
 
 - `.ai_infra/docs/operations/connect-external-mcp.md`
 - `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
+- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -94,7 +94,7 @@ See [consumer-quickstart.md](../../.ai_infra/docs/operations/consumer-quickstart
 |-------|-----------------|---------------|
 | Cursor contract | `.cursor/`, `.agents/`, `AGENTS.md` | Yes |
 | Infrastructure | `.ai_infra/`, `cursor_workflow/` | No — scripts/CLI |
-| Runtime | `.local/` Tier 1 scaffold: trackers, six `workflow-artifacts/*` buckets + README stubs, `pages.json`, dashboards; `user_settings/` exemplars | No — gitignored |
+| Runtime | `.local/` Tier 1 scaffold: trackers, six `workflow-artifacts/*` buckets + README stubs, `.local/canvases/` + `.local/plans/` index stubs (ADR-010), `pages.json`, dashboards; `user_settings/` exemplars | No — gitignored |
 
 Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear when agents/scripts run. See [local-workspace-layout.md](../../.ai_infra/docs/operations/local-workspace-layout.md) § Artifact tiers. Re-activate does not overwrite existing trackers, `user_settings/`, or `AGENTS.md`. Kit-managed dashboard HTML, JS/CSS assets, `module-audit.html`, and `pages.json` are refreshed from the activate source (plugin `payload/` when resolved) or embedded `.ai_infra/templates/local-workspace/` when not.
 
@@ -116,7 +116,7 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 **Dashboards (optional):** from project root run `source .venv/bin/activate && python3 -m http.server 8000`, then open
 http://localhost:8000/.local/agents-control-center/dashboards/index.html (not `file://`).
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
+Optional: `integrate validate`, `health`, `canvas doctor` (ADR-010 three-tier canvases). Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 

--- a/rules/implementation-workflow-governance.mdc
+++ b/rules/implementation-workflow-governance.mdc
@@ -27,6 +27,7 @@ alwaysApply: true
 - After substantive code change: `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when tests or risk change; `updates-log.md` (one line — see `.ai_infra/docs/operations/token-efficiency.md`).
 - Planning-only scope changes: update `plan.md` / `work-tracker.md` + at least one `updates-log.md` entry.
 - Blocked: mark blocker and unblock action in `work-tracker.md`.
+- **ADR-010:** `.local/plans/` is snapshot history only — live plan SSOT stays on the board card (`board_only`) or `plan.md` offline; see `canvas-artifacts` skill.
 - **Slice closure** (before handoff): regenerate `current/coverage-index.md` when coverage mattered; if a new tracker path is added, update `.local/agents-control-center/config/pages.json` and dashboard header **Depends On**; do not edit `.local/agents-control-center/audits/module-audit.html` unless refreshing that export.
 
 ## Merge gates

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 - When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
 - **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
 - **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010; updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
+- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
 - Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
 - Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
 - Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -34,6 +34,15 @@ When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Projec
 **Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
 **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
+## Two-tier plans (ADR-010)
+
+| Tier | Location | Role |
+|------|----------|------|
+| **Live** | Board card body (`board_only`) or `.local/index-and-planning/current/plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
+| **History** | `.local/plans/` (`plan snapshot`, `plan list`, `plan open` for human Build) | Dated snapshots + `index.md` — **never** competing Status or live plan under `board_only` (**DRIFT-012**) |
+
+Agents: `plan list` → read snapshot → execute. Exit: `plan snapshot --slug … --board-item …`. See `.cursor/skills/canvas-artifacts/SKILL.md`.
+
 ## First-run (board shell) — before day-to-day cards
 
 Day-0 requires the kit **default** shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Priority/Size/Estimate/Start date on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.

--- a/skills/canvas-artifacts/SKILL.md
+++ b/skills/canvas-artifacts/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: canvas-artifacts
+description: Three-tier canvas and plan snapshot workflow via cursor_workflow canvas/plan CLI (ADR-010).
+---
+
+# Canvas and plan artifacts (Pattern A)
+
+## When
+
+- Editing kit canvases in `canvases/` and needing IDE preview
+- Saving ephemeral analysis canvases for history
+- Exiting Plan mode and archiving a dated snapshot
+
+## Tiers (do not dual-write)
+
+| Tier | Path | Role |
+|------|------|------|
+| Git SSOT | `canvases/*.canvas.tsx` | Product / onboarding docs |
+| Cursor managed | `~/.cursor/projects/<workspace>/canvases/` | IDE render bridge only |
+| Local evidence | `.local/canvases/` | Session canvases (gitignored) |
+| Live plan | Board card body or `plan.md` (offline) | Writable SSOT |
+| Plan history | `.local/plans/<date>-<slug>.plan.md` | Snapshots only |
+
+## Canvas CLI
+
+```bash
+python3 -m cursor_workflow canvas doctor
+python3 -m cursor_workflow canvas list --tier all
+python3 -m cursor_workflow canvas sync --name mcp-onboarding
+python3 -m cursor_workflow canvas sync --missing
+python3 -m cursor_workflow canvas save --slug billing-review --agent implementer
+```
+
+- Use `export default function NameCanvas()` in `.canvas.tsx` files.
+- `sync --all` requires `--force` (avoid silent overwrite).
+
+## Plan CLI
+
+```bash
+python3 -m cursor_workflow plan snapshot --slug slice-170 --agent implementer --board-item PVTI_xxx
+python3 -m cursor_workflow plan list
+python3 -m cursor_workflow plan open --slug slice-170          # human Build bridge
+python3 -m cursor_workflow plan open --slug slice-170 --force  # overwrite Cursor twin
+python3 -m cursor_workflow plan snapshot --slug my-plan --from cursor-plan:my-plan.plan.md
+```
+
+Never treat `.local/plans/` as active backlog under `board_only`.
+
+## Agent rituals
+
+1. **Product canvas:** edit repo → `canvas sync --name …` → Open Canvas in IDE.
+2. **Ephemeral canvas:** write via Cursor canvas skill to managed path → `canvas save --slug …`.
+3. **Plan mode exit:** `plan snapshot --slug …` with board item id when known.
+
+### Consumer plans (agent build — Path A)
+
+Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
+
+1. `plan list` — discover slugs under `.local/plans/`
+2. Read `.local/plans/<latest>-<slug>.plan.md` (+ sibling `.meta.yaml`)
+3. Execute todos / acceptance as implementer (no Build required)
+4. **Human-only:** `plan open --slug …` → Plans UI → Build (copies latest snapshot to `~/.cursor/plans/<slug>.plan.md`)
+5. After plan-mode work in Cursor: `plan snapshot --from cursor-plan:…` to re-anchor history in `.local/plans/`
+
+`plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
+
+Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/skills/drift-audit/SKILL.md
+++ b/skills/drift-audit/SKILL.md
@@ -25,6 +25,7 @@ Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:
 - plan ↔ tracker ↔ session-pointer incoherence
 - **DRIFT-004b** session Board vs export; **DRIFT-009** dual-write; **DRIFT-010** board vs PRs
 - **DRIFT-011** `.cursor/agents` basenames == eight live kit agent ids
+- **DRIFT-012** `.local/plans/` snapshot-only under `board_only` (no live/current plan SSOT in that dir)
 - Prose goal pulse: board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards (flag gaps; hand off — do not rewrite architecture)
 
 Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
@@ -46,7 +47,7 @@ Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 ## Steps
 
 1. **Board first (when enabled):** `python -m cursor_workflow project status` and `project list --status in_progress` — cite board Status in artifacts. Optionally refresh the read-only snapshot: `python -m cursor_workflow project export` (never writes Status).
-2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** when kit-dev / board_only as applicable (ADR-007/008).
+2. **Script:** `python -m cursor_workflow drift validate --directory .` (or `make drift-validate`). On **consumer app projects**, use `--profile consumer`. Include **DRIFT-004b** / **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when kit-dev / board_only as applicable (ADR-007/008/010).
 3. Capture profile, check IDs, severities, and details from output.
 4. Add prose **Goal pulse** section in drift-audit.md (board/plan/AGENTS gaps). Fuzzy “vision mismatch” stays Probable — not CI.
 5. Write artifacts under `.local/workflow-artifacts/drift/` only.

--- a/skills/implementer-loop/SKILL.md
+++ b/skills/implementer-loop/SKILL.md
@@ -29,6 +29,8 @@ New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slic
 5. **Commits:** trailers per `.cursor/rules/commit-trailer-format.mdc` (`Author`, `GitHub-User`; `Assisted-by:` when applicable; no `Made-with:`).
 6. **Close (board-indexed):** when a PR exists → `mention-pr --pr N`; ensure Assignee via claim/`set-assignee --login` (Issue-at-create); `set-status --to in_review|done`; print `item_id=… · Status=… · Priority=p? · Size=? · Estimate=? · next=…` and `Tasks: [P…]…`. Do **not** dual-write `work-tracker.md` under `board_only`. Fallback: close tracker + `updates-log.md`. Run **`make drift-validate`**; invoke **`drift-guard`** when P0/P1 findings need artifacts (drift-guard also reads/updates the board).
 
+**Plan mode / ADR-010:** Agents execute from `.local/plans/` via `plan list` → read latest snapshot; on slice exit use `plan snapshot --slug <kebab> --agent implementer --board-item <PVTI_>`. Live plan SSOT stays on the board card (`board_only`) or `plan.md` offline — never Status dual-write into `.local/plans/`. Humans bridge IDE Build with `plan open --slug <kebab>`. Canvas evidence: `canvas doctor|sync|save` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+
 ## Output
 
 Slice • item_id • Status before→after • Priority · Size · Estimate • modules/files • gates outcome • blockers • next agent · Tasks `[P…]`

--- a/skills/integrator-protocol/SKILL.md
+++ b/skills/integrator-protocol/SKILL.md
@@ -114,7 +114,16 @@ Follow `.ai_infra/docs/operations/connect-external-mcp.md` plus:
 3. Keys in `.cursor/mcp.registry.yaml` — `agents: [...]` per server
 4. `python -m cursor_workflow mcp validate`
 
-### D. New maintainer script
+### D. Canvases / plans (ADR-010)
+
+When touching `canvases/`, `.local/canvases/`, or `.local/plans/`:
+
+1. Read `.cursor/skills/canvas-artifacts/SKILL.md` and [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md).
+2. Repo `canvases/` = git SSOT → `canvas sync` → optional `canvas save` to `.local/canvases/`.
+3. `.local/plans/` = snapshot history only; live plan stays on board card / `plan.md` — wire `plan snapshot|list|open` in docs/agent cards as needed.
+4. After canvas edits: `python3 -m cursor_workflow canvas sync --name <stem>` (+ `canvas doctor` smoke).
+
+### E. New maintainer script
 
 - Lives under `.ai_infra/scripts/` — never duplicate `GATES` outside `prepare.py`
 - File header per `file-docstring-header-relations.mdc`

--- a/skills/mcp-connect/SKILL.md
+++ b/skills/mcp-connect/SKILL.md
@@ -16,30 +16,45 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 3. Add server entry to `mcp.user.json` **or** run:
 
 ```bash
-cursor-workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
+python3 -m cursor_workflow mcp link --name my-api --file .cursor/mcp.d/my-api.json
 ```
 
 4. Map the server to agents in `mcp.registry.yaml`
 5. Merge and validate:
 
 ```bash
-cursor-workflow mcp validate
+python3 -m cursor_workflow mcp validate
+python3 -m cursor_workflow mcp doctor
 ```
 
-6. Enable MCP in Cursor settings for the workspace.
+6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
 
-**Fastest way to validate this end-to-end:** the `deepwiki` entry already shipped in both
-example files is a free, zero-auth, remote server — copy the examples as-is (no secrets to
-fill in) and skip straight to step 5. Full walkthrough:
-`.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki.
+**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+
+```bash
+python3 -m cursor_workflow mcp list-tools --server workflow-kit
+python3 -m cursor_workflow mcp call --server workflow-kit --tool workflow_gate_count
+python3 -m cursor_workflow mcp auth --server my-api --token-env MY_TOKEN
+python3 -m cursor_workflow mcp smoke --server workflow-kit
+```
+
+**Fastest external smoke:** DeepWiki (zero-auth) — copy examples, validate, then:
+
+```bash
+python3 -m cursor_workflow mcp smoke --server deepwiki
+```
+
+Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `cursor-workflow mcp validate` exits 0
-- `workflow_list_mcp_registry` (workflow-kit MCP) lists external servers
+- `python3 -m cursor_workflow mcp validate` exits 0
+- `python3 -m cursor_workflow mcp doctor` shows configured vs host-loaded
+- `mcp list-tools` / `mcp call` work for allowlisted servers
 - Target agent markdown includes the server under **MCP integration**
 
 ## Reference
 
 - `.ai_infra/docs/operations/connect-external-mcp.md`
 - `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
+- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -94,7 +94,7 @@ See [consumer-quickstart.md](../../.ai_infra/docs/operations/consumer-quickstart
 |-------|-----------------|---------------|
 | Cursor contract | `.cursor/`, `.agents/`, `AGENTS.md` | Yes |
 | Infrastructure | `.ai_infra/`, `cursor_workflow/` | No — scripts/CLI |
-| Runtime | `.local/` Tier 1 scaffold: trackers, six `workflow-artifacts/*` buckets + README stubs, `pages.json`, dashboards; `user_settings/` exemplars | No — gitignored |
+| Runtime | `.local/` Tier 1 scaffold: trackers, six `workflow-artifacts/*` buckets + README stubs, `.local/canvases/` + `.local/plans/` index stubs (ADR-010), `pages.json`, dashboards; `user_settings/` exemplars | No — gitignored |
 
 Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear when agents/scripts run. See [local-workspace-layout.md](../../.ai_infra/docs/operations/local-workspace-layout.md) § Artifact tiers. Re-activate does not overwrite existing trackers, `user_settings/`, or `AGENTS.md`. Kit-managed dashboard HTML, JS/CSS assets, `module-audit.html`, and `pages.json` are refreshed from the activate source (plugin `payload/` when resolved) or embedded `.ai_infra/templates/local-workspace/` when not.
 
@@ -116,7 +116,7 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 **Dashboards (optional):** from project root run `source .venv/bin/activate && python3 -m http.server 8000`, then open
 http://localhost:8000/.local/agents-control-center/dashboards/index.html (not `file://`).
 
-Optional: `integrate validate`, `health`. Add infrastructure later: **`/integrator`**.
+Optional: `integrate validate`, `health`, `canvas doctor` (ADR-010 three-tier canvases). Add infrastructure later: **`/integrator`**.
 
 ## Adding agents/skills/MCP later
 

--- a/tests/modules/canvas_artifacts/test_canvas_cli.py
+++ b/tests/modules/canvas_artifacts/test_canvas_cli.py
@@ -1,0 +1,104 @@
+"""
+File: test_canvas_cli.py
+Path: tests/modules/canvas_artifacts/test_canvas_cli.py
+Role: Tests for canvas Pattern A CLI.
+Used By:
+ - pytest
+Depends On:
+ - canvas_manage, canvas_cli
+Notes:
+ - Monkeypatches Cursor managed dir resolution.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+CANVAS_SRC = """import { Stack, Text } from "cursor/canvas";
+export default function DemoCanvas() {
+  return <Stack><Text>demo</Text></Stack>;
+}
+"""
+
+
+def _load(name: str):
+    if str(PKG) not in sys.path:
+        sys.path.insert(0, str(PKG))
+    spec = importlib.util.spec_from_file_location(name, PKG / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_lwp(root: Path) -> None:
+    pr = root / ".ai_infra" / "scripts" / "pr"
+    pr.mkdir(parents=True)
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "local_workflow_paths.py"
+    (pr / "local_workflow_paths.py").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _layout(root: Path) -> tuple[Path, Path, Path]:
+    _seed_lwp(root)
+    repo = root / "canvases"
+    managed = root / "managed-canvases"
+    local = root / ".local" / "canvases"
+    repo.mkdir(parents=True)
+    managed.mkdir(parents=True)
+    local.mkdir(parents=True)
+    (repo / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    return repo, managed, local
+
+
+def test_sync_name_repo_to_managed(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("canvas_manage")
+    repo, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    copied = manage.sync_canvas(tmp_path, name="demo", source="repo")
+    assert copied == ["demo.canvas.tsx"]
+    assert (managed / "demo.canvas.tsx").is_file()
+
+
+def test_sync_all_requires_force(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("canvas_manage")
+    repo, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    try:
+        manage.sync_canvas(tmp_path, sync_all=True, force=False, source="repo")
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "--force" in str(exc)
+
+
+def test_sync_missing_only(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("canvas_manage")
+    repo, managed, _ = _layout(tmp_path)
+    original = "export default function Old() { return null; }"
+    (managed / "existing.canvas.tsx").write_text(original, encoding="utf-8")
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    copied = manage.sync_canvas(tmp_path, missing=True, source="repo")
+    assert copied == ["demo.canvas.tsx"]
+    assert (managed / "existing.canvas.tsx").read_text() == original
+
+
+def test_save_managed_to_local(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("canvas_manage")
+    _, managed, local = _layout(tmp_path)
+    (managed / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    dst = manage.save_canvas(tmp_path, slug="demo", source="managed", agent="implementer")
+    assert dst == local / "demo.canvas.tsx"
+    assert dst.is_file()
+
+
+def test_doctor_reports_repo_not_managed(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("canvas_manage")
+    repo, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    report = manage.build_doctor_report(tmp_path)
+    assert "demo" in report["repo_not_managed"]

--- a/tests/modules/canvas_artifacts/test_canvas_cli_dispatch.py
+++ b/tests/modules/canvas_artifacts/test_canvas_cli_dispatch.py
@@ -1,0 +1,163 @@
+"""
+File: test_canvas_cli_dispatch.py
+Path: tests/modules/canvas_artifacts/test_canvas_cli_dispatch.py
+Role: Dispatch coverage for canvas_cli via cli.main (ADR-010).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/cli.py
+ - .ai_infra/install/cursor_workflow/canvas_cli.py
+ - .ai_infra/install/cursor_workflow/canvas_manage.py
+Notes:
+ - Imports package modules via sys.path so coverage attributes correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import canvas_manage  # noqa: E402
+import cli  # noqa: E402
+
+CANVAS_SRC = """import { Stack, Text } from "cursor/canvas";
+export default function DemoCanvas() {
+  return <Stack><Text>demo</Text></Stack>;
+}
+"""
+
+CANVAS_SEPARATE_EXPORT = """function Demo() { return null; }
+export default Demo;
+"""
+
+
+def _seed_lwp(root: Path) -> None:
+    pr = root / ".ai_infra" / "scripts" / "pr"
+    pr.mkdir(parents=True)
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "local_workflow_paths.py"
+    (pr / "local_workflow_paths.py").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    exemplars = root / ".ai_infra" / "templates" / "local-workspace" / "exemplars"
+    exemplars.mkdir(parents=True)
+    for name in ("local-canvases-index.md", "local-plans-index.md"):
+        src_idx = REPO_ROOT / ".ai_infra" / "templates" / "local-workspace" / "exemplars" / name
+        if src_idx.is_file():
+            (exemplars / name).write_text(src_idx.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _layout(root: Path) -> tuple[Path, Path, Path]:
+    _seed_lwp(root)
+    repo = root / "canvases"
+    managed = root / "managed-canvases"
+    local = root / ".local" / "canvases"
+    repo.mkdir(parents=True)
+    managed.mkdir(parents=True)
+    local.mkdir(parents=True)
+    (repo / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    return repo, managed, local
+
+
+def test_canvas_doctor_writes_artifact(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    assert cli.main(["canvas", "doctor", "--directory", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "# Canvas doctor" in out
+    assert "artifact:" in out
+    arts = list((tmp_path / ".local" / "workflow-artifacts" / "canvas").glob("doctor-*.md"))
+    assert len(arts) == 1
+
+
+def test_canvas_list_empty_tiers(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: None)
+    assert cli.main(["canvas", "list", "--directory", str(tmp_path), "--tier", "all"]) == 0
+    out = capsys.readouterr().out
+    assert "(none)" in out
+
+
+def test_canvas_list_repo_tier(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    assert cli.main(["canvas", "list", "--directory", str(tmp_path), "--tier", "repo"]) == 0
+    out = capsys.readouterr().out
+    assert "[repo]" in out
+    assert "demo.canvas.tsx" in out
+
+
+def test_canvas_sync_missing_source(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    code = cli.main(["canvas", "sync", "--directory", str(tmp_path), "--name", "nope"])
+    assert code == canvas_manage.EXIT_NOT_FOUND
+    err = capsys.readouterr().err
+    assert "FAIL" in err
+
+
+def test_canvas_sync_all_without_force(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    code = cli.main(["canvas", "sync", "--directory", str(tmp_path), "--all"])
+    assert code == canvas_manage.EXIT_USAGE
+    assert "FAIL" in capsys.readouterr().err
+
+
+def test_canvas_sync_all_force(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    assert cli.main(["canvas", "sync", "--directory", str(tmp_path), "--all", "--force"]) == 0
+    out = capsys.readouterr().out
+    assert "copied" in out
+    assert (managed / "demo.canvas.tsx").is_file()
+
+
+def test_canvas_sync_nothing_to_copy(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo, managed, _ = _layout(tmp_path)
+    (managed / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    assert cli.main(["canvas", "sync", "--directory", str(tmp_path), "--missing"]) == 0
+    assert "nothing to copy" in capsys.readouterr().out
+
+
+def test_canvas_sync_by_name(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    assert cli.main(["canvas", "sync", "--directory", str(tmp_path), "--name", "demo"]) == 0
+    assert "copied 1" in capsys.readouterr().out
+
+
+def test_canvas_save_with_validation_warnings(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    (managed / "demo.canvas.tsx").write_text(CANVAS_SEPARATE_EXPORT, encoding="utf-8")
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    assert cli.main(
+        ["canvas", "save", "--directory", str(tmp_path), "--slug", "demo", "--agent", "implementer"]
+    ) == 0
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err
+    assert "canvas save:" in captured.out
+
+
+def test_canvas_save_not_found(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    code = cli.main(["canvas", "save", "--directory", str(tmp_path), "--slug", "missing"])
+    assert code == canvas_manage.EXIT_NOT_FOUND
+
+
+def test_canvas_save_invalid_slug(tmp_path: Path, monkeypatch, capsys) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    code = cli.main(["canvas", "save", "--directory", str(tmp_path), "--slug", "Bad_Name"])
+    assert code == canvas_manage.EXIT_VALIDATION

--- a/tests/modules/canvas_artifacts/test_canvas_manage_edges.py
+++ b/tests/modules/canvas_artifacts/test_canvas_manage_edges.py
@@ -1,0 +1,216 @@
+"""
+File: test_canvas_manage_edges.py
+Path: tests/modules/canvas_artifacts/test_canvas_manage_edges.py
+Role: Edge coverage for canvas_manage miss lines (ADR-010).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/canvas_manage.py
+Notes:
+ - Direct imports via sys.path for coverage attribution.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import canvas_manage  # noqa: E402
+
+CANVAS_SRC = """import { Stack, Text } from "cursor/canvas";
+export default function DemoCanvas() {
+  return <Stack><Text>demo</Text></Stack>;
+}
+"""
+
+
+def _seed_lwp(root: Path) -> None:
+    pr = root / ".ai_infra" / "scripts" / "pr"
+    pr.mkdir(parents=True)
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "local_workflow_paths.py"
+    (pr / "local_workflow_paths.py").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    exemplars = root / ".ai_infra" / "templates" / "local-workspace" / "exemplars"
+    exemplars.mkdir(parents=True)
+    for name in ("local-canvases-index.md",):
+        src_idx = REPO_ROOT / ".ai_infra" / "templates" / "local-workspace" / "exemplars" / name
+        if src_idx.is_file():
+            (exemplars / name).write_text(src_idx.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _layout(root: Path) -> tuple[Path, Path, Path]:
+    _seed_lwp(root)
+    repo = root / "canvases"
+    managed = root / "managed-canvases"
+    local = root / ".local" / "canvases"
+    repo.mkdir(parents=True)
+    managed.mkdir(parents=True)
+    local.mkdir(parents=True)
+    (repo / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    return repo, managed, local
+
+
+def test_canvas_filename_invalid() -> None:
+    with pytest.raises(ValueError, match="kebab-case"):
+        canvas_manage.canvas_filename("Bad Name")
+
+
+def test_list_canvases_none_and_missing(tmp_path: Path) -> None:
+    assert canvas_manage.list_canvases_in_dir(None) == []
+    assert canvas_manage.list_canvases_in_dir(tmp_path / "nope") == []
+
+
+def test_canvas_base_without_suffix() -> None:
+    assert canvas_manage.canvas_base("plain") == "plain"
+    assert canvas_manage.canvas_base("x.canvas.tsx") == "x"
+
+
+def test_validate_canvas_source_variants() -> None:
+    assert canvas_manage.validate_canvas_source(CANVAS_SRC) == []
+    warns = canvas_manage.validate_canvas_source("export default Foo;")
+    assert any("separate" in w for w in warns)
+    warns2 = canvas_manage.validate_canvas_source("no export here")
+    assert any("missing" in w for w in warns2)
+
+
+def test_format_doctor_markdown_missing_dirs(tmp_path: Path, monkeypatch) -> None:
+    _seed_lwp(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: None)
+    report = canvas_manage.build_doctor_report(tmp_path)
+    body = canvas_manage.format_doctor_markdown(report)
+    assert "(missing)" in body or "(not found)" in body
+    assert "repo not in managed" in body
+
+
+def test_stale_managed_detection(tmp_path: Path, monkeypatch) -> None:
+    repo, managed, _ = _layout(tmp_path)
+    (managed / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    now = time.time()
+    os.utime(managed / "demo.canvas.tsx", (now - 100, now - 100))
+    os.utime(repo / "demo.canvas.tsx", (now, now))
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    report = canvas_manage.build_doctor_report(tmp_path)
+    assert "demo" in report["stale_managed"]
+
+
+def test_sync_creates_managed_when_missing(tmp_path: Path, monkeypatch) -> None:
+    repo, _, _ = _layout(tmp_path)
+    project = tmp_path / "cursor-project"
+    project.mkdir()
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: None)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_project_dir", lambda _r: project)
+    copied = canvas_manage.sync_canvas(tmp_path, name="demo", source="repo")
+    assert copied == ["demo.canvas.tsx"]
+    assert (project / "canvases" / "demo.canvas.tsx").is_file()
+
+
+def test_sync_no_project_dir(tmp_path: Path, monkeypatch) -> None:
+    _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: None)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_project_dir", lambda _r: None)
+    with pytest.raises(FileNotFoundError, match="managed project"):
+        canvas_manage.sync_canvas(tmp_path, name="demo", source="repo")
+
+
+def test_sync_source_missing(tmp_path: Path, monkeypatch) -> None:
+    _seed_lwp(tmp_path)
+    managed = tmp_path / "m"
+    managed.mkdir()
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    with pytest.raises(FileNotFoundError, match="source tier"):
+        canvas_manage.sync_canvas(tmp_path, name="demo", source="local")
+
+
+def test_sync_requires_name(tmp_path: Path, monkeypatch) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    with pytest.raises(ValueError, match="--name"):
+        canvas_manage.sync_canvas(tmp_path, source="repo")
+
+
+def test_sync_from_local(tmp_path: Path, monkeypatch) -> None:
+    _, managed, local = _layout(tmp_path)
+    (local / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    copied = canvas_manage.sync_canvas(tmp_path, name="demo", source="local")
+    assert copied == ["demo.canvas.tsx"]
+
+
+def test_sync_missing_named_file(tmp_path: Path, monkeypatch) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    with pytest.raises(FileNotFoundError, match="missing source canvas"):
+        canvas_manage.sync_canvas(tmp_path, name="ghost", source="repo")
+
+
+def test_save_missing_source_dir(tmp_path: Path, monkeypatch) -> None:
+    _seed_lwp(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: None)
+    with pytest.raises(FileNotFoundError, match="source tier"):
+        canvas_manage.save_canvas(tmp_path, slug="demo", source="managed")
+
+
+def test_save_from_repo_and_index_dedup(tmp_path: Path, monkeypatch) -> None:
+    repo, managed, local = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    # ensure index exists for append + dedup paths
+    index = local / "index.md"
+    index.write_text(
+        "# Canvases\n\n| slug | saved_utc | agent | note |\n| --- | --- | --- | --- |\n",
+        encoding="utf-8",
+    )
+    dst = canvas_manage.save_canvas(tmp_path, slug="demo", source="repo", agent="implementer")
+    assert dst == local / "demo.canvas.tsx"
+    text1 = index.read_text(encoding="utf-8")
+    assert "demo" in text1
+    # second save same slug — dedup (slug already in index)
+    canvas_manage.save_canvas(tmp_path, slug="demo", source="repo", agent="auditor")
+    text2 = index.read_text(encoding="utf-8")
+    assert text1.count("| demo |") == text2.count("| demo |")
+
+
+def test_save_missing_file(tmp_path: Path, monkeypatch) -> None:
+    _, managed, _ = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    with pytest.raises(FileNotFoundError, match="missing canvas"):
+        canvas_manage.save_canvas(tmp_path, slug="nope", source="repo")
+
+
+def test_save_from_local_source_branch(tmp_path: Path, monkeypatch) -> None:
+    """Cover save_canvas else-branch (source=local) without SameFileError."""
+    _, managed, local = _layout(tmp_path)
+    monkeypatch.setattr(canvas_manage.cursor_host_paths, "cursor_canvases_dir", lambda _r: managed)
+    with pytest.raises(FileNotFoundError, match="missing canvas"):
+        canvas_manage.save_canvas(tmp_path, slug="demo", source="local")
+    # now with file present — mock copy to avoid SameFileError
+    (local / "demo.canvas.tsx").write_text(CANVAS_SRC, encoding="utf-8")
+    monkeypatch.setattr(canvas_manage, "_copy_canvas", lambda src, dst: None)
+    monkeypatch.setattr(canvas_manage, "_append_canvas_index", lambda *a, **k: None)
+    dst = canvas_manage.save_canvas(tmp_path, slug="demo", source="local")
+    assert dst == local / "demo.canvas.tsx"
+
+
+def test_append_index_writes_row(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    local = tmp_path / ".local" / "canvases"
+    local.mkdir(parents=True)
+    index = local / "index.md"
+    index.write_text("# idx\n\n| slug | t | a | n |\n", encoding="utf-8")
+    canvas_manage._append_canvas_index(tmp_path, slug="fresh", agent="implementer")
+    assert "fresh" in index.read_text(encoding="utf-8")
+    canvas_manage._append_canvas_index(tmp_path, slug="fresh", agent=None)  # dedup
+
+
+def test_append_index_no_file(tmp_path: Path) -> None:
+    """Index append is a no-op when index file is absent."""
+    _seed_lwp(tmp_path)
+    canvas_manage._append_canvas_index(tmp_path, slug="x", agent=None)

--- a/tests/modules/canvas_artifacts/test_cursor_host_paths.py
+++ b/tests/modules/canvas_artifacts/test_cursor_host_paths.py
@@ -1,0 +1,102 @@
+"""
+File: test_cursor_host_paths.py
+Path: tests/modules/canvas_artifacts/test_cursor_host_paths.py
+Role: Tests for Cursor managed path resolution.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/cursor_host_paths.py
+Notes:
+ - Uses temporary fake ~/.cursor/projects layout; direct import for coverage.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import cursor_host_paths as mod  # noqa: E402
+
+
+def test_cursor_project_dir_exact_slug(tmp_path: Path, monkeypatch) -> None:
+    projects = tmp_path / "projects"
+    workspace = tmp_path / "home" / "user" / "Projects" / "my-app"
+    workspace.mkdir(parents=True)
+    slug_dir = projects / "home-user-Projects-my-app"
+    slug_dir.mkdir(parents=True)
+    (slug_dir / "canvases").mkdir()
+    (slug_dir / "mcps").mkdir()
+    monkeypatch.setattr(mod, "cursor_projects_home", lambda: projects)
+
+    found = mod.cursor_project_dir(workspace)
+    assert found == slug_dir
+    assert mod.cursor_canvases_dir(workspace) == slug_dir / "canvases"
+    assert mod.cursor_project_mcps_dir(workspace) == slug_dir / "mcps"
+
+
+def test_cursor_project_dir_fuzzy_suffix(tmp_path: Path, monkeypatch) -> None:
+    projects = tmp_path / "projects"
+    workspace = tmp_path / "somewhere" / "my-app"
+    workspace.mkdir(parents=True)
+    slug_dir = projects / "weird-prefix-my-app"
+    slug_dir.mkdir(parents=True)
+    (slug_dir / "canvases").mkdir()
+    monkeypatch.setattr(mod, "cursor_projects_home", lambda: projects)
+
+    assert mod.cursor_project_dir(workspace) == slug_dir
+
+
+def test_cursor_projects_home() -> None:
+    assert mod.cursor_projects_home() == Path.home() / ".cursor" / "projects"
+
+
+def test_cursor_plans_dir() -> None:
+    assert mod.cursor_plans_dir() == Path.home() / ".cursor" / "plans"
+
+
+def test_cursor_projects_home_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "cursor_projects_home", lambda: tmp_path / "no-projects")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    assert mod.cursor_project_dir(workspace) is None
+    assert mod.cursor_canvases_dir(workspace) is None
+    assert mod.cursor_project_mcps_dir(workspace) is None
+
+
+def test_cursor_project_dir_no_fuzzy_match(tmp_path: Path, monkeypatch) -> None:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    (projects / "unrelated-other").mkdir()
+    workspace = tmp_path / "nowhere" / "unique-app-xyz"
+    workspace.mkdir(parents=True)
+    monkeypatch.setattr(mod, "cursor_projects_home", lambda: projects)
+    assert mod.cursor_project_dir(workspace) is None
+
+
+def test_cursor_canvases_dir_no_canvases_subdir(tmp_path: Path, monkeypatch) -> None:
+    projects = tmp_path / "projects"
+    workspace = tmp_path / "home" / "user" / "Projects" / "app"
+    workspace.mkdir(parents=True)
+    slug_dir = projects / "home-user-Projects-app"
+    slug_dir.mkdir(parents=True)
+    monkeypatch.setattr(mod, "cursor_projects_home", lambda: projects)
+    assert mod.cursor_project_dir(workspace) == slug_dir
+    assert mod.cursor_canvases_dir(workspace) is None
+    assert mod.cursor_project_mcps_dir(workspace) is None
+
+
+def test_cursor_project_dir_non_home_prefix(tmp_path: Path, monkeypatch) -> None:
+    projects = tmp_path / "projects"
+    workspace = tmp_path / "opt" / "apps" / "kit"
+    workspace.mkdir(parents=True)
+    slug = "home-" + str(workspace).lstrip("/").replace("/", "-")
+    slug_dir = projects / slug
+    slug_dir.mkdir(parents=True)
+    monkeypatch.setattr(mod, "cursor_projects_home", lambda: projects)
+    assert mod.cursor_project_dir(workspace) == slug_dir

--- a/tests/modules/canvas_artifacts/test_plan_cli.py
+++ b/tests/modules/canvas_artifacts/test_plan_cli.py
@@ -1,0 +1,159 @@
+"""
+File: test_plan_cli.py
+Path: tests/modules/canvas_artifacts/test_plan_cli.py
+Role: Tests for plan snapshot CLI.
+Used By:
+ - pytest
+Depends On:
+ - plan_manage
+Notes:
+ - Uses temporary plan sources and .local/plans layout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+
+def _load(name: str):
+    if str(PKG) not in sys.path:
+        sys.path.insert(0, str(PKG))
+    spec = importlib.util.spec_from_file_location(name, PKG / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_lwp(root: Path) -> None:
+    pr = root / ".ai_infra" / "scripts" / "pr"
+    pr.mkdir(parents=True)
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "local_workflow_paths.py"
+    (pr / "local_workflow_paths.py").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    ui = root / ".ai_infra" / "templates" / "local-workspace" / "exemplars"
+    ui.mkdir(parents=True)
+    idx = REPO_ROOT / ".ai_infra" / "templates" / "local-workspace" / "exemplars" / "local-plans-index.md"
+    (ui / "local-plans-index.md").write_text(idx.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def test_snapshot_from_plan_md(tmp_path: Path) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    plan_dir = tmp_path / ".local" / "index-and-planning" / "current"
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "plan.md").write_text("# Plan\n\nSlice work.\n", encoding="utf-8")
+
+    dst, meta = manage.snapshot_plan(tmp_path, slug="slice-one", from_spec="plan.md", agent="implementer")
+    assert dst.is_file()
+    assert meta is not None and meta.is_file()
+    assert "Slice work" in dst.read_text(encoding="utf-8")
+
+
+def test_snapshot_from_cursor_plan(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    cursor_plans = tmp_path / "cursor-plans"
+    cursor_plans.mkdir()
+    (cursor_plans / "my-plan.plan.md").write_text("# Cursor plan\n", encoding="utf-8")
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_plans_dir", lambda: cursor_plans)
+
+    dst, _ = manage.snapshot_plan(tmp_path, slug="my-plan", from_spec="cursor-plan:my-plan")
+    assert dst.is_file()
+    assert "# Cursor plan" in dst.read_text(encoding="utf-8")
+
+
+def test_list_snapshots(tmp_path: Path) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    plan_dir = tmp_path / ".local" / "index-and-planning" / "current"
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    manage.snapshot_plan(
+        tmp_path,
+        slug="alpha",
+        agent="implementer",
+        board_item="PVTI_test",
+    )
+    rows = manage.list_snapshots(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["slug"] == "alpha"
+    assert rows[0]["agent"] == "implementer"
+    assert rows[0]["board_item"] == "PVTI_test"
+    assert rows[0]["source"]  # absolute path to plan.md
+
+
+def _write_snapshot(plans_dir: Path, base: str, slug: str, body: str) -> Path:
+    path = plans_dir / f"{base}.plan.md"
+    path.write_text(body, encoding="utf-8")
+    meta_path = plans_dir / f"{base}.meta.yaml"
+    meta_path.write_text(f"slug: {slug}\n", encoding="utf-8")
+    return path
+
+
+def test_find_latest_snapshot(tmp_path: Path) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    plans_dir = tmp_path / ".local" / "plans"
+    plans_dir.mkdir(parents=True)
+    older = _write_snapshot(plans_dir, "2026-08-01-alpha", "alpha", "older\n")
+    newer = _write_snapshot(plans_dir, "2026-08-05-alpha", "alpha", "newer\n")
+    import os
+    import time
+
+    os.utime(older, (time.time() - 3600, time.time() - 3600))
+    os.utime(newer, (time.time(), time.time()))
+
+    latest = manage.find_latest_snapshot(tmp_path, "alpha")
+    assert latest == newer
+    assert "newer" in latest.read_text(encoding="utf-8")
+
+
+def test_open_plan_copies(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    plans_dir = tmp_path / ".local" / "plans"
+    plans_dir.mkdir(parents=True)
+    _write_snapshot(plans_dir, "2026-08-05-bridge", "bridge", "---\nname: bridge\n---\n# Plan\n")
+
+    cursor_plans = tmp_path / "cursor-plans"
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_plans_dir", lambda: cursor_plans)
+
+    dest = manage.open_plan(tmp_path, slug="bridge")
+    assert dest == cursor_plans / "bridge.plan.md"
+    assert dest.is_file()
+    assert dest.read_text(encoding="utf-8") == (plans_dir / "2026-08-05-bridge.plan.md").read_text(encoding="utf-8")
+
+
+def test_open_plan_requires_force(tmp_path: Path, monkeypatch) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    plans_dir = tmp_path / ".local" / "plans"
+    plans_dir.mkdir(parents=True)
+    _write_snapshot(plans_dir, "2026-08-05-force", "force-test", "v1\n")
+
+    cursor_plans = tmp_path / "cursor-plans"
+    cursor_plans.mkdir()
+    (cursor_plans / "force-test.plan.md").write_text("existing\n", encoding="utf-8")
+    monkeypatch.setattr(manage.cursor_host_paths, "cursor_plans_dir", lambda: cursor_plans)
+
+    import pytest
+
+    with pytest.raises(ValueError, match="--force"):
+        manage.open_plan(tmp_path, slug="force-test")
+
+    dest = manage.open_plan(tmp_path, slug="force-test", force=True)
+    assert "v1" in dest.read_text(encoding="utf-8")
+
+
+def test_open_plan_missing_slug(tmp_path: Path) -> None:
+    manage = _load("plan_manage")
+    _seed_lwp(tmp_path)
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        manage.open_plan(tmp_path, slug="missing-slug")

--- a/tests/modules/canvas_artifacts/test_plan_cli_dispatch.py
+++ b/tests/modules/canvas_artifacts/test_plan_cli_dispatch.py
@@ -1,0 +1,171 @@
+"""
+File: test_plan_cli_dispatch.py
+Path: tests/modules/canvas_artifacts/test_plan_cli_dispatch.py
+Role: Dispatch coverage for plan_cli via cli.main (ADR-010).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/cli.py
+ - .ai_infra/install/cursor_workflow/plan_cli.py
+ - .ai_infra/install/cursor_workflow/plan_manage.py
+Notes:
+ - Imports package modules via sys.path so coverage attributes correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import cli  # noqa: E402
+import plan_manage  # noqa: E402
+
+
+def _seed_lwp(root: Path) -> None:
+    pr = root / ".ai_infra" / "scripts" / "pr"
+    pr.mkdir(parents=True)
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "local_workflow_paths.py"
+    (pr / "local_workflow_paths.py").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    exemplars = root / ".ai_infra" / "templates" / "local-workspace" / "exemplars"
+    exemplars.mkdir(parents=True)
+    idx = REPO_ROOT / ".ai_infra" / "templates" / "local-workspace" / "exemplars" / "local-plans-index.md"
+    (exemplars / "local-plans-index.md").write_text(idx.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _write_plan_md(root: Path, body: str = "# Plan\n\nSlice.\n") -> Path:
+    plan_dir = root / ".local" / "index-and-planning" / "current"
+    plan_dir.mkdir(parents=True)
+    path = plan_dir / "plan.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _write_snapshot(plans_dir: Path, base: str, slug: str, body: str = "# snap\n") -> Path:
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    path = plans_dir / f"{base}.plan.md"
+    path.write_text(body, encoding="utf-8")
+    (plans_dir / f"{base}.meta.yaml").write_text(f"slug: {slug}\nagent: implementer\n", encoding="utf-8")
+    return path
+
+
+def test_plan_snapshot_success(tmp_path: Path, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_plan_md(tmp_path)
+    assert (
+        cli.main(
+            [
+                "plan",
+                "snapshot",
+                "--directory",
+                str(tmp_path),
+                "--slug",
+                "slice-one",
+                "--agent",
+                "implementer",
+                "--board-item",
+                "PVTI_x",
+            ]
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert "plan snapshot:" in out
+    assert "meta:" in out
+
+
+def test_plan_snapshot_missing_source(tmp_path: Path, capsys) -> None:
+    _seed_lwp(tmp_path)
+    code = cli.main(
+        ["plan", "snapshot", "--directory", str(tmp_path), "--slug", "no-src"]
+    )
+    assert code == plan_manage.EXIT_NOT_FOUND
+    assert "FAIL" in capsys.readouterr().err
+
+
+def test_plan_snapshot_invalid_slug(tmp_path: Path, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_plan_md(tmp_path)
+    code = cli.main(
+        ["plan", "snapshot", "--directory", str(tmp_path), "--slug", "Bad_Slug"]
+    )
+    assert code == plan_manage.EXIT_VALIDATION
+    assert "FAIL" in capsys.readouterr().err
+
+
+def test_plan_list_empty(tmp_path: Path, capsys) -> None:
+    _seed_lwp(tmp_path)
+    assert cli.main(["plan", "list", "--directory", str(tmp_path)]) == 0
+    assert "(none)" in capsys.readouterr().out
+
+
+def test_plan_list_with_build_bridge(tmp_path: Path, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_snapshot(tmp_path / ".local" / "plans", "2026-08-05-alpha", "alpha")
+    assert cli.main(["plan", "list", "--directory", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "build_bridge: plan open --slug alpha" in out
+    assert "alpha" in out
+
+
+def test_plan_list_verbose(tmp_path: Path, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_snapshot(tmp_path / ".local" / "plans", "2026-08-05-beta", "beta")
+    assert cli.main(["plan", "list", "--directory", str(tmp_path), "--verbose"]) == 0
+    out = capsys.readouterr().out
+    assert "# local:" in out
+    assert "# build_bridge: plan open --slug beta" in out
+
+
+def test_plan_open_success(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_snapshot(tmp_path / ".local" / "plans", "2026-08-05-bridge", "bridge")
+    cursor_plans = tmp_path / "cursor-plans"
+    monkeypatch.setattr(plan_manage.cursor_host_paths, "cursor_plans_dir", lambda: cursor_plans)
+    assert cli.main(["plan", "open", "--directory", str(tmp_path), "--slug", "bridge"]) == 0
+    out = capsys.readouterr().out
+    assert "plan open:" in out
+    assert "hint:" in out
+    assert (cursor_plans / "bridge.plan.md").is_file()
+
+
+def test_plan_open_requires_force(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_snapshot(tmp_path / ".local" / "plans", "2026-08-05-force", "force-me")
+    cursor_plans = tmp_path / "cursor-plans"
+    cursor_plans.mkdir()
+    (cursor_plans / "force-me.plan.md").write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(plan_manage.cursor_host_paths, "cursor_plans_dir", lambda: cursor_plans)
+    code = cli.main(["plan", "open", "--directory", str(tmp_path), "--slug", "force-me"])
+    assert code == plan_manage.EXIT_VALIDATION
+    assert "FAIL" in capsys.readouterr().err
+
+
+def test_plan_open_force(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    _write_snapshot(tmp_path / ".local" / "plans", "2026-08-05-force2", "force-me", "v2\n")
+    cursor_plans = tmp_path / "cursor-plans"
+    cursor_plans.mkdir()
+    (cursor_plans / "force-me.plan.md").write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(plan_manage.cursor_host_paths, "cursor_plans_dir", lambda: cursor_plans)
+    assert (
+        cli.main(
+            ["plan", "open", "--directory", str(tmp_path), "--slug", "force-me", "--force"]
+        )
+        == 0
+    )
+    assert "v2" in (cursor_plans / "force-me.plan.md").read_text(encoding="utf-8")
+
+
+def test_plan_open_missing(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_lwp(tmp_path)
+    monkeypatch.setattr(
+        plan_manage.cursor_host_paths, "cursor_plans_dir", lambda: tmp_path / "cp"
+    )
+    code = cli.main(["plan", "open", "--directory", str(tmp_path), "--slug", "ghost"])
+    assert code == plan_manage.EXIT_NOT_FOUND

--- a/tests/modules/canvas_artifacts/test_plan_manage_edges.py
+++ b/tests/modules/canvas_artifacts/test_plan_manage_edges.py
@@ -1,0 +1,167 @@
+"""
+File: test_plan_manage_edges.py
+Path: tests/modules/canvas_artifacts/test_plan_manage_edges.py
+Role: Edge coverage for plan_manage miss lines (ADR-010).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/plan_manage.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import plan_manage  # noqa: E402
+
+
+def _seed_lwp(root: Path) -> None:
+    pr = root / ".ai_infra" / "scripts" / "pr"
+    pr.mkdir(parents=True)
+    src = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "local_workflow_paths.py"
+    (pr / "local_workflow_paths.py").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    exemplars = root / ".ai_infra" / "templates" / "local-workspace" / "exemplars"
+    exemplars.mkdir(parents=True)
+    idx = REPO_ROOT / ".ai_infra" / "templates" / "local-workspace" / "exemplars" / "local-plans-index.md"
+    (exemplars / "local-plans-index.md").write_text(idx.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def test_validate_slug_invalid() -> None:
+    with pytest.raises(ValueError, match="kebab-case"):
+        plan_manage.validate_slug("Not_Valid")
+
+
+def test_resolve_cursor_plan_adds_suffix(tmp_path: Path, monkeypatch) -> None:
+    plans = tmp_path / "plans"
+    plans.mkdir()
+    (plans / "foo.plan.md").write_text("# f\n", encoding="utf-8")
+    monkeypatch.setattr(plan_manage.cursor_host_paths, "cursor_plans_dir", lambda: plans)
+    path = plan_manage.resolve_plan_source(tmp_path, "cursor-plan:foo")
+    assert path == plans / "foo.plan.md"
+
+
+def test_resolve_relative_path(tmp_path: Path) -> None:
+    rel = Path("docs") / "plan-x.md"
+    (tmp_path / "docs").mkdir()
+    (tmp_path / rel).write_text("# x\n", encoding="utf-8")
+    path = plan_manage.resolve_plan_source(tmp_path, str(rel))
+    assert path == (tmp_path / rel).resolve() or path == tmp_path / rel
+
+
+def test_snapshot_collision_timestamp(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    plan_dir = tmp_path / ".local" / "index-and-planning" / "current"
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    dst1, _ = plan_manage.snapshot_plan(tmp_path, slug="collide")
+    dst2, _ = plan_manage.snapshot_plan(tmp_path, slug="collide")
+    assert dst1 != dst2
+    assert dst1.is_file() and dst2.is_file()
+
+
+def test_list_snapshots_empty_dir(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    assert plan_manage.list_snapshots(tmp_path) == []
+
+
+def test_list_snapshots_no_meta_and_bad_meta(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    plans = tmp_path / ".local" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-08-05-plain.plan.md").write_text("# p\n", encoding="utf-8")
+    (plans / "2026-08-05-bad.plan.md").write_text("# b\n", encoding="utf-8")
+    (plans / "2026-08-05-bad.meta.yaml").write_text("- not a dict\n", encoding="utf-8")
+    rows = plan_manage.list_snapshots(tmp_path)
+    assert len(rows) == 2
+    slugs = {r["slug"] for r in rows}
+    assert "plain" in slugs
+
+
+def test_canvas_base_from_plan_variants() -> None:
+    assert plan_manage.canvas_base_from_plan("2026-08-05-my-slug.plan.md") == "my-slug"
+    assert plan_manage.canvas_base_from_plan("odd.plan.md") == "odd"
+
+
+def test_find_latest_empty_plans_dir(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        plan_manage.find_latest_snapshot(tmp_path, "none")
+
+
+def test_find_latest_from_filename_when_meta_missing(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    plans = tmp_path / ".local" / "plans"
+    plans.mkdir(parents=True)
+    path = plans / "2026-08-05-from-name.plan.md"
+    path.write_text("# n\n", encoding="utf-8")
+    latest = plan_manage.find_latest_snapshot(tmp_path, "from-name")
+    assert latest == path
+
+
+def test_snapshot_slug_meta_without_slug_key(tmp_path: Path) -> None:
+    plans = tmp_path / "plans"
+    plans.mkdir()
+    path = plans / "2026-08-05-x.plan.md"
+    path.write_text("# x\n", encoding="utf-8")
+    (plans / "2026-08-05-x.meta.yaml").write_text("agent: implementer\n", encoding="utf-8")
+    assert plan_manage._snapshot_slug(path) == "x"
+
+
+def test_append_plan_index_dedup(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    plans = tmp_path / ".local" / "plans"
+    plans.mkdir(parents=True)
+    index = plans / "index.md"
+    index.write_text(
+        "# Plans\n\n| snapshot | slug | agent | board | source |\n| --- | --- | --- | --- | --- |\n",
+        encoding="utf-8",
+    )
+    plan_manage._append_plan_index(
+        tmp_path,
+        snapshot="snap-a",
+        slug="slug-a",
+        agent="implementer",
+        board_item="PVTI_x",
+        source="plan.md",
+    )
+    text1 = index.read_text(encoding="utf-8")
+    assert "snap-a" in text1
+    plan_manage._append_plan_index(
+        tmp_path,
+        snapshot="snap-a",
+        slug="slug-a",
+        agent=None,
+        board_item=None,
+        source="plan.md",
+    )
+    assert text1 == index.read_text(encoding="utf-8")
+
+
+def test_find_latest_no_matching_slug(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    plans = tmp_path / ".local" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-08-05-other.plan.md").write_text("# o\n", encoding="utf-8")
+    with pytest.raises(FileNotFoundError, match="no plan snapshot"):
+        plan_manage.find_latest_snapshot(tmp_path, "wanted")
+
+
+def test_append_plan_index_missing_file(tmp_path: Path) -> None:
+    _seed_lwp(tmp_path)
+    plan_manage._append_plan_index(
+        tmp_path,
+        snapshot="x",
+        slug="x",
+        agent=None,
+        board_item=None,
+        source="plan.md",
+    )

--- a/tests/modules/install/test_cursor_workflow_cli_full.py
+++ b/tests/modules/install/test_cursor_workflow_cli_full.py
@@ -32,6 +32,7 @@ import paths  # noqa: E402
 import contributors_cli  # noqa: E402
 import drift_cli  # noqa: E402
 import integrate_cli  # noqa: E402
+import mcp_cli  # noqa: E402
 import mcp_manage  # noqa: E402
 
 
@@ -344,13 +345,13 @@ def _write_mcp_fixture(root: Path) -> None:
 def test_cmd_mcp_validate_pass(tmp_path: Path) -> None:
     _write_mcp_fixture(tmp_path)
     args = argparse.Namespace(directory=tmp_path)
-    assert cli.cmd_mcp_validate(args) == 0
+    assert mcp_cli.cmd_mcp_validate(args) == 0
 
 
 def test_cmd_mcp_validate_fail_missing_fragment(tmp_path: Path) -> None:
     (tmp_path / ".cursor").mkdir()
     args = argparse.Namespace(directory=tmp_path)
-    assert cli.cmd_mcp_validate(args) == 1
+    assert mcp_cli.cmd_mcp_validate(args) == 1
 
 
 def test_cmd_mcp_validate_fail_registry_mismatch(tmp_path: Path) -> None:
@@ -361,7 +362,7 @@ def test_cmd_mcp_validate_fail_registry_mismatch(tmp_path: Path) -> None:
         yaml.safe_dump({"servers": {"missing-server": {"agents": []}}}), encoding="utf-8"
     )
     args = argparse.Namespace(directory=tmp_path)
-    assert cli.cmd_mcp_validate(args) == 1
+    assert mcp_cli.cmd_mcp_validate(args) == 1
 
 
 def test_cmd_mcp_link_success(tmp_path: Path) -> None:
@@ -369,7 +370,7 @@ def test_cmd_mcp_link_success(tmp_path: Path) -> None:
     fragment = tmp_path / "fragment.json"
     fragment.write_text(json.dumps({"mcpServers": {"new-server": {"command": "bar"}}}), encoding="utf-8")
     args = argparse.Namespace(directory=tmp_path, name="new-server", file=fragment)
-    assert cli.cmd_mcp_link(args) == 0
+    assert mcp_cli.cmd_mcp_link(args) == 0
     assert (tmp_path / ".gitignore").is_file()
 
 
@@ -379,7 +380,7 @@ def test_cmd_mcp_link_failure(tmp_path: Path) -> None:
     fragment = tmp_path / "fragment.json"
     fragment.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
     args = argparse.Namespace(directory=tmp_path, name="whatever", file=fragment)
-    assert cli.cmd_mcp_link(args) == 1
+    assert mcp_cli.cmd_mcp_link(args) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/modules/install/test_cursor_workflow_entrypoints.py
+++ b/tests/modules/install/test_cursor_workflow_entrypoints.py
@@ -1,0 +1,60 @@
+"""
+File: test_cursor_workflow_entrypoints.py
+Path: tests/modules/install/test_cursor_workflow_entrypoints.py
+Role: Cover install-tree cursor_workflow __init__ and __main__ (Miss=0).
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/__init__.py
+ - .ai_infra/install/cursor_workflow/__main__.py
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_PARENT = REPO_ROOT / ".ai_infra" / "install"
+PKG = INSTALL_PARENT / "cursor_workflow"
+
+
+def test_install_init_version() -> None:
+    """Execute install package __init__.py so coverage sees __version__."""
+    spec = importlib.util.spec_from_file_location(
+        "cursor_workflow_install_init",
+        PKG / "__init__.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.__version__ == "0.4.0"
+
+
+def test_install_main_module(monkeypatch) -> None:
+    """Run install __main__ with a stub cursor_workflow.cli.main."""
+    calls: list[object] = []
+
+    stub_cli = ModuleType("cursor_workflow.cli")
+
+    def fake_main(argv=None):
+        calls.append(argv)
+        return 7
+
+    stub_cli.main = fake_main  # type: ignore[attr-defined]
+
+    stub_pkg = ModuleType("cursor_workflow")
+    stub_pkg.cli = stub_cli  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cursor_workflow", stub_pkg)
+    monkeypatch.setitem(sys.modules, "cursor_workflow.cli", stub_cli)
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(str(PKG / "__main__.py"), run_name="__main__")
+    assert exc.value.code == 7
+    assert calls == [None] or len(calls) == 1

--- a/tests/modules/install/test_gh_project_adapter_coverage.py
+++ b/tests/modules/install/test_gh_project_adapter_coverage.py
@@ -623,6 +623,76 @@ def test_set_item_assignee_draft_hint(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "DraftIssue" in detail
 
 
+def test_fetch_project_item_by_id_empty_item_id() -> None:
+    """Line 427: return None, 'empty item id' when iid is blank."""
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, "")
+    assert item is None
+    assert "empty item id" in (err or "")
+
+
+def test_fetch_project_item_by_id_graphql_errors_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 453-454: errors[0] is a dict with 'message'."""
+    payload = json.dumps({"errors": [{"message": "Node not accessible"}]})
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok(payload))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is None
+    assert err == "Node not accessible"
+
+
+def test_fetch_project_item_by_id_graphql_errors_non_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 453-454: errors[0] is not a dict → str(errors)."""
+    payload = json.dumps({"errors": ["some string error"]})
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok(payload))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is None
+    assert err is not None
+
+
+def test_fetch_project_item_by_id_non_dict_field_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 478: non-dict entries in fieldValues.nodes are skipped via continue."""
+    payload = json.dumps({
+        "data": {
+            "node": {
+                "id": VALID_PVTI,
+                "content": {"__typename": "Issue", "body": ""},
+                "fieldValues": {
+                    "nodes": [
+                        None,
+                        "bad-string",
+                        42,
+                    ]
+                },
+            }
+        }
+    })
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok(payload))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is not None
+    assert err is None
+
+
+def test_fetch_project_item_by_id_empty_field_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 484: entries where field_name resolves to empty string are skipped."""
+    payload = json.dumps({
+        "data": {
+            "node": {
+                "id": VALID_PVTI,
+                "content": {"__typename": "Issue", "body": ""},
+                "fieldValues": {
+                    "nodes": [
+                        {"__typename": "text", "text": "val", "field": {"name": ""}},
+                        {"__typename": "text", "text": "val2", "field": None},
+                    ]
+                },
+            }
+        }
+    })
+    monkeypatch.setattr(project_cli, "run_gh", lambda *a, **k: _gh_ok(payload))
+    item, err = gha.fetch_project_item_by_id(SAMPLE_SSOT, VALID_PVTI)
+    assert item is not None
+    assert err is None
+
+
 def test_promote_post_mutation_resolve_not_issue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/modules/install/test_project_cov100_closure.py
+++ b/tests/modules/install/test_project_cov100_closure.py
@@ -965,3 +965,156 @@ def test_project_cli_remaining_gaps(monkeypatch: pytest.MonkeyPatch, capsys: pyt
 
 def test_section_body_content_empty_target_direct() -> None:
     assert pa.section_body_content("## A\n\nx", "   ") == ""
+
+
+# --- board_shell.py: missing lines 228, 241, 244, 293 ---
+
+
+def test_is_kit_dev_install_false_on_consumer_root(tmp_path: Path) -> None:
+    """Line 228: is_kit_dev_install returns False when test_scaffold.py is absent."""
+    assert bs.is_kit_dev_install(tmp_path) is False
+
+
+def test_init_minimal_overlay_already_exists(tmp_path: Path) -> None:
+    """Line 241: returns (1, ...) when overlay exists and force=False."""
+    dest = bs.consumer_overlay_path(tmp_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("version: 1\n", encoding="utf-8")
+    code, msg = bs.init_minimal_overlay(tmp_path, force=False)
+    assert code == 1
+    assert "already exists" in msg
+
+
+def test_init_minimal_overlay_exemplar_missing(tmp_path: Path) -> None:
+    """Line 244: returns (2, ...) when exemplar YAML is absent."""
+    code, msg = bs.init_minimal_overlay(tmp_path, force=False)
+    assert code == 2
+    assert "missing" in msg
+
+
+def test_bootstrap_view_fail_message_min_count_le_2() -> None:
+    """Line 293: bootstrap_view_fail_message returns 2-view hint when min_count <= 2."""
+    schema = {
+        "views": {
+            "minimum": [
+                {"name": "Status board", "layout": "BOARD_LAYOUT"},
+            ]
+        }
+    }
+    problems = ["missing minimum view 'Prioritized backlog'"]
+    live_views: list[dict] = []
+    msg = bs.bootstrap_view_fail_message(schema, problems, live_views)
+    assert "Turn A Status board" in msg or "2-view" in msg or "Minimal" in msg
+
+
+# --- project_handlers.py: line 153 (handoff body gate + fetch fails) ---
+
+
+def test_run_handoff_fetch_fails_no_body_gate_no_queue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Line 153: fetch fails, status_to is empty (not body-gate), _try_queue returns None → EXIT_GH."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "resolve_human_github_user", lambda root: "@test")
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "some non-rate-limit gh error"),
+    )
+    # _try_queue_rate_limit returns None because error is not a rate-limit error
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id="PVTI_lAHOBl46-84A9KZxtest01",
+        last=False,
+        agent="implementer",
+        next="verifier",
+        to="",        # empty → no body gate → goes to _try_queue_rate_limit path
+        text="",
+        limit=100,
+    )
+    result = project_handlers.run_handoff(args)
+    assert result == project_cli.EXIT_GH
+
+
+# --- project_handlers.py: lines 340-342 (json.JSONDecodeError in close_linked_issue) ---
+
+
+def test_run_close_linked_issue_invalid_json_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 340-342: gh issue view returns non-JSON → DEFERRED + EXIT_GH."""
+    ssot = {**_ssot(), "conventions": {"close_linked_issue_on_cleanup": True, "body_sections": []}}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_for_pr",
+        lambda *a, **k: ("PVTI_lAHOBl46-84A9KZxtest01", [], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_content",
+        lambda *a, **k: ("issue", "42", {"repo": "o/r"}, None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "run_gh",
+        lambda *a, **k: _gh_ok("not-valid-json"),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        pr="12",
+        repo="o/r",
+        dry_run=False,
+    )
+    result = project_handlers.run_close_linked_issue(args)
+    assert result == project_cli.EXIT_GH
+
+
+# --- project_handlers.py: lines 518-544 (run_board_shell_init) ---
+
+
+def test_run_board_shell_init_no_minimal_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """run_board_shell_init without --minimal → EXIT_USAGE."""
+    args = argparse.Namespace(directory=tmp_path, minimal=False, force=False)
+    result = project_handlers.run_board_shell_init(args)
+    assert result == project_cli.EXIT_USAGE
+
+
+def test_run_board_shell_init_exemplar_missing(tmp_path: Path) -> None:
+    """run_board_shell_init --minimal but exemplar missing → EXIT_USAGE (code 2)."""
+    args = argparse.Namespace(directory=tmp_path, minimal=True, force=False)
+    result = project_handlers.run_board_shell_init(args)
+    assert result == project_cli.EXIT_USAGE
+
+
+def test_run_board_shell_init_overlay_exists_no_force(tmp_path: Path) -> None:
+    """run_board_shell_init --minimal, overlay exists but no --force → EXIT_USAGE (code 1)."""
+    dest = bs.consumer_overlay_path(tmp_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("version: 1\n", encoding="utf-8")
+    args = argparse.Namespace(directory=tmp_path, minimal=True, force=False)
+    result = project_handlers.run_board_shell_init(args)
+    assert result == project_cli.EXIT_USAGE
+
+
+def test_run_board_shell_init_writes_overlay(tmp_path: Path) -> None:
+    """run_board_shell_init --minimal with exemplar present → EXIT_OK."""
+    import shutil
+    minimal_src = (
+        REPO_ROOT / ".ai_infra" / "templates" / "user-settings" / "exemplars"
+        / "board-shell.schema.minimal.yaml"
+    )
+    exemplar_dest_dir = (
+        tmp_path / ".ai_infra" / "templates" / "user-settings" / "exemplars"
+    )
+    exemplar_dest_dir.mkdir(parents=True)
+    if minimal_src.is_file():
+        shutil.copy(minimal_src, exemplar_dest_dir / "board-shell.schema.minimal.yaml")
+    else:
+        (exemplar_dest_dir / "board-shell.schema.minimal.yaml").write_text(
+            "version: 1\nviews:\n  minimum: []\n", encoding="utf-8"
+        )
+    args = argparse.Namespace(directory=tmp_path, minimal=True, force=False)
+    result = project_handlers.run_board_shell_init(args)
+    assert result == project_cli.EXIT_OK

--- a/tests/modules/install/test_project_outbox.py
+++ b/tests/modules/install/test_project_outbox.py
@@ -1592,3 +1592,423 @@ def test_maybe_enqueue_scope_miss_not_queued(tmp_path: Path) -> None:
         )
         is None
     )
+
+
+# --- validate_outbox_entry: set-section payload validation (lines 319-322) ---
+
+
+def test_validate_outbox_entry_set_section_missing_section() -> None:
+    """Line 319-320: set-section without section → validation error."""
+    entry = {
+        "id": "00000000-0000-4000-8000-000000000099",
+        "ts": "2026-07-18T10:00:00Z",
+        "agent": "implementer",
+        "github_user": "@test",
+        "op": "set-section",
+        "item_id": VALID_ITEM_ID,
+        "payload": {"section": "", "text": "some text"},
+        "status": "pending",
+        "attempts": 0,
+        "last_error": None,
+    }
+    errs = project_outbox.validate_outbox_entry(entry)
+    assert any("section" in e for e in errs)
+
+
+def test_validate_outbox_entry_set_section_missing_text() -> None:
+    """Lines 321-322: set-section without text → validation error."""
+    entry = {
+        "id": "00000000-0000-4000-8000-000000000098",
+        "ts": "2026-07-18T10:00:00Z",
+        "agent": "implementer",
+        "github_user": "@test",
+        "op": "set-section",
+        "item_id": VALID_ITEM_ID,
+        "payload": {"section": "acceptance", "text": ""},
+        "status": "pending",
+        "attempts": 0,
+        "last_error": None,
+    }
+    errs = project_outbox.validate_outbox_entry(entry)
+    assert any("text" in e for e in errs)
+
+
+# --- apply_outbox_entry: set-section op (lines 607-641) ---
+
+
+def test_apply_outbox_set_section_invalid_section_name(tmp_path: Path) -> None:
+    """Lines 607-610: invalid section name → ValueError → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-section", payload={"section": "notes", "text": "some text"}),
+    )
+    assert not ok
+    assert "acceptance|rollback" in detail or "section" in detail
+
+
+def test_apply_outbox_set_section_empty_text(tmp_path: Path) -> None:
+    """Lines 611-613: empty/placeholder text → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-section", payload={"section": "acceptance", "text": "(TBD)"}),
+    )
+    assert not ok
+    assert "TBD" in detail or "empty" in detail
+
+
+def test_apply_outbox_set_section_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 614-616: fetch_project_items fails → (False, err)."""
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "gh list failed"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-section", payload={"section": "acceptance", "text": "- real"}),
+    )
+    assert not ok
+    assert "gh list failed" in detail
+
+
+def test_apply_outbox_set_section_item_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 617-619: item not found → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-section", payload={"section": "acceptance", "text": "- real"}),
+    )
+    assert not ok
+    assert "not found" in detail
+
+
+def test_apply_outbox_set_section_replace_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 621-624: replace_section_content raises ValueError → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    item_body = {"body": "no headings here"}
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID_ITEM_ID, "title": "T", "content": item_body}], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-section", payload={"section": "acceptance", "text": "- real"}),
+    )
+    assert not ok
+    assert "missing" in detail or "heading" in detail
+
+
+def test_apply_outbox_set_section_edit_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 625-628: edit_item_body fails → (False, detail)."""
+    ssot = _outbox_ssot(tmp_path)
+    item_body = {"body": "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"}
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID_ITEM_ID, "title": "T", "content": item_body}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (False, "body edit failed"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-section", payload={"section": "acceptance", "text": "- criteria met"}),
+    )
+    assert not ok
+    assert "body edit failed" in detail
+
+
+def test_apply_outbox_set_section_notes_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 629-640: agent notes fails → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    item_body = {"body": "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"}
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID_ITEM_ID, "title": "T", "content": item_body}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (True, "ok"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "notes write failed", project_cli.EXIT_GH),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(
+            op="set-section",
+            payload={"section": "acceptance", "text": "- criteria met"},
+        ),
+    )
+    assert not ok
+    assert "Notes failed" in detail
+
+
+def test_apply_outbox_set_section_ok_with_agent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 629-641: set-section with agent succeeds → (True, '...updated')."""
+    ssot = _outbox_ssot(tmp_path)
+    item_body = {"body": "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"}
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID_ITEM_ID, "title": "T", "content": item_body}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (True, "ok"),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (True, "updated", project_cli.EXIT_OK),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(
+            op="set-section",
+            payload={"section": "acceptance", "text": "- criteria met"},
+        ),
+    )
+    assert ok
+    assert "updated" in detail
+
+
+def test_apply_outbox_set_section_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Line 641: set-section unchanged → (True, '...unchanged')."""
+    ssot = _outbox_ssot(tmp_path)
+    item_body = {"body": "## Acceptance\n\n- criteria met\n\n## Rollback\n\n- ok\n"}
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID_ITEM_ID, "title": "T", "content": item_body}], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(
+            op="set-section",
+            agent="",   # empty agent → skip append_notes_helper call
+            payload={"section": "acceptance", "text": "- criteria met"},
+        ),
+    )
+    assert ok
+    assert "unchanged" in detail
+
+
+# --- apply_outbox_entry: set-status body gate (lines 646-654) ---
+
+
+def test_apply_outbox_set_status_body_gate_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 646-648: body gate fetch fails → (False, err)."""
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "gh list failed"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-status", payload={"to": "in_review"}),
+    )
+    assert not ok
+    assert "gh list failed" in detail
+
+
+def test_apply_outbox_set_status_body_gate_item_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 649-651: body gate item not found → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-status", payload={"to": "in_review"}),
+    )
+    assert not ok
+    assert "not found" in detail
+
+
+def test_apply_outbox_set_status_body_gate_tbd_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 652-654: body gate assert fails (TBD content) → (False, detail)."""
+    ssot = _outbox_ssot(tmp_path)
+    ssot["conventions"] = {
+        **ssot.get("conventions", {}),
+        "body_sections": ["Acceptance", "Rollback"],
+    }
+    item = {
+        "id": VALID_ITEM_ID,
+        "title": "T",
+        "status": "In Progress",
+        "content": {"body": "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- (TBD)\n"},
+    }
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([item], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="set-status", payload={"to": "done"}),
+    )
+    assert not ok
+    assert detail  # body gate detail message
+
+
+# --- apply_outbox_entry: handoff body gate (lines 757, 760, 763) ---
+
+
+def test_apply_outbox_handoff_body_gate_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Line 757: handoff with body gate status and fetch fails → (False, err)."""
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "gh list failed"),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="handoff", payload={"next": "verifier", "to": "in_review"}),
+    )
+    assert not ok
+    assert "gh list failed" in detail
+
+
+def test_apply_outbox_handoff_body_gate_item_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Line 760: handoff with body gate status, item not found → (False, ...)."""
+    ssot = _outbox_ssot(tmp_path)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="handoff", payload={"next": "verifier", "to": "done"}),
+    )
+    assert not ok
+    assert "not found" in detail
+
+
+def test_apply_outbox_handoff_body_gate_tbd_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Line 763: handoff body gate assert fails → (False, detail)."""
+    ssot = _outbox_ssot(tmp_path)
+    ssot["conventions"] = {
+        **ssot.get("conventions", {}),
+        "body_sections": ["Acceptance", "Rollback"],
+    }
+    item = {
+        "id": VALID_ITEM_ID,
+        "title": "T",
+        "status": "In Progress",
+        "content": {"body": "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- (TBD)\n"},
+    }
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([item], None),
+    )
+    ok, detail = project_outbox.apply_outbox_entry(
+        tmp_path,
+        ssot,
+        _valid_entry(op="handoff", payload={"next": "verifier", "to": "in_review"}),
+    )
+    assert not ok
+    assert detail
+
+
+# --- regression: --limit default=200 on claim/handoff/get parsers ---
+
+
+def test_project_parser_limit_defaults_200() -> None:
+    """Regression: claim/handoff/get parsers have --limit default=200."""
+    import project_parser  # noqa: E402
+
+    import argparse as ap
+
+    parser = ap.ArgumentParser()
+    sub = parser.add_subparsers()
+    project_parser.register_project_subparser(sub)
+
+    # claim
+    claim_ns = parser.parse_args([
+        "project", "claim",
+        "--id", VALID_ITEM_ID,
+        "--agent", "implementer",
+        "--directory", ".",
+    ])
+    assert claim_ns.limit == 200
+
+    # handoff
+    handoff_ns = parser.parse_args([
+        "project", "handoff",
+        "--id", VALID_ITEM_ID,
+        "--agent", "implementer",
+        "--next", "verifier",
+        "--directory", ".",
+    ])
+    assert handoff_ns.limit == 200
+
+    # get
+    get_ns = parser.parse_args([
+        "project", "get",
+        "--id", VALID_ITEM_ID,
+        "--directory", ".",
+    ])
+    assert get_ns.limit == 200

--- a/tests/modules/install/test_project_set_section.py
+++ b/tests/modules/install/test_project_set_section.py
@@ -26,6 +26,7 @@ if str(_PKG_DIR) not in sys.path:
 
 import project_atomics as atomics  # noqa: E402
 import project_cli  # noqa: E402
+import project_handlers  # noqa: E402
 from test_project_cli import SAMPLE_SSOT  # noqa: E402
 
 VALID = "PVTI_lAHOBl46-84A9KZxsect01"
@@ -52,11 +53,24 @@ def _ssot(**overrides):
     return data
 
 
+def test_is_placeholder_all_whitespace_lines() -> None:
+    """Line 89: lines list is empty after stripping whitespace-only lines."""
+    assert atomics.is_placeholder_section_content("   \n   \n   ")
+
+
 def test_is_placeholder_list_tbd() -> None:
     assert atomics.is_placeholder_section_content("- (TBD)")
     assert atomics.is_placeholder_section_content("* (TBD)")
     assert atomics.is_placeholder_section_content("(TBD)")
     assert not atomics.is_placeholder_section_content("- real criterion")
+
+
+def test_replace_section_content_empty_name_noop() -> None:
+    """Line 131: replace_section_content returns (body, False) when name is empty."""
+    body = "## Acceptance\n\nok\n"
+    result, changed = atomics.replace_section_content(body, "", "new text")
+    assert not changed
+    assert result == body
 
 
 def test_replace_section_content_roundtrip() -> None:
@@ -75,6 +89,14 @@ def test_normalize_set_section_rejects_notes() -> None:
     with pytest.raises(ValueError, match="acceptance\\|rollback"):
         atomics.normalize_set_section_name("Notes")
     assert atomics.normalize_set_section_name("ACCEPTANCE") == "Acceptance"
+
+
+def test_assert_body_ready_item_not_mapping() -> None:
+    """Line 172: assert_body_ready_for_status returns (False, ...) when item is not a dict."""
+    ssot = _ssot()
+    ok, detail = atomics.assert_body_ready_for_status(ssot, None, "in_review")
+    assert not ok
+    assert "not a mapping" in detail
 
 
 def test_assert_body_ready_blocks_tbd() -> None:
@@ -305,3 +327,460 @@ def test_handoff_ok_after_real_acceptance(monkeypatch: pytest.MonkeyPatch) -> No
         limit=50,
     )
     assert project_cli.cmd_handoff(args) == 0
+
+
+# --- project_cli.py: set-status body gate (lines 816, 819) ---
+
+
+def test_cmd_set_status_body_gate_fetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 816: fetch_project_items fails during body gate → EXIT_GH."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "gh item-list failed"),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        to="done",
+        agent="project-cli",
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_GH
+
+
+def test_cmd_set_status_body_gate_item_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 819: item not found during body gate → EXIT_NOT_FOUND."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], None),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        to="in_review",
+        agent="project-cli",
+    )
+    assert project_cli.cmd_set_status(args) == project_cli.EXIT_NOT_FOUND
+
+
+# --- project_cli.py: cmd_set_section edge paths ---
+
+
+def test_cmd_set_section_ssot_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 1018: _load_enabled_ssot returns None → return code."""
+    ssot_disabled = {**SAMPLE_SSOT, "enabled": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot_disabled, []))
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="ok",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) != 0
+
+
+def test_cmd_set_section_id_not_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 1021: resolve_item_id_arg returns None → return id_code."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli,
+        "resolve_item_id_arg",
+        lambda root, args, cmd: (None, project_cli.EXIT_NOT_FOUND),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=None,
+        last=False,
+        section="acceptance",
+        text="ok",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_NOT_FOUND
+
+
+def test_cmd_set_section_empty_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 1028: empty text → EXIT_USAGE."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_USAGE
+
+
+def test_cmd_set_section_guard_queues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 1048: guard_write_or_queue returns non-None → return pre."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: project_cli.EXIT_QUEUED)
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="implementer",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_set_section_fetch_fails_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 1051-1063: fetch_project_items fails with rate limit → EXIT_QUEUED via try_queue."""
+    import yaml
+    ssot = _ssot()
+    outbox_rel = "outbox/set-section-test.jsonl"
+    ssot["outbox"] = {"enabled": True, "path": outbox_rel, "precheck_writes": False}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "API rate limit exceeded"),
+    )
+    collab_path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    collab_path.parent.mkdir(parents=True, exist_ok=True)
+    collab_path.write_text(yaml.safe_dump({
+        "version": 1,
+        "owner": {"display_name": "Test User", "github_user": "@test"},
+        "project_ssot": ssot,
+        "commit_provenance": {"ai_disclosure_mode": "assisted_by"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }), encoding="utf-8")
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="implementer",
+        limit=50,
+    )
+    result = project_cli.cmd_set_section(args)
+    assert result in (project_cli.EXIT_QUEUED, project_cli.EXIT_GH)
+
+
+def test_cmd_set_section_fetch_fails_not_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 1063: fetch fails, not a rate limit → EXIT_GH."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([], "some other gh error"),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_GH
+
+
+def test_cmd_set_section_item_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 1066: item not found → EXIT_NOT_FOUND."""
+    ssot = _ssot()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(project_cli, "fetch_project_items", lambda *a, **k: ([], None))
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_NOT_FOUND
+
+
+def test_cmd_set_section_replace_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 1070-1071: replace_section_content raises ValueError (missing heading)."""
+    ssot = _ssot()
+    body_no_heading = {"body": "no section headings here"}
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": body_no_heading}], None),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_VALIDATION
+
+
+def test_cmd_set_section_edit_fails_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 1075-1087: edit_item_body fails → try rate-limit queue → EXIT_QUEUED."""
+    import yaml
+    ssot = _ssot()
+    ssot["outbox"] = {"enabled": True, "path": "outbox/set-section-edit.jsonl", "precheck_writes": False}
+    body = "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": {"body": body}}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (False, "API rate limit exceeded"),
+    )
+    collab_path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    collab_path.parent.mkdir(parents=True, exist_ok=True)
+    collab_path.write_text(yaml.safe_dump({
+        "version": 1,
+        "owner": {"display_name": "Test User", "github_user": "@test"},
+        "project_ssot": ssot,
+        "commit_provenance": {"ai_disclosure_mode": "assisted_by"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }), encoding="utf-8")
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="",
+        limit=50,
+    )
+    result = project_cli.cmd_set_section(args)
+    assert result in (project_cli.EXIT_QUEUED, project_cli.EXIT_GH)
+
+
+def test_cmd_set_section_edit_fails_not_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 1087: edit_item_body fails, not rate limit → EXIT_GH."""
+    ssot = _ssot()
+    body = "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": {"body": body}}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (False, "some gh error"),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_GH
+
+
+def test_cmd_set_section_idempotent(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Line 1091: body unchanged → print 'unchanged (idempotent)'."""
+    ssot = _ssot()
+    body = "## Acceptance\n\n- criteria met\n\n## Rollback\n\n- revert\n"
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": {"body": body}}], None),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_OK
+    assert "unchanged (idempotent)" in capsys.readouterr().out
+
+
+def test_cmd_set_section_notes_exit_queued(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 1103-1104: append_notes_helper returns EXIT_QUEUED → propagate EXIT_QUEUED."""
+    ssot = _ssot()
+    body = "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": {"body": body}}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (True, "ok"),
+    )
+    monkeypatch.setattr(project_cli, "note_successful_write", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "queued", project_cli.EXIT_QUEUED),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="implementer",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_QUEUED
+
+
+def test_cmd_set_section_notes_gh_fail_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines 1105-1117: notes fails with EXIT_GH → try rate-limit queue."""
+    import yaml
+    ssot = _ssot()
+    ssot["outbox"] = {"enabled": True, "path": "outbox/set-section-notes.jsonl", "precheck_writes": False}
+    body = "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": {"body": body}}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (True, "ok"),
+    )
+    monkeypatch.setattr(project_cli, "note_successful_write", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "API rate limit exceeded", project_cli.EXIT_GH),
+    )
+    collab_path = tmp_path / ".local" / "user_settings" / "github.collaboration.yaml"
+    collab_path.parent.mkdir(parents=True, exist_ok=True)
+    collab_path.write_text(yaml.safe_dump({
+        "version": 1,
+        "owner": {"display_name": "Test User", "github_user": "@test"},
+        "project_ssot": ssot,
+        "commit_provenance": {"ai_disclosure_mode": "assisted_by"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }), encoding="utf-8")
+    args = argparse.Namespace(
+        directory=tmp_path,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="implementer",
+        limit=50,
+    )
+    result = project_cli.cmd_set_section(args)
+    assert result in (project_cli.EXIT_QUEUED, project_cli.EXIT_GH)
+
+
+def test_cmd_set_section_notes_non_gh_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line 1118: notes fails with non-EXIT_GH/QUEUED → fail with that code."""
+    ssot = _ssot()
+    body = "## Acceptance\n\n- (TBD)\n\n## Rollback\n\n- ok\n"
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(project_cli, "guard_write_or_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda *a, **k: ([{"id": VALID, "title": "T", "content": {"body": body}}], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "edit_item_body",
+        lambda *a, **k: (True, "ok"),
+    )
+    monkeypatch.setattr(project_cli, "note_successful_write", lambda *a, **k: None)
+    monkeypatch.setattr(
+        project_cli,
+        "append_notes_helper",
+        lambda *a, **k: (False, "notes write failed", project_cli.EXIT_VALIDATION),
+    )
+    args = argparse.Namespace(
+        directory=REPO_ROOT,
+        id=VALID,
+        last=False,
+        section="acceptance",
+        text="- criteria met",
+        agent="implementer",
+        limit=50,
+    )
+    assert project_cli.cmd_set_section(args) == project_cli.EXIT_VALIDATION
+
+
+# --- project_cli.py: cmd_board_shell_init and cmd_close_linked_issue delegates ---
+
+
+def test_cmd_board_shell_init_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 1228-1230: cmd_board_shell_init calls run_board_shell_init."""
+    called = {"n": 0}
+
+    def fake_run(args):
+        called["n"] += 1
+        return project_cli.EXIT_OK
+
+    monkeypatch.setattr(project_handlers, "run_board_shell_init", fake_run)
+    args = SimpleNamespace(directory=REPO_ROOT, minimal=True, force=False)
+    assert project_cli.cmd_board_shell_init(args) == project_cli.EXIT_OK
+    assert called["n"] == 1
+
+
+def test_cmd_close_linked_issue_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lines 1331-1332: cmd_close_linked_issue calls run_close_linked_issue."""
+    called = {"n": 0}
+
+    def fake_run(args):
+        called["n"] += 1
+        return project_cli.EXIT_OK
+
+    monkeypatch.setattr(project_handlers, "run_close_linked_issue", fake_run)
+    args = SimpleNamespace(directory=REPO_ROOT)
+    assert project_cli.cmd_close_linked_issue(args) == project_cli.EXIT_OK
+    assert called["n"] == 1

--- a/tests/modules/install/test_scaffold.py
+++ b/tests/modules/install/test_scaffold.py
@@ -74,6 +74,19 @@ def test_scaffold_creates_workflow_artifact_buckets(tmp_path: Path) -> None:
         assert (target / ".local" / "workflow-artifacts" / bucket / "README.md").is_file()
 
 
+def test_scaffold_creates_local_canvas_plan_buckets(tmp_path: Path) -> None:
+    mod = _load_scaffold()
+    target = tmp_path / "project"
+    mod.scaffold(target, REPO_ROOT)
+    lwp = mod._load_local_workflow_paths(REPO_ROOT)
+    assert (target / lwp.LOCAL_CANVASES_DIR).is_dir()
+    assert (target / lwp.LOCAL_PLANS_DIR).is_dir()
+    assert (target / lwp.LOCAL_CANVASES_INDEX).is_file()
+    assert (target / lwp.LOCAL_PLANS_INDEX).is_file()
+    assert (target / lwp.LOCAL_CANVASES_DIR / "README.md").is_file()
+    assert (target / lwp.LOCAL_PLANS_DIR / "README.md").is_file()
+
+
 def test_scaffold_creates_agents_md(tmp_path: Path) -> None:
     mod = _load_scaffold()
     target = tmp_path / "project"

--- a/tests/modules/mcp_client/test_mcp_call_allowlist.py
+++ b/tests/modules/mcp_client/test_mcp_call_allowlist.py
@@ -1,0 +1,100 @@
+"""
+File: test_mcp_call_allowlist.py
+Path: tests/modules/mcp_client/test_mcp_call_allowlist.py
+Role: Registry allowlist + live stdio smoke against workflow-kit when available.
+Used By:
+ - pytest
+Depends On:
+ - mcp_client, mcp_manage, cli
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CW = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+
+def _load(name: str, path: Path):
+    if str(CW) not in sys.path:
+        sys.path.insert(0, str(CW))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed(root: Path) -> None:
+    cursor = root / ".cursor"
+    cursor.mkdir(parents=True)
+    kit = json.loads((REPO_ROOT / ".cursor" / "mcp.json.kit.example").read_text(encoding="utf-8"))
+    # Point command at repo venv + servers for live smoke when root==REPO
+    (cursor / "mcp.json.kit.example").write_text(json.dumps(kit, indent=2), encoding="utf-8")
+    registry = {
+        "version": 1,
+        "servers": {
+            "workflow-kit": {
+                "tier": "kit",
+                "description": "kit",
+                "agents": ["implementer"],
+                "tools_hint": [],
+            }
+        },
+    }
+    (cursor / "mcp.registry.yaml").write_text(yaml.dump(registry), encoding="utf-8")
+
+
+def test_assert_server_rejects_unknown(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    manage = _load("mcp_manage_al", CW / "mcp_manage.py")
+    manage.write_merged_mcp(tmp_path)
+    err = manage.assert_server_allowed(tmp_path, "nope")
+    assert err is not None
+    err2 = manage.assert_server_allowed(tmp_path, "workflow-kit", agent="researcher")
+    assert err2 is not None
+    err3 = manage.assert_server_allowed(tmp_path, "workflow-kit", agent="implementer")
+    assert err3 is None
+
+
+def test_parse_args_json() -> None:
+    client = _load("mcp_client_al", CW / "mcp_client.py")
+    assert client.parse_args_json('{"a":1}') == {"a": 1}
+    with pytest.raises(client.McpClientError):
+        client.parse_args_json("[1]")
+
+
+@pytest.mark.skipif(
+    not (REPO_ROOT / ".venv" / "bin" / "python").is_file(),
+    reason="venv required for live stdio smoke",
+)
+def test_list_tools_workflow_kit_live() -> None:
+    """Live stdio against this kit's workflow-kit server."""
+    manage = _load("mcp_manage_live", CW / "mcp_manage.py")
+    client = _load("mcp_client_live", CW / "mcp_client.py")
+    # Ensure registry exists for allowlist — use example-only path: no live registry
+    # means allowlist skips registry check and only requires merged mcp.json
+    tools = client.list_tools(REPO_ROOT, "workflow-kit")
+    names = {t["name"] for t in tools}
+    assert "workflow_gate_count" in names
+    assert len(tools) >= 5
+
+
+@pytest.mark.skipif(
+    not (REPO_ROOT / ".venv" / "bin" / "python").is_file(),
+    reason="venv required",
+)
+def test_smoke_cli_workflow_kit() -> None:
+    cli = _load("cli_smoke", CW / "cli.py")
+    code = cli.main(["mcp", "smoke", "--directory", str(REPO_ROOT), "--server", "workflow-kit"])
+    assert code == 0
+    arts = list((REPO_ROOT / ".local" / "workflow-artifacts" / "mcp").glob("smoke-*.md"))
+    assert arts

--- a/tests/modules/mcp_client/test_mcp_cli_handlers.py
+++ b/tests/modules/mcp_client/test_mcp_cli_handlers.py
@@ -1,0 +1,318 @@
+"""
+File: test_mcp_cli_handlers.py
+Path: tests/modules/mcp_client/test_mcp_cli_handlers.py
+Role: Handler coverage for mcp_cli Pattern A commands (ADR-009).
+Used By:
+ - pytest
+Depends On:
+ - mcp_cli, mcp_client, mcp_manage, mcp_secrets
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import mcp_cli  # noqa: E402
+import mcp_client  # noqa: E402
+import mcp_manage  # noqa: E402
+import mcp_secrets  # noqa: E402
+
+
+def _seed_kit(root: Path, *, with_registry: bool = True) -> None:
+    cursor = root / ".cursor"
+    cursor.mkdir(parents=True)
+    (cursor / "mcp.json.kit.example").write_text(
+        json.dumps({"mcpServers": {"kit-server": {"command": "echo"}}}),
+        encoding="utf-8",
+    )
+    if with_registry:
+        (cursor / "mcp.registry.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "servers": {
+                        "kit-server": {"agents": ["implementer"], "tier": "kit"},
+                        "bad": "not-a-dict",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def test_build_doctor_report_merge_error(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    (tmp_path / ".cursor" / "mcp.json").write_text("{not-json", encoding="utf-8")
+    report = mcp_cli.build_doctor_report(tmp_path)
+    assert report["merge_error"]
+    assert report["merged_servers"] == []
+
+
+def test_build_doctor_report_skips_non_dict_spec(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    mcp_manage.write_merged_mcp(tmp_path)
+    report = mcp_cli.build_doctor_report(tmp_path)
+    assert "implementer" in report["agent_mappings"]
+    assert "kit-server" in report["agent_mappings"]["implementer"]
+    assert "bad" not in report["registry_servers"] or "bad" in report["registry_servers"]
+
+
+def test_format_doctor_markdown_merge_error_and_empty_mappings() -> None:
+    report = {
+        "root": "/tmp/x",
+        "user_fragment_present": False,
+        "registry_path": None,
+        "registry_live": False,
+        "merged_servers": [],
+        "registry_servers": [],
+        "cursor_mcps_dir": None,
+        "cursor_host_loaded": [],
+        "configured_not_host_loaded": [],
+        "host_loaded_not_configured": [],
+        "workflow_mcp": {"venv_python": None, "import_ok": False, "error": "missing"},
+        "merge_error": "boom",
+        "agent_mappings": {},
+    }
+    body = mcp_cli.format_doctor_markdown(report)
+    assert "**merge error:** boom" in body
+    assert "(none)" in body
+    assert "error: missing" in body
+
+
+def test_format_doctor_markdown_with_mappings() -> None:
+    report = {
+        "root": "/tmp/x",
+        "user_fragment_present": True,
+        "registry_path": "/r.yaml",
+        "registry_live": True,
+        "merged_servers": ["a"],
+        "registry_servers": ["a"],
+        "cursor_mcps_dir": "/mcps",
+        "cursor_host_loaded": ["a"],
+        "configured_not_host_loaded": [],
+        "host_loaded_not_configured": [],
+        "workflow_mcp": {"venv_python": "/py", "import_ok": True},
+        "agent_mappings": {"implementer": ["a"]},
+    }
+    body = mcp_cli.format_doctor_markdown(report)
+    assert "`implementer`: a" in body
+
+
+def test_cmd_mcp_doctor_warns_on_merge_failure(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_manage, "write_merged_mcp", lambda _r: (_ for _ in ()).throw(FileNotFoundError("no kit"))
+    )
+    args = argparse.Namespace(directory=tmp_path)
+    assert mcp_cli.cmd_mcp_doctor(args) == 0
+    err = capsys.readouterr().err
+    assert "WARN" in err
+    assert "merge failed" in err
+
+
+def test_cmd_mcp_list_tools_success(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_client,
+        "list_tools",
+        lambda root, server, agent=None: [{"name": "t1", "description": "line1\nline2"}],
+    )
+    args = argparse.Namespace(directory=tmp_path, server="kit-server", agent=None)
+    assert mcp_cli.cmd_mcp_list_tools(args) == 0
+    assert "t1\tline1 line2" in capsys.readouterr().out
+
+
+def test_cmd_mcp_list_tools_client_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_client,
+        "list_tools",
+        lambda *a, **k: (_ for _ in ()).throw(mcp_client.McpClientError("nope", code=3)),
+    )
+    args = argparse.Namespace(directory=tmp_path, server="kit-server", agent=None)
+    assert mcp_cli.cmd_mcp_list_tools(args) == 3
+
+
+def test_cmd_mcp_list_tools_validation_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_manage, "write_merged_mcp", lambda _r: (_ for _ in ()).throw(ValueError("bad"))
+    )
+    args = argparse.Namespace(directory=tmp_path, server="kit-server", agent=None)
+    assert mcp_cli.cmd_mcp_list_tools(args) == mcp_manage.EXIT_VALIDATION
+
+
+def test_cmd_mcp_call_json_and_string(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(mcp_client, "call_tool", lambda *a, **k: {"ok": True})
+    args = argparse.Namespace(
+        directory=tmp_path, server="kit-server", tool="t", args_json='{"a":1}', agent=None
+    )
+    assert mcp_cli.cmd_mcp_call(args) == 0
+    assert '"ok"' in capsys.readouterr().out
+
+    monkeypatch.setattr(mcp_client, "call_tool", lambda *a, **k: "plain")
+    assert mcp_cli.cmd_mcp_call(args) == 0
+    assert "plain" in capsys.readouterr().out
+
+
+def test_cmd_mcp_call_errors(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_client,
+        "call_tool",
+        lambda *a, **k: (_ for _ in ()).throw(mcp_client.McpClientError("x", code=4)),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, server="kit-server", tool="t", args_json=None, agent=None
+    )
+    assert mcp_cli.cmd_mcp_call(args) == 4
+
+    monkeypatch.setattr(
+        mcp_manage, "write_merged_mcp", lambda _r: (_ for _ in ()).throw(FileNotFoundError("x"))
+    )
+    assert mcp_cli.cmd_mcp_call(args) == mcp_manage.EXIT_VALIDATION
+
+
+def test_cmd_mcp_auth_empty_token_env(tmp_path: Path, monkeypatch, capsys) -> None:
+    args = argparse.Namespace(
+        directory=tmp_path,
+        server="s",
+        token=None,
+        token_env="EMPTY_TOKEN_XYZ",
+        header=None,
+        env_pair=[],
+    )
+    monkeypatch.delenv("EMPTY_TOKEN_XYZ", raising=False)
+    assert mcp_cli.cmd_mcp_auth(args) == mcp_manage.EXIT_USAGE
+    assert "empty" in capsys.readouterr().err
+
+
+def test_cmd_mcp_auth_no_credentials(tmp_path: Path, capsys) -> None:
+    args = argparse.Namespace(
+        directory=tmp_path, server="s", token=None, token_env=None, header=None, env_pair=[]
+    )
+    assert mcp_cli.cmd_mcp_auth(args) == mcp_manage.EXIT_USAGE
+
+
+def test_cmd_mcp_auth_bad_env_pair(tmp_path: Path, capsys) -> None:
+    args = argparse.Namespace(
+        directory=tmp_path,
+        server="s",
+        token="tok",
+        token_env=None,
+        header=None,
+        env_pair=["NOEQUALS"],
+    )
+    assert mcp_cli.cmd_mcp_auth(args) == mcp_manage.EXIT_USAGE
+    assert "bad --env" in capsys.readouterr().err
+
+
+def test_cmd_mcp_auth_write_failure(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        mcp_secrets,
+        "set_server_secret",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("disk")),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        server="s",
+        token="tok",
+        token_env=None,
+        header=None,
+        env_pair=["A=B"],
+    )
+    assert mcp_cli.cmd_mcp_auth(args) == mcp_manage.EXIT_VALIDATION
+
+
+def test_cmd_mcp_auth_success_with_env(tmp_path: Path, capsys) -> None:
+    args = argparse.Namespace(
+        directory=tmp_path,
+        server="s",
+        token="tok",
+        token_env=None,
+        header="X-Api-Key",
+        env_pair=["FOO=bar"],
+    )
+    assert mcp_cli.cmd_mcp_auth(args) == 0
+    entry = mcp_secrets.secrets_for_server(tmp_path, "s")
+    assert entry["token"] == "tok"
+    assert entry["env"]["FOO"] == "bar"
+
+
+def test_cmd_mcp_smoke_client_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_client,
+        "smoke_server",
+        lambda *a, **k: (_ for _ in ()).throw(mcp_client.McpClientError("fail", code=3)),
+    )
+    args = argparse.Namespace(directory=tmp_path, server="kit-server", agent=None)
+    assert mcp_cli.cmd_mcp_smoke(args) == 3
+    err = capsys.readouterr().err
+    assert "artifact:" in err
+    arts = list((tmp_path / ".local" / "workflow-artifacts" / "mcp").glob("smoke-*.md"))
+    assert arts
+
+
+def test_cmd_mcp_smoke_validation_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_manage, "write_merged_mcp", lambda _r: (_ for _ in ()).throw(ValueError("bad"))
+    )
+    args = argparse.Namespace(directory=tmp_path, server="kit-server", agent=None)
+    assert mcp_cli.cmd_mcp_smoke(args) == mcp_manage.EXIT_VALIDATION
+
+
+def test_cmd_mcp_smoke_success(tmp_path: Path, monkeypatch, capsys) -> None:
+    _seed_kit(tmp_path)
+    monkeypatch.setattr(
+        mcp_client,
+        "smoke_server",
+        lambda *a, **k: {"server": "kit-server", "ok": True, "tool_count": 1, "tools": ["t"]},
+    )
+    args = argparse.Namespace(directory=tmp_path, server="kit-server", agent=None)
+    assert mcp_cli.cmd_mcp_smoke(args) == 0
+    out = capsys.readouterr().out
+    assert "MCP smoke OK" in out
+    assert "artifact:" in out
+
+
+def test_cmd_mcp_validate_merge_fail(tmp_path: Path, capsys) -> None:
+    (tmp_path / ".cursor").mkdir()
+    args = argparse.Namespace(directory=tmp_path, strict=False)
+    assert mcp_cli.cmd_mcp_validate(args) == 1
+    assert "FAIL" in capsys.readouterr().err
+
+
+def test_cmd_mcp_link_success_and_fail(tmp_path: Path, capsys) -> None:
+    _seed_kit(tmp_path)
+    fragment = tmp_path / "frag.json"
+    fragment.write_text(
+        json.dumps({"mcpServers": {"new-server": {"command": "bar"}}}), encoding="utf-8"
+    )
+    args = argparse.Namespace(directory=tmp_path, name="new-server", file=fragment)
+    assert mcp_cli.cmd_mcp_link(args) == 0
+    assert "linked" in capsys.readouterr().out
+    assert (tmp_path / ".gitignore").is_file()
+
+    bad = argparse.Namespace(directory=tmp_path, name="x", file=fragment)
+    # fragment has new-server only; linking name x with multi? empty rename path —
+    # use empty fragment for failure
+    empty = tmp_path / "empty.json"
+    empty.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+    bad.file = empty
+    assert mcp_cli.cmd_mcp_link(bad) == 1
+    assert "FAIL" in capsys.readouterr().err

--- a/tests/modules/mcp_client/test_mcp_client_http.py
+++ b/tests/modules/mcp_client/test_mcp_client_http.py
@@ -1,0 +1,223 @@
+"""
+File: test_mcp_client_http.py
+Path: tests/modules/mcp_client/test_mcp_client_http.py
+Role: HTTP transport + call_tool result shaping + error wrapping for mcp_client.
+Used By:
+ - pytest
+Depends On:
+ - mcp_client, mcp_manage, mcp_secrets
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import mcp_client  # noqa: E402
+import mcp_manage  # noqa: E402
+import mcp_secrets  # noqa: E402
+
+
+def _seed(root: Path, server_spec: dict[str, Any], *, agents: list[str] | None = None) -> None:
+    cursor = root / ".cursor"
+    cursor.mkdir(parents=True)
+    (cursor / "mcp.json.kit.example").write_text(
+        json.dumps({"mcpServers": {"svc": server_spec}}), encoding="utf-8"
+    )
+    (cursor / "mcp.registry.yaml").write_text(
+        yaml.safe_dump(
+            {"servers": {"svc": {"agents": agents or ["implementer"], "tier": "kit"}}}
+        ),
+        encoding="utf-8",
+    )
+    mcp_manage.write_merged_mcp(root)
+
+
+def test_parse_args_json_none_and_invalid() -> None:
+    assert mcp_client.parse_args_json(None) == {}
+    assert mcp_client.parse_args_json("") == {}
+    with pytest.raises(mcp_client.McpClientError) as exc:
+        mcp_client.parse_args_json("{bad")
+    assert exc.value.code == mcp_client.EXIT_USAGE
+
+
+def test_resolve_spec_rejects_unknown(tmp_path: Path) -> None:
+    _seed(tmp_path, {"command": "echo"})
+    with pytest.raises(mcp_client.McpClientError) as exc:
+        mcp_client._resolve_spec(tmp_path, "ghost")
+    assert exc.value.code == mcp_client.EXIT_VALIDATION
+
+
+def test_open_session_agent_not_allowed(tmp_path: Path) -> None:
+    _seed(tmp_path, {"command": "echo"}, agents=["implementer"])
+    with pytest.raises(mcp_client.McpClientError, match="not mapped"):
+        mcp_client.list_tools(tmp_path, "svc", agent="researcher")
+
+
+def test_open_session_needs_command_or_url(tmp_path: Path) -> None:
+    _seed(tmp_path, {})
+    with pytest.raises(mcp_client.McpClientError, match="needs 'command'"):
+        mcp_client.list_tools(tmp_path, "svc")
+
+
+def test_open_session_args_must_be_list(tmp_path: Path) -> None:
+    _seed(tmp_path, {"command": "echo", "args": "nope"})
+    with pytest.raises(mcp_client.McpClientError, match="args must be a list"):
+        mcp_client.list_tools(tmp_path, "svc")
+
+
+def test_list_tools_wraps_unexpected(tmp_path: Path, monkeypatch) -> None:
+    async def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mcp_client, "_list_tools_async", boom)
+    with pytest.raises(mcp_client.McpClientError) as exc:
+        mcp_client.list_tools(tmp_path, "svc")
+    assert exc.value.code == mcp_client.EXIT_GH
+
+
+def test_call_tool_wraps_unexpected(tmp_path: Path, monkeypatch) -> None:
+    async def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mcp_client, "_call_tool_async", boom)
+    with pytest.raises(mcp_client.McpClientError) as exc:
+        mcp_client.call_tool(tmp_path, "svc", "t", {})
+    assert exc.value.code == mcp_client.EXIT_GH
+
+
+def test_call_tool_reraises_mcp_client_error(tmp_path: Path, monkeypatch) -> None:
+    async def boom(*a, **k):
+        raise mcp_client.McpClientError("nope", code=5)
+
+    monkeypatch.setattr(mcp_client, "_call_tool_async", boom)
+    with pytest.raises(mcp_client.McpClientError) as exc:
+        mcp_client.call_tool(tmp_path, "svc", "t", {})
+    assert exc.value.code == 5
+    assert str(exc.value) == "nope"
+
+
+def test_call_tool_result_shaping(tmp_path: Path, monkeypatch) -> None:
+    class Session:
+        def __init__(self, result):
+            self._result = result
+
+        async def call_tool(self, tool, arguments=None):
+            return self._result
+
+    @asynccontextmanager
+    async def fake_open(root, server, *, agent=None):
+        yield Session(SimpleNamespace(structuredContent={"a": 1}, content=None))
+
+    monkeypatch.setattr(mcp_client, "_open_session", fake_open)
+    assert mcp_client.call_tool(tmp_path, "svc", "t") == {"a": 1}
+
+    @asynccontextmanager
+    async def fake_open_text(root, server, *, agent=None):
+        yield Session(
+            SimpleNamespace(
+                structuredContent=None,
+                content=[SimpleNamespace(text="only")],
+            )
+        )
+
+    monkeypatch.setattr(mcp_client, "_open_session", fake_open_text)
+    assert mcp_client.call_tool(tmp_path, "svc", "t") == "only"
+
+    @asynccontextmanager
+    async def fake_open_multi(root, server, *, agent=None):
+        yield Session(
+            SimpleNamespace(
+                structuredContent=None,
+                content=[SimpleNamespace(text="a"), SimpleNamespace(text="b"), object()],
+            )
+        )
+
+    monkeypatch.setattr(mcp_client, "_open_session", fake_open_multi)
+    result = mcp_client.call_tool(tmp_path, "svc", "t")
+    assert result[0] == "a" and result[1] == "b"
+    assert len(result) == 3
+
+
+def test_http_transport_with_and_without_headers(tmp_path: Path, monkeypatch) -> None:
+    _seed(tmp_path, {"url": "https://example.test/mcp"})
+    mcp_secrets.set_server_secret(tmp_path, "svc", token="tok")
+
+    calls: list[str] = []
+
+    class FakeSession:
+        async def initialize(self):
+            return None
+
+        async def list_tools(self):
+            return SimpleNamespace(tools=[SimpleNamespace(name="ht", description="d")])
+
+    @asynccontextmanager
+    async def fake_http_client(*, headers=None):
+        calls.append(f"http_client:{bool(headers)}")
+        yield object()
+
+    @asynccontextmanager
+    async def fake_streamable(url, http_client=None):
+        calls.append(f"streamable:{url}:{http_client is not None}")
+        yield (object(), object())
+
+    @asynccontextmanager
+    async def fake_client_session(read, write):
+        yield FakeSession()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mcp.client.streamable_http",
+        SimpleNamespace(
+            streamable_http_client=fake_streamable,
+            create_mcp_http_client=fake_http_client,
+        ),
+    )
+    # Also patch imports used inside _open_session
+    import mcp.client.streamable_http as sh  # noqa: F401
+
+    monkeypatch.setattr(
+        "mcp.client.streamable_http.streamable_http_client", fake_streamable, raising=False
+    )
+    monkeypatch.setattr(
+        "mcp.client.streamable_http.create_mcp_http_client", fake_http_client, raising=False
+    )
+    monkeypatch.setattr("mcp.ClientSession", fake_client_session)
+
+    tools = mcp_client.list_tools(tmp_path, "svc")
+    assert tools[0]["name"] == "ht"
+    assert any(c.startswith("http_client:True") for c in calls)
+
+    # without headers
+    secrets_path = tmp_path / ".local" / "user_settings" / "mcp.secrets.yaml"
+    if secrets_path.is_file():
+        secrets_path.unlink()
+    calls.clear()
+    tools = mcp_client.list_tools(tmp_path, "svc")
+    assert tools[0]["name"] == "ht"
+    assert any("streamable:" in c and ":False" in c for c in calls)
+
+
+def test_smoke_server(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        mcp_client,
+        "list_tools",
+        lambda *a, **k: [{"name": "a", "description": ""}],
+    )
+    out = mcp_client.smoke_server(tmp_path, "svc")
+    assert out["tool_count"] == 1
+    assert out["tools"] == ["a"]

--- a/tests/modules/mcp_client/test_mcp_doctor.py
+++ b/tests/modules/mcp_client/test_mcp_doctor.py
@@ -1,0 +1,111 @@
+"""
+File: test_mcp_doctor.py
+Path: tests/modules/mcp_client/test_mcp_doctor.py
+Role: Unit tests for mcp doctor report builders and validate --strict.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/cursor_workflow/mcp_cli.py
+ - .ai_infra/install/cursor_workflow/mcp_manage.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CW = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    # Ensure sibling imports resolve
+    if str(CW) not in sys.path:
+        sys.path.insert(0, str(CW))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_kit(root: Path, *, with_registry: bool = False, with_user: bool = False) -> None:
+    cursor = root / ".cursor"
+    cursor.mkdir(parents=True)
+    kit = json.loads((REPO_ROOT / ".cursor" / "mcp.json.kit.example").read_text(encoding="utf-8"))
+    (cursor / "mcp.json.kit.example").write_text(json.dumps(kit, indent=2), encoding="utf-8")
+    if with_user:
+        user = {
+            "mcpServers": {
+                "deepwiki": {"url": "https://mcp.deepwiki.com/mcp"},
+            }
+        }
+        (cursor / "mcp.user.json").write_text(json.dumps(user, indent=2), encoding="utf-8")
+    if with_registry:
+        registry = yaml.safe_load(
+            (REPO_ROOT / ".cursor" / "mcp.registry.yaml.example").read_text(encoding="utf-8")
+        )
+        # only keep servers we can satisfy
+        if with_user:
+            registry["servers"] = {
+                k: v
+                for k, v in registry["servers"].items()
+                if k in ("workflow-kit", "deepwiki")
+            }
+        else:
+            registry["servers"] = {"workflow-kit": registry["servers"]["workflow-kit"]}
+        (cursor / "mcp.registry.yaml").write_text(yaml.dump(registry), encoding="utf-8")
+    else:
+        # still ship example for doctor fallback
+        example = (REPO_ROOT / ".cursor" / "mcp.registry.yaml.example").read_text(encoding="utf-8")
+        (cursor / "mcp.registry.yaml.example").write_text(example, encoding="utf-8")
+
+
+def test_doctor_report_configured_vs_host(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    if str(CW) not in sys.path:
+        sys.path.insert(0, str(CW))
+    manage = _load("mcp_manage", CW / "mcp_manage.py")
+    mcp_cli = _load("mcp_cli", CW / "mcp_cli.py")
+    manage.write_merged_mcp(tmp_path)
+    mcps = tmp_path / "fake-mcps"
+    (mcps / "cursor-ide-browser").mkdir(parents=True)
+    original = manage.cursor_project_mcps_dir
+    manage.cursor_project_mcps_dir = lambda _root: mcps  # type: ignore[assignment]
+    try:
+        report = mcp_cli.build_doctor_report(tmp_path)
+    finally:
+        manage.cursor_project_mcps_dir = original  # type: ignore[assignment]
+    assert "workflow-kit" in report["merged_servers"]
+    assert "workflow-kit" in report["configured_not_host_loaded"]
+    assert "cursor-ide-browser" in report["host_loaded_not_configured"]
+    md = mcp_cli.format_doctor_markdown(report)
+    assert "configured but NOT host-loaded" in md
+
+
+def test_validate_strict_fails_without_live_registry(tmp_path: Path) -> None:
+    _seed_kit(tmp_path, with_registry=False)
+    cli = _load("cursor_workflow_cli_doc", REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow" / "cli.py")
+    code = cli.main(["mcp", "validate", "--directory", str(tmp_path), "--strict"])
+    assert code == 1
+
+
+def test_validate_strict_passes_with_live_registry(tmp_path: Path) -> None:
+    _seed_kit(tmp_path, with_registry=True, with_user=False)
+    cli = _load("cursor_workflow_cli_doc2", REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow" / "cli.py")
+    code = cli.main(["mcp", "validate", "--directory", str(tmp_path), "--strict"])
+    assert code == 0
+
+
+def test_doctor_cli_writes_artifact(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    cli = _load("cursor_workflow_cli_doc3", REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow" / "cli.py")
+    code = cli.main(["mcp", "doctor", "--directory", str(tmp_path)])
+    assert code == 0
+    arts = list((tmp_path / ".local" / "workflow-artifacts" / "mcp").glob("doctor-*.md"))
+    assert arts

--- a/tests/modules/mcp_client/test_mcp_secrets.py
+++ b/tests/modules/mcp_client/test_mcp_secrets.py
@@ -1,0 +1,64 @@
+"""
+File: test_mcp_secrets.py
+Path: tests/modules/mcp_client/test_mcp_secrets.py
+Role: Unit tests for mcp.secrets.yaml helpers and auth CLI.
+Used By:
+ - pytest
+Depends On:
+ - mcp_secrets, cli
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CW = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+
+def _load(name: str, path: Path):
+    if str(CW) not in sys.path:
+        sys.path.insert(0, str(CW))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_set_and_load_secrets(tmp_path: Path) -> None:
+    secrets = _load("mcp_secrets_t", CW / "mcp_secrets.py")
+    secrets.set_server_secret(tmp_path, "my-api", token="sekrit", header_name="Authorization")
+    entry = secrets.secrets_for_server(tmp_path, "my-api")
+    assert entry["token"] == "sekrit"
+    headers = secrets.http_headers_from_secrets(entry)
+    assert headers["Authorization"].startswith("Bearer ")
+
+
+def test_auth_cli(tmp_path: Path, monkeypatch) -> None:
+    cursor = tmp_path / ".cursor"
+    cursor.mkdir()
+    kit = json.loads((REPO_ROOT / ".cursor" / "mcp.json.kit.example").read_text(encoding="utf-8"))
+    (cursor / "mcp.json.kit.example").write_text(json.dumps(kit), encoding="utf-8")
+    monkeypatch.setenv("MCP_TEST_TOKEN", "abc123")
+    cli = _load("cli_auth", CW / "cli.py")
+    code = cli.main(
+        [
+            "mcp",
+            "auth",
+            "--directory",
+            str(tmp_path),
+            "--server",
+            "my-api",
+            "--token-env",
+            "MCP_TEST_TOKEN",
+        ]
+    )
+    assert code == 0
+    text = (tmp_path / ".local" / "user_settings" / "mcp.secrets.yaml").read_text(encoding="utf-8")
+    assert "abc123" in text
+    assert "my-api" in text

--- a/tests/modules/mcp_client/test_mcp_secrets_edges.py
+++ b/tests/modules/mcp_client/test_mcp_secrets_edges.py
@@ -1,0 +1,92 @@
+"""
+File: test_mcp_secrets_edges.py
+Path: tests/modules/mcp_client/test_mcp_secrets_edges.py
+Role: Edge coverage for mcp_secrets miss lines.
+Used By:
+ - pytest
+Depends On:
+ - mcp_secrets
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import mcp_secrets  # noqa: E402
+
+
+def test_load_secrets_invalid_root(tmp_path: Path) -> None:
+    path = mcp_secrets.secrets_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("- list\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid secrets file"):
+        mcp_secrets.load_secrets(tmp_path)
+
+
+def test_load_secrets_missing_servers_key(tmp_path: Path) -> None:
+    path = mcp_secrets.secrets_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("version: 1\n", encoding="utf-8")
+    data = mcp_secrets.load_secrets(tmp_path)
+    assert data["servers"] == {}
+
+
+def test_load_secrets_servers_not_dict(tmp_path: Path) -> None:
+    path = mcp_secrets.secrets_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("servers: []\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a mapping"):
+        mcp_secrets.load_secrets(tmp_path)
+
+
+def test_set_server_secret_servers_not_dict(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(mcp_secrets, "load_secrets", lambda _r: {"servers": []})
+    with pytest.raises(ValueError, match="must be a mapping"):
+        mcp_secrets.set_server_secret(tmp_path, "s", token="t")
+
+
+def test_set_server_secret_with_env_and_merge(tmp_path: Path) -> None:
+    mcp_secrets.set_server_secret(tmp_path, "api", token="t1")
+    mcp_secrets.set_server_secret(
+        tmp_path, "api", header_name="X-Api-Key", env={"K": "V"}
+    )
+    entry = mcp_secrets.secrets_for_server(tmp_path, "api")
+    assert entry["token"] == "t1"
+    assert entry["header"] == "X-Api-Key"
+    assert entry["env"]["K"] == "V"
+
+
+def test_secrets_for_server_invalid_servers(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(mcp_secrets, "load_secrets", lambda _r: {"servers": "bad"})
+    assert mcp_secrets.secrets_for_server(tmp_path, "x") == {}
+
+
+def test_http_headers_custom_and_bearer_and_extra() -> None:
+    h1 = mcp_secrets.http_headers_from_secrets(
+        {"token": "Bearer xyz", "header": "Authorization"}
+    )
+    assert h1["Authorization"] == "Bearer xyz"
+    h2 = mcp_secrets.http_headers_from_secrets({"token": "raw", "header": "X-Auth"})
+    assert h2["X-Auth"] == "raw"
+    h3 = mcp_secrets.http_headers_from_secrets(
+        {"token": "t", "headers": {"X-Custom": "v", 1: "skip", "bad": 2}}
+    )
+    assert h3["Authorization"].startswith("Bearer ")
+    assert h3["X-Custom"] == "v"
+    assert "bad" not in h3
+
+
+def test_env_from_secrets() -> None:
+    assert mcp_secrets.env_from_secrets({}) == {}
+    assert mcp_secrets.env_from_secrets({"env": "nope"}) == {}
+    assert mcp_secrets.env_from_secrets({"env": {"A": 1}}) == {"A": "1"}

--- a/tests/modules/mcp_registry/test_mcp_manage_edges.py
+++ b/tests/modules/mcp_registry/test_mcp_manage_edges.py
@@ -1,0 +1,172 @@
+"""
+File: test_mcp_manage_edges.py
+Path: tests/modules/mcp_registry/test_mcp_manage_edges.py
+Role: Edge coverage for mcp_manage doctor/load helpers (ADR-009).
+Used By:
+ - pytest
+Depends On:
+ - mcp_manage
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG = REPO_ROOT / ".ai_infra" / "install" / "cursor_workflow"
+
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import mcp_manage  # noqa: E402
+
+
+def _seed_kit(root: Path) -> None:
+    cursor = root / ".cursor"
+    cursor.mkdir(parents=True)
+    (cursor / "mcp.json.kit.example").write_text(
+        json.dumps({"mcpServers": {"kit-server": {"command": "echo"}}}),
+        encoding="utf-8",
+    )
+
+
+def test_validate_registry_strict_external_and_bad_spec(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    mcp_manage.write_merged_mcp(tmp_path)
+    (tmp_path / ".cursor" / "mcp.registry.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "servers": {
+                    "kit-server": {"agents": [], "tier": "kit"},
+                    "bad": [],
+                    "ext-svc": {"agents": [], "tier": "external"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    errors = mcp_manage.validate_registry(tmp_path, strict=True)
+    assert any("ext-svc" in e for e in errors)
+
+
+def test_load_merged_servers_write_and_auto(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    servers = mcp_manage.load_merged_servers(tmp_path, write=True)
+    assert "kit-server" in servers
+    mcp_path = tmp_path / ".cursor" / "mcp.json"
+    assert mcp_path.is_file()
+    mcp_path.unlink()
+    servers2 = mcp_manage.load_merged_servers(tmp_path)
+    assert "kit-server" in servers2
+
+
+def test_load_merged_servers_invalid_mcp_servers(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    mcp_manage.write_merged_mcp(tmp_path)
+    (tmp_path / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": []}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="must be an object"):
+        mcp_manage.load_merged_servers(tmp_path)
+
+
+def test_registry_path_used_live_and_none(tmp_path: Path) -> None:
+    cursor = tmp_path / ".cursor"
+    cursor.mkdir()
+    assert mcp_manage.registry_path_used(tmp_path) is None
+    (cursor / "mcp.registry.yaml").write_text("servers: {}\n", encoding="utf-8")
+    assert mcp_manage.registry_path_used(tmp_path) == cursor / "mcp.registry.yaml"
+
+
+def test_registry_servers_missing(tmp_path: Path) -> None:
+    assert mcp_manage.registry_servers(tmp_path) == {}
+
+
+def test_servers_for_agent_none_and_skips_bad(tmp_path: Path) -> None:
+    assert mcp_manage.servers_for_agent(tmp_path, None) is None
+    _seed_kit(tmp_path)
+    (tmp_path / ".cursor" / "mcp.registry.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "servers": {
+                    "good": {"agents": ["implementer"]},
+                    "bad": "x",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    allowed = mcp_manage.servers_for_agent(tmp_path, "implementer")
+    assert allowed == {"good"}
+
+
+def test_assert_server_in_registry_not_in_merged(tmp_path: Path) -> None:
+    _seed_kit(tmp_path)
+    mcp_manage.write_merged_mcp(tmp_path)
+    (tmp_path / ".cursor" / "mcp.registry.yaml").write_text(
+        yaml.safe_dump({"servers": {"ghost": {"agents": []}, "kit-server": {"agents": []}}}),
+        encoding="utf-8",
+    )
+    # ghost in registry but not mcp.json
+    err = mcp_manage.assert_server_allowed(tmp_path, "ghost")
+    assert err is not None
+    assert "not in merged" in err or "not in registry" in err or "ghost" in err
+
+
+def test_expand_server_env_passthrough(tmp_path: Path) -> None:
+    out = mcp_manage.expand_server_env(
+        {"command": "${workspaceFolder}/bin", "timeout": 30, "args": ["${workspaceFolder}"]},
+        tmp_path,
+    )
+    assert str(tmp_path) in out["command"]
+    assert out["timeout"] == 30
+    assert out["args"][0] == str(tmp_path)
+
+
+def test_list_cursor_host_servers(tmp_path: Path) -> None:
+    assert mcp_manage.list_cursor_host_servers(None) == []
+    mcps = tmp_path / "mcps"
+    mcps.mkdir()
+    (mcps / "alpha").mkdir()
+    (mcps / ".hidden").mkdir()
+    (mcps / "file.txt").write_text("x", encoding="utf-8")
+    assert mcp_manage.list_cursor_host_servers(mcps) == ["alpha"]
+
+
+def test_check_workflow_mcp_import_missing(tmp_path: Path) -> None:
+    result = mcp_manage.check_workflow_mcp_import(tmp_path)
+    assert result["import_ok"] is False
+    assert result["error"]
+
+
+def test_check_workflow_mcp_import_success_and_fail(tmp_path: Path, monkeypatch) -> None:
+    venv_py = tmp_path / ".venv" / "bin" / "python"
+    venv_py.parent.mkdir(parents=True)
+    venv_py.write_text("#!/bin/sh\n", encoding="utf-8")
+    venv_py.chmod(0o755)
+    (tmp_path / ".ai_infra" / "mcp_servers").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="/mod.py\n", stderr=""),
+    )
+    ok = mcp_manage.check_workflow_mcp_import(tmp_path)
+    assert ok["import_ok"] is True
+    assert ok["module_file"] == "/mod.py"
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="No module"),
+    )
+    fail = mcp_manage.check_workflow_mcp_import(tmp_path)
+    assert fail["import_ok"] is False
+    assert "No module" in fail["error"]

--- a/tests/modules/mcp_registry/test_mcp_manage_full.py
+++ b/tests/modules/mcp_registry/test_mcp_manage_full.py
@@ -297,10 +297,24 @@ def test_ensure_mcp_gitignore_appends_when_missing(tmp_path: Path) -> None:
     text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
     assert "node_modules/" in text
     assert ".cursor/mcp.user.json" in text
+    assert ".local/user_settings/mcp.secrets.yaml" in text
 
 
 def test_ensure_mcp_gitignore_noop_when_present(tmp_path: Path) -> None:
-    existing = "node_modules/\n.cursor/mcp.user.json\n"
+    existing = (
+        "node_modules/\n"
+        ".cursor/mcp.user.json\n"
+        ".local/user_settings/mcp.secrets.yaml\n"
+    )
     (tmp_path / ".gitignore").write_text(existing, encoding="utf-8")
     mcp_manage.ensure_mcp_gitignore(tmp_path)
     assert (tmp_path / ".gitignore").read_text(encoding="utf-8") == existing
+
+
+def test_ensure_mcp_gitignore_adds_secrets_line(tmp_path: Path) -> None:
+    existing = "node_modules/\n.cursor/mcp.user.json\n"
+    (tmp_path / ".gitignore").write_text(existing, encoding="utf-8")
+    mcp_manage.ensure_mcp_gitignore(tmp_path)
+    text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert ".local/user_settings/mcp.secrets.yaml" in text
+    assert ".cursor/mcp.user.json" in text

--- a/tests/modules/pr_workflow/test_local_workflow_paths.py
+++ b/tests/modules/pr_workflow/test_local_workflow_paths.py
@@ -45,3 +45,11 @@ def test_workflow_artifact_buckets_count() -> None:
     assert len(mod.WORKFLOW_ARTIFACT_BUCKETS) == 6
     assert len(mod.ARTIFACT_STUB_BUCKET_NAMES) == 6
     assert mod.ARTIFACT_STUB_BUCKET_NAMES == tuple(p.name for p in mod.WORKFLOW_ARTIFACT_BUCKETS)
+
+
+def test_ensure_local_artifact_tree_creates_canvas_and_plans(tmp_path: Path) -> None:
+    mod = _load_local_workflow_paths()
+    mod.ensure_local_artifact_tree(root=tmp_path)
+    for directory in mod.LOCAL_ARTIFACT_DIRS:
+        assert (tmp_path / directory).is_dir(), f"missing: {directory}"
+    assert (tmp_path / mod.WORKFLOW_CANVAS_DIR).is_dir()

--- a/tests/modules/workflow_drift/test_check_drift_full.py
+++ b/tests/modules/workflow_drift/test_check_drift_full.py
@@ -109,6 +109,7 @@ def test_run_checks_uses_consumer_board_when_board_only(tmp_path: Path) -> None:
         "DRIFT-008",
         "DRIFT-009",
         "DRIFT-010",
+        "DRIFT-012",
     ]
 
 

--- a/tests/modules/workflow_drift/test_drift012_plan_snapshots.py
+++ b/tests/modules/workflow_drift/test_drift012_plan_snapshots.py
@@ -1,0 +1,54 @@
+"""
+File: test_drift012_plan_snapshots.py
+Path: tests/modules/workflow_drift/test_drift012_plan_snapshots.py
+Role: Tests for DRIFT-012 .local/plans live-plan misuse guard.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/workflow/drift_checks.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".ai_infra" / "scripts" / "workflow"
+if str(WORKFLOW_DIR) not in sys.path:
+    sys.path.insert(0, str(WORKFLOW_DIR))
+
+from drift_checks import check_drift012, drift_paths  # noqa: E402
+
+
+def _board_only_root(tmp: Path) -> Path:
+    settings = tmp / ".local" / "user_settings"
+    settings.mkdir(parents=True)
+    data = {
+        "version": 1,
+        "owner": {"display_name": "T", "github_user": "@t"},
+        "project_ssot": {"enabled": True, "sync_policy": "board_only"},
+        "commit_provenance": {"ai_disclosure_mode": "none"},
+        "pr_collaboration": {"pipelines": {"default": {"agents": ["review-pr"]}}},
+    }
+    (settings / "github.collaboration.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+    return tmp
+
+
+def test_drift012_passes_when_plans_dir_absent(tmp_path: Path) -> None:
+    root = _board_only_root(tmp_path)
+    result = check_drift012(drift_paths(root))
+    assert result.passed
+    assert result.check_id == "DRIFT-012"
+
+
+def test_drift012_fails_on_current_plan_filename(tmp_path: Path) -> None:
+    root = _board_only_root(tmp_path)
+    plans = root / ".local" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "current.plan.md").write_text("# Current\n", encoding="utf-8")
+    result = check_drift012(drift_paths(root))
+    assert not result.passed
+    assert "current.plan.md" in result.detail


### PR DESCRIPTION
## Summary
- Align agents, skills, docs, and canvases with ADR-010 (`.local/canvases` / `.local/plans` history; board live plan SSOT; `plan open` for human Build).
- Close install-package coverage to **5199 stmts / Miss=0** (27 modules); raise project item-fetch `--limit` default to **200**.
- Ship Pattern A MCP/canvas/plan CLI surfaces (ADR-009/010), DRIFT-012, dual coverage metrics in IMPLEMENTATION-STATUS.

## Test plan
- [x] `pytest tests/modules/ -q` — 1409 passed, 2 intentional live skips
- [x] `--cov=.ai_infra/install/cursor_workflow` — 100% Miss=0
- [x] DOC-006 / INT-013 (test count 1411)
- [x] `python3 -m cursor_workflow plan -h` lists `open`
- [x] `make check-plugin` + governance consistency PASS
- [ ] prepare.py gates green on PR

## Collaboration
- Board-Item: PVTI_lAHOBl46-84A9KZxzg1YKjg
- Pipeline: architecture_impacting