### PR TITLE
chore: post-rename doc hygiene (13 skills + snapshot path)

### DIFF
--- a/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/.ai_infra/docs/governance/workflow-source-owners.md
@@ -24,8 +24,8 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `full-pr-workflow` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (12 folders) | Plugin sync, agents |
-| Maintainer slash skills | `.agents/skills/` (5 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
+| Canonical Cursor skills | `.cursor/skills/` (13 folders) | Plugin sync, agents |
+| Maintainer slash skills | `.agents/skills/` (6 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |
 | Audit / dedup rules | `.ai_infra/docs/operations/agent-workflow-procedures.md` | Alignment + governance |

--- a/.ai_infra/templates/local-workspace/local-board-snapshot.js
+++ b/.ai_infra/templates/local-workspace/local-board-snapshot.js
@@ -7,7 +7,7 @@
  * Depends On:
  *  - local-markdown.js (escapeHtml)
  * Notes:
- *  - Reads `.local/generated-data/project-project-board-snapshot.json` only; never writes board Status.
+ *  - Reads `.local/generated-data/project-board-snapshot.json` only; never writes board Status.
  *  - Copy to `.local/agents-control-center/dashboards/` with other dashboard assets.
  */
 (function (global) {
@@ -161,7 +161,7 @@
       '<p class="status-bad">Project board snapshot not found.</p>' +
       "<p>Export a read-only snapshot from the CLI:</p>" +
       "<pre><code>python3 -m agent_colony project export</code></pre>" +
-      "<p>Output path: <code>.local/generated-data/project-project-board-snapshot.json</code></p>" +
+      "<p>Output path: <code>.local/generated-data/project-board-snapshot.json</code></p>" +
       "</div>"
     );
   }

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -856,7 +856,7 @@ export default function NamingRosterAuditCanvas() {
             B-safe SHIPPED
           </Pill>
           <Pill tone="neutral" size="sm">
-            8 agents · 12 skills
+            8 agents · 13 skills
           </Pill>
         </Row>
         <Text tone="secondary" size="small">
@@ -897,7 +897,7 @@ export default function NamingRosterAuditCanvas() {
       {view === "plan" ? (
         <Stack gap={16}>
           <Callout tone="success" title="B-safe rename SHIPPED — 2026-08-03">
-            Live filesystem roster: 8 agents / 12 canonical skills / 7 rules.
+            Live filesystem roster: 8 agents / 13 canonical skills / 7 rules.
             Agent descriptions prefixed Agent Colony (#153). Shared board-ssot is
             Entry/Exit for all agents. Plan rows below are keep/keep against the
             shipped names — not a pending rename plan.

--- a/payload/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/payload/.ai_infra/docs/governance/workflow-source-owners.md
@@ -24,8 +24,8 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `full-pr-workflow` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (12 folders) | Plugin sync, agents |
-| Maintainer slash skills | `.agents/skills/` (5 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
+| Canonical Cursor skills | `.cursor/skills/` (13 folders) | Plugin sync, agents |
+| Maintainer slash skills | `.agents/skills/` (6 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |
 | Audit / dedup rules | `.ai_infra/docs/operations/agent-workflow-procedures.md` | Alignment + governance |

--- a/payload/.ai_infra/templates/local-workspace/local-board-snapshot.js
+++ b/payload/.ai_infra/templates/local-workspace/local-board-snapshot.js
@@ -7,7 +7,7 @@
  * Depends On:
  *  - local-markdown.js (escapeHtml)
  * Notes:
- *  - Reads `.local/generated-data/project-project-board-snapshot.json` only; never writes board Status.
+ *  - Reads `.local/generated-data/project-board-snapshot.json` only; never writes board Status.
  *  - Copy to `.local/agents-control-center/dashboards/` with other dashboard assets.
  */
 (function (global) {
@@ -161,7 +161,7 @@
       '<p class="status-bad">Project board snapshot not found.</p>' +
       "<p>Export a read-only snapshot from the CLI:</p>" +
       "<pre><code>python3 -m agent_colony project export</code></pre>" +
-      "<p>Output path: <code>.local/generated-data/project-project-board-snapshot.json</code></p>" +
+      "<p>Output path: <code>.local/generated-data/project-board-snapshot.json</code></p>" +
       "</div>"
     );
   }


### PR DESCRIPTION
## Summary
- Align naming-roster canvas and `workflow-source-owners.md` to **13** canonical / **6** maintainer skills.
- Fix `project-project-board-snapshot.json` typo → `project-board-snapshot.json` in local-board-snapshot.js (+ payload).

## Test plan
- [x] `make sync-plugin && make check-plugin`
- [x] `drift validate` 13/13 after session Board format fix
- [ ] prepare.py with venv

## Collaboration
- Board: Issue #195 · `PVTI_lAHOBl46-84A9KZxzg1qTmY`
- Follows merged #194