### PR TITLE
fix: mock claim/handoff by-id fallback in unit tests

### DIFF
--- a/tests/modules/install/test_project_cli_coverage.py
+++ b/tests/modules/install/test_project_cli_coverage.py
@@ -1922,6 +1922,12 @@ def test_cmd_claim_not_found_and_assignee_ok(
         "fetch_project_items",
         lambda *a, **k: ([], None),
     )
+    # Claim falls back to node-id lookup when the item is outside the list page.
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_item_by_id",
+        lambda *a, **k: (None, f"project item not found: {VALID_ITEM}"),
+    )
     args = argparse.Namespace(
         directory=tmp_path,
         id=VALID_ITEM,
@@ -1978,6 +1984,11 @@ def test_cmd_handoff_not_found_and_queued_paths(
         project_cli,
         "fetch_project_items",
         lambda *a, **k: ([], None),
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_item_by_id",
+        lambda *a, **k: (None, f"project item not found: {VALID_ITEM}"),
     )
     assert project_cli.cmd_handoff(argparse.Namespace(**base)) == project_cli.EXIT_NOT_FOUND
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Claim/handoff now fall back to `fetch_project_item_by_id` when the card is missing from the item-list page.
- Existing not-found unit tests only mocked `fetch_project_items`, so CI called real `gh` (no `GH_TOKEN`) and got `EXIT_GH` (3) instead of `EXIT_NOT_FOUND` (4).
- Mock the by-id path to return a not-found error so the tests match the new control flow.

## Test plan
- [x] `pytest …::test_cmd_claim_not_found_and_assignee_ok`
- [x] `pytest …::test_cmd_handoff_not_found_and_queued_paths`
- [ ] Kit Quality CI green on this PR