### PR TITLE
feat: auto-discover plugin payload for consumer activate

### DIFF
--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -118,13 +118,24 @@ python3 -m agent_colony activate --directory .
 
 ### First activate troubleshooting
 
-On a **brand-new app repo**, `python3 -m agent_colony` fails with *No module named agent_colony* until activate copies infrastructure. **Agents:** run activate from the plugin **payload** entrypoint (not bare `python3 -m agent_colony` in an empty folder):
+On a **brand-new app repo**, `python3 -m agent_colony` fails with *No module named agent_colony* until activate copies infrastructure. **Agents:** run activate from the **Cursor plugin cache payload** (created by `/add-plugin`) — not bare `python3 -m agent_colony` in an empty folder:
 
 ```bash
-export KIT=~/Projects/agent-colony   # or plugin cache checkout
+cd ~/Projects/my-app
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+test -n "$PAYLOAD" || { echo "Re-run /add-plugin first"; exit 1; }
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
+# or: python3 "$PAYLOAD/.ai_infra/scripts/install/bootstrap_activate.py" --directory .
+source .venv/bin/activate
+```
+
+Kit-dev checkout (optional alternative):
+
+```bash
+export KIT=~/Projects/agent-colony
 export TARGET=~/Projects/my-app
 mkdir -p "$TARGET"
-"$KIT/.venv/bin/python" "$KIT/payload/agent_colony" activate \
+python3 "$KIT/payload/agent_colony" activate \
   --directory "$TARGET" --source "$KIT/payload"
 cd "$TARGET"
 source .venv/bin/activate

--- a/.ai_infra/install/agent_colony/activate_cli.py
+++ b/.ai_infra/install/agent_colony/activate_cli.py
@@ -32,35 +32,79 @@ def _import_plane_status() -> object:
     return plane_status
 
 
+def _manifest_root(path: Path) -> bool:
+    return (path / ".ai_infra" / "manifest.yaml").is_file()
+
+
+def discover_cursor_plugin_payload(*, home: Path | None = None) -> Path | None:
+    """Newest Agent Colony ``payload/`` under Cursor plugin cache or marketplaces.
+
+    After ``/add-plugin``, Cursor stores a checkout under
+    ``~/.cursor/plugins/cache/agent-colony/agent-colony/<sha>/`` with a full
+    ``payload/`` tree (``with_mcp`` profile). Agents on a brand-new app can
+    activate from that path without a local kit clone.
+    """
+    home_path = home if home is not None else Path.home()
+    plugins = home_path / ".cursor" / "plugins"
+    if not plugins.is_dir():
+        return None
+
+    candidates: list[Path] = []
+    patterns = (
+        "cache/agent-colony/agent-colony/*/payload",
+        "cache/agent-colony/*/payload",
+        "marketplaces/**/agent-colony/*/payload",
+        "marketplaces/**/agent-colony/payload",
+        "local/**/agent-colony/*/payload",
+        "local/**/agent-colony/payload",
+    )
+    for pattern in patterns:
+        for match in plugins.glob(pattern):
+            if match.is_dir() and _manifest_root(match):
+                candidates.append(match.resolve())
+
+    if not candidates:
+        return None
+    # Newest checkout wins (mtime of payload dir).
+    return max(set(candidates), key=lambda p: p.stat().st_mtime)
+
+
 def resolve_activate_source(raw: Path | None, target: Path, default_kit_root: Path) -> Path:
     if raw is not None:
         resolved = raw.resolve()
-        if (resolved / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(resolved):
             return resolved
-        if (resolved / "payload" / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(resolved / "payload"):
             return (resolved / "payload").resolve()
         raise FileNotFoundError(f"invalid activate source (no manifest): {resolved}")
 
     env_payload = os.environ.get("WORKFLOW_KIT_PAYLOAD", "").strip()
     if env_payload:
         candidate = Path(env_payload).resolve()
-        if (candidate / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(candidate):
             return candidate
+        if _manifest_root(candidate / "payload"):
+            return (candidate / "payload").resolve()
 
     for candidate in (
         target / "payload",
         default_kit_root / "payload",
     ):
-        if (candidate / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(candidate):
             return candidate.resolve()
 
-    if (default_kit_root / ".ai_infra" / "manifest.yaml").is_file():
+    if _manifest_root(default_kit_root):
         if target.resolve() != default_kit_root.resolve():
             return default_kit_root.resolve()
 
+    plugin_payload = discover_cursor_plugin_payload()
+    if plugin_payload is not None:
+        return plugin_payload
+
     raise FileNotFoundError(
         "activate source not found. Set WORKFLOW_KIT_PAYLOAD to the plugin payload/ directory, "
-        "or pass --source <kit-root|payload/>."
+        "pass --source <kit-root|payload/>, or install the Agent Colony plugin "
+        "(/add-plugin) so ~/.cursor/plugins/cache/agent-colony/*/payload is available."
     )
 
 
@@ -350,7 +394,10 @@ def register_activate_subparser(sub: argparse._SubParsersAction) -> None:
         "--source",
         type=Path,
         default=None,
-        help="Kit root or payload/ (default: auto — WORKFLOW_KIT_PAYLOAD, ./payload, kit root)",
+        help=(
+            "Kit root or payload/ (default: auto — WORKFLOW_KIT_PAYLOAD, ./payload, "
+            "kit root, then ~/.cursor/plugins/cache/agent-colony/*/payload)"
+        ),
     )
     activate.add_argument(
         "--profile",

--- a/.ai_infra/scripts/install/bootstrap_activate.py
+++ b/.ai_infra/scripts/install/bootstrap_activate.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+File: bootstrap_activate.py
+Path: .ai_infra/scripts/install/bootstrap_activate.py
+Role: Zero-dep first-install activate from Cursor plugin payload (no agent_colony on PYTHONPATH).
+Used By:
+ - .cursor/skills/workflow-activate/SKILL.md
+ - consumer-quickstart.md § First activate troubleshooting
+Depends On:
+ - Sibling payload tree (.ai_infra/manifest.yaml) or discover_cursor_plugin_payload
+Notes:
+ - Run as: python3 <payload>/.ai_infra/scripts/install/bootstrap_activate.py --directory <app>
+ - Or from kit-dev: python3 .ai_infra/scripts/install/bootstrap_activate.py --directory <app>
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _payload_from_this_script() -> Path | None:
+    """Resolve payload/ or kit root from this file's location under .ai_infra/scripts/install/."""
+    here = Path(__file__).resolve()
+    # .../<root>/.ai_infra/scripts/install/bootstrap_activate.py → root = parents[3]
+    try:
+        root = here.parents[3]
+    except IndexError:
+        return None
+    nested = root / "payload"
+    if (nested / ".ai_infra" / "manifest.yaml").is_file():
+        return nested
+    if (root / ".ai_infra" / "manifest.yaml").is_file():
+        return root
+    return None
+
+
+def _load_activate_cli(payload: Path):
+    cli_path = payload / ".ai_infra" / "install" / "agent_colony" / "activate_cli.py"
+    if not cli_path.is_file():
+        raise FileNotFoundError(f"activate_cli.py missing under {payload}")
+    # Ensure paths.py (sibling of install/) is importable for kit_root().
+    ai_infra = str(payload / ".ai_infra")
+    if ai_infra not in sys.path:
+        sys.path.insert(0, ai_infra)
+    pkg = str(payload / ".ai_infra" / "install" / "agent_colony")
+    if pkg not in sys.path:
+        sys.path.insert(0, pkg)
+    spec = importlib.util.spec_from_file_location("activate_cli_bootstrap", cli_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {cli_path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap Agent Colony activate from plugin payload (first install)."
+    )
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=Path("."),
+        help="Consumer app workspace (default: cwd)",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Optional payload/ or kit root (default: auto-discover)",
+    )
+    parser.add_argument("--profile", default="with_mcp", choices=("default", "with_mcp"))
+    parser.add_argument("--no-venv", action="store_true", help="Skip .venv creation")
+    parser.add_argument("--no-verify", action="store_true", help="Skip post-install verify gates")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args(argv)
+
+    payload = args.source
+    if payload is not None:
+        payload = payload.resolve()
+        if (payload / "payload" / ".ai_infra" / "manifest.yaml").is_file():
+            payload = payload / "payload"
+        elif not (payload / ".ai_infra" / "manifest.yaml").is_file():
+            print(f"bootstrap_activate: FAIL — no manifest under {payload}", file=sys.stderr)
+            return 1
+    else:
+        payload = _payload_from_this_script()
+        if payload is None:
+            # Late import after path setup is impossible — duplicate tiny discover here.
+            home = Path.home()
+            plugins = home / ".cursor" / "plugins"
+            found: list[Path] = []
+            if plugins.is_dir():
+                for pattern in (
+                    "cache/agent-colony/agent-colony/*/payload",
+                    "cache/agent-colony/*/payload",
+                ):
+                    for match in plugins.glob(pattern):
+                        if (match / ".ai_infra" / "manifest.yaml").is_file():
+                            found.append(match.resolve())
+            if found:
+                payload = max(set(found), key=lambda p: p.stat().st_mtime)
+
+    if payload is None:
+        print(
+            "bootstrap_activate: FAIL — could not find plugin payload. "
+            "Run /add-plugin https://github.com/SavinRazvan/agent-colony first, "
+            "or pass --source <path-to-payload>.",
+            file=sys.stderr,
+        )
+        return 1
+
+    activate_cli = _load_activate_cli(payload)
+    ns = argparse.Namespace(
+        directory=args.directory.resolve(),
+        source=payload,
+        profile=args.profile,
+        with_venv=not args.no_venv,
+        with_mcp_json=True,
+        verify=not args.no_verify,
+        force=bool(args.force),
+        allow_settings_pending=True,
+    )
+    print(f"bootstrap_activate: source={payload}")
+    return int(activate_cli.cmd_activate(ns))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.ai_infra/templates/AGENTS.stub.md
+++ b/.ai_infra/templates/AGENTS.stub.md
@@ -16,7 +16,14 @@
 /workflow-activate
 ```
 
