### PR TITLE
chore: MCP roster — all 8 agents in registry and mcp.agents

### DIFF
--- a/.ai_infra/docs/operations/connect-external-mcp.md
+++ b/.ai_infra/docs/operations/connect-external-mcp.md
@@ -101,7 +101,7 @@ servers:
   deepwiki:
     tier: external
     description: Public GitHub repo docs/Q&A (no auth) — Cognition DeepWiki
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
 ```
 

--- a/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
@@ -23,10 +23,14 @@ kit:
     - auditor
     - researcher
     - integrator
+    - drift-guard
+    - board
   tools_hint:
     - workflow_run_prepare
     - workflow_get_tracker
     - workflow_list_mcp_registry
+    - workflow_integrate_validate
+    - workflow_drift_validate
     - workflow_mcp_connection_guide
 
 # External servers — add rows as you connect more capability
@@ -93,6 +97,9 @@ agent_defaults:
   test-runner:
     primary_servers: [agent-colony-mcp]
     optional_servers: []
+  verifier:
+    primary_servers: [agent-colony-mcp]
+    optional_servers: []
   auditor:
     primary_servers: [agent-colony-mcp]
     optional_servers: [deepwiki]
@@ -100,6 +107,12 @@ agent_defaults:
     primary_servers: [agent-colony-mcp]
     optional_servers: [deepwiki]
   integrator:
+    primary_servers: [agent-colony-mcp]
+    optional_servers: []
+  drift-guard:
+    primary_servers: [agent-colony-mcp]
+    optional_servers: []
+  board:
     primary_servers: [agent-colony-mcp]
     optional_servers: []
 

--- a/.cursor/mcp.registry.yaml
+++ b/.cursor/mcp.registry.yaml
@@ -3,7 +3,7 @@ servers:
   agent-colony-mcp:
     tier: kit
     description: PR workflow, trackers, gates
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [workflow_run_prepare, workflow_get_tracker, workflow_list_mcp_registry, workflow_integrate_validate, workflow_drift_validate]
 # External servers (deepwiki, …): copy mcp.registry.yaml.example + mcp.user.example.json,
 # then `python3 -m agent_colony mcp validate` / health. Do not commit user fragment.

--- a/.cursor/mcp.registry.yaml.example
+++ b/.cursor/mcp.registry.yaml.example
@@ -3,13 +3,13 @@ servers:
   agent-colony-mcp:
     tier: kit
     description: PR workflow, trackers, gates
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [workflow_run_prepare, workflow_get_tracker, workflow_list_mcp_registry, workflow_integrate_validate, workflow_drift_validate]
   # User adds keys matching mcp.json mcpServers:
   deepwiki:
     tier: external
     description: Public GitHub repo docs/Q&A (no auth) — Cognition DeepWiki
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
   my-custom-server:
     tier: external

--- a/payload/.ai_infra/docs/operations/connect-external-mcp.md
+++ b/payload/.ai_infra/docs/operations/connect-external-mcp.md
@@ -101,7 +101,7 @@ servers:
   deepwiki:
     tier: external
     description: Public GitHub repo docs/Q&A (no auth) — Cognition DeepWiki
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
 ```
 

--- a/payload/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/mcp.agents.yaml
@@ -23,10 +23,14 @@ kit:
     - auditor
     - researcher
     - integrator
+    - drift-guard
+    - board
   tools_hint:
     - workflow_run_prepare
     - workflow_get_tracker
     - workflow_list_mcp_registry
+    - workflow_integrate_validate
+    - workflow_drift_validate
     - workflow_mcp_connection_guide
 
 # External servers — add rows as you connect more capability
@@ -93,6 +97,9 @@ agent_defaults:
   test-runner:
     primary_servers: [agent-colony-mcp]
     optional_servers: []
+  verifier:
+    primary_servers: [agent-colony-mcp]
+    optional_servers: []
   auditor:
     primary_servers: [agent-colony-mcp]
     optional_servers: [deepwiki]
@@ -100,6 +107,12 @@ agent_defaults:
     primary_servers: [agent-colony-mcp]
     optional_servers: [deepwiki]
   integrator:
+    primary_servers: [agent-colony-mcp]
+    optional_servers: []
+  drift-guard:
+    primary_servers: [agent-colony-mcp]
+    optional_servers: []
+  board:
     primary_servers: [agent-colony-mcp]
     optional_servers: []
 

--- a/payload/.cursor/mcp.registry.yaml.example
+++ b/payload/.cursor/mcp.registry.yaml.example
@@ -3,13 +3,13 @@ servers:
   agent-colony-mcp:
     tier: kit
     description: PR workflow, trackers, gates
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [workflow_run_prepare, workflow_get_tracker, workflow_list_mcp_registry, workflow_integrate_validate, workflow_drift_validate]
   # User adds keys matching mcp.json mcpServers:
   deepwiki:
     tier: external
     description: Public GitHub repo docs/Q&A (no auth) — Cognition DeepWiki
-    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard]
+    agents: [implementer, test-runner, verifier, auditor, researcher, integrator, drift-guard, board]
     tools_hint: [read_wiki_structure, read_wiki_contents, ask_question]
   my-custom-server:
     tier: external


### PR DESCRIPTION
## Summary
- Add `board` to `mcp.registry.yaml` (+ example, DeepWiki worksheet).
- Expand `mcp.agents.yaml` kit agents + `agent_defaults` for all 8 agents (`verifier`, `drift-guard`, `board`).
- Align `connect-external-mcp.md` worked example; sync payload.

## Test plan
- [x] `make sync-plugin && make check-plugin`
- [x] `python3 -m agent_colony mcp validate`
- [x] `integrate validate` 14/14
- [x] `pytest tests/modules/mcp_registry/` (68 passed)

## Collaboration
- Issue #197 (board item-add rate-limited; close on merge)