### PR TITLE
fix: gitignore exact-line match so .local/ is ignored

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1478
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1479
 
 ## Shipped (confirmed in repo)
 
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1478 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1479 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -227,7 +227,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-08-07 consumer activate hardening):** Re-verified after activate gitignore/venv/STARTER/MCP-tool hardening — **1465** tests; agent/skill/rule counts (**8** / **13** / **7**); kit version **0.6.1**.
 
-**Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1478** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
+**Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1479** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1478; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1479; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1478; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1479; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/install/agent_colony/mcp_manage.py
+++ b/.ai_infra/install/agent_colony/mcp_manage.py
@@ -603,7 +603,10 @@ def _append_gitignore_lines(root: Path, lines: tuple[str, ...], *, header: str) 
     gitignore = root / ".gitignore"
     if gitignore.is_file():
         text = gitignore.read_text(encoding="utf-8")
-        additions = [ln for ln in lines if ln not in text]
+        # Exact line match — substring checks wrongly skip ".local/" when
+        # ".local/user_settings/mcp.secrets.yaml" is already present.
+        existing = set(text.splitlines())
+        additions = [ln for ln in lines if ln not in existing]
         if additions:
             gitignore.write_text(text.rstrip() + "\n" + "\n".join(additions) + "\n", encoding="utf-8")
         return

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [agent-colony](https://github.com/SavinRazvan/agent-colony) |
-| **Version** | `0.6.1` · **Tests** · 1478 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.6.1` · **Tests** · 1479 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 
 ---

--- a/payload/.ai_infra/install/agent_colony/mcp_manage.py
+++ b/payload/.ai_infra/install/agent_colony/mcp_manage.py
@@ -603,7 +603,10 @@ def _append_gitignore_lines(root: Path, lines: tuple[str, ...], *, header: str) 
     gitignore = root / ".gitignore"
     if gitignore.is_file():
         text = gitignore.read_text(encoding="utf-8")
-        additions = [ln for ln in lines if ln not in text]
+        # Exact line match — substring checks wrongly skip ".local/" when
+        # ".local/user_settings/mcp.secrets.yaml" is already present.
+        existing = set(text.splitlines())
+        additions = [ln for ln in lines if ln not in existing]
         if additions:
             gitignore.write_text(text.rstrip() + "\n" + "\n".join(additions) + "\n", encoding="utf-8")
         return

--- a/tests/modules/mcp_registry/test_mcp_manage_full.py
+++ b/tests/modules/mcp_registry/test_mcp_manage_full.py
@@ -500,6 +500,18 @@ def test_ensure_runtime_gitignore_appends_when_missing(tmp_path: Path) -> None:
     assert ".venv/" in text
 
 
+def test_ensure_runtime_gitignore_adds_local_despite_secrets_path(tmp_path: Path) -> None:
+    """Substring '.local/' must not block when only a nested .local path exists."""
+    (tmp_path / ".gitignore").write_text(
+        ".local/user_settings/mcp.secrets.yaml\n.venv/\n",
+        encoding="utf-8",
+    )
+    mcp_manage.ensure_runtime_gitignore(tmp_path)
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert ".local/" in lines
+    assert ".venv/" in lines
+
+
 def test_ensure_consumer_gitignore_combines_runtime_and_mcp(tmp_path: Path) -> None:
     mcp_manage.ensure_consumer_gitignore(tmp_path)
     text = (tmp_path / ".gitignore").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- `_append_gitignore_lines` used substring containment; `.local/` was skipped when `.local/user_settings/mcp.secrets.yaml` already existed.
- Regression test + test count 1479.

## Test plan
- [x] targeted pytest for new case
- [ ] CI green