### PR TITLE
fix: rename leftover template/doc sync (cursor_workflow → agent_colony)

### DIFF
--- a/.ai_infra/README.md
+++ b/.ai_infra/README.md
@@ -13,7 +13,7 @@ Versioned workflow kit assets live here. **`.cursor/` and `.agents/` stay at rep
 | `.ai_infra/mcp_servers/agent_colony_mcp/` | Optional MCP server (wraps scripts) |
 | `.ai_infra/docs/` | governance, operations, roadmap, handoff, architecture |
 | `.ai_infra/templates/` | AGENTS stub, local-workspace exemplars, plugin skills |
-| `.ai_infra/install/agent_colony/` | `agent-colony` CLI — twelve top-level commands (`install`, `activate`, `gates`, `health`, `mcp`, `contributors`, `integrate`, `drift`, `doc`, `verify`, `project`, `research`; see `agent-colony --help`) |
+| `.ai_infra/install/agent_colony/` | `agent-colony` CLI — fourteen top-level commands (`install`, `activate`, `gates`, `health`, `mcp`, `contributors`, `integrate`, `drift`, `doc`, `verify`, `project`, `research`, `canvas`, `plan`; see `agent-colony --help`) |
 
 ## Path resolution
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1456
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1458
 
 ## Shipped (confirmed in repo)
 
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1456 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1458 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -223,6 +223,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-08-06 agent-colony rename):** Re-verified against `IMPLEMENTATION-STATUS.md` + filesystem — **1427** tests; agent/skill/rule counts (**8** / **13** / **7**); kit version **0.4.0**.
 
