### PR TITLE
docs: plan orphans under .local/plans are not indexed

### DIFF
--- a/.ai_infra/docs/operations/upgrade-kit.md
+++ b/.ai_infra/docs/operations/upgrade-kit.md
@@ -79,6 +79,8 @@ Same as Agent chat **`/update-agent-colony`**. See [update-agent-colony skill](.
 
 **Kit-dev product repo:** do not run `update --force` here (scaffold is consumer-only and will refuse). Sync mirrors with `make sync-plugin` instead. Light `update` / heal on kit-dev refreshes dashboards only and does not overwrite authoring `install/` from `payload/`.
 
+**Plan orphans:** only `*.plan.md` files (via `plan snapshot`) are indexed under `.local/plans/`. Plain `.md` files in that folder are ignored by `plan list` — delete them or re-snapshot with `--from`.
+
 **Advanced aliases** (same underlying scaffold paths):
 
 ```bash

--- a/.cursor/skills/canvas-artifacts/SKILL.md
+++ b/.cursor/skills/canvas-artifacts/SKILL.md
@@ -64,4 +64,6 @@ Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
 
 `plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
 
+**Indexing:** only `*.plan.md` (+ sibling `*.meta.yaml`) appear in `plan list` / `index.md`. Plain `.md` files dropped under `.local/plans/` are orphans — remove or re-snapshot via `plan snapshot --from <path>`.
+
 Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/payload/.ai_infra/docs/operations/upgrade-kit.md
+++ b/payload/.ai_infra/docs/operations/upgrade-kit.md
@@ -79,6 +79,8 @@ Same as Agent chat **`/update-agent-colony`**. See [update-agent-colony skill](.
 
 **Kit-dev product repo:** do not run `update --force` here (scaffold is consumer-only and will refuse). Sync mirrors with `make sync-plugin` instead. Light `update` / heal on kit-dev refreshes dashboards only and does not overwrite authoring `install/` from `payload/`.
 
+**Plan orphans:** only `*.plan.md` files (via `plan snapshot`) are indexed under `.local/plans/`. Plain `.md` files in that folder are ignored by `plan list` — delete them or re-snapshot with `--from`.
+
 **Advanced aliases** (same underlying scaffold paths):
 
 ```bash

--- a/payload/.cursor/skills/canvas-artifacts/SKILL.md
+++ b/payload/.cursor/skills/canvas-artifacts/SKILL.md
@@ -64,4 +64,6 @@ Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
 
 `plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
 
+**Indexing:** only `*.plan.md` (+ sibling `*.meta.yaml`) appear in `plan list` / `index.md`. Plain `.md` files dropped under `.local/plans/` are orphans — remove or re-snapshot via `plan snapshot --from <path>`.
+
 Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/skills/canvas-artifacts/SKILL.md
+++ b/skills/canvas-artifacts/SKILL.md
@@ -64,4 +64,6 @@ Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
 
 `plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
 
+**Indexing:** only `*.plan.md` (+ sibling `*.meta.yaml`) appear in `plan list` / `index.md`. Plain `.md` files dropped under `.local/plans/` are orphans — remove or re-snapshot via `plan snapshot --from <path>`.
+
 Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)


### PR DESCRIPTION
## Summary
- Document that only \`*.plan.md\` via \`plan snapshot\` is indexed; plain \`.md\` under \`.local/plans/\` are orphans.

## Test plan
- [x] sync-plugin
- Doc-only