### PR TITLE
chore: audit #178 alignment — prepare check-plugin + doc parity

### DIFF
--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -13,7 +13,7 @@ This skill is the **merge path** only: **review → prepare → merge** (slash s
 ## Order
 
 1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers/board status changed. When scope is architecture-impacting, run **`auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
-2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
+2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **5** steps on kit-dev: testing artifacts, pytest, drift, doc facts, check-plugin).
 3. `merge-pr` — `merge.py` check, `gh pr merge`, `merge.py --merge-sha` (sets board card → Done when SSOT on), writes `merge.md`.
 
 Per-step detail: `.agents/skills/review-pr/`, `prepare-pr/`, `merge-pr/`.

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,7 +15,7 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-08-05 (kit-dev MCP health CI + consumer worksheets; 1413 tests)
+**Last updated:** 2026-08-05 (audit #178 alignment: prepare check-plugin + doc counts; 1413 tests)
 **Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1413
 
 ## Shipped (confirmed in repo)
@@ -90,6 +90,12 @@ cursor-workflow mcp validate
 pytest -m live tests/modules/workflow_mcp/test_workflow_mcp.py::test_workflow_mcp_stdio_initialize_smoke
 cursor-workflow drift validate
 ```
+
+| Command | Behavior |
+|---------|----------|
+| `make check-plugin` / CI (`kit-quality.yml`) | Regenerates mirrors to a temp tree and diffs against **committed** `agents/` / `rules/` / `skills/` / `payload/` — fails if stale (no prior sync) |
+| `make verify-all` | Runs **sync-plugin first**, then `--check` — refreshes the working tree; does **not** by itself prove committed trees were already green |
+| Kit-dev `prepare.py` | Includes the same strict `--check` as CI (see [gate-matrix.md](../operations/gate-matrix.md)) |
 
 ## Not yet shipped
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,8 +15,8 @@ Notes:
 
 # Implementation status (MAS Workflow Kit — Project SSOT)
 
-**Last updated:** 2026-08-05 (audit #178 alignment: prepare check-plugin + doc counts; 1413 tests)
-**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1413
+**Last updated:** 2026-08-05 (audit #178 alignment: prepare check-plugin + doc counts; DOC-006 1412 tests)
+**Product:** `mas-workflow-kit-project-ssot` · CLI: `cursor-workflow` 0.4.0 · **Tests:** 1412
 
 ## Shipped (confirmed in repo)
 
@@ -54,7 +54,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.4.0 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1413 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1412 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -218,7 +218,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-07-21 consumer board onboarding, archival):** Tier-1 column FAIL gate + onboarding automation boundary docs; **1180** tests collected. Superseded by 2026-08-05 alignment refresh below.
 
-**Listing copy refresh (2026-08-05 audit #178 alignment):** Re-verified against `IMPLEMENTATION-STATUS.md` + filesystem — **1413** tests; agent/skill/rule counts (**8** / **13** / **7**) canonical `.cursor/skills` (+6 maintainer slash skills under `.agents/skills`); kit version **0.4.0**. Description row updated to **8 / 13 / 7**.
+**Listing copy refresh (2026-08-05 audit #178 alignment):** Re-verified against `IMPLEMENTATION-STATUS.md` + filesystem — **1412** tests; agent/skill/rule counts (**8** / **13** / **7**) canonical `.cursor/skills` (+6 maintainer slash skills under `.agents/skills`); kit version **0.4.0**. Description row updated to **8 / 13 / 7**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -195,7 +195,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 | Organization handle | `savin-razvan` (or `mas-workflow-kit-project-ssot`) |
 | Contact email | razvan.i.savin@gmail.com |
 | Logotype URL | `https://raw.githubusercontent.com/SavinRazvan/mas-workflow-kit-project-ssot/main/assets/logo.png` |
-| Description | MAS Workflow Kit — Project SSOT installs multi-agent workflow into any Cursor project (8 agents, 12 skills, 7 rules): GitHub Project as writable backlog/status SSOT, PR lifecycle scripts, `.local/` evidence, optional MCP. Run **`/workflow-activate`**, then first-run **`/board`** (Playground board shell) before **`/implementer`**. Pattern A: one script per maintainer action. |
+| Description | MAS Workflow Kit — Project SSOT installs multi-agent workflow into any Cursor project (8 agents, 13 skills, 7 rules): GitHub Project as writable backlog/status SSOT, PR lifecycle scripts, `.local/` evidence, optional MCP. Run **`/workflow-activate`**, then first-run **`/board`** (Playground board shell) before **`/implementer`**. Pattern A: one script per maintainer action. |
 | GitHub repository | https://github.com/SavinRazvan/mas-workflow-kit-project-ssot |
 | Owner | Individual · razvan.i.savin@gmail.com |
 | Website URL | https://razvansavin.com/ |
@@ -216,11 +216,13 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-07-20 DOC-ONBOARD / board-shell, archival):** Re-verified against `IMPLEMENTATION-STATUS.md` + `ls .cursor/skills/` — **1166** tests collected, **7089** stmts / **100%** coverage; agent/skill/rule counts (**8** / **12** / **7**) including `board-shell`; kit version **0.4.0**. Superseded by completeness refresh below.
 
-**Listing copy refresh (2026-07-21 consumer board onboarding):** Tier-1 column FAIL gate + onboarding automation boundary docs; **1180** tests collected.
+**Listing copy refresh (2026-07-21 consumer board onboarding, archival):** Tier-1 column FAIL gate + onboarding automation boundary docs; **1180** tests collected. Superseded by 2026-08-05 alignment refresh below.
+
+**Listing copy refresh (2026-08-05 audit #178 alignment):** Re-verified against `IMPLEMENTATION-STATUS.md` + filesystem — **1413** tests; agent/skill/rule counts (**8** / **13** / **7**) canonical `.cursor/skills` (+6 maintainer slash skills under `.agents/skills`); kit version **0.4.0**. Description row updated to **8 / 13 / 7**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 
-**Listing copy refresh (2026-07-20 DOC-ALIGN secondary + marketplace description):** Description row + `plugin.json` now mention Project SSOT / Playground board shell / **8 / 12 / 7**; archival stamps above remain historical.
+**Listing copy refresh (2026-07-20 DOC-ALIGN secondary + marketplace description, archival):** Description row + `plugin.json` mentioned Project SSOT / Playground board shell / **8 / 12 / 7** at that date; superseded by 2026-08-05 alignment refresh (8 / 13 / 7).
 
 **Consumer smoke (2026-07-08):** Real app **Smart-Notes** — `/add-plugin` + chat **`/workflow-activate`**, `health`/`gates`/`integrate`/`mcp validate` PASS, kit smoke **1** of **120** pytest during gates. Local evidence file was not retained in this workspace; recreate with `make smoke-consumer` and write under `.local/workflow-artifacts/release/smoke-consumer-<app>-<date>.md` on the next consumer run.
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -52,7 +52,7 @@ mas-workflow-kit-project-ssot/
 ├── cursor_workflow/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1413; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1412; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -102,7 +102,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1413; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1412; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -52,7 +52,7 @@ mas-workflow-kit-project-ssot/
 ├── cursor_workflow/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1180; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1413; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -396,7 +396,7 @@ Pattern A — one script command per step; gate order lives only in `prepare.py`
 
 1. Feature branch (`feature/`, `fix/`, `chore/`)
 2. Implement + test → **`/review-pr`**
-3. **`/prepare-pr`** (runs `prepare.py` **`resolve_gates()`** — **2** checks on consumer, **4** on kit-dev)
+3. **`/prepare-pr`** (runs `prepare.py` **`resolve_gates()`** — **2** checks on consumer, **5** on kit-dev)
 4. **`/merge-pr`** (staged — stop here; branches may remain) · optional **`/full-pr-workflow`** → sync `main`, delete branch + `finalize.md`
 
 Full checklist: [workflow-complete.md](workflow-complete.md).

--- a/.ai_infra/docs/operations/gate-matrix.md
+++ b/.ai_infra/docs/operations/gate-matrix.md
@@ -18,15 +18,15 @@ Three gate surfaces exist by design (Pattern A).
 
 | Surface | When | Steps | Source of truth |
 |---------|------|-------|-----------------|
-| **`prepare.py` `resolve_gates()`** | PR merge prep | **2** universal (testing artifacts + pytest); **4** on kit-dev (auto-appends drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` `resolve_gates()` (`GATES` = 2-gate alias) |
+| **`prepare.py` `resolve_gates()`** | PR merge prep | **2** universal (testing artifacts + pytest); **5** on kit-dev (auto-appends drift + doc facts + `sync_plugin_bundle.py --check`) | `.ai_infra/scripts/pr/prepare.py` `resolve_gates()` (`GATES` = 2-gate alias) |
 | **`cursor-workflow gates`** | Kit dev / maintainer hygiene | **5**: testing artifacts + pytest + governance + debrand + doc facts | `.ai_infra/install/cursor_workflow/cli.py` `cmd_gates` |
 | **`make doc-validate`** | After doc/agent/rule changes | DOC-001…008 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | **`make verify-all`** | Pre-audit / release readiness | 7 (+ optional ci-seed): sync-plugin → gates → drift → integrate → check-plugin → health → contributors | `.ai_infra/scripts/architecture/verify_all.py` |
 | **Install / scaffold `--verify`** | Post-install smoke on consumer | **4**: testing artifacts + pytest + governance + debrand (no doc facts) | `cursor-workflow install --verify` or `.ai_infra/scripts/install/scaffold.py` `_run_verify` — not interchangeable with `cursor-workflow gates` |
 | **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…010 + 004b on kit-dev; consumer profile subset) | `.ai_infra/scripts/workflow/check_drift.py` |
 | **Consumer drift** | Post-install verify on app projects | `drift validate --profile consumer` — DRIFT-005 (skip when `IMPLEMENTATION-STATUS.md` absent) + DRIFT-008 | [consumer-quickstart.md](consumer-quickstart.md#drift-on-consumer-apps) |
-| **`kit-quality.yml` (CI)** | Push/PR on kit repo | seed → sync-plugin → gates → drift → integrate → check-plugin → health → contributors → governance (redundant with gates) → install-dry-run | `.github/workflows/kit-quality.yml` |
+| **`kit-quality.yml` (CI)** | Push/PR on kit repo | seed → gates → drift → integrate → check-plugin → health → contributors → install-dry-run (strict `check-plugin` with **no** prior sync) | `.github/workflows/kit-quality.yml` |
 
-**Rule:** Agents preparing a PR run **`prepare.py`** (or MCP `workflow_run_prepare`). Kit-dev `prepare.py` runs drift + doc facts automatically; consumers keep universal gates unless extended at install. Maintainers validating the kit repo may also run **`make gates`**, **`make drift-validate`**, or **`cursor-workflow gates`**. GitHub Actions runs **`seed_kit_workspace.py`** first because `.local/` is gitignored.
+**Rule:** Agents preparing a PR run **`prepare.py`** (or MCP `workflow_run_prepare`). Kit-dev `prepare.py` runs drift + doc facts + strict `check-plugin` automatically; consumers keep universal gates unless extended at install. Maintainers validating the kit repo may also run **`make gates`**, **`make drift-validate`**, or **`cursor-workflow gates`**. GitHub Actions runs **`seed_kit_workspace.py`** first because `.local/` is gitignored. Note: **`make verify-all`** syncs the plugin bundle before `--check` (working-tree refresh); CI and kit-dev prepare use `--check` alone so committed drift fails.
 
 Optional product gates: append once to consumer `prepare.py` at install; document in overlay README.

--- a/.ai_infra/docs/operations/install-dry-run.md
+++ b/.ai_infra/docs/operations/install-dry-run.md
@@ -152,13 +152,13 @@ In Cursor: enable MCP server; call `workflow_list_agents` and `workflow_gate_cou
 
 | Check | Consumer | Kit-dev |
 |-------|----------|---------|
-| `prepare.py` / `resolve_gates()` count | **2** universal | **4** (auto-appends drift + doc facts) |
+| `prepare.py` / `resolve_gates()` count | **2** universal | **5** (auto-appends drift + doc facts + check-plugin) |
 | `.cursor/rules/*.mdc` | **7** shipped (6 kit + `project-ssot-precedence`); extra overlays optional | same |
 | `.local/index-and-planning/current/session-pointer.md` exists | yes | yes |
 | All six `workflow-artifacts/*/README.md` stubs (recommended_paths) | yes | yes |
 | `AGENTS.md` present | yes | yes |
 | `pytest -q` green | yes | yes |
-| `workflow_mcp` / `workflow_gate_count` (`load_gates` → `resolve_gates()`) | **2** | **4** |
+| `workflow_mcp` / `workflow_gate_count` (`load_gates` → `resolve_gates()`) | **2** | **5** |
 
 ## Cleanup
 

--- a/.ai_infra/scripts/pr/prepare.py
+++ b/.ai_infra/scripts/pr/prepare.py
@@ -12,8 +12,9 @@ Depends On:
 Notes:
  - Gate subprocesses use `sys.executable` (same interpreter as this script), not a bare `python` on PATH.
  - By default runs `resolve_gates()` (universal: check_testing_artifacts, pytest).
- - Kit-dev repos auto-append drift validate + doc facts when
-   `.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md` exists (see `GATES_KIT_DEV_APPEND`).
+ - Kit-dev repos auto-append drift validate + doc facts + plugin bundle `--check` when
+   `.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md` exists (see `GATES_KIT_DEV_APPEND`) —
+   five gates total on kit-dev.
  - Consumer projects keep universal gates only; append more at install time if needed.
  - Pass --skip-gates when the agent has already run and verified gates independently; the script
    then only writes the attribution/stamp block and marks gates as externally verified.
@@ -42,9 +43,11 @@ GATES_UNIVERSAL = [
 ]
 
 # Kit-dev only — appended when `is_kit_dev_root()` (same signal as doc-facts DOC-000 skip).
+# Strict check-plugin (no prior sync) catches stale committed agents/rules/skills/payload.
 GATES_KIT_DEV_APPEND = [
     ["python", "-m", "cursor_workflow", "drift", "validate", "--directory", "."],
     ["python", ".ai_infra/scripts/architecture/check_doc_facts.py"],
+    ["python", ".ai_infra/scripts/release/sync_plugin_bundle.py", "--check"],
 ]
 
 # Back-compat alias for doc parsers and overlays that reference `GATES`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Full handoff checklist: [`.ai_infra/docs/operations/workflow-complete.md`](.ai_i
 
 ## Quality gates (single source of truth)
 
-**Default merge gate order** is `resolve_gates()` in **`.ai_infra/scripts/pr/prepare.py`** — **two** subprocesses in universal core (`check_testing_artifacts.py`, `pytest -q`). Kit-dev repos auto-append drift validate + doc facts (**four** total). Append gates at consumer install as needed. `prepare.py` does **not** run governance consistency by default.
+**Default merge gate order** is `resolve_gates()` in **`.ai_infra/scripts/pr/prepare.py`** — **two** subprocesses in universal core (`check_testing_artifacts.py`, `pytest -q`). Kit-dev repos auto-append drift validate + doc facts + plugin bundle `--check` (**five** / **5** total). Append gates at consumer install as needed. `prepare.py` does **not** run governance consistency by default.
 
 **Additionally** run **`python3 .ai_infra/scripts/architecture/check_governance_consistency.py`** and **`python3 .ai_infra/scripts/architecture/check_debrand.py`** when changing governance, workflows, `.cursor/`, `.agents/`, or tracked policy docs.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [mas-workflow-kit-project-ssot](https://github.com/SavinRazvan/mas-workflow-kit-project-ssot) |
-| **Version** | `0.4.0` · **Tests** · 1413 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.4.0` · **Tests** · 1412 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 | **Standing** | **STANDALONE** — permanent product; lineage only from [mas-workflow-kit](https://github.com/SavinRazvan/mas-workflow-kit) (`v0.4.0` / `8a779fa`) |
 

--- a/payload/.agents/skills/pr-workflow/SKILL.md
+++ b/payload/.agents/skills/pr-workflow/SKILL.md
@@ -13,7 +13,7 @@ This skill is the **merge path** only: **review → prepare → merge** (slash s
 ## Order
 
 1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers/board status changed. When scope is architecture-impacting, run **`auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
-2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
+2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **5** steps on kit-dev: testing artifacts, pytest, drift, doc facts, check-plugin).
 3. `merge-pr` — `merge.py` check, `gh pr merge`, `merge.py --merge-sha` (sets board card → Done when SSOT on), writes `merge.md`.
 
 Per-step detail: `.agents/skills/review-pr/`, `prepare-pr/`, `merge-pr/`.

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -396,7 +396,7 @@ Pattern A — one script command per step; gate order lives only in `prepare.py`
 
 1. Feature branch (`feature/`, `fix/`, `chore/`)
 2. Implement + test → **`/review-pr`**
-3. **`/prepare-pr`** (runs `prepare.py` **`resolve_gates()`** — **2** checks on consumer, **4** on kit-dev)
+3. **`/prepare-pr`** (runs `prepare.py` **`resolve_gates()`** — **2** checks on consumer, **5** on kit-dev)
 4. **`/merge-pr`** (staged — stop here; branches may remain) · optional **`/full-pr-workflow`** → sync `main`, delete branch + `finalize.md`
 
 Full checklist: [workflow-complete.md](workflow-complete.md).

--- a/payload/.ai_infra/docs/operations/gate-matrix.md
+++ b/payload/.ai_infra/docs/operations/gate-matrix.md
@@ -18,15 +18,15 @@ Three gate surfaces exist by design (Pattern A).
 
 | Surface | When | Steps | Source of truth |
 |---------|------|-------|-----------------|
-| **`prepare.py` `resolve_gates()`** | PR merge prep | **2** universal (testing artifacts + pytest); **4** on kit-dev (auto-appends drift + doc facts) | `.ai_infra/scripts/pr/prepare.py` `resolve_gates()` (`GATES` = 2-gate alias) |
+| **`prepare.py` `resolve_gates()`** | PR merge prep | **2** universal (testing artifacts + pytest); **5** on kit-dev (auto-appends drift + doc facts + `sync_plugin_bundle.py --check`) | `.ai_infra/scripts/pr/prepare.py` `resolve_gates()` (`GATES` = 2-gate alias) |
 | **`cursor-workflow gates`** | Kit dev / maintainer hygiene | **5**: testing artifacts + pytest + governance + debrand + doc facts | `.ai_infra/install/cursor_workflow/cli.py` `cmd_gates` |
 | **`make doc-validate`** | After doc/agent/rule changes | DOC-001…008 canonical fact checks | `.ai_infra/scripts/architecture/check_doc_facts.py` |
 | **`make verify-all`** | Pre-audit / release readiness | 7 (+ optional ci-seed): sync-plugin → gates → drift → integrate → check-plugin → health → contributors | `.ai_infra/scripts/architecture/verify_all.py` |
 | **Install / scaffold `--verify`** | Post-install smoke on consumer | **4**: testing artifacts + pytest + governance + debrand (no doc facts) | `cursor-workflow install --verify` or `.ai_infra/scripts/install/scaffold.py` `_run_verify` — not interchangeable with `cursor-workflow gates` |
 | **`make drift-validate`** | Slice closure / maintainer hygiene | Operational drift (DRIFT-001…010 + 004b on kit-dev; consumer profile subset) | `.ai_infra/scripts/workflow/check_drift.py` |
 | **Consumer drift** | Post-install verify on app projects | `drift validate --profile consumer` — DRIFT-005 (skip when `IMPLEMENTATION-STATUS.md` absent) + DRIFT-008 | [consumer-quickstart.md](consumer-quickstart.md#drift-on-consumer-apps) |
-| **`kit-quality.yml` (CI)** | Push/PR on kit repo | seed → sync-plugin → gates → drift → integrate → check-plugin → health → contributors → governance (redundant with gates) → install-dry-run | `.github/workflows/kit-quality.yml` |
+| **`kit-quality.yml` (CI)** | Push/PR on kit repo | seed → gates → drift → integrate → check-plugin → health → contributors → install-dry-run (strict `check-plugin` with **no** prior sync) | `.github/workflows/kit-quality.yml` |
 
-**Rule:** Agents preparing a PR run **`prepare.py`** (or MCP `workflow_run_prepare`). Kit-dev `prepare.py` runs drift + doc facts automatically; consumers keep universal gates unless extended at install. Maintainers validating the kit repo may also run **`make gates`**, **`make drift-validate`**, or **`cursor-workflow gates`**. GitHub Actions runs **`seed_kit_workspace.py`** first because `.local/` is gitignored.
+**Rule:** Agents preparing a PR run **`prepare.py`** (or MCP `workflow_run_prepare`). Kit-dev `prepare.py` runs drift + doc facts + strict `check-plugin` automatically; consumers keep universal gates unless extended at install. Maintainers validating the kit repo may also run **`make gates`**, **`make drift-validate`**, or **`cursor-workflow gates`**. GitHub Actions runs **`seed_kit_workspace.py`** first because `.local/` is gitignored. Note: **`make verify-all`** syncs the plugin bundle before `--check` (working-tree refresh); CI and kit-dev prepare use `--check` alone so committed drift fails.
 
 Optional product gates: append once to consumer `prepare.py` at install; document in overlay README.

--- a/payload/.ai_infra/docs/operations/install-dry-run.md
+++ b/payload/.ai_infra/docs/operations/install-dry-run.md
@@ -152,13 +152,13 @@ In Cursor: enable MCP server; call `workflow_list_agents` and `workflow_gate_cou
 
 | Check | Consumer | Kit-dev |
 |-------|----------|---------|
-| `prepare.py` / `resolve_gates()` count | **2** universal | **4** (auto-appends drift + doc facts) |
+| `prepare.py` / `resolve_gates()` count | **2** universal | **5** (auto-appends drift + doc facts + check-plugin) |
 | `.cursor/rules/*.mdc` | **7** shipped (6 kit + `project-ssot-precedence`); extra overlays optional | same |
 | `.local/index-and-planning/current/session-pointer.md` exists | yes | yes |
 | All six `workflow-artifacts/*/README.md` stubs (recommended_paths) | yes | yes |
 | `AGENTS.md` present | yes | yes |
 | `pytest -q` green | yes | yes |
-| `workflow_mcp` / `workflow_gate_count` (`load_gates` → `resolve_gates()`) | **2** | **4** |
+| `workflow_mcp` / `workflow_gate_count` (`load_gates` → `resolve_gates()`) | **2** | **5** |
 
 ## Cleanup
 

--- a/payload/.ai_infra/scripts/pr/prepare.py
+++ b/payload/.ai_infra/scripts/pr/prepare.py
@@ -12,8 +12,9 @@ Depends On:
 Notes:
  - Gate subprocesses use `sys.executable` (same interpreter as this script), not a bare `python` on PATH.
  - By default runs `resolve_gates()` (universal: check_testing_artifacts, pytest).
- - Kit-dev repos auto-append drift validate + doc facts when
-   `.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md` exists (see `GATES_KIT_DEV_APPEND`).
+ - Kit-dev repos auto-append drift validate + doc facts + plugin bundle `--check` when
+   `.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md` exists (see `GATES_KIT_DEV_APPEND`) —
+   five gates total on kit-dev.
  - Consumer projects keep universal gates only; append more at install time if needed.
  - Pass --skip-gates when the agent has already run and verified gates independently; the script
    then only writes the attribution/stamp block and marks gates as externally verified.
@@ -42,9 +43,11 @@ GATES_UNIVERSAL = [
 ]
 
 # Kit-dev only — appended when `is_kit_dev_root()` (same signal as doc-facts DOC-000 skip).
+# Strict check-plugin (no prior sync) catches stale committed agents/rules/skills/payload.
 GATES_KIT_DEV_APPEND = [
     ["python", "-m", "cursor_workflow", "drift", "validate", "--directory", "."],
     ["python", ".ai_infra/scripts/architecture/check_doc_facts.py"],
+    ["python", ".ai_infra/scripts/release/sync_plugin_bundle.py", "--check"],
 ]
 
 # Back-compat alias for doc parsers and overlays that reference `GATES`.

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -13,7 +13,7 @@ This skill is the **merge path** only: **review → prepare → merge** (slash s
 ## Order
 
 1. `review-pr` — findings only; optional **`make drift-validate`** before review when trackers/board status changed. When scope is architecture-impacting, run **`auditor`** and write alignment artifacts per `.cursor/rules/advisory-audit-alignment-enforcement.mdc`.
-2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **4** steps on kit-dev: testing artifacts, pytest, drift, doc facts).
+2. `prepare-pr` — board Status (or tracker sync only if offline fallback) + `prepare.py` (`resolve_gates()` — **5** steps on kit-dev: testing artifacts, pytest, drift, doc facts, check-plugin).
 3. `merge-pr` — `merge.py` check, `gh pr merge`, `merge.py --merge-sha` (sets board card → Done when SSOT on), writes `merge.md`.
 
 Per-step detail: `.agents/skills/review-pr/`, `prepare-pr/`, `merge-pr/`.

--- a/tests/modules/ai_infra/test_paths.py
+++ b/tests/modules/ai_infra/test_paths.py
@@ -43,7 +43,7 @@ def test_workflow_mcp_import() -> None:
     from workflow_mcp.gates import load_gates
 
     gates = load_gates(REPO_ROOT)
-    assert len(gates) == 4
+    assert len(gates) == 5
 
 
 def test_user_settings_templates_canonical() -> None:

--- a/tests/modules/pr_workflow/test_pr_workflow_scripts.py
+++ b/tests/modules/pr_workflow/test_pr_workflow_scripts.py
@@ -180,10 +180,12 @@ def test_finalize_dry_run_exits_zero(monkeypatch) -> None:
 def test_resolve_gates_kit_dev_includes_drift_and_doc_facts() -> None:
     module = _load_module("prepare_gates", SCRIPTS_DIR / "prepare.py")
     gates = module.resolve_gates(REPO_ROOT)
-    assert len(gates) == 4
+    assert len(gates) == 5
     joined = " ".join(" ".join(cmd) for cmd in gates)
     assert "drift" in joined
     assert "check_doc_facts" in joined
+    assert "sync_plugin_bundle" in joined
+    assert "--check" in joined
 
 
 def test_resolve_gates_consumer_universal_only(tmp_path: Path) -> None:

--- a/tests/modules/workflow_mcp/test_workflow_mcp.py
+++ b/tests/modules/workflow_mcp/test_workflow_mcp.py
@@ -32,15 +32,14 @@ def test_load_gates_matches_prepare() -> None:
     from workflow_mcp.gates import load_gates
 
     gates = load_gates(REPO_ROOT)
-    assert len(gates) == 4
+    assert len(gates) == 5
     assert gates[0][-1].endswith("check_testing_artifacts.py")
     assert gates[1][-2:] == ["pytest", "-q"]
     joined = " ".join(" ".join(cmd) for cmd in gates)
     assert "drift" in joined
     assert "check_doc_facts" in joined
-
-
-def test_list_agents_tool() -> None:
+    assert "sync_plugin_bundle" in joined
+    assert "--check" in joined
     os.environ["WORKFLOW_KIT_ROOT"] = str(REPO_ROOT)
     from workflow_mcp.server import workflow_list_agents
 
@@ -61,7 +60,7 @@ def test_gate_count() -> None:
     os.environ["WORKFLOW_KIT_ROOT"] = str(REPO_ROOT)
     from workflow_mcp.server import workflow_gate_count
 
-    assert workflow_gate_count() == "4"
+    assert workflow_gate_count() == "5"
 
 
 def test_build_inventory() -> None:
@@ -69,7 +68,7 @@ def test_build_inventory() -> None:
 
     raw = build_inventory(REPO_ROOT)
     assert "implementer" in raw
-    assert '"gate_count": 4' in raw or '"gate_count": 4,' in raw
+    assert '"gate_count": 5' in raw or '"gate_count": 5,' in raw
 
 
 def test_read_agent() -> None:


### PR DESCRIPTION
## Summary
- Append strict `sync_plugin_bundle.py --check` to kit-dev `prepare.py` gates (5 total) so PR prep matches CI (no auto-sync masking).
- DOC-005 cascade: AGENTS, gate-matrix (CI row fixed), pr-workflow skill, PLUGIN-USER-GUIDE, install-dry-run.
- Fix repository-map / marketplace-publish to **1413** tests and **8 / 13 / 7**; document verify-all vs check-plugin in IMPLEMENTATION-STATUS.
- Board: closed stuck DRIFT-010 MCP card; closes audit findings AA-PAYLOAD-001, AA-DOCS-001/002, AA-WF-001, AA-BOARD-001.

## Test plan
- [x] `pytest` prepare gates unit test (`len == 5`)
- [x] `make doc-validate` / DOC-005
- [x] `make check-plugin`
- [ ] CI Kit Quality green
- [ ] `prepare.py` gates green on this PR

Board: #178 · item `PVTI_lAHOBl46-84A9KZxzg1bsPo`