+**Listing copy refresh (2026-08-07 rename leftover sync):** Re-verified against `IMPLEMENTATION-STATUS.md` + filesystem post v0.6.0/v0.6.1 CLI/MCP rename + local-workspace template cleanup — **1458** tests; agent/skill/rule counts (**8** / **13** / **7**); kit version **0.6.1**.
+
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 
 **Listing copy refresh (2026-07-20 DOC-ALIGN secondary + marketplace description, archival):** Description row + `plugin.json` mentioned Project SSOT / Playground board shell / **8 / 12 / 7** at that date; superseded by 2026-08-05 alignment refresh (8 / 13 / 7).

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1427; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1458; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1427; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1458; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/upgrade-kit.md
+++ b/.ai_infra/docs/operations/upgrade-kit.md
@@ -6,12 +6,14 @@ Re-run install from a **newer kit source** (git tag, plugin payload, or local cl
 
 Kit **0.6.0** renames the Python CLI module and console script:
 
-| Before (removed) | After |
-|------------------|-------|
-| `python -m` old module name | `python -m agent_colony` |
-| Console script old name | `agent-colony` |
-| Root package dir | `agent_colony/` |
-| Install package | `.ai_infra/install/agent_colony/` |
+
+| Before (removed)            | After                             |
+| --------------------------- | --------------------------------- |
+| `python -m cursor_workflow` | `python -m agent_colony`          |
+| Console script `cursor-workflow` | `agent-colony`               |
+| Root package dir `cursor_workflow/` | `agent_colony/`             |
+| Install package `.ai_infra/install/cursor_workflow/` | `.ai_infra/install/agent_colony/` |
+
 
 **Cold cut** — old names are not aliased. After upgrading:
 
@@ -19,23 +21,29 @@ Kit **0.6.0** renames the Python CLI module and console script:
 2. Reinstall editable tooling: `pip install -e ".[dev,mcp]"` (kit-dev) so the `agent-colony` console script is on PATH
 3. Update any local scripts/CI that still call the old module or console script
 
+
+
 ## Breaking change (0.6.1)
 
 Kit **0.6.1** renames the MCP Python package (Cursor server id unchanged):
 
-| Before (removed) | After |
-|------------------|-------|
-| `python -m` old MCP package | `python -m agent_colony_mcp` |
-| Package dir | `.ai_infra/mcp_servers/agent_colony_mcp/` |
-| Cursor server id | `agent-colony-mcp` (**unchanged**) |
 
-Update `.cursor/mcp.json` `args` to `["-m", "agent_colony_mcp"]` (or re-run activate / `mcp seed`). MCP **tool** names such as `workflow_*` are unchanged.
+| Before (removed)            | After                                     |
+| --------------------------- | ----------------------------------------- |
+| `python -m workflow_mcp`    | `python -m agent_colony_mcp`              |
+| Package dir `.ai_infra/mcp_servers/workflow_mcp/` | `.ai_infra/mcp_servers/agent_colony_mcp/` |
+| Cursor server id            | `agent-colony-mcp` (**unchanged**)        |
+
+
+Update `.cursor/mcp.json` `args` to `["-m", "agent_colony_mcp"]` (or re-run activate / `mcp seed`). MCP **tool** names such as `workflow_`* are unchanged.
 
 ## Before upgrade
 
 1. Note current version: `cat .ai_infra/.kit-version`
 2. Commit or stash local changes (especially `.cursor/`, `.ai_infra/`, `.local/`)
 3. Back up custom overlays under `overlays/rules/` and any `mcp.user.json` secrets
+
+
 
 ## Upgrade command
 
@@ -47,9 +55,9 @@ source .venv/bin/activate
 python3 -m agent_colony activate --directory .
 ```
 
-Same as **`/workflow-activate`** in Agent chat when planes are already ready. Refreshes kit-managed dashboard HTML, `pages.json`, and install scripts from the plugin payload.
+Same as `/workflow-activate` in Agent chat when planes are already ready. Refreshes kit-managed dashboard HTML, `pages.json`, and install scripts from the plugin payload.
 
-**Full reinstall (scripts, agents, rules — review `.local/` merge):**
+**Full reinstall (scripts, agents, rules — review** `.local/` **merge):**
 
 ```bash
 python3 -m agent_colony activate --directory . --force
@@ -71,15 +79,19 @@ Use `--source payload` when running from the distribution root (see `workflow-ac
 
 ## What install updates
 
-| Area | Behavior |
-|------|----------|
-| `.ai_infra/scripts/` | Overwritten from manifest profile |
-| `.cursor/agents`, rules, skills | Overwritten from kit |
-| `.local/` exemplars | Re-copied on **`--force`** only; light re-activate refreshes dashboards + `pages.json` |
-| Dashboard HTML / `pages.json` | Refreshed on every `activate` (idempotent) |
-| `AGENTS.md` | **Not** overwritten if present — delete to refresh from stub, or merge manually |
-| `mcp.user.json` | **Not** overwritten — merge via `python3 -m agent_colony mcp validate` |
-| `.kit-version` | Updated to manifest `kit_version` |
+
+| Area                            | Behavior                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `.ai_infra/scripts/`            | Overwritten from manifest profile                                                  |
+| `.cursor/agents`, rules, skills | Overwritten from kit                                                               |
+| `.local/` exemplars             | Re-copied on `--force` only; light re-activate refreshes dashboards + `pages.json` |
+| Dashboard HTML / `pages.json`   | Refreshed on every `activate` (idempotent)                                         |
+| `AGENTS.md`                     | **Not** overwritten if present — delete to refresh from stub, or merge manually    |
+| `mcp.user.json`                 | **Not** overwritten — merge via `python3 -m agent_colony mcp validate`             |
+| `.kit-version`                  | Updated to manifest `kit_version`                                                  |
+
+
+
 
 ## After upgrade
 
@@ -89,6 +101,8 @@ python3 -m agent_colony gates
 python3 -m agent_colony health
 python3 -m agent_colony mcp validate
 ```
+
+
 
 ## Rollback
 

--- a/.ai_infra/scripts/architecture/check_debrand.py
+++ b/.ai_infra/scripts/architecture/check_debrand.py
@@ -86,13 +86,28 @@ BANNED_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 
 LINEAGE_ALLOWLIST_SUBSTRINGS: tuple[str, ...] = ()
 
-TEXT_SUFFIXES = {".md", ".mdc", ".py", ".yaml", ".yml", ".txt", ".json", ".jsonc", ".tsx", ".ts"}
+TEXT_SUFFIXES = {
+    ".md",
+    ".mdc",
+    ".py",
+    ".yaml",
+    ".yml",
+    ".txt",
+    ".json",
+    ".jsonc",
+    ".tsx",
+    ".ts",
+    ".html",
+    ".js",
+}
 
 SKIP_REL_PATHS = frozenset(
     {
         ".ai_infra/scripts/architecture/check_debrand.py",
         ".ai_infra/scripts/architecture/check_governance_consistency.py",
         "tests/modules/architecture_scripts/test_check_debrand.py",
+        # Cold-cut upgrade notes must name removed modules (cursor_workflow / workflow_mcp).
+        ".ai_infra/docs/operations/upgrade-kit.md",
     }
 )
 

--- a/.ai_infra/templates/local-workspace/implementation-control-center.html
+++ b/.ai_infra/templates/local-workspace/implementation-control-center.html
@@ -26,7 +26,7 @@ Notes:
     <aside class="local-deprecation" role="status">
       <strong>Deprecated.</strong>
       When <code>project_ssot.enabled</code>, the GitHub Project is the writable SSOT — not this HTML UI.
-      Use <code>python3 -m cursor_workflow project status</code> / board recipes; open kit canvases via
+      Use <code>python3 -m agent_colony project status</code> / board recipes; open kit canvases via
       <strong>Ctrl+Shift+P → Open Canvas</strong>. This page is an offline markdown browser only.
     </aside>
     <section class="local-surface local-page-head">

--- a/.ai_infra/templates/local-workspace/index.html
+++ b/.ai_infra/templates/local-workspace/index.html
@@ -24,7 +24,7 @@ Notes:
     <aside class="local-deprecation" role="status">
       <strong>Deprecated.</strong>
       Prefer the <strong>GitHub Project board</strong>
-      (<code>python3 -m cursor_workflow project status</code>) for backlog/status,
+      (<code>python3 -m agent_colony project status</code>) for backlog/status,
       and <strong>Ctrl+Shift+P → Open Canvas</strong> for kit visualizations.
       These HTML pages remain as an offline tracker browser only.
     </aside>

--- a/.ai_infra/templates/local-workspace/local-board-snapshot.js
+++ b/.ai_infra/templates/local-workspace/local-board-snapshot.js
@@ -72,7 +72,7 @@
     return (
       '<div class="local-board-empty-state">' +
       "<p>No board items in this snapshot.</p>" +
-      "<p>Run <code>python3 -m cursor_workflow project export</code> after updating cards on GitHub.</p>" +
+      "<p>Run <code>python3 -m agent_colony project export</code> after updating cards on GitHub.</p>" +
       "</div>"
     );
   }
@@ -160,7 +160,7 @@
       '<div class="local-board-missing">' +
       '<p class="status-bad">Project board snapshot not found.</p>' +
       "<p>Export a read-only snapshot from the CLI:</p>" +
-      "<pre><code>python3 -m cursor_workflow project export</code></pre>" +
+      "<pre><code>python3 -m agent_colony project export</code></pre>" +
       "<p>Output path: <code>.local/generated-data/project-project-board-snapshot.json</code></p>" +
       "</div>"
     );

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -15,7 +15,6 @@
     "agent-colony",
     "project-ssot",
     "multi-agent",
