### PR TITLE
chore: bump documented test count to 1484 (DOC-006)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1479
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1484
 
 ## Shipped (confirmed in repo)
 
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1479 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1484 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -229,6 +229,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1479** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
 
+**Listing copy refresh (2026-08-07 plugin-cache activate bootstrap):** Auto-discover Cursor plugin cache payload + `bootstrap_activate.py` — **1484** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
+
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 
 **Listing copy refresh (2026-07-20 DOC-ALIGN secondary + marketplace description, archival):** Description row + `plugin.json` mentioned Project SSOT / Playground board shell / **8 / 12 / 7** at that date; superseded by 2026-08-05 alignment refresh (8 / 13 / 7).

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1479; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1484; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1479; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1484; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | | |
 |--|--|
 | **Product repo** | [agent-colony](https://github.com/SavinRazvan/agent-colony) |
-| **Version** | `0.6.1` · **Tests** · 1479 · **Agents** · 8 · **Rules** · **7 universal** |
+| **Version** | `0.6.1` · **Tests** · 1484 · **Agents** · 8 · **Rules** · **7 universal** |
 | **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
 
 ---


### PR DESCRIPTION
## Summary
- DOC-006: documented test count **1479 → 1484** after PR #206 tests landed
- Marketplace listing refresh row for plugin-cache activate bootstrap

## Test plan
- [x] `python3 .ai_infra/scripts/architecture/check_doc_facts.py` → DOC-006 PASS
- [ ] CI quality green