### PR TITLE
Fix consumer activate crash and ship MCP worksheets in payload

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-08-05 (cursor_workflow install COV-100; 1411 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1411
+**Last updated:** 2026-08-05 (consumer activate MCP fix; 1412 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1412
 
 ## Shipped (confirmed in repo)
 
@@ -54,7 +54,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1411 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1412 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
+++ b/.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
@@ -104,7 +104,7 @@ Maintainer megadocs live under `.ai_infra/docs/maintainer/` (not copied to consu
 ```text
 my-app/
 ├── AGENTS.md                 # thin router
-├── .cursor/                  # agents, rules, skills
+├── .cursor/                  # agents, rules, skills + MCP examples (with_mcp)
 ├── .agents/                  # maintainer slash skills
 ├── .ai_infra/                # slim infrastructure bundle
 │   ├── manifest.yaml
@@ -115,8 +115,8 @@ my-app/
 │   ├── templates/local-workspace|user-settings|agent-integration|project-board|research-corpus/
 │   ├── mcp_servers/workflow_mcp/   # with_mcp profile
 │   └── workflows/
-├── overlays/                 # product rules source (copy → .cursor/rules/)
-└── .local/                   # scaffolded trackers
+├── cursor_workflow/          # CLI entry
+└── .local/                   # scaffolded trackers + canvases/ + plans/
 ```
 
 **Not installed by default:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs under `docs/maintainer/`.
@@ -137,10 +137,10 @@ The path `.ai_infra/templates/local-workspace/ci/kit-dev/` holds **kit-repositor
 | Profile    | Adds                                                                             |
 | ---------- | -------------------------------------------------------------------------------- |
 | `default`  | `.cursor/`, `.agents/`, slim `.ai_infra/`, `.local/` exemplars, `AGENTS.md` stub |
-| `with_mcp` | `.ai_infra/mcp_servers/workflow_mcp/`, `requirements-mcp.txt`, `mcp.json`        |
+| `with_mcp` | `.ai_infra/mcp_servers/workflow_mcp/`, `requirements-mcp.txt`, merged `.cursor/mcp.json`, MCP worksheets (`mcp.*.example`, `.cursor/mcp.d/`) |
 
 
-Product rules: copy `overlays/rules/*.mdc` into `.cursor/rules/` after install (not a separate profile).
+Product rules already ship in `.cursor/rules/` via activate. Optional `overlays/rules/*.mdc` remain kit-dev / install-time extras — not a separate consumer profile.
 
 **Skill merge policy:**
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1411; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1412; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/scripts/install/scaffold.py
+++ b/.ai_infra/scripts/install/scaffold.py
@@ -10,6 +10,7 @@ Depends On:
  - .ai_infra/bootstrap.py
 Notes:
  - Default profile: .cursor, .agents, slim .ai_infra, .local exemplars, AGENTS stub.
+ - MCP merge loads mcp_manage with install/cursor_workflow on sys.path (cursor_host_paths).
 """
 
 from __future__ import annotations
@@ -479,6 +480,28 @@ def _apply_overlay_rules(source: Path, target: Path, rel_overlay: str, dry_run: 
         _copy_file(mdc, dest / mdc.name, dry_run, log)
 
 
+def _load_mcp_manage(source: Path) -> Any | None:
+    """Load mcp_manage from the install package with sibling imports resolvable.
+
+    Scaffold runs as a standalone script; pytest's pythonpath does not apply.
+    mcp_manage imports cursor_host_paths from the same directory.
+    """
+    import importlib.util
+
+    mcp_manage_path = source / ".ai_infra" / "install" / "cursor_workflow" / "mcp_manage.py"
+    if not mcp_manage_path.is_file():
+        return None
+    cw_dir = str(mcp_manage_path.parent)
+    if cw_dir not in sys.path:
+        sys.path.insert(0, cw_dir)
+    spec_mod = importlib.util.spec_from_file_location("mcp_manage", mcp_manage_path)
+    if spec_mod is None or spec_mod.loader is None:
+        return None
+    mcp_manage = importlib.util.module_from_spec(spec_mod)
+    spec_mod.loader.exec_module(mcp_manage)
+    return mcp_manage
+
+
 def _sanity_check(target: Path, log: list[str], *, with_tests: bool = False) -> list[str]:
     errors: list[str] = []
     agents = target / ".cursor" / "agents"
@@ -640,14 +663,8 @@ def scaffold(
         if dry_run:
             _log(log, "DRY-RUN merge .cursor/mcp.json from kit + user fragments")
         else:
-            mcp_manage_path = source / ".ai_infra" / "install" / "cursor_workflow" / "mcp_manage.py"
-            if mcp_manage_path.is_file():
-                import importlib.util
-
-                spec_mod = importlib.util.spec_from_file_location("mcp_manage", mcp_manage_path)
-                assert spec_mod is not None and spec_mod.loader is not None
-                mcp_manage = importlib.util.module_from_spec(spec_mod)
-                spec_mod.loader.exec_module(mcp_manage)
+            mcp_manage = _load_mcp_manage(source)
+            if mcp_manage is not None:
                 dest = mcp_manage.write_merged_mcp(target)
                 mcp_manage.ensure_mcp_gitignore(target)
                 _log(log, f"WRITE merged MCP config {dest}")

--- a/.ai_infra/scripts/release/sync_plugin_bundle.py
+++ b/.ai_infra/scripts/release/sync_plugin_bundle.py
@@ -58,6 +58,17 @@ CONNECT_SKILL_SRC = (
     ai_infra_dir() / "templates" / "plugin" / "skills" / "mcp-connect" / "SKILL.md"
 )
 LICENSE_FILES = ("LICENSE", "NOTICE")
+# Consumer MCP worksheets for /mcp-connect (examples only — never live mcp.json /
+# mcp.user.json / mcp.registry.yaml with kit-dev secrets or local servers).
+MCP_PAYLOAD_EXAMPLES = (
+    "mcp.json.kit.example",
+    "mcp.registry.yaml.example",
+    "mcp.user.example.json",
+)
+MCP_D_PAYLOAD_FILES = (
+    "README.md",
+    "user.example.json",
+)
 
 _SKIP_DIR_NAMES = frozenset({"__pycache__", ".pytest_cache", ".mypy_cache"})
 _SKIP_FILE_SUFFIXES = (".pyc", ".pyo")
@@ -219,9 +230,20 @@ def sync_payload(payload_dir: Path, plugin_dir: Path, profile: str = "with_mcp")
     # loading — do not copy merged skills/ into payload or install --verify fails governance.
     _copy_tree(KIT_ROOT / ".cursor" / "skills", payload_dir / ".cursor" / "skills")
 
-    mcp_kit = KIT_ROOT / ".cursor" / "mcp.json.kit.example"
-    if mcp_kit.is_file() and profile == "with_mcp":
-        _copy_file(mcp_kit, payload_dir / ".cursor" / "mcp.json.kit.example")
+    if profile == "with_mcp":
+        cursor_src = KIT_ROOT / ".cursor"
+        cursor_dst = payload_dir / ".cursor"
+        for name in MCP_PAYLOAD_EXAMPLES:
+            src = cursor_src / name
+            if src.is_file():
+                _copy_file(src, cursor_dst / name)
+        mcp_d_src = cursor_src / "mcp.d"
+        if mcp_d_src.is_dir():
+            mcp_d_dst = cursor_dst / "mcp.d"
+            for name in MCP_D_PAYLOAD_FILES:
+                src = mcp_d_src / name
+                if src.is_file():
+                    _copy_file(src, mcp_d_dst / name)
 
     _copy_tree(CURSOR_WORKFLOW_SRC, payload_dir / "cursor_workflow")
 

--- a/.ai_infra/scripts/release/sync_plugin_bundle.py
+++ b/.ai_infra/scripts/release/sync_plugin_bundle.py
@@ -64,6 +64,7 @@ MCP_PAYLOAD_EXAMPLES = (
     "mcp.json.kit.example",
     "mcp.registry.yaml.example",
     "mcp.user.example.json",
+    "MCP-CONFIG.md",
 )
 MCP_D_PAYLOAD_FILES = (
     "README.md",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1411 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1412 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 

--- a/payload/.ai_infra/scripts/install/scaffold.py
+++ b/payload/.ai_infra/scripts/install/scaffold.py
@@ -10,6 +10,7 @@ Depends On:
  - .ai_infra/bootstrap.py
 Notes:
  - Default profile: .cursor, .agents, slim .ai_infra, .local exemplars, AGENTS stub.
+ - MCP merge loads mcp_manage with install/cursor_workflow on sys.path (cursor_host_paths).
 """
 
 from __future__ import annotations
@@ -479,6 +480,28 @@ def _apply_overlay_rules(source: Path, target: Path, rel_overlay: str, dry_run: 
         _copy_file(mdc, dest / mdc.name, dry_run, log)
 
 
+def _load_mcp_manage(source: Path) -> Any | None:
+    """Load mcp_manage from the install package with sibling imports resolvable.
+
+    Scaffold runs as a standalone script; pytest's pythonpath does not apply.
+    mcp_manage imports cursor_host_paths from the same directory.
+    """
+    import importlib.util
+
+    mcp_manage_path = source / ".ai_infra" / "install" / "cursor_workflow" / "mcp_manage.py"
+    if not mcp_manage_path.is_file():
+        return None
+    cw_dir = str(mcp_manage_path.parent)
+    if cw_dir not in sys.path:
+        sys.path.insert(0, cw_dir)
+    spec_mod = importlib.util.spec_from_file_location("mcp_manage", mcp_manage_path)
+    if spec_mod is None or spec_mod.loader is None:
+        return None
+    mcp_manage = importlib.util.module_from_spec(spec_mod)
+    spec_mod.loader.exec_module(mcp_manage)
+    return mcp_manage
+
+
 def _sanity_check(target: Path, log: list[str], *, with_tests: bool = False) -> list[str]:
     errors: list[str] = []
     agents = target / ".cursor" / "agents"
@@ -640,14 +663,8 @@ def scaffold(
         if dry_run:
             _log(log, "DRY-RUN merge .cursor/mcp.json from kit + user fragments")
         else:
-            mcp_manage_path = source / ".ai_infra" / "install" / "cursor_workflow" / "mcp_manage.py"
-            if mcp_manage_path.is_file():
-                import importlib.util
-
-                spec_mod = importlib.util.spec_from_file_location("mcp_manage", mcp_manage_path)
-                assert spec_mod is not None and spec_mod.loader is not None
-                mcp_manage = importlib.util.module_from_spec(spec_mod)
-                spec_mod.loader.exec_module(mcp_manage)
+            mcp_manage = _load_mcp_manage(source)
+            if mcp_manage is not None:
                 dest = mcp_manage.write_merged_mcp(target)
                 mcp_manage.ensure_mcp_gitignore(target)
                 _log(log, f"WRITE merged MCP config {dest}")

--- a/payload/.cursor/MCP-CONFIG.md
+++ b/payload/.cursor/MCP-CONFIG.md
@@ -1,0 +1,11 @@
+# MCP config files
+
+| File | Role |
+|------|------|
+| **`mcp.json.kit.example`** | Canonical kit-only fragment (`workflow-kit` server) |
+| **`mcp.user.example.json`** | Template for external servers (copy to `mcp.user.json`, gitignored) |
+| **`mcp.registry.yaml.example`** | Agent ↔ server mapping template |
+
+Install with `--with-mcp-json` merges kit + user fragments via `mcp_manage.py` → `.cursor/mcp.json`.
+
+See [`.ai_infra/docs/operations/connect-external-mcp.md`](../.ai_infra/docs/operations/connect-external-mcp.md).

--- a/payload/.cursor/mcp.d/README.md
+++ b/payload/.cursor/mcp.d/README.md
@@ -1,0 +1,9 @@
+# User MCP drop-in pattern
+
+Copy `user.example.json` to a named fragment (e.g. `slack.json`) and link with:
+
+```bash
+cursor-workflow mcp link --name slack --file .cursor/mcp.d/slack.json
+```
+
+Fragments must contain a top-level `mcpServers` object with one or more server entries.

--- a/payload/.cursor/mcp.d/user.example.json
+++ b/payload/.cursor/mcp.d/user.example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "example-external": {
+      "command": "echo",
+      "args": ["external-mcp-stub"]
+    }
+  }
+}

--- a/payload/.cursor/mcp.registry.yaml.example
+++ b/payload/.cursor/mcp.registry.yaml.example
@@ -1,0 +1,18 @@
+version: 1
+servers:
+  workflow-kit:
+    tier: kit
+    description: PR workflow, trackers, gates
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    tools_hint: [workflow_run_prepare, workflow_get_tracker, workflow_list_mcp_registry, workflow_integrate_validate, workflow_drift_validate]
+  # User adds keys matching mcp.json mcpServers:
+  deepwiki:
+    tier: external
+    description: Public GitHub repo docs/Q&A (no auth) — Cognition DeepWiki
+    agents: [researcher, implementer, auditor]
+    tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
+  my-custom-server:
+    tier: external
+    description: "Fill in — e.g. database, Slack, GitHub"
+    agents: [implementer]
+    tools_hint: []

--- a/payload/.cursor/mcp.user.example.json
+++ b/payload/.cursor/mcp.user.example.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Copy to .cursor/mcp.user.json (gitignored). Add external MCP servers here.",
+  "mcpServers": {
+    "deepwiki": {
+      "_comment": "Zero-auth remote server — URL-based shape (no command/args)",
+      "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "my-custom-server": {
+      "_comment": "Example — replace with your server command/args",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-example"]
+    }
+  }
+}

--- a/tests/modules/install/test_scaffold_full.py
+++ b/tests/modules/install/test_scaffold_full.py
@@ -11,8 +11,10 @@ Depends On:
 from __future__ import annotations
 
 import importlib.util
+import os
 import runpy
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -244,6 +246,33 @@ def test_scaffold_with_mcp_json_uses_mcp_manage(tmp_path: Path) -> None:
     target = tmp_path / "project"
     mod.scaffold(target, REPO_ROOT, with_mcp_json=True)
     assert (target / ".cursor" / "mcp.json").is_file()
+
+
+def test_scaffold_subprocess_with_mcp_json_resolves_cursor_host_paths(tmp_path: Path) -> None:
+    """Regression: real activate runs scaffold as a script without pytest pythonpath."""
+    target = tmp_path / "consumer"
+    target.mkdir()
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    env["PYTHONPATH"] = ""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCAFFOLD_PATH),
+            "--target",
+            str(target),
+            "--source",
+            str(REPO_ROOT),
+            "--with-mcp-json",
+        ],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert (target / ".cursor" / "mcp.json").is_file()
+    assert "cursor_host_paths" not in (result.stderr or "")
 
 
 def test_scaffold_with_mcp_json_fallback_to_example(

--- a/tests/modules/release/test_sync_plugin_bundle.py
+++ b/tests/modules/release/test_sync_plugin_bundle.py
@@ -49,6 +49,7 @@ def test_sync_builds_plugin_and_payload(tmp_path: Path) -> None:
     assert (payload_dir / ".cursor" / "mcp.json.kit.example").is_file()
     assert (payload_dir / ".cursor" / "mcp.registry.yaml.example").is_file()
     assert (payload_dir / ".cursor" / "mcp.user.example.json").is_file()
+    assert (payload_dir / ".cursor" / "MCP-CONFIG.md").is_file()
     assert (payload_dir / ".cursor" / "mcp.d" / "user.example.json").is_file()
     assert (payload_dir / ".cursor" / "mcp.d" / "README.md").is_file()
 

--- a/tests/modules/release/test_sync_plugin_bundle.py
+++ b/tests/modules/release/test_sync_plugin_bundle.py
@@ -46,6 +46,11 @@ def test_sync_builds_plugin_and_payload(tmp_path: Path) -> None:
     assert (payload_dir / ".cursor" / "agents" / "implementer.md").is_file()
     assert (payload_dir / "LICENSE").is_file()
     assert (payload_dir / "NOTICE").is_file()
+    assert (payload_dir / ".cursor" / "mcp.json.kit.example").is_file()
+    assert (payload_dir / ".cursor" / "mcp.registry.yaml.example").is_file()
+    assert (payload_dir / ".cursor" / "mcp.user.example.json").is_file()
+    assert (payload_dir / ".cursor" / "mcp.d" / "user.example.json").is_file()
+    assert (payload_dir / ".cursor" / "mcp.d" / "README.md").is_file()
 
 
 def test_check_bundle_passes_after_sync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Fix P0: `scaffold.py` loads `mcp_manage` with `install/cursor_workflow` on `sys.path` so first-run `/workflow-activate` writes `.cursor/mcp.json` (no `cursor_host_paths` ImportError).
- Fix P1: `sync_plugin_bundle` ships MCP worksheets for `/mcp-connect` (`mcp.registry.yaml.example`, `mcp.user.example.json`, `.cursor/mcp.d/`).
- Docs: consumer install tree in PLUGIN-ARCHITECTURE matches activate reality (no fake `overlays/` row).

## Test plan
- [x] Subprocess scaffold `--with-mcp-json` (cleared PYTHONPATH) writes `mcp.json`
- [x] `activate --source payload` exits 0 with MCP examples present
- [x] `make install-dry-run` + `make check-plugin` PASS
- [x] scaffold + sync_plugin_bundle tests green

## Collaboration
- Board-Item: PVTI_lAHOBl46-84A9KZxzg1ZXXk
- Issue: #174