-    "agent-colony",
     "pr-workflow",
     "github-projects",
     "architecture-audit",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [agent-colony](https://github.com/SavinRazvan/agent-colony) |
-| **Version** | `0.6.1` · **Tests** · 1456 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.6.1` · **Tests** · 1458 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 
 ---
@@ -26,7 +26,7 @@
 ## What you get
 
 - **8 agents:** `implementer`, `test-runner`, `verifier`, `auditor`, `researcher`, `integrator`, `drift-guard`, `board`
-- **12 canonical skills** + maintainer PR slash skills (`/review-pr` → `/prepare-pr` → `/merge-pr`)
+- **13 canonical skills** + maintainer PR slash skills (`/review-pr` → `/prepare-pr` → `/merge-pr`)
 - **Board Pattern A CLI:** `python3 -m agent_colony project …` (claim, handoff, Tier-1 fields, outbox)
 - **PR gates** via `prepare.py` · optional MCP (`agent_colony_mcp`) · research corpus under `_research_results/` (opt-in)
 

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -16,6 +16,8 @@
  *  - Roster scorecard 2026-08-04 (AA-ROSTER-001…008) mirrored on Stack/Future views.
  *  - Intentional non-renames: artifact dir enterprise-architecture-audit/, ops doc
  *    project-board-collaboration.md, snapshot project-board-snapshot.json.
+ *  - CLI/MCP stack as of v0.6.0/v0.6.1: agent_colony / agent-colony console;
+ *    agent_colony_mcp package; Cursor server id agent-colony-mcp unchanged.
  *  - Avoid "star-slash" globs in this block comment — they terminate the comment early.
  */
 
@@ -1118,6 +1120,10 @@ export default function NamingRosterAuditCanvas() {
             Live ids: board · implementer · test-runner · verifier · integrator ·
             auditor · drift-guard · researcher. KEEP all 8 — residual score debt
             (drift-guard 16 / auditor 17) is naming debt, not redundancy.
+          </Callout>
+          <Callout tone="neutral" title="CLI / MCP stack (v0.6.0 / v0.6.1)">
+            Python CLI module agent_colony · console agent-colony · MCP package
+            agent_colony_mcp · Cursor server id agent-colony-mcp (unchanged).
           </Callout>
           <H2>Scorecard keep (agent /25)</H2>
           <Table

--- a/payload/.ai_infra/docs/operations/upgrade-kit.md
+++ b/payload/.ai_infra/docs/operations/upgrade-kit.md
@@ -6,12 +6,14 @@ Re-run install from a **newer kit source** (git tag, plugin payload, or local cl
 
 Kit **0.6.0** renames the Python CLI module and console script:
 
-| Before (removed) | After |
-|------------------|-------|
-| `python -m` old module name | `python -m agent_colony` |
-| Console script old name | `agent-colony` |
-| Root package dir | `agent_colony/` |
-| Install package | `.ai_infra/install/agent_colony/` |
+
+| Before (removed)            | After                             |
+| --------------------------- | --------------------------------- |
+| `python -m cursor_workflow` | `python -m agent_colony`          |
+| Console script `cursor-workflow` | `agent-colony`               |
+| Root package dir `cursor_workflow/` | `agent_colony/`             |
+| Install package `.ai_infra/install/cursor_workflow/` | `.ai_infra/install/agent_colony/` |
+
 
 **Cold cut** — old names are not aliased. After upgrading:
 
@@ -19,23 +21,29 @@ Kit **0.6.0** renames the Python CLI module and console script:
 2. Reinstall editable tooling: `pip install -e ".[dev,mcp]"` (kit-dev) so the `agent-colony` console script is on PATH
 3. Update any local scripts/CI that still call the old module or console script
 
+
+
 ## Breaking change (0.6.1)
 
 Kit **0.6.1** renames the MCP Python package (Cursor server id unchanged):
 
-| Before (removed) | After |
-|------------------|-------|
-| `python -m` old MCP package | `python -m agent_colony_mcp` |
-| Package dir | `.ai_infra/mcp_servers/agent_colony_mcp/` |
-| Cursor server id | `agent-colony-mcp` (**unchanged**) |
 
-Update `.cursor/mcp.json` `args` to `["-m", "agent_colony_mcp"]` (or re-run activate / `mcp seed`). MCP **tool** names such as `workflow_*` are unchanged.
+| Before (removed)            | After                                     |
+| --------------------------- | ----------------------------------------- |
+| `python -m workflow_mcp`    | `python -m agent_colony_mcp`              |
+| Package dir `.ai_infra/mcp_servers/workflow_mcp/` | `.ai_infra/mcp_servers/agent_colony_mcp/` |
+| Cursor server id            | `agent-colony-mcp` (**unchanged**)        |
+
+
+Update `.cursor/mcp.json` `args` to `["-m", "agent_colony_mcp"]` (or re-run activate / `mcp seed`). MCP **tool** names such as `workflow_`* are unchanged.
 
 ## Before upgrade
 
 1. Note current version: `cat .ai_infra/.kit-version`
 2. Commit or stash local changes (especially `.cursor/`, `.ai_infra/`, `.local/`)
 3. Back up custom overlays under `overlays/rules/` and any `mcp.user.json` secrets
+
+
 
 ## Upgrade command
 
@@ -47,9 +55,9 @@ source .venv/bin/activate
 python3 -m agent_colony activate --directory .
 ```
 
-Same as **`/workflow-activate`** in Agent chat when planes are already ready. Refreshes kit-managed dashboard HTML, `pages.json`, and install scripts from the plugin payload.
+Same as `/workflow-activate` in Agent chat when planes are already ready. Refreshes kit-managed dashboard HTML, `pages.json`, and install scripts from the plugin payload.
 
-**Full reinstall (scripts, agents, rules — review `.local/` merge):**
+**Full reinstall (scripts, agents, rules — review** `.local/` **merge):**
 
 ```bash
 python3 -m agent_colony activate --directory . --force
@@ -71,15 +79,19 @@ Use `--source payload` when running from the distribution root (see `workflow-ac
 
 ## What install updates
 
-| Area | Behavior |
-|------|----------|
-| `.ai_infra/scripts/` | Overwritten from manifest profile |
-| `.cursor/agents`, rules, skills | Overwritten from kit |
-| `.local/` exemplars | Re-copied on **`--force`** only; light re-activate refreshes dashboards + `pages.json` |
-| Dashboard HTML / `pages.json` | Refreshed on every `activate` (idempotent) |
-| `AGENTS.md` | **Not** overwritten if present — delete to refresh from stub, or merge manually |
-| `mcp.user.json` | **Not** overwritten — merge via `python3 -m agent_colony mcp validate` |
-| `.kit-version` | Updated to manifest `kit_version` |
+
+| Area                            | Behavior                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `.ai_infra/scripts/`            | Overwritten from manifest profile                                                  |
+| `.cursor/agents`, rules, skills | Overwritten from kit                                                               |
+| `.local/` exemplars             | Re-copied on `--force` only; light re-activate refreshes dashboards + `pages.json` |
+| Dashboard HTML / `pages.json`   | Refreshed on every `activate` (idempotent)                                         |
+| `AGENTS.md`                     | **Not** overwritten if present — delete to refresh from stub, or merge manually    |
+| `mcp.user.json`                 | **Not** overwritten — merge via `python3 -m agent_colony mcp validate`             |
+| `.kit-version`                  | Updated to manifest `kit_version`                                                  |
+
+
+
 
 ## After upgrade
 
@@ -89,6 +101,8 @@ python3 -m agent_colony gates
 python3 -m agent_colony health
 python3 -m agent_colony mcp validate
 ```
+
+
 
 ## Rollback
 

--- a/payload/.ai_infra/scripts/architecture/check_debrand.py
+++ b/payload/.ai_infra/scripts/architecture/check_debrand.py
@@ -86,13 +86,28 @@ BANNED_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 
 LINEAGE_ALLOWLIST_SUBSTRINGS: tuple[str, ...] = ()
 
-TEXT_SUFFIXES = {".md", ".mdc", ".py", ".yaml", ".yml", ".txt", ".json", ".jsonc", ".tsx", ".ts"}
+TEXT_SUFFIXES = {
+    ".md",
+    ".mdc",
+    ".py",
+    ".yaml",
+    ".yml",
+    ".txt",
+    ".json",
+    ".jsonc",
+    ".tsx",
+    ".ts",
+    ".html",
+    ".js",
+}
 
 SKIP_REL_PATHS = frozenset(
     {
         ".ai_infra/scripts/architecture/check_debrand.py",
         ".ai_infra/scripts/architecture/check_governance_consistency.py",
         "tests/modules/architecture_scripts/test_check_debrand.py",
+        # Cold-cut upgrade notes must name removed modules (cursor_workflow / workflow_mcp).
+        ".ai_infra/docs/operations/upgrade-kit.md",
     }
 )
 

--- a/payload/.ai_infra/templates/local-workspace/implementation-control-center.html
+++ b/payload/.ai_infra/templates/local-workspace/implementation-control-center.html
@@ -26,7 +26,7 @@ Notes:
     <aside class="local-deprecation" role="status">
       <strong>Deprecated.</strong>
       When <code>project_ssot.enabled</code>, the GitHub Project is the writable SSOT — not this HTML UI.
-      Use <code>python3 -m cursor_workflow project status</code> / board recipes; open kit canvases via
+      Use <code>python3 -m agent_colony project status</code> / board recipes; open kit canvases via
       <strong>Ctrl+Shift+P → Open Canvas</strong>. This page is an offline markdown browser only.
     </aside>
     <section class="local-surface local-page-head">

--- a/payload/.ai_infra/templates/local-workspace/index.html
+++ b/payload/.ai_infra/templates/local-workspace/index.html
@@ -24,7 +24,7 @@ Notes:
     <aside class="local-deprecation" role="status">
       <strong>Deprecated.</strong>
       Prefer the <strong>GitHub Project board</strong>
-      (<code>python3 -m cursor_workflow project status</code>) for backlog/status,
+      (<code>python3 -m agent_colony project status</code>) for backlog/status,
       and <strong>Ctrl+Shift+P → Open Canvas</strong> for kit visualizations.
       These HTML pages remain as an offline tracker browser only.
     </aside>

--- a/payload/.ai_infra/templates/local-workspace/local-board-snapshot.js
+++ b/payload/.ai_infra/templates/local-workspace/local-board-snapshot.js
@@ -72,7 +72,7 @@
     return (
       '<div class="local-board-empty-state">' +
       "<p>No board items in this snapshot.</p>" +
-      "<p>Run <code>python3 -m cursor_workflow project export</code> after updating cards on GitHub.</p>" +
+      "<p>Run <code>python3 -m agent_colony project export</code> after updating cards on GitHub.</p>" +
       "</div>"
     );
   }
@@ -160,7 +160,7 @@
       '<div class="local-board-missing">' +
       '<p class="status-bad">Project board snapshot not found.</p>' +
       "<p>Export a read-only snapshot from the CLI:</p>" +
-      "<pre><code>python3 -m cursor_workflow project export</code></pre>" +
+      "<pre><code>python3 -m agent_colony project export</code></pre>" +
       "<p>Output path: <code>.local/generated-data/project-project-board-snapshot.json</code></p>" +
       "</div>"
     );

--- a/tests/modules/architecture_scripts/test_check_debrand.py
+++ b/tests/modules/architecture_scripts/test_check_debrand.py
@@ -86,3 +86,16 @@ def test_debrand_flags_legacy_cli_module_name() -> None:
         "Run python -m cursor_workflow health",
         pattern,
     )
+
+
+def test_debrand_text_suffixes_include_html_and_js() -> None:
+    mod = _load_debrand_module()
+    assert ".html" in mod.TEXT_SUFFIXES
+    assert ".js" in mod.TEXT_SUFFIXES
+
+
+def test_debrand_flags_cursor_workflow_in_html_sample() -> None:
+    mod = _load_debrand_module()
+    pattern = dict(mod.BANNED_PATTERNS)["cursor_workflow"]
+    sample = '<code>python3 -m cursor_workflow project status</code>'
+    assert mod.text_has_banned_pattern(sample, pattern)


### PR DESCRIPTION
## Summary
- Replace removed `python3 -m cursor_workflow` strings in local-workspace dashboard templates (SSOT + payload via sync-plugin).
- Extend `check_debrand` to scan `.html`/`.js`; skip `upgrade-kit.md` so cold-cut docs can name removed modules.
- Align docs: 13 canonical skills, 14 CLI commands (`canvas`/`plan`), test count 1458, marketplace refresh row, naming-roster note, dedupe plugin keyword.

## Test plan
- [x] `python3 .ai_infra/scripts/architecture/check_debrand.py`
- [x] `python3 .ai_infra/scripts/architecture/check_governance_consistency.py`
- [x] `make sync-plugin && make check-plugin`
- [x] `pytest tests/modules/architecture_scripts/test_check_debrand.py -q` (8 passed)
- [x] `python3 -m agent_colony doc validate` / `drift validate`
- [ ] `python .ai_infra/scripts/pr/prepare.py --pipeline` after PR open

## Collaboration
- Board: Issue #193 · `PVTI_lAHOBl46-84A9KZxzg1qJQs`
- Agent/s: implementer | review-pr | prepare-pr | merge-pr