### PR TITLE
feat: /update-agent-colony version-gated consumer upgrade

### DIFF
--- a/.ai_infra/README.md
+++ b/.ai_infra/README.md
@@ -13,7 +13,7 @@ Versioned workflow kit assets live here. **`.cursor/` and `.agents/` stay at rep
 | `.ai_infra/mcp_servers/agent_colony_mcp/` | Optional MCP server (wraps scripts) |
 | `.ai_infra/docs/` | governance, operations, roadmap, handoff, architecture |
 | `.ai_infra/templates/` | AGENTS stub, local-workspace exemplars, plugin skills |
-| `.ai_infra/install/agent_colony/` | `agent-colony` CLI — fourteen top-level commands (`install`, `activate`, `gates`, `health`, `mcp`, `contributors`, `integrate`, `drift`, `doc`, `verify`, `project`, `research`, `canvas`, `plan`; see `agent-colony --help`) |
+| `.ai_infra/install/agent_colony/` | `agent-colony` CLI — fifteen top-level commands (`install`, `activate`, `update`, `gates`, `health`, `mcp`, `contributors`, `integrate`, `drift`, `doc`, `verify`, `project`, `research`, `canvas`, `plan`; see `agent-colony --help`) |
 
 ## Path resolution
 

--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -68,7 +68,7 @@ Drift validation: `make drift-validate` — see [gate-matrix.md](../operations/g
 
 | Root | Contents |
 |------|----------|
-| `.cursor/skills/` | Canonical protocols (**13**): `workflow-activate`, `board-ssot`, `board-shell`, `canvas-artifacts`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
+| `.cursor/skills/` | Canonical protocols (**14**): `workflow-activate`, `update-agent-colony`, `board-ssot`, `board-shell`, `canvas-artifacts`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
 | `.agents/skills/` | Maintainer slash skills: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` (redirect) |
 
 Plugin bundle copies `.cursor/skills/` first; maintainer skills are **additive only** (no overwrite).

--- a/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/.ai_infra/docs/governance/workflow-source-owners.md
@@ -24,7 +24,7 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `full-pr-workflow` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (13 folders) | Plugin sync, agents |
+| Canonical Cursor skills | `.cursor/skills/` (14 folders) | Plugin sync, agents |
 | Maintainer slash skills | `.agents/skills/` (6 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1476
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1478
 
 ## Shipped (confirmed in repo)
 
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1476 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1478 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1465
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1476
 
 ## Shipped (confirmed in repo)
 
@@ -24,7 +24,7 @@ Notes:
 |------|--------|----------|
 | Universal rules | 7 `.mdc` | `.cursor/rules/` **and** `payload/.cursor/rules/` (6 kit + `project-ssot-precedence`) |
 | Agents | 8 core; `model: auto`; audit agents write `.local/` artifacts only (no `readonly`) | `.cursor/agents/` |
-| Canonical skills | 13 folders | `.cursor/skills/` |
+| Canonical skills | 14 folders | `.cursor/skills/` |
 | Maintainer skills | 6 folders (additive plugin merge; includes `full-pr-workflow`) | `.agents/skills/` |
 | Cursor skill merge | Canonical wins in plugin sync | `sync_plugin_bundle.py` |
 | workflow-activate skill | Kit dev + plugin | `.cursor/skills/workflow-activate/` |
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1465 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1476 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -198,7 +198,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 | Organization handle | `savin-razvan` (or `agent-colony`) |
 | Contact email | razvan.i.savin@gmail.com |
 | Logotype URL | `https://raw.githubusercontent.com/SavinRazvan/agent-colony/main/assets/logo.png` |
-| Description | Agent Colony installs multi-agent workflow into any Cursor project (8 agents, 13 skills, 7 rules): GitHub Project as writable backlog/status SSOT, PR lifecycle scripts, `.local/` evidence, optional MCP. Run **`/workflow-activate`**, then first-run **`/board`** (Playground board shell) before **`/implementer`**. Pattern A: one script per maintainer action. |
+| Description | Agent Colony installs multi-agent workflow into any Cursor project (8 agents, 14 skills, 7 rules): GitHub Project as writable backlog/status SSOT, PR lifecycle scripts, `.local/` evidence, optional MCP. Run **`/workflow-activate`**, then first-run **`/board`** (Playground board shell) before **`/implementer`**. Pattern A: one script per maintainer action. |
 | GitHub repository | https://github.com/SavinRazvan/agent-colony |
 | Owner | Individual · razvan.i.savin@gmail.com |
 | Website URL | https://razvansavin.com/ |
@@ -226,6 +226,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 **Listing copy refresh (2026-08-07 rename leftover sync):** Re-verified against `IMPLEMENTATION-STATUS.md` + filesystem post v0.6.0/v0.6.1 CLI/MCP rename + local-workspace template cleanup — **1458** tests; agent/skill/rule counts (**8** / **13** / **7**); kit version **0.6.1**.
 
 **Listing copy refresh (2026-08-07 consumer activate hardening):** Re-verified after activate gitignore/venv/STARTER/MCP-tool hardening — **1465** tests; agent/skill/rule counts (**8** / **13** / **7**); kit version **0.6.1**.
+
+**Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1476** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -227,7 +227,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-08-07 consumer activate hardening):** Re-verified after activate gitignore/venv/STARTER/MCP-tool hardening — **1465** tests; agent/skill/rule counts (**8** / **13** / **7**); kit version **0.6.1**.
 
-**Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1476** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
+**Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1478** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1465; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1476; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -69,9 +69,9 @@ Deep dive: [PLUGIN-ARCHITECTURE.md](PLUGIN-ARCHITECTURE.md).
 |------|------|------------|
 | `.cursor/agents/*.md` | 8 agent cards | **Here** |
 | `.cursor/rules/*.mdc` | 7 kit-dev rules | **Here** |
-| `.cursor/skills/*/` | 13 canonical protocols | **Here** |
+| `.cursor/skills/*/` | 14 canonical protocols | **Here** |
 | `.agents/skills/*/` | Maintainer slash skills | **Here** |
-| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (19 skill folders = 13 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
+| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (20 skill folders = 14 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
 | `payload/` | Consumer install bundle | `make sync-plugin` from above + manifest |
 | `skills/audit-alignment/` | Deprecated stub in merged `skills/` | `.agents/skills/audit-alignment/` |
 
@@ -87,7 +87,7 @@ my-app/
 ├── .cursor/
 │   ├── agents/                     8 agents (from payload; incl. board)
 │   ├── rules/                      7 rules (6 kit + project-ssot-precedence)
-│   └── skills/                     13 canonical skills only (no repo-root skills/ merge)
+│   └── skills/                     14 canonical skills only (no repo-root skills/ merge)
 ├── .agents/skills/                 6 maintainer slash folders (incl. full-pr-workflow; + audit-alignment stub)
 ├── .ai_infra/                      Slim bundle (manifest copy_ai_infra only)
 │   ├── scripts/pr|architecture|integration|workflow|install/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1465; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1476; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 
@@ -141,7 +141,7 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 
 ## Skills
 
-### Canonical — `.cursor/skills/` (13) → consumer `.cursor/skills/`
+### Canonical — `.cursor/skills/` (14) → consumer `.cursor/skills/`
 
 | Skill | Paired agent |
 |-------|----------------|
@@ -155,7 +155,8 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 | `board-ssot` | `board` (board Entry/Exit; ADR-008) |
 | `board-shell` | `board` (first-run shell coach) |
 | `canvas-artifacts` | Canvas/plan Pattern A CLI (ADR-010) |
-| `workflow-activate` | Install / re-activate |
+| `workflow-activate` | Install / first activate |
+| `update-agent-colony` | Version-gated consumer upgrade |
 | `mcp-connect` | MCP setup |
 | `research-corpus` | `researcher` |
 
@@ -174,7 +175,7 @@ Also under `.agents/skills/`: `README.md`, `PR_WORKFLOW.md` (legacy redirect), `
 
 ### Repo-root `skills/` — Marketplace plugin mirror only
 
-Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (13) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
+Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (14) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
 
 ---
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1476; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1478; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1476; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1478; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -254,7 +254,8 @@ your-project/
 | Goal | Type in chat |
 |------|--------------|
 | Install plugin | `/add-plugin https://github.com/SavinRazvan/agent-colony` |
-| Activate / refresh | `/workflow-activate` |
+| Activate (first install) | `/workflow-activate` |
+| Upgrade kit (version-gated) | `/update-agent-colony` |
 | Implement | `/implementer` |
 | Tests | `/test-runner` |
 | PR lifecycle | `/review-pr` → `/prepare-pr` → `/merge-pr` |
@@ -269,7 +270,8 @@ source .venv/bin/activate
 
 | Command | Purpose |
 |---------|---------|
-| `python3 -m agent_colony activate --directory .` | Install, re-activate, refresh dashboards |
+| `python3 -m agent_colony activate --directory .` | First install / light heal when planes ready |
+| `python3 -m agent_colony update --directory .` | Version-gated upgrade (heal or full refresh) |
 | `python3 -m agent_colony contributors validate` | After editing collaboration YAML |
 | `python3 -m agent_colony health` | Layout + version |
 | `python3 -m agent_colony integrate validate` | Integration checks |
@@ -328,7 +330,7 @@ python3 -m http.server 8000
 | Control Center | http://localhost:8000/.local/agents-control-center/dashboards/implementation-control-center.html |
 | Module audit | http://localhost:8000/.local/agents-control-center/audits/module-audit.html |
 
-Refresh after kit update: **`/workflow-activate`** or `python3 -m agent_colony activate --directory .`
+Refresh after kit update: **`/update-agent-colony`** or `python3 -m agent_colony update --directory .`
 
 Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dashboards.
 
@@ -348,7 +350,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
 | **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [integrator-protocol skill](../../.cursor/skills/integrator-protocol/SKILL.md) · [mas-infrastructure-integration.md](mas-infrastructure-integration.md) (ops filename kept) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
-| **Upgrade / refresh dashboards** | `/workflow-activate` | `python3 -m agent_colony activate --directory .` | [upgrade-kit.md](upgrade-kit.md) |
+| **Upgrade / version-gated refresh** | `/update-agent-colony` | `python3 -m agent_colony update --directory .` | [upgrade-kit.md](upgrade-kit.md) · [update-agent-colony skill](../../.cursor/skills/update-agent-colony/SKILL.md) |
 | **Check install health** | — | `python3 -m agent_colony health` | [gate-matrix.md](gate-matrix.md) |
 | **Dry-run install preview** | — | `python3 -m agent_colony install --target <dir> --dry-run` | [install-dry-run.md](install-dry-run.md) |
 
@@ -357,6 +359,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | Chat name | Disk path |
 |-----------|-----------|
 | `/workflow-activate` | `.cursor/skills/workflow-activate/` |
+| `/update-agent-colony` | `.cursor/skills/update-agent-colony/` |
 | `/implementer` | `.cursor/agents/implementer.md` |
 | `/test-runner` | `.cursor/agents/test-runner.md` |
 | `/verifier` | `.cursor/agents/verifier.md` |
@@ -459,7 +462,7 @@ Details: [gate-matrix.md](gate-matrix.md). **`make gates`** / **`make verify-all
 | Activate blocked in kit repo | Open your app folder — activate refuses self-install |
 | Broken YAML in collaboration file | Keep `human_coauthors: []` or use a proper list |
 | Control Center **Failed to fetch** | `python3 -m http.server 8000` from project root, then http://localhost:8000/.local/agents-control-center/dashboards/index.html — not `file://` |
-| Stale dashboard after kit update | Re-run `/workflow-activate` or `activate --directory .` |
+| Stale dashboard / kit files after plugin update | Re-run `/update-agent-colony` or `python3 -m agent_colony update --directory .` |
 | `DRIFT-005 FAIL` on consumer drift | **Kit bug (not your app)** — upgrade kit or ignore until skip-if-absent fix ships. Details: [consumer-quickstart](consumer-quickstart.md#drift-005-fail--kit-bug-not-your-app) |
 | `mcp validate` → typer required | Use `python3 -m agent_colony mcp validate` — not bare `mcp validate` |
 

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -39,7 +39,7 @@ Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No
 
 **Healthy install?** `python3 -m agent_colony health` · with board on: `gh auth status` → `project doctor` → `project board-bootstrap --check`
 
-**Update kit later (optional):** merge kit changes to `main` → in your app Agent chat `/add-plugin https://github.com/SavinRazvan/agent-colony` → `/workflow-activate` (or `python3 -m agent_colony activate --directory .`). Full force/semver: [upgrade-kit.md](upgrade-kit.md). **Does not** create GitHub Project views — finish step 4 for that.
+**Update kit later (optional):** merge kit changes to `main` → in your app Agent chat `/add-plugin https://github.com/SavinRazvan/agent-colony` → **`/update-agent-colony`** (or `python3 -m agent_colony update --directory .`). First install remains `/workflow-activate`. Full force/semver: [upgrade-kit.md](upgrade-kit.md). **Does not** create GitHub Project views — finish step 4 for that.
 
 > **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards (deprecated)](#control-center-dashboards-deprecated) · [All CLI commands](#terminal-commands-cheat-sheet)
 

--- a/.ai_infra/docs/operations/upgrade-kit.md
+++ b/.ai_infra/docs/operations/upgrade-kit.md
@@ -77,6 +77,8 @@ Compares `.ai_infra/.kit-version` to the activate source `manifest.yaml` `kit_ve
 
 Same as Agent chat **`/update-agent-colony`**. See [update-agent-colony skill](../../.cursor/skills/update-agent-colony/SKILL.md).
 
+**Kit-dev product repo:** do not run `update --force` here (scaffold is consumer-only and will refuse). Sync mirrors with `make sync-plugin` instead. Light `update` / heal on kit-dev refreshes dashboards only and does not overwrite authoring `install/` from `payload/`.
+
 **Advanced aliases** (same underlying scaffold paths):
 
 ```bash

--- a/.ai_infra/docs/operations/upgrade-kit.md
+++ b/.ai_infra/docs/operations/upgrade-kit.md
@@ -41,8 +41,8 @@ Update `.cursor/mcp.json` `args` to `["-m", "agent_colony_mcp"]` (or re-run acti
 
 If an older activate left only MCP secret lines in `.gitignore`, or omitted the consumer `STARTER-001` drift marker:
 
-1. Re-run `source .venv/bin/activate && python3 -m agent_colony activate --directory .`  
-   (heals `.gitignore` for `.local/` + `.venv/`, seeds `STARTER-001` into `work-tracker.md`, creates `.venv` only if missing and `--with-venv` is on).
+1. Re-run `source .venv/bin/activate && python3 -m agent_colony update --directory .`  
+   (when up to date: heals `.gitignore` for `.local/` + `.venv/`, seeds `STARTER-001`, creates missing `.venv`; when source newer: full kit refresh). Plain `activate` also heals when planes are ready.
 2. If `.venv/` or `.local/` were already committed: keep the healed `.gitignore`, then  
    `git rm -r --cached .venv .local` and commit app sources (`src/`, `pyproject.toml`, …) instead.
 3. MCP tool rename: `workflow_mcp_connection_guide` → `workflow_agent_colony_mcp_connection_guide` (re-copy exemplar `mcp.agents.yaml` tools_hint or edit locally).
@@ -57,19 +57,33 @@ If an older activate left only MCP secret lines in `.gitignore`, or omitted the 
 
 ## Upgrade command
 
-**Light refresh (dashboards + activate scripts, keeps trackers):**
+**Preferred (version-gated):**
 
 ```bash
 cd ~/Projects/my-app    # your activated project
 source .venv/bin/activate
-python3 -m agent_colony activate --directory .
+python3 -m agent_colony update --directory .
+# or Agent chat: /update-agent-colony
 ```
 
-Same as `/workflow-activate` in Agent chat when planes are already ready. Refreshes kit-managed dashboard HTML, `pages.json`, and install scripts from the plugin payload.
+Compares `.ai_infra/.kit-version` to the activate source `manifest.yaml` `kit_version`:
 
-**Full reinstall (scripts, agents, rules — review** `.local/` **merge):**
+| Result | Action |
+|--------|--------|
+| Up to date | Light heal — dashboards, runtime `.gitignore`, `STARTER-001`, missing `.venv` |
+| Source newer | Full kit-managed refresh (agents/rules/skills/scripts) |
+| `--check` | Report only (no writes) |
+| `--force` | Full refresh even when versions match |
+
+Same as Agent chat **`/update-agent-colony`**. See [update-agent-colony skill](../../.cursor/skills/update-agent-colony/SKILL.md).
+
+**Advanced aliases** (same underlying scaffold paths):
 
 ```bash
+# Light heal only (no version compare) — also what plain re-activate does when planes are ready
+python3 -m agent_colony activate --directory .
+
+# Full reinstall without version gate
 python3 -m agent_colony activate --directory . --force
 ```
 

--- a/.ai_infra/install/agent_colony/cli.py
+++ b/.ai_infra/install/agent_colony/cli.py
@@ -9,9 +9,12 @@ Depends On:
  - .ai_infra/scripts/install/scaffold.py
  - .ai_infra/install/agent_colony/mcp_manage.py
  - .ai_infra/install/agent_colony/mcp_cli.py
+ - .ai_infra/install/agent_colony/activate_cli.py
+ - .ai_infra/install/agent_colony/update_cli.py
 Notes:
  - install forwards to scaffold.py; gates runs prepare-aligned checks.
  - ADR-009 MCP; ADR-010 canvas/plan Pattern A CLI.
+ - update = version-gated consumer upgrade (heal vs full refresh).
 """
 
 from __future__ import annotations
@@ -50,6 +53,7 @@ import drift_cli  # noqa: E402
 import doc_cli  # noqa: E402
 import verify_cli  # noqa: E402
 import activate_cli  # noqa: E402
+import update_cli  # noqa: E402
 import project_cli  # noqa: E402
 import research_cli  # noqa: E402
 
@@ -269,6 +273,7 @@ def build_parser() -> argparse.ArgumentParser:
     doc_cli.register_doc_subparser(sub)
     verify_cli.register_verify_subparser(sub)
     activate_cli.register_activate_subparser(sub)
+    update_cli.register_update_subparser(sub)
     project_cli.register_project_subparser(sub)
     research_cli.register_research_subparser(sub)
 

--- a/.ai_infra/install/agent_colony/update_cli.py
+++ b/.ai_infra/install/agent_colony/update_cli.py
@@ -1,0 +1,272 @@
+"""
+File: update_cli.py
+Path: .ai_infra/install/agent_colony/update_cli.py
+Role: Version-gated consumer kit upgrade — heal when current, full scaffold when newer.
+Used By:
+ - .ai_infra/install/agent_colony/cli.py
+ - .cursor/skills/update-agent-colony/SKILL.md
+Depends On:
+ - .ai_infra/install/agent_colony/activate_cli.py
+ - .ai_infra/scripts/install/plane_status.py
+ - .ai_infra/scripts/install/scaffold.py (via activate force path)
+Notes:
+ - First install remains activate; update is for already-activated apps after plugin/kit bump.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+import activate_cli
+
+
+_VERSION_RE = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[.-].*)?$")
+
+
+def read_installed_version(target: Path) -> str | None:
+    path = target / ".ai_infra" / ".kit-version"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def read_source_version(source: Path) -> str:
+    manifest = source / ".ai_infra" / "manifest.yaml"
+    if not manifest.is_file():
+        raise FileNotFoundError(f"missing manifest: {manifest}")
+    raw = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"invalid manifest (not a mapping): {manifest}")
+    version = str(raw.get("kit_version", "")).strip()
+    if not version:
+        raise ValueError(f"manifest missing kit_version: {manifest}")
+    return version
+
+
+def _parse_version_tuple(version: str) -> tuple[int, ...] | None:
+    match = _VERSION_RE.match(version.strip())
+    if not match:
+        return None
+    parts = [int(p) if p is not None else 0 for p in match.groups()]
+    return tuple(parts)
+
+
+def compare_versions(installed: str, available: str) -> int:
+    """Return -1 if installed < available, 0 if equal, 1 if installed > available."""
+    left = _parse_version_tuple(installed)
+    right = _parse_version_tuple(available)
+    if left is not None and right is not None:
+        if left < right:
+            return -1
+        if left > right:
+            return 1
+        return 0
+    if installed == available:
+        return 0
+    return -1 if installed < available else 1
+
+
+def decide_action(*, installed: str | None, available: str, force: bool) -> str:
+    """Return heal | upgrade | missing."""
+    if installed is None:
+        return "missing"
+    if force:
+        return "upgrade"
+    if compare_versions(installed, available) < 0:
+        return "upgrade"
+    return "heal"
+
+
+def _run_scaffold_upgrade(
+    target: Path,
+    source: Path,
+    *,
+    profile: str,
+    with_venv: bool,
+    with_mcp_json: bool,
+    verify: bool,
+) -> int:
+    from paths import kit_root, scripts_dir
+
+    script = scripts_dir("install", kit_root()) / "scaffold.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--target",
+        str(target),
+        "--source",
+        str(source),
+        "--profile",
+        profile,
+    ]
+    if with_venv:
+        cmd.append("--with-venv")
+    if with_mcp_json:
+        cmd.append("--with-mcp-json")
+    if verify:
+        cmd.append("--verify")
+    proc = subprocess.run(cmd, cwd=kit_root())
+    return int(proc.returncode)
+
+
+def _run_light_heal(target: Path, source: Path, *, with_venv: bool) -> None:
+    from paths import kit_root
+
+    activate_cli._refresh_dashboard_templates(target, source, kit_root())
+    activate_cli._heal_consumer_runtime(target, with_venv=with_venv)
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    from paths import kit_root
+
+    target = Path(args.directory).resolve()
+    kit_ver_path = target / ".ai_infra" / ".kit-version"
+    if not (target / ".ai_infra").is_dir():
+        print(
+            "update: FAIL — workspace not activated (.ai_infra missing). "
+            "Run: python3 -m agent_colony activate --directory .",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        source = activate_cli.resolve_activate_source(args.source, target, kit_root())
+    except FileNotFoundError as exc:
+        print(f"update: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    if source.resolve() == target.resolve():
+        print(
+            "update: FAIL — cannot upgrade a workspace from itself; "
+            "pass --source <kit-root|payload/> or set WORKFLOW_KIT_PAYLOAD",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        available = read_source_version(source)
+    except (OSError, ValueError, FileNotFoundError) as exc:
+        print(f"update: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    installed = read_installed_version(target)
+    action = decide_action(
+        installed=installed,
+        available=available,
+        force=bool(args.force),
+    )
+
+    print(f"installed={installed or '(none)'}")
+    print(f"available={available}")
+    print(f"source={source}")
+    print(f"action={action}")
+
+    if args.check:
+        if action == "missing":
+            print("check: would_activate (no .kit-version — run activate first)")
+            return 1
+        if action == "upgrade":
+            print("check: would_upgrade (full kit-managed refresh)")
+        else:
+            print("check: would_heal (dashboards + runtime gitignore/STARTER/venv)")
+        return 0
+
+    if action == "missing":
+        print(
+            "update: FAIL — missing .ai_infra/.kit-version. "
+            "First install: python3 -m agent_colony activate --directory .",
+            file=sys.stderr,
+        )
+        return 1
+
+    plane_status = activate_cli._import_plane_status()
+
+    if action == "heal":
+        print("\nKit up to date — light heal (dashboards + runtime).")
+        _run_light_heal(target, source, with_venv=bool(args.with_venv))
+        status = plane_status.assess_planes(
+            target, profile=args.profile, require_venv=bool(args.with_venv)
+        )
+        print(plane_status.format_plane_report(status))
+        if not status.all_ready:
+            print("update: FAIL — runtime still incomplete after heal", file=sys.stderr)
+            return 1
+        print("update: OK — healed (no version bump)")
+        return 0
+
+    print(f"\nUpgrading three planes from {source} → {target}")
+    code = _run_scaffold_upgrade(
+        target,
+        source,
+        profile=args.profile,
+        with_venv=bool(args.with_venv),
+        with_mcp_json=bool(args.with_mcp_json),
+        verify=bool(args.verify),
+    )
+    if code != 0:
+        return code
+
+    activate_cli._heal_consumer_runtime(target, with_venv=bool(args.with_venv))
+    status = plane_status.assess_planes(
+        target, profile=args.profile, require_venv=bool(args.with_venv)
+    )
+    print("\nPost-update plane status:")
+    print(plane_status.format_plane_report(status))
+    if not status.all_ready:
+        print("update: FAIL — planes still incomplete after upgrade", file=sys.stderr)
+        return 1
+
+    new_installed = read_installed_version(target)
+    print(f"update: OK — upgraded to {new_installed or available}")
+    print("Preserved: AGENTS.md (if present), mcp.user.json, .local/user_settings/, trackers.")
+    print("Next: python3 -m agent_colony health && python3 -m agent_colony mcp validate")
+    return 0
+
+
+def register_update_subparser(sub: argparse._SubParsersAction) -> None:
+    update = sub.add_parser(
+        "update",
+        help="Version-gated kit upgrade (heal if current; full refresh if newer)",
+    )
+    update.add_argument(
+        "--directory",
+        type=Path,
+        default=".",
+        help="Target workspace (default: current directory)",
+    )
+    update.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Kit root or payload/ (default: same auto-resolve as activate)",
+    )
+    update.add_argument(
+        "--profile",
+        default="with_mcp",
+        choices=("default", "with_mcp"),
+        help="Install profile (default: with_mcp)",
+    )
+    update.add_argument("--with-venv", action="store_true", default=True)
+    update.add_argument("--no-venv", action="store_false", dest="with_venv")
+    update.add_argument("--with-mcp-json", action="store_true", default=True)
+    update.add_argument("--no-mcp-json", action="store_false", dest="with_mcp_json")
+    update.add_argument("--verify", action="store_true", default=True)
+    update.add_argument("--no-verify", action="store_false", dest="verify")
+    update.add_argument(
+        "--check",
+        action="store_true",
+        help="Report installed vs available and planned action; no writes",
+    )
+    update.add_argument(
+        "--force",
+        action="store_true",
+        help="Full kit-managed refresh even when versions match",
+    )
+    update.set_defaults(func=cmd_update)

--- a/.ai_infra/install/agent_colony/update_cli.py
+++ b/.ai_infra/install/agent_colony/update_cli.py
@@ -27,6 +27,13 @@ import activate_cli
 
 
 _VERSION_RE = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[.-].*)?$")
+# Same marker scaffold uses to detect the kit product repo (not a consumer app).
+KIT_TESTS_MARKER = Path("tests") / "modules" / "install" / "test_scaffold.py"
+
+
+def is_kit_dev_repo(target: Path) -> bool:
+    """True when target is the Agent Colony product repo (full kit tests present)."""
+    return (target / KIT_TESTS_MARKER).is_file()
 
 
 def read_installed_version(target: Path) -> str | None:
@@ -119,15 +126,38 @@ def _run_scaffold_upgrade(
 def _run_light_heal(target: Path, source: Path, *, with_venv: bool) -> None:
     from paths import kit_root
 
+    if is_kit_dev_repo(target):
+        # Do not copy payload install/scripts onto kit-dev authoring SSOT.
+        scaffold = activate_cli._import_scaffold_refresh()
+        for line in scaffold.sync_kit_ui_templates(source, target):
+            print(line)
+        ui_root = scaffold.ui_local_workspace(source)
+        log: list[str] = []
+        scaffold._scaffold_dashboards(ui_root, target, False, log)
+        for line in log:
+            print(line)
+        activate_cli._heal_consumer_runtime(target, with_venv=with_venv)
+        return
+
     activate_cli._refresh_dashboard_templates(target, source, kit_root())
     activate_cli._heal_consumer_runtime(target, with_venv=with_venv)
+
+
+def _refuse_kit_dev_upgrade() -> int:
+    print(
+        "update: FAIL — full upgrade is for consumer apps, not the kit-dev product repo.\n"
+        "  Kit-dev: edit sources → make sync-plugin (updates payload/) → commit/push.\n"
+        "  Consumer apps: python3 -m agent_colony update --directory . "
+        "(after updating the Agent Colony plugin).",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def cmd_update(args: argparse.Namespace) -> int:
     from paths import kit_root
 
     target = Path(args.directory).resolve()
-    kit_ver_path = target / ".ai_infra" / ".kit-version"
     if not (target / ".ai_infra").is_dir():
         print(
             "update: FAIL — workspace not activated (.ai_infra missing). "
@@ -162,15 +192,21 @@ def cmd_update(args: argparse.Namespace) -> int:
         available=available,
         force=bool(args.force),
     )
+    kit_dev = is_kit_dev_repo(target)
 
     print(f"installed={installed or '(none)'}")
     print(f"available={available}")
     print(f"source={source}")
     print(f"action={action}")
+    if kit_dev:
+        print("target_kind=kit-dev")
 
     if args.check:
         if action == "missing":
             print("check: would_activate (no .kit-version — run activate first)")
+            return 1
+        if action == "upgrade" and kit_dev:
+            print("check: would_refuse_kit_dev (full upgrade not allowed here)")
             return 1
         if action == "upgrade":
             print("check: would_upgrade (full kit-managed refresh)")
@@ -185,6 +221,9 @@ def cmd_update(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+
+    if action == "upgrade" and kit_dev:
+        return _refuse_kit_dev_upgrade()
 
     plane_status = activate_cli._import_plane_status()
 

--- a/.cursor/skills/update-agent-colony/SKILL.md
+++ b/.cursor/skills/update-agent-colony/SKILL.md
@@ -80,4 +80,4 @@ Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.
 
 - Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
 - Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
-- Do not run update against the kit-dev repo as a self-upgrade without an explicit external `--source`.
+- Do **not** run `update --force` inside the **kit-dev product repo** (`agent-colony`) — scaffold treats it as a consumer install and fails (`forbidden in slim install: full kit tests tree`). Kit-dev workflow: edit sources → `make sync-plugin` → commit. Use `update` only in **activated consumer apps**.

--- a/.cursor/skills/update-agent-colony/SKILL.md
+++ b/.cursor/skills/update-agent-colony/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: update-agent-colony
+description: Upgrade an already-activated consumer workspace to the latest kit payload (version-gated heal vs full refresh).
+---
+<!--
+File: SKILL.md
+Path: .cursor/skills/update-agent-colony/SKILL.md
+Role: Consumer-facing kit upgrade after Marketplace/plugin bump (ADR-001 Option B follow-on).
+Used By:
+ - PLUGIN-USER-GUIDE.md
+ - upgrade-kit.md
+ - sync_plugin_bundle.py (canonical; template fallback at .ai_infra/templates/plugin/skills/)
+Depends On:
+ - .ai_infra/install/agent_colony/update_cli.py
+ - .cursor/skills/workflow-activate/SKILL.md (first install only)
+Notes:
+ - Pattern A: one script command per action. First install remains /workflow-activate.
+-->
+
+# Update Agent Colony
+
+## When
+
+User already ran **`/workflow-activate`** in **their app**, then updated the **Agent Colony** plugin (or kit tag) and needs kit-managed files refreshed.
+
+**Not for first install** — use [workflow-activate](workflow-activate/SKILL.md) when `.ai_infra/` is missing.
+
+## Guide the user
+
+1. Confirm the open folder is **their activated app**, not the kit product repo.
+2. Prefer Agent chat **`/update-agent-colony`**, or the Pattern A command below.
+3. Explain version gate briefly:
+   - **same / newer installed** → light heal (dashboards, `.gitignore`, `STARTER-001`, missing `.venv`)
+   - **source newer** or **`--force`** → full overwrite of kit-managed agents/rules/skills/scripts
+4. After upgrade: `health` + `mcp validate`.
+
+## One command
+
+```bash
+source .venv/bin/activate
+python3 -m agent_colony update --directory .
+```
+
+**Check only (no writes):**
+
+```bash
+python3 -m agent_colony update --directory . --check
+```
+
+**Force full refresh** (even when versions match):
+
+```bash
+python3 -m agent_colony update --directory . --force
+```
+
+**Source resolution** matches activate: `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
+
+## What update does
+
+| Condition | Action |
+|-----------|--------|
+| No `.ai_infra/` or missing `.kit-version` | Fail — tell user to run `/workflow-activate` |
+| `installed == available` (and not `--force`) | Light heal only |
+| `available > installed` or `--force` | Full scaffold refresh (same as `activate --force`) |
+
+**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, existing trackers.
+
+**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI copy, `.kit-version`, kit-managed dashboards.
+
+## Post-update
+
+```bash
+python3 -m agent_colony health
+python3 -m agent_colony mcp validate
+```
+
+Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.md](../../.ai_infra/docs/operations/upgrade-kit.md).
+
+## Anti-patterns
+
+- Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
+- Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
+- Do not run update against the kit-dev repo as a self-upgrade without an explicit external `--source`.

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -98,6 +98,8 @@ See [consumer-quickstart.md](../../.ai_infra/docs/operations/consumer-quickstart
 
 Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear when agents/scripts run. See [local-workspace-layout.md](../../.ai_infra/docs/operations/local-workspace-layout.md) § Artifact tiers. Re-activate does not overwrite existing trackers, `user_settings/`, or `AGENTS.md`. Kit-managed dashboard HTML, JS/CSS assets, `module-audit.html`, and `pages.json` are refreshed from the activate source (plugin `payload/` when resolved) or embedded `.ai_infra/templates/local-workspace/` when not.
 
+**Later upgrades** (after Marketplace/plugin kit bump): use **`/update-agent-colony`** (`python3 -m agent_colony update`) — version-gated heal vs full kit-managed refresh. Plain re-activate does **not** overwrite agents/skills/scripts unless `--force`. See [update-agent-colony](update-agent-colony/SKILL.md) and [upgrade-kit.md](../../.ai_infra/docs/operations/upgrade-kit.md).
+
 - Idempotent: skips full install when all planes already pass `install-contract.json`, but still refreshes dashboards
 - Creates `.venv`, merges MCP json, runs verify gates
 - Prints **settings-only** next steps (no re-install)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Required in every commit message (see **`.cursor/rules/commit-trailer-format.mdc
 | Root | Role |
 |------|------|
 | `.cursor/agents/` | Subagent cards (8) — Task delegation; **`model: auto`**; audit agents write `.local/` artifacts only |
-| `.cursor/skills/` | **Canonical protocols** (13 folders: `auditor-protocol`, `audit-orchestration`, `audit-module-map`, `board-ssot`, `board-shell`, `canvas-artifacts`, `drift-audit`, `implementer-loop`, `integrator-protocol`, `mcp-connect`, `research-corpus`, `test-coverage`, `workflow-activate`) — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
+| `.cursor/skills/` | **Canonical protocols** (14 folders: `auditor-protocol`, `audit-orchestration`, `audit-module-map`, `board-ssot`, `board-shell`, `canvas-artifacts`, `drift-audit`, `implementer-loop`, `integrator-protocol`, `mcp-connect`, `research-corpus`, `test-coverage`, `update-agent-colony`, `workflow-activate`) — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
 | `.agents/skills/` | **Maintainer slash skills** (6 folders: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` stub → `auditor`) — additive in plugin sync |
 | `.cursor/rules/` | **7** `alwaysApply` rules in this product repo (6 kit + `project-ssot-precedence`) — high context cost by design |
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [agent-colony](https://github.com/SavinRazvan/agent-colony) |
-| **Version** | `0.6.1` · **Tests** · 1465 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.6.1` · **Tests** · 1476 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 
 ---
@@ -26,7 +26,7 @@
 ## What you get
 
 - **8 agents:** `implementer`, `test-runner`, `verifier`, `auditor`, `researcher`, `integrator`, `drift-guard`, `board`
-- **13 canonical skills** + maintainer PR slash skills (`/review-pr` → `/prepare-pr` → `/merge-pr`)
+- **14 canonical skills** + maintainer PR slash skills (`/review-pr` → `/prepare-pr` → `/merge-pr`)
 - **Board Pattern A CLI:** `python3 -m agent_colony project …` (claim, handoff, Tier-1 fields, outbox)
 - **PR gates** via `prepare.py` · optional MCP (`agent_colony_mcp`) · research corpus under `_research_results/` (opt-in)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [agent-colony](https://github.com/SavinRazvan/agent-colony) |
-| **Version** | `0.6.1` · **Tests** · 1476 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.6.1` · **Tests** · 1478 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 
 ---

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -856,7 +856,7 @@ export default function NamingRosterAuditCanvas() {
             B-safe SHIPPED
           </Pill>
           <Pill tone="neutral" size="sm">
-            8 agents · 13 skills
+            8 agents · 14 skills
           </Pill>
         </Row>
         <Text tone="secondary" size="small">
@@ -897,7 +897,7 @@ export default function NamingRosterAuditCanvas() {
       {view === "plan" ? (
         <Stack gap={16}>
           <Callout tone="success" title="B-safe rename SHIPPED — 2026-08-03">
-            Live filesystem roster: 8 agents / 13 canonical skills / 7 rules.
+            Live filesystem roster: 8 agents / 14 canonical skills / 7 rules.
             Agent descriptions prefixed Agent Colony (#153). Shared board-ssot is
             Entry/Exit for all agents. Plan rows below are keep/keep against the
             shipped names — not a pending rename plan.

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -68,7 +68,7 @@ Drift validation: `make drift-validate` — see [gate-matrix.md](../operations/g
 
 | Root | Contents |
 |------|----------|
-| `.cursor/skills/` | Canonical protocols (**13**): `workflow-activate`, `board-ssot`, `board-shell`, `canvas-artifacts`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
+| `.cursor/skills/` | Canonical protocols (**14**): `workflow-activate`, `update-agent-colony`, `board-ssot`, `board-shell`, `canvas-artifacts`, `implementer-loop`, `auditor-protocol`, `drift-audit`, … — full list in [repository-map.md](../handoff/repository-map.md) |
 | `.agents/skills/` | Maintainer slash skills: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` (redirect) |
 
 Plugin bundle copies `.cursor/skills/` first; maintainer skills are **additive only** (no overwrite).

--- a/payload/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/payload/.ai_infra/docs/governance/workflow-source-owners.md
@@ -24,7 +24,7 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `full-pr-workflow` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (13 folders) | Plugin sync, agents |
+| Canonical Cursor skills | `.cursor/skills/` (14 folders) | Plugin sync, agents |
 | Maintainer slash skills | `.agents/skills/` (6 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -254,7 +254,8 @@ your-project/
 | Goal | Type in chat |
 |------|--------------|
 | Install plugin | `/add-plugin https://github.com/SavinRazvan/agent-colony` |
-| Activate / refresh | `/workflow-activate` |
+| Activate (first install) | `/workflow-activate` |
+| Upgrade kit (version-gated) | `/update-agent-colony` |
 | Implement | `/implementer` |
 | Tests | `/test-runner` |
 | PR lifecycle | `/review-pr` → `/prepare-pr` → `/merge-pr` |
@@ -269,7 +270,8 @@ source .venv/bin/activate
 
 | Command | Purpose |
 |---------|---------|
-| `python3 -m agent_colony activate --directory .` | Install, re-activate, refresh dashboards |
+| `python3 -m agent_colony activate --directory .` | First install / light heal when planes ready |
+| `python3 -m agent_colony update --directory .` | Version-gated upgrade (heal or full refresh) |
 | `python3 -m agent_colony contributors validate` | After editing collaboration YAML |
 | `python3 -m agent_colony health` | Layout + version |
 | `python3 -m agent_colony integrate validate` | Integration checks |
@@ -328,7 +330,7 @@ python3 -m http.server 8000
 | Control Center | http://localhost:8000/.local/agents-control-center/dashboards/implementation-control-center.html |
 | Module audit | http://localhost:8000/.local/agents-control-center/audits/module-audit.html |
 
-Refresh after kit update: **`/workflow-activate`** or `python3 -m agent_colony activate --directory .`
+Refresh after kit update: **`/update-agent-colony`** or `python3 -m agent_colony update --directory .`
 
 Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dashboards.
 
@@ -348,7 +350,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
 | **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [integrator-protocol skill](../../.cursor/skills/integrator-protocol/SKILL.md) · [mas-infrastructure-integration.md](mas-infrastructure-integration.md) (ops filename kept) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
-| **Upgrade / refresh dashboards** | `/workflow-activate` | `python3 -m agent_colony activate --directory .` | [upgrade-kit.md](upgrade-kit.md) |
+| **Upgrade / version-gated refresh** | `/update-agent-colony` | `python3 -m agent_colony update --directory .` | [upgrade-kit.md](upgrade-kit.md) · [update-agent-colony skill](../../.cursor/skills/update-agent-colony/SKILL.md) |
 | **Check install health** | — | `python3 -m agent_colony health` | [gate-matrix.md](gate-matrix.md) |
 | **Dry-run install preview** | — | `python3 -m agent_colony install --target <dir> --dry-run` | [install-dry-run.md](install-dry-run.md) |
 
@@ -357,6 +359,7 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | Chat name | Disk path |
 |-----------|-----------|
 | `/workflow-activate` | `.cursor/skills/workflow-activate/` |
+| `/update-agent-colony` | `.cursor/skills/update-agent-colony/` |
 | `/implementer` | `.cursor/agents/implementer.md` |
 | `/test-runner` | `.cursor/agents/test-runner.md` |
 | `/verifier` | `.cursor/agents/verifier.md` |
@@ -459,7 +462,7 @@ Details: [gate-matrix.md](gate-matrix.md). **`make gates`** / **`make verify-all
 | Activate blocked in kit repo | Open your app folder — activate refuses self-install |
 | Broken YAML in collaboration file | Keep `human_coauthors: []` or use a proper list |
 | Control Center **Failed to fetch** | `python3 -m http.server 8000` from project root, then http://localhost:8000/.local/agents-control-center/dashboards/index.html — not `file://` |
-| Stale dashboard after kit update | Re-run `/workflow-activate` or `activate --directory .` |
+| Stale dashboard / kit files after plugin update | Re-run `/update-agent-colony` or `python3 -m agent_colony update --directory .` |
 | `DRIFT-005 FAIL` on consumer drift | **Kit bug (not your app)** — upgrade kit or ignore until skip-if-absent fix ships. Details: [consumer-quickstart](consumer-quickstart.md#drift-005-fail--kit-bug-not-your-app) |
 | `mcp validate` → typer required | Use `python3 -m agent_colony mcp validate` — not bare `mcp validate` |
 

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -39,7 +39,7 @@ Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No
 
 **Healthy install?** `python3 -m agent_colony health` · with board on: `gh auth status` → `project doctor` → `project board-bootstrap --check`
 
-**Update kit later (optional):** merge kit changes to `main` → in your app Agent chat `/add-plugin https://github.com/SavinRazvan/agent-colony` → `/workflow-activate` (or `python3 -m agent_colony activate --directory .`). Full force/semver: [upgrade-kit.md](upgrade-kit.md). **Does not** create GitHub Project views — finish step 4 for that.
+**Update kit later (optional):** merge kit changes to `main` → in your app Agent chat `/add-plugin https://github.com/SavinRazvan/agent-colony` → **`/update-agent-colony`** (or `python3 -m agent_colony update --directory .`). First install remains `/workflow-activate`. Full force/semver: [upgrade-kit.md](upgrade-kit.md). **Does not** create GitHub Project views — finish step 4 for that.
 
 > **Cheat sheet:** [Agent chat vs terminal](#agent-chat-vs-terminal) · [Dashboards (deprecated)](#control-center-dashboards-deprecated) · [All CLI commands](#terminal-commands-cheat-sheet)
 

--- a/payload/.ai_infra/docs/operations/upgrade-kit.md
+++ b/payload/.ai_infra/docs/operations/upgrade-kit.md
@@ -77,6 +77,8 @@ Compares `.ai_infra/.kit-version` to the activate source `manifest.yaml` `kit_ve
 
 Same as Agent chat **`/update-agent-colony`**. See [update-agent-colony skill](../../.cursor/skills/update-agent-colony/SKILL.md).
 
+**Kit-dev product repo:** do not run `update --force` here (scaffold is consumer-only and will refuse). Sync mirrors with `make sync-plugin` instead. Light `update` / heal on kit-dev refreshes dashboards only and does not overwrite authoring `install/` from `payload/`.
+
 **Advanced aliases** (same underlying scaffold paths):
 
 ```bash

--- a/payload/.ai_infra/docs/operations/upgrade-kit.md
+++ b/payload/.ai_infra/docs/operations/upgrade-kit.md
@@ -41,8 +41,8 @@ Update `.cursor/mcp.json` `args` to `["-m", "agent_colony_mcp"]` (or re-run acti
 
 If an older activate left only MCP secret lines in `.gitignore`, or omitted the consumer `STARTER-001` drift marker:
 
-1. Re-run `source .venv/bin/activate && python3 -m agent_colony activate --directory .`  
-   (heals `.gitignore` for `.local/` + `.venv/`, seeds `STARTER-001` into `work-tracker.md`, creates `.venv` only if missing and `--with-venv` is on).
+1. Re-run `source .venv/bin/activate && python3 -m agent_colony update --directory .`  
+   (when up to date: heals `.gitignore` for `.local/` + `.venv/`, seeds `STARTER-001`, creates missing `.venv`; when source newer: full kit refresh). Plain `activate` also heals when planes are ready.
 2. If `.venv/` or `.local/` were already committed: keep the healed `.gitignore`, then  
    `git rm -r --cached .venv .local` and commit app sources (`src/`, `pyproject.toml`, …) instead.
 3. MCP tool rename: `workflow_mcp_connection_guide` → `workflow_agent_colony_mcp_connection_guide` (re-copy exemplar `mcp.agents.yaml` tools_hint or edit locally).
@@ -57,19 +57,33 @@ If an older activate left only MCP secret lines in `.gitignore`, or omitted the 
 
 ## Upgrade command
 
-**Light refresh (dashboards + activate scripts, keeps trackers):**
+**Preferred (version-gated):**
 
 ```bash
 cd ~/Projects/my-app    # your activated project
 source .venv/bin/activate
-python3 -m agent_colony activate --directory .
+python3 -m agent_colony update --directory .
+# or Agent chat: /update-agent-colony
 ```
 
-Same as `/workflow-activate` in Agent chat when planes are already ready. Refreshes kit-managed dashboard HTML, `pages.json`, and install scripts from the plugin payload.
+Compares `.ai_infra/.kit-version` to the activate source `manifest.yaml` `kit_version`:
 
-**Full reinstall (scripts, agents, rules — review** `.local/` **merge):**
+| Result | Action |
+|--------|--------|
+| Up to date | Light heal — dashboards, runtime `.gitignore`, `STARTER-001`, missing `.venv` |
+| Source newer | Full kit-managed refresh (agents/rules/skills/scripts) |
+| `--check` | Report only (no writes) |
+| `--force` | Full refresh even when versions match |
+
+Same as Agent chat **`/update-agent-colony`**. See [update-agent-colony skill](../../.cursor/skills/update-agent-colony/SKILL.md).
+
+**Advanced aliases** (same underlying scaffold paths):
 
 ```bash
+# Light heal only (no version compare) — also what plain re-activate does when planes are ready
+python3 -m agent_colony activate --directory .
+
+# Full reinstall without version gate
 python3 -m agent_colony activate --directory . --force
 ```
 

--- a/payload/.ai_infra/install/agent_colony/cli.py
+++ b/payload/.ai_infra/install/agent_colony/cli.py
@@ -9,9 +9,12 @@ Depends On:
  - .ai_infra/scripts/install/scaffold.py
  - .ai_infra/install/agent_colony/mcp_manage.py
  - .ai_infra/install/agent_colony/mcp_cli.py
+ - .ai_infra/install/agent_colony/activate_cli.py
+ - .ai_infra/install/agent_colony/update_cli.py
 Notes:
  - install forwards to scaffold.py; gates runs prepare-aligned checks.
  - ADR-009 MCP; ADR-010 canvas/plan Pattern A CLI.
+ - update = version-gated consumer upgrade (heal vs full refresh).
 """
 
 from __future__ import annotations
@@ -50,6 +53,7 @@ import drift_cli  # noqa: E402
 import doc_cli  # noqa: E402
 import verify_cli  # noqa: E402
 import activate_cli  # noqa: E402
+import update_cli  # noqa: E402
 import project_cli  # noqa: E402
 import research_cli  # noqa: E402
 
@@ -269,6 +273,7 @@ def build_parser() -> argparse.ArgumentParser:
     doc_cli.register_doc_subparser(sub)
     verify_cli.register_verify_subparser(sub)
     activate_cli.register_activate_subparser(sub)
+    update_cli.register_update_subparser(sub)
     project_cli.register_project_subparser(sub)
     research_cli.register_research_subparser(sub)
 

--- a/payload/.ai_infra/install/agent_colony/update_cli.py
+++ b/payload/.ai_infra/install/agent_colony/update_cli.py
@@ -1,0 +1,272 @@
+"""
+File: update_cli.py
+Path: .ai_infra/install/agent_colony/update_cli.py
+Role: Version-gated consumer kit upgrade — heal when current, full scaffold when newer.
+Used By:
+ - .ai_infra/install/agent_colony/cli.py
+ - .cursor/skills/update-agent-colony/SKILL.md
+Depends On:
+ - .ai_infra/install/agent_colony/activate_cli.py
+ - .ai_infra/scripts/install/plane_status.py
+ - .ai_infra/scripts/install/scaffold.py (via activate force path)
+Notes:
+ - First install remains activate; update is for already-activated apps after plugin/kit bump.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+import activate_cli
+
+
+_VERSION_RE = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[.-].*)?$")
+
+
+def read_installed_version(target: Path) -> str | None:
+    path = target / ".ai_infra" / ".kit-version"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def read_source_version(source: Path) -> str:
+    manifest = source / ".ai_infra" / "manifest.yaml"
+    if not manifest.is_file():
+        raise FileNotFoundError(f"missing manifest: {manifest}")
+    raw = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"invalid manifest (not a mapping): {manifest}")
+    version = str(raw.get("kit_version", "")).strip()
+    if not version:
+        raise ValueError(f"manifest missing kit_version: {manifest}")
+    return version
+
+
+def _parse_version_tuple(version: str) -> tuple[int, ...] | None:
+    match = _VERSION_RE.match(version.strip())
+    if not match:
+        return None
+    parts = [int(p) if p is not None else 0 for p in match.groups()]
+    return tuple(parts)
+
+
+def compare_versions(installed: str, available: str) -> int:
+    """Return -1 if installed < available, 0 if equal, 1 if installed > available."""
+    left = _parse_version_tuple(installed)
+    right = _parse_version_tuple(available)
+    if left is not None and right is not None:
+        if left < right:
+            return -1
+        if left > right:
+            return 1
+        return 0
+    if installed == available:
+        return 0
+    return -1 if installed < available else 1
+
+
+def decide_action(*, installed: str | None, available: str, force: bool) -> str:
+    """Return heal | upgrade | missing."""
+    if installed is None:
+        return "missing"
+    if force:
+        return "upgrade"
+    if compare_versions(installed, available) < 0:
+        return "upgrade"
+    return "heal"
+
+
+def _run_scaffold_upgrade(
+    target: Path,
+    source: Path,
+    *,
+    profile: str,
+    with_venv: bool,
+    with_mcp_json: bool,
+    verify: bool,
+) -> int:
+    from paths import kit_root, scripts_dir
+
+    script = scripts_dir("install", kit_root()) / "scaffold.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--target",
+        str(target),
+        "--source",
+        str(source),
+        "--profile",
+        profile,
+    ]
+    if with_venv:
+        cmd.append("--with-venv")
+    if with_mcp_json:
+        cmd.append("--with-mcp-json")
+    if verify:
+        cmd.append("--verify")
+    proc = subprocess.run(cmd, cwd=kit_root())
+    return int(proc.returncode)
+
+
+def _run_light_heal(target: Path, source: Path, *, with_venv: bool) -> None:
+    from paths import kit_root
+
+    activate_cli._refresh_dashboard_templates(target, source, kit_root())
+    activate_cli._heal_consumer_runtime(target, with_venv=with_venv)
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    from paths import kit_root
+
+    target = Path(args.directory).resolve()
+    kit_ver_path = target / ".ai_infra" / ".kit-version"
+    if not (target / ".ai_infra").is_dir():
+        print(
+            "update: FAIL — workspace not activated (.ai_infra missing). "
+            "Run: python3 -m agent_colony activate --directory .",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        source = activate_cli.resolve_activate_source(args.source, target, kit_root())
+    except FileNotFoundError as exc:
+        print(f"update: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    if source.resolve() == target.resolve():
+        print(
+            "update: FAIL — cannot upgrade a workspace from itself; "
+            "pass --source <kit-root|payload/> or set WORKFLOW_KIT_PAYLOAD",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        available = read_source_version(source)
+    except (OSError, ValueError, FileNotFoundError) as exc:
+        print(f"update: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    installed = read_installed_version(target)
+    action = decide_action(
+        installed=installed,
+        available=available,
+        force=bool(args.force),
+    )
+
+    print(f"installed={installed or '(none)'}")
+    print(f"available={available}")
+    print(f"source={source}")
+    print(f"action={action}")
+
+    if args.check:
+        if action == "missing":
+            print("check: would_activate (no .kit-version — run activate first)")
+            return 1
+        if action == "upgrade":
+            print("check: would_upgrade (full kit-managed refresh)")
+        else:
+            print("check: would_heal (dashboards + runtime gitignore/STARTER/venv)")
+        return 0
+
+    if action == "missing":
+        print(
+            "update: FAIL — missing .ai_infra/.kit-version. "
+            "First install: python3 -m agent_colony activate --directory .",
+            file=sys.stderr,
+        )
+        return 1
+
+    plane_status = activate_cli._import_plane_status()
+
+    if action == "heal":
+        print("\nKit up to date — light heal (dashboards + runtime).")
+        _run_light_heal(target, source, with_venv=bool(args.with_venv))
+        status = plane_status.assess_planes(
+            target, profile=args.profile, require_venv=bool(args.with_venv)
+        )
+        print(plane_status.format_plane_report(status))
+        if not status.all_ready:
+            print("update: FAIL — runtime still incomplete after heal", file=sys.stderr)
+            return 1
+        print("update: OK — healed (no version bump)")
+        return 0
+
+    print(f"\nUpgrading three planes from {source} → {target}")
+    code = _run_scaffold_upgrade(
+        target,
+        source,
+        profile=args.profile,
+        with_venv=bool(args.with_venv),
+        with_mcp_json=bool(args.with_mcp_json),
+        verify=bool(args.verify),
+    )
+    if code != 0:
+        return code
+
+    activate_cli._heal_consumer_runtime(target, with_venv=bool(args.with_venv))
+    status = plane_status.assess_planes(
+        target, profile=args.profile, require_venv=bool(args.with_venv)
+    )
+    print("\nPost-update plane status:")
+    print(plane_status.format_plane_report(status))
+    if not status.all_ready:
+        print("update: FAIL — planes still incomplete after upgrade", file=sys.stderr)
+        return 1
+
+    new_installed = read_installed_version(target)
+    print(f"update: OK — upgraded to {new_installed or available}")
+    print("Preserved: AGENTS.md (if present), mcp.user.json, .local/user_settings/, trackers.")
+    print("Next: python3 -m agent_colony health && python3 -m agent_colony mcp validate")
+    return 0
+
+
+def register_update_subparser(sub: argparse._SubParsersAction) -> None:
+    update = sub.add_parser(
+        "update",
+        help="Version-gated kit upgrade (heal if current; full refresh if newer)",
+    )
+    update.add_argument(
+        "--directory",
+        type=Path,
+        default=".",
+        help="Target workspace (default: current directory)",
+    )
+    update.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Kit root or payload/ (default: same auto-resolve as activate)",
+    )
+    update.add_argument(
+        "--profile",
+        default="with_mcp",
+        choices=("default", "with_mcp"),
+        help="Install profile (default: with_mcp)",
+    )
+    update.add_argument("--with-venv", action="store_true", default=True)
+    update.add_argument("--no-venv", action="store_false", dest="with_venv")
+    update.add_argument("--with-mcp-json", action="store_true", default=True)
+    update.add_argument("--no-mcp-json", action="store_false", dest="with_mcp_json")
+    update.add_argument("--verify", action="store_true", default=True)
+    update.add_argument("--no-verify", action="store_false", dest="verify")
+    update.add_argument(
+        "--check",
+        action="store_true",
+        help="Report installed vs available and planned action; no writes",
+    )
+    update.add_argument(
+        "--force",
+        action="store_true",
+        help="Full kit-managed refresh even when versions match",
+    )
+    update.set_defaults(func=cmd_update)

--- a/payload/.ai_infra/install/agent_colony/update_cli.py
+++ b/payload/.ai_infra/install/agent_colony/update_cli.py
@@ -27,6 +27,13 @@ import activate_cli
 
 
 _VERSION_RE = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[.-].*)?$")
+# Same marker scaffold uses to detect the kit product repo (not a consumer app).
+KIT_TESTS_MARKER = Path("tests") / "modules" / "install" / "test_scaffold.py"
+
+
+def is_kit_dev_repo(target: Path) -> bool:
+    """True when target is the Agent Colony product repo (full kit tests present)."""
+    return (target / KIT_TESTS_MARKER).is_file()
 
 
 def read_installed_version(target: Path) -> str | None:
@@ -119,15 +126,38 @@ def _run_scaffold_upgrade(
 def _run_light_heal(target: Path, source: Path, *, with_venv: bool) -> None:
     from paths import kit_root
 
+    if is_kit_dev_repo(target):
+        # Do not copy payload install/scripts onto kit-dev authoring SSOT.
+        scaffold = activate_cli._import_scaffold_refresh()
+        for line in scaffold.sync_kit_ui_templates(source, target):
+            print(line)
+        ui_root = scaffold.ui_local_workspace(source)
+        log: list[str] = []
+        scaffold._scaffold_dashboards(ui_root, target, False, log)
+        for line in log:
+            print(line)
+        activate_cli._heal_consumer_runtime(target, with_venv=with_venv)
+        return
+
     activate_cli._refresh_dashboard_templates(target, source, kit_root())
     activate_cli._heal_consumer_runtime(target, with_venv=with_venv)
+
+
+def _refuse_kit_dev_upgrade() -> int:
+    print(
+        "update: FAIL — full upgrade is for consumer apps, not the kit-dev product repo.\n"
+        "  Kit-dev: edit sources → make sync-plugin (updates payload/) → commit/push.\n"
+        "  Consumer apps: python3 -m agent_colony update --directory . "
+        "(after updating the Agent Colony plugin).",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def cmd_update(args: argparse.Namespace) -> int:
     from paths import kit_root
 
     target = Path(args.directory).resolve()
-    kit_ver_path = target / ".ai_infra" / ".kit-version"
     if not (target / ".ai_infra").is_dir():
         print(
             "update: FAIL — workspace not activated (.ai_infra missing). "
@@ -162,15 +192,21 @@ def cmd_update(args: argparse.Namespace) -> int:
         available=available,
         force=bool(args.force),
     )
+    kit_dev = is_kit_dev_repo(target)
 
     print(f"installed={installed or '(none)'}")
     print(f"available={available}")
     print(f"source={source}")
     print(f"action={action}")
+    if kit_dev:
+        print("target_kind=kit-dev")
 
     if args.check:
         if action == "missing":
             print("check: would_activate (no .kit-version — run activate first)")
+            return 1
+        if action == "upgrade" and kit_dev:
+            print("check: would_refuse_kit_dev (full upgrade not allowed here)")
             return 1
         if action == "upgrade":
             print("check: would_upgrade (full kit-managed refresh)")
@@ -185,6 +221,9 @@ def cmd_update(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+
+    if action == "upgrade" and kit_dev:
+        return _refuse_kit_dev_upgrade()
 
     plane_status = activate_cli._import_plane_status()
 

--- a/payload/.cursor/skills/update-agent-colony/SKILL.md
+++ b/payload/.cursor/skills/update-agent-colony/SKILL.md
@@ -80,4 +80,4 @@ Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.
 
 - Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
 - Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
-- Do not run update against the kit-dev repo as a self-upgrade without an explicit external `--source`.
+- Do **not** run `update --force` inside the **kit-dev product repo** (`agent-colony`) — scaffold treats it as a consumer install and fails (`forbidden in slim install: full kit tests tree`). Kit-dev workflow: edit sources → `make sync-plugin` → commit. Use `update` only in **activated consumer apps**.

--- a/payload/.cursor/skills/update-agent-colony/SKILL.md
+++ b/payload/.cursor/skills/update-agent-colony/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: update-agent-colony
+description: Upgrade an already-activated consumer workspace to the latest kit payload (version-gated heal vs full refresh).
+---
+<!--
+File: SKILL.md
+Path: .cursor/skills/update-agent-colony/SKILL.md
+Role: Consumer-facing kit upgrade after Marketplace/plugin bump (ADR-001 Option B follow-on).
+Used By:
+ - PLUGIN-USER-GUIDE.md
+ - upgrade-kit.md
+ - sync_plugin_bundle.py (canonical; template fallback at .ai_infra/templates/plugin/skills/)
+Depends On:
+ - .ai_infra/install/agent_colony/update_cli.py
+ - .cursor/skills/workflow-activate/SKILL.md (first install only)
+Notes:
+ - Pattern A: one script command per action. First install remains /workflow-activate.
+-->
+
+# Update Agent Colony
+
+## When
+
+User already ran **`/workflow-activate`** in **their app**, then updated the **Agent Colony** plugin (or kit tag) and needs kit-managed files refreshed.
+
+**Not for first install** — use [workflow-activate](workflow-activate/SKILL.md) when `.ai_infra/` is missing.
+
+## Guide the user
+
+1. Confirm the open folder is **their activated app**, not the kit product repo.
+2. Prefer Agent chat **`/update-agent-colony`**, or the Pattern A command below.
+3. Explain version gate briefly:
+   - **same / newer installed** → light heal (dashboards, `.gitignore`, `STARTER-001`, missing `.venv`)
+   - **source newer** or **`--force`** → full overwrite of kit-managed agents/rules/skills/scripts
+4. After upgrade: `health` + `mcp validate`.
+
+## One command
+
+```bash
+source .venv/bin/activate
+python3 -m agent_colony update --directory .
+```
+
+**Check only (no writes):**
+
+```bash
+python3 -m agent_colony update --directory . --check
+```
+
+**Force full refresh** (even when versions match):
+
+```bash
+python3 -m agent_colony update --directory . --force
+```
+
+**Source resolution** matches activate: `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
+
+## What update does
+
+| Condition | Action |
+|-----------|--------|
+| No `.ai_infra/` or missing `.kit-version` | Fail — tell user to run `/workflow-activate` |
+| `installed == available` (and not `--force`) | Light heal only |
+| `available > installed` or `--force` | Full scaffold refresh (same as `activate --force`) |
+
+**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, existing trackers.
+
+**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI copy, `.kit-version`, kit-managed dashboards.
+
+## Post-update
+
+```bash
+python3 -m agent_colony health
+python3 -m agent_colony mcp validate
+```
+
+Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.md](../../.ai_infra/docs/operations/upgrade-kit.md).
+
+## Anti-patterns
+
+- Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
+- Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
+- Do not run update against the kit-dev repo as a self-upgrade without an explicit external `--source`.

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -98,6 +98,8 @@ See [consumer-quickstart.md](../../.ai_infra/docs/operations/consumer-quickstart
 
 Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear when agents/scripts run. See [local-workspace-layout.md](../../.ai_infra/docs/operations/local-workspace-layout.md) § Artifact tiers. Re-activate does not overwrite existing trackers, `user_settings/`, or `AGENTS.md`. Kit-managed dashboard HTML, JS/CSS assets, `module-audit.html`, and `pages.json` are refreshed from the activate source (plugin `payload/` when resolved) or embedded `.ai_infra/templates/local-workspace/` when not.
 
+**Later upgrades** (after Marketplace/plugin kit bump): use **`/update-agent-colony`** (`python3 -m agent_colony update`) — version-gated heal vs full kit-managed refresh. Plain re-activate does **not** overwrite agents/skills/scripts unless `--force`. See [update-agent-colony](update-agent-colony/SKILL.md) and [upgrade-kit.md](../../.ai_infra/docs/operations/upgrade-kit.md).
+
 - Idempotent: skips full install when all planes already pass `install-contract.json`, but still refreshes dashboards
 - Creates `.venv`, merges MCP json, runs verify gates
 - Prints **settings-only** next steps (no re-install)

--- a/skills/update-agent-colony/SKILL.md
+++ b/skills/update-agent-colony/SKILL.md
@@ -80,4 +80,4 @@ Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.
 
 - Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
 - Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
-- Do not run update against the kit-dev repo as a self-upgrade without an explicit external `--source`.
+- Do **not** run `update --force` inside the **kit-dev product repo** (`agent-colony`) — scaffold treats it as a consumer install and fails (`forbidden in slim install: full kit tests tree`). Kit-dev workflow: edit sources → `make sync-plugin` → commit. Use `update` only in **activated consumer apps**.

--- a/skills/update-agent-colony/SKILL.md
+++ b/skills/update-agent-colony/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: update-agent-colony
+description: Upgrade an already-activated consumer workspace to the latest kit payload (version-gated heal vs full refresh).
+---
+<!--
+File: SKILL.md
+Path: .cursor/skills/update-agent-colony/SKILL.md
+Role: Consumer-facing kit upgrade after Marketplace/plugin bump (ADR-001 Option B follow-on).
+Used By:
+ - PLUGIN-USER-GUIDE.md
+ - upgrade-kit.md
+ - sync_plugin_bundle.py (canonical; template fallback at .ai_infra/templates/plugin/skills/)
+Depends On:
+ - .ai_infra/install/agent_colony/update_cli.py
+ - .cursor/skills/workflow-activate/SKILL.md (first install only)
+Notes:
+ - Pattern A: one script command per action. First install remains /workflow-activate.
+-->
+
+# Update Agent Colony
+
+## When
+
+User already ran **`/workflow-activate`** in **their app**, then updated the **Agent Colony** plugin (or kit tag) and needs kit-managed files refreshed.
+
+**Not for first install** — use [workflow-activate](workflow-activate/SKILL.md) when `.ai_infra/` is missing.
+
+## Guide the user
+
+1. Confirm the open folder is **their activated app**, not the kit product repo.
+2. Prefer Agent chat **`/update-agent-colony`**, or the Pattern A command below.
+3. Explain version gate briefly:
+   - **same / newer installed** → light heal (dashboards, `.gitignore`, `STARTER-001`, missing `.venv`)
+   - **source newer** or **`--force`** → full overwrite of kit-managed agents/rules/skills/scripts
+4. After upgrade: `health` + `mcp validate`.
+
+## One command
+
+```bash
+source .venv/bin/activate
+python3 -m agent_colony update --directory .
+```
+
+**Check only (no writes):**
+
+```bash
+python3 -m agent_colony update --directory . --check
+```
+
+**Force full refresh** (even when versions match):
+
+```bash
+python3 -m agent_colony update --directory . --force
+```
+
+**Source resolution** matches activate: `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
+
+## What update does
+
+| Condition | Action |
+|-----------|--------|
+| No `.ai_infra/` or missing `.kit-version` | Fail — tell user to run `/workflow-activate` |
+| `installed == available` (and not `--force`) | Light heal only |
+| `available > installed` or `--force` | Full scaffold refresh (same as `activate --force`) |
+
+**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, existing trackers.
+
+**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI copy, `.kit-version`, kit-managed dashboards.
+
+## Post-update
+
+```bash
+python3 -m agent_colony health
+python3 -m agent_colony mcp validate
+```
+
+Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.md](../../.ai_infra/docs/operations/upgrade-kit.md).
+
+## Anti-patterns
+
+- Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
+- Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
+- Do not run update against the kit-dev repo as a self-upgrade without an explicit external `--source`.

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -98,6 +98,8 @@ See [consumer-quickstart.md](../../.ai_infra/docs/operations/consumer-quickstart
 
 Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear when agents/scripts run. See [local-workspace-layout.md](../../.ai_infra/docs/operations/local-workspace-layout.md) § Artifact tiers. Re-activate does not overwrite existing trackers, `user_settings/`, or `AGENTS.md`. Kit-managed dashboard HTML, JS/CSS assets, `module-audit.html`, and `pages.json` are refreshed from the activate source (plugin `payload/` when resolved) or embedded `.ai_infra/templates/local-workspace/` when not.
 
+**Later upgrades** (after Marketplace/plugin kit bump): use **`/update-agent-colony`** (`python3 -m agent_colony update`) — version-gated heal vs full kit-managed refresh. Plain re-activate does **not** overwrite agents/skills/scripts unless `--force`. See [update-agent-colony](update-agent-colony/SKILL.md) and [upgrade-kit.md](../../.ai_infra/docs/operations/upgrade-kit.md).
+
 - Idempotent: skips full install when all planes already pass `install-contract.json`, but still refreshes dashboards
 - Creates `.venv`, merges MCP json, runs verify gates
 - Prints **settings-only** next steps (no re-install)

--- a/tests/modules/install/test_update_cli.py
+++ b/tests/modules/install/test_update_cli.py
@@ -1,0 +1,262 @@
+"""
+File: test_update_cli.py
+Path: tests/modules/install/test_update_cli.py
+Role: Coverage for update_cli version gate, --check, heal, upgrade, --force.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/agent_colony/update_cli.py
+ - .ai_infra/install/agent_colony/activate_cli.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PKG_DIR = REPO_ROOT / ".ai_infra" / "install" / "agent_colony"
+_AI_INFRA_DIR = REPO_ROOT / ".ai_infra"
+
+for _p in (str(_PKG_DIR), str(_AI_INFRA_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import activate_cli  # noqa: E402
+import update_cli  # noqa: E402
+
+
+def _write_manifest(base: Path, version: str) -> Path:
+    ai = base / ".ai_infra"
+    ai.mkdir(parents=True, exist_ok=True)
+    (ai / "manifest.yaml").write_text(f"kit_version: {version}\n", encoding="utf-8")
+    return base
+
+
+def _write_installed(target: Path, version: str | None) -> Path:
+    ai = target / ".ai_infra"
+    ai.mkdir(parents=True, exist_ok=True)
+    if version is not None:
+        (ai / ".kit-version").write_text(f"{version}\n", encoding="utf-8")
+    return target
+
+
+def test_compare_versions_semver() -> None:
+    assert update_cli.compare_versions("0.6.0", "0.6.1") == -1
+    assert update_cli.compare_versions("0.6.1", "0.6.1") == 0
+    assert update_cli.compare_versions("0.7.0", "0.6.1") == 1
+
+
+def test_decide_action_matrix() -> None:
+    assert update_cli.decide_action(installed=None, available="0.6.1", force=False) == "missing"
+    assert update_cli.decide_action(installed="0.6.1", available="0.6.1", force=False) == "heal"
+    assert update_cli.decide_action(installed="0.6.0", available="0.6.1", force=False) == "upgrade"
+    assert update_cli.decide_action(installed="0.6.1", available="0.6.1", force=True) == "upgrade"
+
+
+def test_read_installed_and_source_version(tmp_path: Path) -> None:
+    target = _write_installed(tmp_path / "app", "0.6.0")
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    assert update_cli.read_installed_version(target) == "0.6.0"
+    assert update_cli.read_source_version(source) == "0.6.1"
+    assert update_cli.read_installed_version(tmp_path / "empty") is None
+
+
+def test_cmd_update_check_heal(tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _write_installed(tmp_path / "app", "0.6.1")
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    monkeypatch.setattr(
+        activate_cli,
+        "resolve_activate_source",
+        lambda *a, **k: source,
+    )
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=True,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 0
+    out = capsys.readouterr().out
+    assert "action=heal" in out
+    assert "would_heal" in out
+
+
+def test_cmd_update_check_upgrade(tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _write_installed(tmp_path / "app", "0.6.0")
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=True,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 0
+    out = capsys.readouterr().out
+    assert "action=upgrade" in out
+    assert "would_upgrade" in out
+
+
+def test_cmd_update_missing_ai_infra(tmp_path: Path) -> None:
+    target = tmp_path / "bare"
+    target.mkdir()
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=False,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 1
+
+
+def test_cmd_update_missing_kit_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _write_installed(tmp_path / "app", None)
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=False,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 1
+
+
+def test_cmd_update_heal_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _write_installed(tmp_path / "app", "0.6.1")
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    calls: list[str] = []
+
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+
+    def _fake_heal(t: Path, *, with_venv: bool) -> None:
+        calls.append(f"heal:{with_venv}")
+
+    def _fake_refresh(t: Path, s: Path | None, k: Path) -> None:
+        calls.append("refresh")
+
+    monkeypatch.setattr(activate_cli, "_heal_consumer_runtime", _fake_heal)
+    monkeypatch.setattr(activate_cli, "_refresh_dashboard_templates", _fake_refresh)
+
+    plane = SimpleNamespace(
+        assess_planes=lambda *a, **k: SimpleNamespace(all_ready=True),
+        format_plane_report=lambda s: "planes ok",
+    )
+    monkeypatch.setattr(activate_cli, "_import_plane_status", lambda: plane)
+
+    scaffold_calls: list[list[str]] = []
+
+    def _boom(*a, **k):
+        scaffold_calls.append(["scaffold"])
+        return 99
+
+    monkeypatch.setattr(update_cli, "_run_scaffold_upgrade", _boom)
+
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=False,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 0
+    assert "refresh" in calls
+    assert any(c.startswith("heal:") for c in calls)
+    assert scaffold_calls == []
+
+
+def test_cmd_update_upgrade_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _write_installed(tmp_path / "app", "0.6.0")
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+
+    def _scaffold(*a, **k) -> int:
+        (target / ".ai_infra" / ".kit-version").write_text("0.6.1\n", encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(update_cli, "_run_scaffold_upgrade", _scaffold)
+    monkeypatch.setattr(activate_cli, "_heal_consumer_runtime", lambda *a, **k: None)
+    plane = SimpleNamespace(
+        assess_planes=lambda *a, **k: SimpleNamespace(all_ready=True),
+        format_plane_report=lambda s: "planes ok",
+    )
+    monkeypatch.setattr(activate_cli, "_import_plane_status", lambda: plane)
+
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=False,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 0
+    assert update_cli.read_installed_version(target) == "0.6.1"
+
+
+def test_cmd_update_force_when_equal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _write_installed(tmp_path / "app", "0.6.1")
+    source = _write_manifest(tmp_path / "kit", "0.6.1")
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+    ran: list[str] = []
+
+    def _scaffold(*a, **k) -> int:
+        ran.append("upgrade")
+        return 0
+
+    monkeypatch.setattr(update_cli, "_run_scaffold_upgrade", _scaffold)
+    monkeypatch.setattr(activate_cli, "_heal_consumer_runtime", lambda *a, **k: None)
+    plane = SimpleNamespace(
+        assess_planes=lambda *a, **k: SimpleNamespace(all_ready=True),
+        format_plane_report=lambda s: "planes ok",
+    )
+    monkeypatch.setattr(activate_cli, "_import_plane_status", lambda: plane)
+
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=False,
+        force=True,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 0
+    assert ran == ["upgrade"]
+
+
+def test_register_update_subparser() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    update_cli.register_update_subparser(sub)
+    args = parser.parse_args(["update", "--check", "--directory", "."])
+    assert args.command == "update"
+    assert args.check is True
+    assert args.func is update_cli.cmd_update

--- a/tests/modules/install/test_update_cli.py
+++ b/tests/modules/install/test_update_cli.py
@@ -252,6 +252,60 @@ def test_cmd_update_force_when_equal(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert ran == ["upgrade"]
 
 
+def test_cmd_update_refuses_kit_dev_force(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = _write_installed(tmp_path / "kit-dev", "0.6.1")
+    marker = target / update_cli.KIT_TESTS_MARKER
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("# kit-dev\n", encoding="utf-8")
+    source = _write_manifest(tmp_path / "payload", "0.6.1")
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+
+    def _boom(*a, **k) -> int:
+        raise AssertionError("scaffold must not run on kit-dev")
+
+    monkeypatch.setattr(update_cli, "_run_scaffold_upgrade", _boom)
+
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=False,
+        force=True,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 1
+    err = capsys.readouterr().err
+    assert "kit-dev product repo" in err
+
+
+def test_cmd_update_check_refuses_kit_dev_upgrade(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = _write_installed(tmp_path / "kit-dev", "0.6.0")
+    marker = target / update_cli.KIT_TESTS_MARKER
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("# kit-dev\n", encoding="utf-8")
+    source = _write_manifest(tmp_path / "payload", "0.6.1")
+    monkeypatch.setattr(activate_cli, "resolve_activate_source", lambda *a, **k: source)
+    args = argparse.Namespace(
+        directory=target,
+        source=None,
+        check=True,
+        force=False,
+        with_venv=True,
+        with_mcp_json=True,
+        verify=False,
+        profile="with_mcp",
+    )
+    assert update_cli.cmd_update(args) == 1
+    out = capsys.readouterr().out
+    assert "would_refuse_kit_dev" in out
+
+
 def test_register_update_subparser() -> None:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)


### PR DESCRIPTION
## Summary
- Add `python3 -m agent_colony update` with version gate: heal when `.kit-version` matches source, full kit-managed refresh when newer (or `--force`); `--check` is report-only.
- Add canonical skill `/update-agent-colony`; first install stays `/workflow-activate`.
- Docs (upgrade-kit, PLUGIN-USER-GUIDE, AGENTS, repository-map) now lead with update; skill count **13 → 14**; tests **1476**.

## Test plan
- [x] `pytest -q tests/modules/install/test_update_cli.py` (11 passed)
- [x] `make sync-plugin` + `make check-plugin`
- [x] `check_debrand.py`, `doc validate`, `integrate validate`, governance consistency
- [x] `python3 -m agent_colony update --check` on kit-dev → `action=heal`
- [ ] CI Kit Quality green

## Board
- Board-Item: PVTI_lAHOBl46-84A9KZxzg1tiYo