-**First install note:** if activate fails with *No module named agent_colony*, run from kit payload per [consumer-quickstart § First activate troubleshooting](.ai_infra/docs/operations/consumer-quickstart.md#first-activate-troubleshooting).
+**First install note:** if activate fails with *No module named agent_colony*, use the Cursor plugin cache payload (after `/add-plugin`):
+
+```bash
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
+```
+
+Details: [consumer-quickstart § First activate troubleshooting](.ai_infra/docs/operations/consumer-quickstart.md#first-activate-troubleshooting).
 
 ## Just installed?
 

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -50,29 +50,36 @@ Do **not** dump gate lists or maintainer `make` commands.
 
 ## One command
 
-From the **open workspace** (Pattern A — one script command):
+From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 14 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
 
 ```bash
 python3 -m agent_colony activate --directory .
 ```
 
-**Auto source resolution:** `WORKFLOW_KIT_PAYLOAD` env → `./payload/` → kit `payload/` (plugin bundle). Override with `--source /path/to/payload`.
+**Auto source resolution:** `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit `payload/` → **`~/.cursor/plugins/cache/agent-colony/*/payload`** (after `/add-plugin`). Override with `--source /path/to/payload`.
 
 **MCP:** `workflow_activate` on the `agent-colony-mcp` server (same behavior).
 
 ### First install (`agent_colony` module absent)
 
-On a **brand-new app repo**, `python3 -m agent_colony` fails until activate copies infrastructure. **Do not stop** — run activate from the **plugin payload** (or kit checkout):
+On a **brand-new app repo**, `python3 -m agent_colony` fails until activate copies infrastructure. **Do not stop** — prefer the **Cursor plugin cache** (created by `/add-plugin`):
 
 ```bash
-export KIT=~/Projects/agent-colony   # or plugin cache path
-export TARGET=~/Projects/my-app
-cd "$TARGET"
-"$KIT/.venv/bin/python" "$KIT/payload/agent_colony" activate \
-  --directory "$TARGET" --source "$KIT/payload"
+cd /path/to/your-app
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+test -n "$PAYLOAD" || { echo "Plugin payload missing — re-run /add-plugin"; exit 1; }
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
 ```
 
-Or set `WORKFLOW_KIT_PAYLOAD` to the payload directory and invoke the payload entrypoint the same way. After **VERIFY PASS**, all later commands use:
+Equivalent zero-dep helper (same payload):
+
+```bash
+python3 "$PAYLOAD/.ai_infra/scripts/install/bootstrap_activate.py" --directory .
+```
+
+Kit-dev checkout (optional): `KIT=~/Projects/agent-colony` then `python3 "$KIT/payload/agent_colony" activate --directory . --source "$KIT/payload"`.
+
+After **VERIFY PASS**, all later commands use:
 
 ```bash
 source .venv/bin/activate && python3 -m agent_colony …

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Still in **your app** folder, Agent chat:
 
 Wait for **`VERIFY PASS`** and all three planes **ready**. Activate is idempotent (safe to re-run).
 
+This copies the **full consumer kit** from the plugin `payload/` (same surface kit maintainers ship): **8 agents**, **14 skills** (incl. `/update-agent-colony`), **7 rules**, maintainer PR slash skills, `agent_colony` CLI (project/PR/drift/MCP/canvas/plan/update), MCP server, ops docs, `.local/` scaffold, `.venv`, and runtime `.gitignore` (`.local/` + `.venv/`). You only personalize identity / board YAML in step 3 — you do **not** pick optional install profiles.
+
 | Plane | Paths | Purpose |
 |-------|-------|---------|
 | Cursor contract | `.cursor/`, `.agents/`, `AGENTS.md` | Agents, skills, rules |
@@ -248,27 +250,29 @@ Shorter path: [consumer-quickstart.md](.ai_infra/docs/operations/consumer-quicks
 
 ### Optional — Update the kit / plugin later
 
-Docs and agents in **your app** come from the plugin payload + `/workflow-activate`. Re-reading the kit README on GitHub does **not** change Smart-Notes until you refresh.
+Docs and agents in **your app** come from the plugin payload. Re-reading this README on GitHub does **not** refresh your app until you update the plugin + run the upgrade command.
 
 1. **Ship on the kit repo first** (maintainer): merge the change to `main` (PR workflow).
-2. **In your app** (e.g. Smart-Notes), Agent chat — refresh the plugin from GitHub:
+2. **In your app**, Agent chat — refresh the plugin from GitHub:
 
 ```text
 /add-plugin https://github.com/SavinRazvan/agent-colony
 ```
 
-3. Re-activate (safe / idempotent — keeps `.local/user_settings/` and existing `AGENTS.md`):
+3. **Upgrade** (version-gated heal vs full kit-managed refresh — preferred):
 
 ```text
-/workflow-activate
+/update-agent-colony
 ```
 
 Or terminal:
 
 ```bash
 source .venv/bin/activate
-python3 -m agent_colony activate --directory .
+python3 -m agent_colony update --directory .
 ```
+
+Plain `/workflow-activate` / `activate` only **heals** (dashboards, gitignore, STARTER, missing `.venv`) when planes are already ready — it does **not** overwrite agents/skills/scripts unless you use `update` (or advanced `activate --force`).
 
 4. Sanity check:
 
@@ -277,8 +281,7 @@ python3 -m agent_colony health
 python3 -m agent_colony project board-bootstrap --check   # still FAIL until you finish step 4 views in GitHub UI
 ```
 
-**Force** full overwrite of agents/skills/scripts (review diffs): `python3 -m agent_colony activate --directory . --force`  
-Details: [upgrade-kit.md](.ai_infra/docs/operations/upgrade-kit.md).
+Details: [upgrade-kit.md](.ai_infra/docs/operations/upgrade-kit.md) · skill [update-agent-colony](.cursor/skills/update-agent-colony/SKILL.md).
 
 **Board views are not fixed by a plugin update.** `board-bootstrap --check` FAIL on missing views only clears after you complete **step 4** (`/board` + human UI). Updating the plugin only refreshes docs/coaching text.
 

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -118,13 +118,24 @@ python3 -m agent_colony activate --directory .
 
 ### First activate troubleshooting
 
-On a **brand-new app repo**, `python3 -m agent_colony` fails with *No module named agent_colony* until activate copies infrastructure. **Agents:** run activate from the plugin **payload** entrypoint (not bare `python3 -m agent_colony` in an empty folder):
+On a **brand-new app repo**, `python3 -m agent_colony` fails with *No module named agent_colony* until activate copies infrastructure. **Agents:** run activate from the **Cursor plugin cache payload** (created by `/add-plugin`) — not bare `python3 -m agent_colony` in an empty folder:
 
 ```bash
-export KIT=~/Projects/agent-colony   # or plugin cache checkout
+cd ~/Projects/my-app
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+test -n "$PAYLOAD" || { echo "Re-run /add-plugin first"; exit 1; }
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
+# or: python3 "$PAYLOAD/.ai_infra/scripts/install/bootstrap_activate.py" --directory .
+source .venv/bin/activate
+```
+
+Kit-dev checkout (optional alternative):
+
+```bash
+export KIT=~/Projects/agent-colony
 export TARGET=~/Projects/my-app
 mkdir -p "$TARGET"
-"$KIT/.venv/bin/python" "$KIT/payload/agent_colony" activate \
+python3 "$KIT/payload/agent_colony" activate \
   --directory "$TARGET" --source "$KIT/payload"
 cd "$TARGET"
 source .venv/bin/activate

--- a/payload/.ai_infra/install/agent_colony/activate_cli.py
+++ b/payload/.ai_infra/install/agent_colony/activate_cli.py
@@ -32,35 +32,79 @@ def _import_plane_status() -> object:
     return plane_status
 
 
+def _manifest_root(path: Path) -> bool:
+    return (path / ".ai_infra" / "manifest.yaml").is_file()
+
+
+def discover_cursor_plugin_payload(*, home: Path | None = None) -> Path | None:
+    """Newest Agent Colony ``payload/`` under Cursor plugin cache or marketplaces.
+
+    After ``/add-plugin``, Cursor stores a checkout under
+    ``~/.cursor/plugins/cache/agent-colony/agent-colony/<sha>/`` with a full
+    ``payload/`` tree (``with_mcp`` profile). Agents on a brand-new app can
+    activate from that path without a local kit clone.
+    """
+    home_path = home if home is not None else Path.home()
+    plugins = home_path / ".cursor" / "plugins"
+    if not plugins.is_dir():
+        return None
+
+    candidates: list[Path] = []
+    patterns = (
+        "cache/agent-colony/agent-colony/*/payload",
+        "cache/agent-colony/*/payload",
+        "marketplaces/**/agent-colony/*/payload",
+        "marketplaces/**/agent-colony/payload",
+        "local/**/agent-colony/*/payload",
+        "local/**/agent-colony/payload",
+    )
+    for pattern in patterns:
+        for match in plugins.glob(pattern):
+            if match.is_dir() and _manifest_root(match):
+                candidates.append(match.resolve())
+
+    if not candidates:
+        return None
+    # Newest checkout wins (mtime of payload dir).
+    return max(set(candidates), key=lambda p: p.stat().st_mtime)
+
+
 def resolve_activate_source(raw: Path | None, target: Path, default_kit_root: Path) -> Path:
     if raw is not None:
         resolved = raw.resolve()
-        if (resolved / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(resolved):
             return resolved
-        if (resolved / "payload" / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(resolved / "payload"):
             return (resolved / "payload").resolve()
         raise FileNotFoundError(f"invalid activate source (no manifest): {resolved}")
 
     env_payload = os.environ.get("WORKFLOW_KIT_PAYLOAD", "").strip()
     if env_payload:
         candidate = Path(env_payload).resolve()
-        if (candidate / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(candidate):
             return candidate
+        if _manifest_root(candidate / "payload"):
+            return (candidate / "payload").resolve()
 
     for candidate in (
         target / "payload",
         default_kit_root / "payload",
     ):
-        if (candidate / ".ai_infra" / "manifest.yaml").is_file():
+        if _manifest_root(candidate):
             return candidate.resolve()
 
-    if (default_kit_root / ".ai_infra" / "manifest.yaml").is_file():
+    if _manifest_root(default_kit_root):
         if target.resolve() != default_kit_root.resolve():
             return default_kit_root.resolve()
 
+    plugin_payload = discover_cursor_plugin_payload()
+    if plugin_payload is not None:
+        return plugin_payload
+
     raise FileNotFoundError(
         "activate source not found. Set WORKFLOW_KIT_PAYLOAD to the plugin payload/ directory, "
-        "or pass --source <kit-root|payload/>."
+        "pass --source <kit-root|payload/>, or install the Agent Colony plugin "
+        "(/add-plugin) so ~/.cursor/plugins/cache/agent-colony/*/payload is available."
     )
 
 
@@ -350,7 +394,10 @@ def register_activate_subparser(sub: argparse._SubParsersAction) -> None:
         "--source",
         type=Path,
         default=None,
-        help="Kit root or payload/ (default: auto — WORKFLOW_KIT_PAYLOAD, ./payload, kit root)",
+        help=(
+            "Kit root or payload/ (default: auto — WORKFLOW_KIT_PAYLOAD, ./payload, "
+            "kit root, then ~/.cursor/plugins/cache/agent-colony/*/payload)"
+        ),
     )
     activate.add_argument(
         "--profile",

--- a/payload/.ai_infra/scripts/install/bootstrap_activate.py
+++ b/payload/.ai_infra/scripts/install/bootstrap_activate.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+File: bootstrap_activate.py
+Path: .ai_infra/scripts/install/bootstrap_activate.py
+Role: Zero-dep first-install activate from Cursor plugin payload (no agent_colony on PYTHONPATH).
+Used By:
+ - .cursor/skills/workflow-activate/SKILL.md
+ - consumer-quickstart.md § First activate troubleshooting
+Depends On:
+ - Sibling payload tree (.ai_infra/manifest.yaml) or discover_cursor_plugin_payload
+Notes:
+ - Run as: python3 <payload>/.ai_infra/scripts/install/bootstrap_activate.py --directory <app>
+ - Or from kit-dev: python3 .ai_infra/scripts/install/bootstrap_activate.py --directory <app>
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _payload_from_this_script() -> Path | None:
+    """Resolve payload/ or kit root from this file's location under .ai_infra/scripts/install/."""
+    here = Path(__file__).resolve()
+    # .../<root>/.ai_infra/scripts/install/bootstrap_activate.py → root = parents[3]
+    try:
+        root = here.parents[3]
+    except IndexError:
+        return None
+    nested = root / "payload"
+    if (nested / ".ai_infra" / "manifest.yaml").is_file():
+        return nested
+    if (root / ".ai_infra" / "manifest.yaml").is_file():
+        return root
+    return None
+
+
+def _load_activate_cli(payload: Path):
+    cli_path = payload / ".ai_infra" / "install" / "agent_colony" / "activate_cli.py"
+    if not cli_path.is_file():
+        raise FileNotFoundError(f"activate_cli.py missing under {payload}")
+    # Ensure paths.py (sibling of install/) is importable for kit_root().
+    ai_infra = str(payload / ".ai_infra")
+    if ai_infra not in sys.path:
+        sys.path.insert(0, ai_infra)
+    pkg = str(payload / ".ai_infra" / "install" / "agent_colony")
+    if pkg not in sys.path:
+        sys.path.insert(0, pkg)
+    spec = importlib.util.spec_from_file_location("activate_cli_bootstrap", cli_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {cli_path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap Agent Colony activate from plugin payload (first install)."
+    )
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=Path("."),
+        help="Consumer app workspace (default: cwd)",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Optional payload/ or kit root (default: auto-discover)",
+    )
+    parser.add_argument("--profile", default="with_mcp", choices=("default", "with_mcp"))
+    parser.add_argument("--no-venv", action="store_true", help="Skip .venv creation")
+    parser.add_argument("--no-verify", action="store_true", help="Skip post-install verify gates")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args(argv)
+
+    payload = args.source
+    if payload is not None:
+        payload = payload.resolve()
+        if (payload / "payload" / ".ai_infra" / "manifest.yaml").is_file():
+            payload = payload / "payload"
+        elif not (payload / ".ai_infra" / "manifest.yaml").is_file():
+            print(f"bootstrap_activate: FAIL — no manifest under {payload}", file=sys.stderr)
+            return 1
+    else:
+        payload = _payload_from_this_script()
+        if payload is None:
+            # Late import after path setup is impossible — duplicate tiny discover here.
+            home = Path.home()
+            plugins = home / ".cursor" / "plugins"
+            found: list[Path] = []
+            if plugins.is_dir():
+                for pattern in (
+                    "cache/agent-colony/agent-colony/*/payload",
+                    "cache/agent-colony/*/payload",
+                ):
+                    for match in plugins.glob(pattern):
+                        if (match / ".ai_infra" / "manifest.yaml").is_file():
+                            found.append(match.resolve())
+            if found:
+                payload = max(set(found), key=lambda p: p.stat().st_mtime)
+
+    if payload is None:
+        print(
+            "bootstrap_activate: FAIL — could not find plugin payload. "
+            "Run /add-plugin https://github.com/SavinRazvan/agent-colony first, "
+            "or pass --source <path-to-payload>.",
+            file=sys.stderr,
+        )
+        return 1
+
+    activate_cli = _load_activate_cli(payload)
+    ns = argparse.Namespace(
+        directory=args.directory.resolve(),
+        source=payload,
+        profile=args.profile,
+        with_venv=not args.no_venv,
+        with_mcp_json=True,
+        verify=not args.no_verify,
+        force=bool(args.force),
+        allow_settings_pending=True,
+    )
+    print(f"bootstrap_activate: source={payload}")
+    return int(activate_cli.cmd_activate(ns))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/payload/.ai_infra/templates/AGENTS.stub.md
+++ b/payload/.ai_infra/templates/AGENTS.stub.md
@@ -16,7 +16,14 @@
 /workflow-activate
 ```
 
-**First install note:** if activate fails with *No module named agent_colony*, run from kit payload per [consumer-quickstart § First activate troubleshooting](.ai_infra/docs/operations/consumer-quickstart.md#first-activate-troubleshooting).
+**First install note:** if activate fails with *No module named agent_colony*, use the Cursor plugin cache payload (after `/add-plugin`):
+
+```bash
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
+```
+
+Details: [consumer-quickstart § First activate troubleshooting](.ai_infra/docs/operations/consumer-quickstart.md#first-activate-troubleshooting).
 
 ## Just installed?
 

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -50,29 +50,36 @@ Do **not** dump gate lists or maintainer `make` commands.
 
 ## One command
 
-From the **open workspace** (Pattern A — one script command):
+From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 14 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
 
 ```bash
 python3 -m agent_colony activate --directory .
 ```
 
-**Auto source resolution:** `WORKFLOW_KIT_PAYLOAD` env → `./payload/` → kit `payload/` (plugin bundle). Override with `--source /path/to/payload`.
+**Auto source resolution:** `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit `payload/` → **`~/.cursor/plugins/cache/agent-colony/*/payload`** (after `/add-plugin`). Override with `--source /path/to/payload`.
 
 **MCP:** `workflow_activate` on the `agent-colony-mcp` server (same behavior).
 
 ### First install (`agent_colony` module absent)
 
-On a **brand-new app repo**, `python3 -m agent_colony` fails until activate copies infrastructure. **Do not stop** — run activate from the **plugin payload** (or kit checkout):
+On a **brand-new app repo**, `python3 -m agent_colony` fails until activate copies infrastructure. **Do not stop** — prefer the **Cursor plugin cache** (created by `/add-plugin`):
 
 ```bash
-export KIT=~/Projects/agent-colony   # or plugin cache path
-export TARGET=~/Projects/my-app
-cd "$TARGET"
-"$KIT/.venv/bin/python" "$KIT/payload/agent_colony" activate \
-  --directory "$TARGET" --source "$KIT/payload"
+cd /path/to/your-app
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+test -n "$PAYLOAD" || { echo "Plugin payload missing — re-run /add-plugin"; exit 1; }
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
 ```
 
-Or set `WORKFLOW_KIT_PAYLOAD` to the payload directory and invoke the payload entrypoint the same way. After **VERIFY PASS**, all later commands use:
+Equivalent zero-dep helper (same payload):
+
+```bash
+python3 "$PAYLOAD/.ai_infra/scripts/install/bootstrap_activate.py" --directory .
+```
+
+Kit-dev checkout (optional): `KIT=~/Projects/agent-colony` then `python3 "$KIT/payload/agent_colony" activate --directory . --source "$KIT/payload"`.
+
+After **VERIFY PASS**, all later commands use:
 
 ```bash
 source .venv/bin/activate && python3 -m agent_colony …

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -50,29 +50,36 @@ Do **not** dump gate lists or maintainer `make` commands.
 
 ## One command
 
-From the **open workspace** (Pattern A — one script command):
+From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 14 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
 
 ```bash
 python3 -m agent_colony activate --directory .
 ```
 
-**Auto source resolution:** `WORKFLOW_KIT_PAYLOAD` env → `./payload/` → kit `payload/` (plugin bundle). Override with `--source /path/to/payload`.
+**Auto source resolution:** `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit `payload/` → **`~/.cursor/plugins/cache/agent-colony/*/payload`** (after `/add-plugin`). Override with `--source /path/to/payload`.
 
 **MCP:** `workflow_activate` on the `agent-colony-mcp` server (same behavior).
 
 ### First install (`agent_colony` module absent)
 
-On a **brand-new app repo**, `python3 -m agent_colony` fails until activate copies infrastructure. **Do not stop** — run activate from the **plugin payload** (or kit checkout):
+On a **brand-new app repo**, `python3 -m agent_colony` fails until activate copies infrastructure. **Do not stop** — prefer the **Cursor plugin cache** (created by `/add-plugin`):
 
 ```bash
-export KIT=~/Projects/agent-colony   # or plugin cache path
-export TARGET=~/Projects/my-app
-cd "$TARGET"
-"$KIT/.venv/bin/python" "$KIT/payload/agent_colony" activate \
-  --directory "$TARGET" --source "$KIT/payload"
+cd /path/to/your-app
+PAYLOAD="$(ls -1dt ~/.cursor/plugins/cache/agent-colony/agent-colony/*/payload 2>/dev/null | head -1)"
+test -n "$PAYLOAD" || { echo "Plugin payload missing — re-run /add-plugin"; exit 1; }
+python3 "$PAYLOAD/agent_colony" activate --directory . --source "$PAYLOAD"
 ```
 
-Or set `WORKFLOW_KIT_PAYLOAD` to the payload directory and invoke the payload entrypoint the same way. After **VERIFY PASS**, all later commands use:
+Equivalent zero-dep helper (same payload):
+
+```bash
+python3 "$PAYLOAD/.ai_infra/scripts/install/bootstrap_activate.py" --directory .
+```
+
+Kit-dev checkout (optional): `KIT=~/Projects/agent-colony` then `python3 "$KIT/payload/agent_colony" activate --directory . --source "$KIT/payload"`.
+
+After **VERIFY PASS**, all later commands use:
 
 ```bash
 source .venv/bin/activate && python3 -m agent_colony …

--- a/tests/modules/install/test_activate_cli.py
+++ b/tests/modules/install/test_activate_cli.py
@@ -106,6 +106,7 @@ def test_resolve_source_default_kit_root_equals_target_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("WORKFLOW_KIT_PAYLOAD", raising=False)
+    monkeypatch.setattr(activate_cli, "discover_cursor_plugin_payload", lambda **k: None)
     default_root = _manifest_dir(tmp_path / "same")
     with pytest.raises(FileNotFoundError, match="activate source not found"):
         activate_cli.resolve_activate_source(None, default_root, default_root)
@@ -113,8 +114,40 @@ def test_resolve_source_default_kit_root_equals_target_raises(
 
 def test_resolve_source_nothing_found_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("WORKFLOW_KIT_PAYLOAD", raising=False)
+    monkeypatch.setattr(activate_cli, "discover_cursor_plugin_payload", lambda **k: None)
     with pytest.raises(FileNotFoundError, match="activate source not found"):
         activate_cli.resolve_activate_source(None, tmp_path / "target", tmp_path / "default")
+
+
+def test_discover_cursor_plugin_payload_newest(tmp_path: Path) -> None:
+    plugins = tmp_path / ".cursor" / "plugins"
+    older = plugins / "cache" / "agent-colony" / "agent-colony" / "aaa" / "payload"
+    newer = plugins / "cache" / "agent-colony" / "agent-colony" / "bbb" / "payload"
+    _manifest_dir(older)
+    _manifest_dir(newer)
+    import os
+    import time
+
+    now = time.time()
+    os.utime(older, (now - 100, now - 100))
+    os.utime(newer, (now, now))
+    found = activate_cli.discover_cursor_plugin_payload(home=tmp_path)
+    assert found == newer.resolve()
+
+
+def test_resolve_source_falls_back_to_cursor_plugin_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WORKFLOW_KIT_PAYLOAD", raising=False)
+    payload = (
+        tmp_path / ".cursor" / "plugins" / "cache" / "agent-colony" / "agent-colony" / "deadbeef" / "payload"
+    )
+    _manifest_dir(payload)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    result = activate_cli.resolve_activate_source(
+        None, tmp_path / "empty-app", tmp_path / "no-kit"
+    )
+    assert result == payload.resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -398,6 +431,7 @@ def test_cmd_activate_source_not_found(tmp_path: Path, monkeypatch: pytest.Monke
     target.mkdir()
     monkeypatch.delenv("WORKFLOW_KIT_PAYLOAD", raising=False)
     monkeypatch.setattr(paths, "kit_root", lambda: tmp_path / "no-manifest-here")
+    monkeypatch.setattr(activate_cli, "discover_cursor_plugin_payload", lambda **k: None)
     code = activate_cli.cmd_activate(_args(directory=target, source=None))
     assert code == 1
 

--- a/tests/modules/install/test_bootstrap_activate.py
+++ b/tests/modules/install/test_bootstrap_activate.py
@@ -1,0 +1,88 @@
+"""
+File: test_bootstrap_activate.py
+Path: tests/modules/install/test_bootstrap_activate.py
+Role: Coverage for zero-dep bootstrap_activate.py first-install entrypoint.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/install/bootstrap_activate.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BOOTSTRAP = REPO_ROOT / ".ai_infra" / "scripts" / "install" / "bootstrap_activate.py"
+
+
+def _load_bootstrap():
+    spec = importlib.util.spec_from_file_location("bootstrap_activate", BOOTSTRAP)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _manifest_dir(base: Path) -> Path:
+    (base / ".ai_infra").mkdir(parents=True, exist_ok=True)
+    (base / ".ai_infra" / "manifest.yaml").write_text("kit_version: 0.0.0\n", encoding="utf-8")
+    return base
+
+
+def test_payload_from_this_script_prefers_kit_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_bootstrap()
+    # Point __file__ at a fake kit-layout copy of the script.
+    kit = tmp_path / "kit"
+    payload = _manifest_dir(kit / "payload")
+    script = kit / ".ai_infra" / "scripts" / "install" / "bootstrap_activate.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# stub\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "__file__", str(script))
+    assert mod._payload_from_this_script() == payload.resolve()
+
+
+def test_main_fails_without_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_bootstrap()
+    monkeypatch.setattr(mod, "_payload_from_this_script", lambda: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    code = mod.main(["--directory", str(tmp_path / "app")])
+    assert code == 1
+
+
+def test_main_invokes_cmd_activate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_bootstrap()
+    payload = _manifest_dir(tmp_path / "payload")
+    # Minimal install package so _load_activate_cli can open activate_cli.py
+    cli = payload / ".ai_infra" / "install" / "agent_colony" / "activate_cli.py"
+    cli.parent.mkdir(parents=True)
+    # Re-use real activate_cli from kit for loader; patch cmd_activate after load.
+    real_cli = REPO_ROOT / ".ai_infra" / "install" / "agent_colony" / "activate_cli.py"
+    cli.write_text(real_cli.read_text(encoding="utf-8"), encoding="utf-8")
+    (payload / ".ai_infra" / "paths.py").write_text(
+        (REPO_ROOT / ".ai_infra" / "paths.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    called: dict[str, object] = {}
+
+    def _fake_cmd(ns: SimpleNamespace) -> int:
+        called["directory"] = Path(ns.directory)
+        called["source"] = Path(ns.source)
+        return 0
+
+    monkeypatch.setattr(mod, "_payload_from_this_script", lambda: payload)
+
+    def _load(_payload: Path):
+        return SimpleNamespace(cmd_activate=_fake_cmd)
+
+    monkeypatch.setattr(mod, "_load_activate_cli", _load)
+    code = mod.main(["--directory", str(tmp_path / "app")])
+    assert code == 0
+    assert called["directory"] == (tmp_path / "app").resolve()
+    assert called["source"] == payload.resolve()


### PR DESCRIPTION
## Summary
- Auto-discover Agent Colony `payload/` under `~/.cursor/plugins/cache/agent-colony/*/payload` after `/add-plugin`
- Add zero-dep `bootstrap_activate.py` for first install when `agent_colony` is not on PYTHONPATH yet
- Align README / workflow-activate / consumer-quickstart / AGENTS.stub: full kit promise; upgrades via `/update-agent-colony`

## Test plan
- [x] `pytest tests/modules/install/test_activate_cli.py tests/modules/install/test_bootstrap_activate.py`
- [x] `make sync-plugin` / `make check-plugin`
- [x] Dry `bootstrap_activate.py` into temp app → 14 skills, gitignore, STARTER, DeepWiki path, venv
- [ ] CI green on PR