### PR TITLE
docs: slim README landing + factual onboard pitch

### DIFF
--- a/.ai_infra/docs/README.md
+++ b/.ai_infra/docs/README.md
@@ -6,8 +6,9 @@
 
 | You are | Read first |
 |---------|------------|
-| **New consumer** | [PLUGIN-USER-GUIDE](operations/PLUGIN-USER-GUIDE.md) → [consumer-quickstart](operations/consumer-quickstart.md) |
-| **Kit maintainer** | [repository-map](handoff/repository-map.md) → [PLUGIN-ARCHITECTURE](handoff/PLUGIN-ARCHITECTURE.md) → [IMPLEMENTATION-STATUS](handoff/IMPLEMENTATION-STATUS.md) |
+| **Visitor / public** | Root [README.md](../../README.md) (landing) → [consumer-quickstart](operations/consumer-quickstart.md) |
+| **New consumer** | [consumer-quickstart](operations/consumer-quickstart.md) → [PLUGIN-USER-GUIDE](operations/PLUGIN-USER-GUIDE.md) |
+| **Kit maintainer** | [CONTRIBUTING.md](../../CONTRIBUTING.md) → [AGENTS.md](../../AGENTS.md) → [repository-map](handoff/repository-map.md) → [PLUGIN-ARCHITECTURE](handoff/PLUGIN-ARCHITECTURE.md) → [IMPLEMENTATION-STATUS](handoff/IMPLEMENTATION-STATUS.md) |
 | **Governance / policy** | [governance/README](governance/README.md) |
 
 ## Folders

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -198,7 +198,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 | Organization handle | `savin-razvan` (or `agent-colony`) |
 | Contact email | razvan.i.savin@gmail.com |
 | Logotype URL | `https://raw.githubusercontent.com/SavinRazvan/agent-colony/main/assets/agent-colony-logo.png` |
-| Description | Agent Colony installs multi-agent workflow into any Cursor project (8 agents, 14 skills, 7 rules): GitHub Project as writable backlog/status SSOT, PR lifecycle scripts, `.local/` evidence, optional MCP. Run **`/workflow-activate`**, then first-run **`/board`** (Playground board shell) before **`/implementer`**. Pattern A: one script per maintainer action. |
+| Description | Stop losing Status in chat — install Agent Colony into your Cursor app: 8 agents, optional GitHub Project coordination, PR gates, local evidence. `/add-plugin` → `/workflow-activate`; enable Project SSOT then `/board` + shell until `board-bootstrap --check` exits 0. |
 | GitHub repository | https://github.com/SavinRazvan/agent-colony |
 | Owner | Individual · razvan.i.savin@gmail.com |
 | Website URL | https://razvansavin.com/ |
@@ -230,6 +230,10 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 **Listing copy refresh (2026-08-07 update-agent-colony command):** Added `/update-agent-colony` + `agent_colony update` version-gated upgrade — **1479** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
 
 **Listing copy refresh (2026-08-07 plugin-cache activate bootstrap):** Auto-discover Cursor plugin cache payload + `bootstrap_activate.py` — **1484** tests; agent/skill/rule counts (**8** / **14** / **7**); kit version **0.6.1**.
+
+**Listing copy refresh (2026-08-09 slim README + docs routing):** Public README is a landing page (video, two-speed CTA); consumer depth in quickstart/PLUGIN-USER-GUIDE; kit-dev setup in root `CONTRIBUTING.md`. Marketplace Description row + `plugin.json` tagline aligned; **1484** tests; **8** / **14** / **7**; kit version **0.6.1**.
+
+**Listing copy refresh (2026-08-09 pitch + factual onboard):** Outcome pitch (“Stop losing Status in chat”) with optional board SSOT wording; README full-board ladder mirrors quickstart (`contributors validate` → `/board` → `board-bootstrap --check`); **1484** tests; **8** / **14** / **7**; kit version **0.6.1**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -16,6 +16,8 @@ Notes:
 
 # Agent Colony · Plugin User Guide
 
+> **From the [kit README](https://github.com/SavinRazvan/agent-colony):** public landing lives on GitHub. Prefer the short path? [consumer-quickstart.md](consumer-quickstart.md). This guide is the full consumer manual.
+
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.
 
 ---
@@ -474,10 +476,14 @@ More: [consumer-quickstart.md](consumer-quickstart.md) § Troubleshooting.
 
 | Topic | Doc |
 |-------|-----|
+| 5-step cheat sheet | [consumer-quickstart.md](consumer-quickstart.md) |
 | All runbooks | [operations README](README.md) |
 | Three-plane architecture | [workflow-architecture.md](../architecture/workflow-architecture.md) |
+| Board day-to-day | skill `board-ssot` · shell coach `board-shell` |
+| MCP (DeepWiki, custom) | [connect-external-mcp.md](connect-external-mcp.md) |
+| Research packs | skill `research-corpus` |
 | Why plugin + payload | [ADR-001](../decisions/ADR-001-distribution-activation.md) |
 | Upgrade / semver | [upgrade-kit.md](upgrade-kit.md) |
 | Optional project metadata | [project-config.md](project-config.md) |
 
-**Kit maintainers** (not copied to your project): `PLUGIN-ARCHITECTURE.md` and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/agent-colony/tree/main/.ai_infra/docs/handoff).
+**Kit maintainers** (not copied to your project): [CONTRIBUTING.md](https://github.com/SavinRazvan/agent-colony/blob/main/CONTRIBUTING.md), `PLUGIN-ARCHITECTURE.md`, and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/agent-colony/tree/main/.ai_infra/docs/handoff).

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -15,11 +15,13 @@ Notes:
 
 # Consumer quickstart
 
+> **From the [kit README](https://github.com/SavinRazvan/agent-colony#install-consumers):** this is the 5-step install path after `/add-plugin` + `/workflow-activate`. Full manual: [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md).
+
 Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No special git setup required.
 
 **Product promise:** Install the plugin → open **your app repo** → **`/workflow-activate`** installs the **full kit**. Customize identity in `github.collaboration.yaml`, then **`/board`** wires board ids from Project + repo URLs. **Ready for agents** requires `board-bootstrap --check` **exit 0** — either **two views** (minimal overlay, matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)) or **six Playground views** (kit default). Wire-only is not enough. Details: [PLUGIN-USER-GUIDE § Product promise](PLUGIN-USER-GUIDE.md#product-promise).
 
-> **Full manual:** [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) — plugin vs activate, complete file tree, use-case matrix, PR and audit chapters.
+> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · skill `research-corpus` · skill `board-shell`
 
 ---
 

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "agent-colony",
   "displayName": "Agent Colony",
   "version": "0.6.1",
-  "description": "Multi-agent Cursor workflow with GitHub Projects as the coordination SSOT — install once, wire your board, ship with PR gates and evidence.",
+  "description": "Stop losing Status in chat — install Agent Colony into your Cursor app: 8 agents, optional GitHub Project coordination, PR gates, local evidence.",
   "author": {
     "name": "Savin Ionuț Răzvan",
     "email": "razvan.i.savin@gmail.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 
 ## First reads (onboarding)
 
-1. [`README.md`](README.md) — install, Pattern A, overlay model, `.local/` anchoring
+1. [`README.md`](README.md) — public landing · [`CONTRIBUTING.md`](CONTRIBUTING.md) — kit-dev setup · consumer install → [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md)
 2. [`.ai_infra/docs/README.md`](.ai_infra/docs/README.md) — docs index (linked navigation)
 3. [`.ai_infra/docs/handoff/repository-map.md`](.ai_infra/docs/handoff/repository-map.md) — **kit repo only** — SSOT vs generated vs consumer install (not shipped to consumers)
 4. [`.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md`](.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md) — plugin bundle, install profiles

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+<!--
+File: CONTRIBUTING.md
+Path: CONTRIBUTING.md
+Role: Kit-dev human setup — clone, venv, gates; points to AGENTS.md for agent doctrine.
+Used By:
+ - README.md (kit maintainers CTA)
+ - .ai_infra/docs/README.md
+Depends On:
+ - AGENTS.md
+ - .ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+Notes:
+ - Consumer install lives in .ai_infra/docs/operations/consumer-quickstart.md — not here.
+-->
+
+# Contributing (kit-dev)
+
+This page is for people developing the **agent-colony** product repository itself.
+
+**Consumers** installing into an app repo: start at [README.md](README.md) → [consumer-quickstart.md](.ai_infra/docs/operations/consumer-quickstart.md).
+
+**Agents** working in this repo: read **[AGENTS.md](AGENTS.md)** first (identity, board SSOT, roster, gates).
+
+---
+
+## Setup
+
+```bash
+gh repo clone SavinRazvan/agent-colony
+cd agent-colony
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,mcp]"
+```
+
+1. Open the folder in Cursor.
+2. Confirm `.local/user_settings/github.collaboration.yaml` (owner + `project_ssot`).
+3. Entry when board SSOT is on:
+
+```bash
+python3 -m agent_colony project status
+python3 -m agent_colony project list --status ready
+# create / claim — see: python3 -m agent_colony project guide
+```
+
+---
+
+## Maintainer gates
+
+```bash
+make gates
+make drift-validate
+make doc-validate
+```
+
+Before release / plugin ship: `make sync-plugin` · `make check-plugin` · see [marketplace-publish.md](.ai_infra/docs/handoff/marketplace-publish.md).
+
+Do **not** run `agent_colony update --force` against this kit-dev tree — use `make sync-plugin` instead.
+
+---
+
+## Further reading
+
+| Doc | Role |
+|-----|------|
+| [AGENTS.md](AGENTS.md) | Agent doctrine, continuation, commit trailers |
+| [repository-map.md](.ai_infra/docs/handoff/repository-map.md) | SSOT vs generated vs consumer install |
+| [PLUGIN-ARCHITECTURE.md](.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md) | Plugin bundle, three planes |
+| [IMPLEMENTATION-STATUS.md](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) | Shipped vs spec, test counts, canvases |
+| [Docs index](.ai_infra/docs/README.md) | Full `.ai_infra/docs/` navigation |
+
+---
+
+## License
+
+By contributing, you agree that your contributions are licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,46 +1,77 @@
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/f9015ab5-28bf-47f7-a065-2127c098b80e" width="100%" controls>
-  </video>
+  <video src="https://github.com/user-attachments/assets/f9015ab5-28bf-47f7-a065-2127c098b80e" width="100%" controls></video>
 </p>
-
 
 # Agent Colony
 
-**Installable multi-agent workflow infrastructure for Cursor**, with a **GitHub Project** as the only writable SSOT for backlog, Status, and agent continuation when `project_ssot.enabled` and `sync_policy: board_only`. Local `.local/` holds PR gates, audits, and evidence — never a second Status writer.
+**Stop losing Status in chat.** Agent Colony installs a full multi-agent kit into *your* [Cursor](https://cursor.com) app repo — **8** agents, PR gates, and optional GitHub Project coordination so backlog and Status live on the board when you enable it.
 
 | | |
 |--|--|
-| **Product repo** | [agent-colony](https://github.com/SavinRazvan/agent-colony) |
-| **Version** | `0.6.1` · **Tests** · 1484 · **Agents** · 8 · **Rules** · **7 universal** |
-| **Board (kit-dev)** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) — reference layout for **Prioritized backlog** + **Status board** |
+| **Version** | [`0.6.1`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1484 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
+| **Reference board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 
 ---
 
-## Who is this for?
+## The problem
 
-| Audience | Start here |
-|----------|------------|
-| **Consumer** — install into *your* app repo | [§ Install in your project](#install-in-your-project-consumers) → [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md) |
-| **Kit maintainer / agent** — develop *this* repo | [§ Work in this repository](#work-in-this-repository-kit-dev) → **[AGENTS.md](AGENTS.md)** (read first) |
+Agent chats lose Status. Trackers and docs drift. Teams re-explain the same slice every session.
 
----
+## The solution
 
-## What you get
+**Agent Colony** installs a full Cursor kit into *your* app repo (not this kit repo). When Project SSOT is on, the **GitHub Project** is the only writable place for backlog and Status — agents **enter** by reading the board and **exit** by updating Status and Notes. Local `.local/` holds gates, audits, and evidence — not a second Status writer.
 
-- **8 agents:** `implementer`, `test-runner`, `verifier`, `auditor`, `researcher`, `integrator`, `drift-guard`, `board`
-- **14 canonical skills** + maintainer PR slash skills (`/review-pr` → `/prepare-pr` → `/merge-pr`)
-- **Board Pattern A CLI:** `python3 -m agent_colony project …` (claim, handoff, Tier-1 fields, outbox)
-- **PR gates** via `prepare.py` · optional MCP (`agent_colony_mcp`) · research corpus under `_research_results/` (opt-in)
-
-**North star:** Entry = read the Project; Exit = update Status + Notes. Details: [ADR-008](.ai_infra/docs/decisions/ADR-008-project-board-ssot.md) · [project-board-collaboration.md](.ai_infra/docs/operations/project-board-collaboration.md).
+**Proof:** 1484 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
 
 ---
 
-## Install in your project (consumers)
+## What this is / is not
 
-**Need:** [Cursor](https://cursor.com) · Python 3.11+ · **your app folder** open (not this kit repo).
+| | |
+|--|--|
+| **Is** | Installable Cursor workflow kit: 8 agents, PR gates, local evidence; optional GitHub Project coordination, MCP, and research packs |
+| **Is not** | A new LLM runtime, chatbot framework, or hosted SaaS |
 
-### 1. Add the plugin (Agent chat — not the terminal)
+---
+
+## Why teams use it
+
+- **Optional board SSOT** — when enabled, backlog and Status stay on the GitHub Project; chat is execution, not the source of truth
+- **Eight specialized agents** — implement, test, verify, audit, research, integrate, drift-check, board coach
+- **PR gates** — prepare/merge evidence before ship
+- **MCP-ready** — kit MCP server; DeepWiki seeded on consumer activate by default
+- **Local evidence** — `.local/` for audits, coverage, and workflow artifacts (gitignored)
+
+---
+
+## Agents
+
+| Agent | Job |
+|-------|-----|
+| `implementer` | Ship disciplined slices |
+| `test-runner` | Module tests and coverage evidence |
+| `verifier` | Falsify claims with fresh evidence |
+| `auditor` | Deep / periodic architecture audit |
+| `researcher` | Brief-driven research packs |
+| `integrator` | Add agents, skills, MCP, kit expansions |
+| `drift-guard` | Goal/plan/doctrine + DRIFT scripts |
+| `board` | Wire Project SSOT and coach the board shell |
+
+Slash skills cover activate, update, board protocols, PR lifecycle (`/review-pr` → `/prepare-pr` → `/merge-pr`), and more — see the [Plugin User Guide](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md).
+
+---
+
+## Requirements
+
+[Cursor](https://cursor.com) · Python 3.11+ · open **your app folder** (not this kit repo) · for board SSOT: [GitHub CLI](https://cli.github.com/) with Project access
+
+---
+
+## Install (consumers)
+
+### Try in ~2 minutes
+
+In **Agent chat** (not the terminal):
 
 ```text
 /add-plugin https://github.com/SavinRazvan/agent-colony
@@ -50,266 +81,55 @@ Click the **Agent Colony** card:
 
 ![Install Agent Colony from Agent chat](assets/agent-colony-install.png)
 
-*Marketplace listing is deferred; `/add-plugin` from GitHub is the supported path today.*
-
-### 2. Activate into your workspace
-
-Still in **your app** folder, Agent chat:
+Then in **your app** folder:
 
 ```text
 /workflow-activate
 ```
 
-Wait for **`VERIFY PASS`** and all three planes **ready**. Activate is idempotent (safe to re-run).
-
-This copies the **full consumer kit** from the plugin `payload/` (same surface kit maintainers ship): **8 agents**, **14 skills** (incl. `/update-agent-colony`), **7 rules**, maintainer PR slash skills, `agent_colony` CLI (project/PR/drift/MCP/canvas/plan/update), MCP server, ops docs, `.local/` scaffold, `.venv`, and runtime `.gitignore` (`.local/` + `.venv/`). You only personalize identity / board YAML in step 3 — you do **not** pick optional install profiles.
-
-| Plane | Paths | Purpose |
-|-------|-------|---------|
-| Cursor contract | `.cursor/`, `.agents/`, `AGENTS.md` | Agents, skills, rules |
-| Infrastructure | `.ai_infra/`, `agent_colony/` | CLI, scripts, docs, templates |
-| Runtime | `.local/`, `.venv` | Trackers, **user settings** (gitignored) |
-
-### 3. Your identity, then wire the board (Project SSOT)
-
-**Order matters:** set identity → validate → (optional) `gh` check → **`/board`** wires YAML → shell UI.
-
-#### 3a. Identity
-
-Edit **`.local/user_settings/github.collaboration.yaml`**:
-
-```yaml
-owner:
-  display_name: "Your Full Name"    # → Author: / Action-By:
-  github_user: "@yourhandle"        # → GitHub-User:
-```
-
-Set **`project_ssot.enabled: true`** when you want the GitHub Project as SSOT (you can leave board ids empty until step 3c).
+Wait for **`VERIFY PASS`**. Sanity check:
 
 ```bash
 source .venv/bin/activate
-python3 -m agent_colony contributors validate   # must PASS
 python3 -m agent_colony health
 ```
 
-#### 3b. GitHub CLI (Project SSOT only)
+### Full board experience (when Project SSOT is on)
 
-Agents call **`gh`** for board operations. Check scopes first — **skip refresh** if you already have Project access:
+Same Try steps, then finish this ladder (detail: [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) · [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md)):
 
-```bash
-gh auth status   # need: repo + project (read:project may appear too)
-```
-
-If Project scopes are missing:
+1. **Identity** — edit `.local/user_settings/github.collaboration.yaml` (`display_name`, `github_user`; enable `project_ssot`) → `python3 -m agent_colony contributors validate`
+2. **Wire board** — Agent chat `/board` with your **Project URL** and **repo URL** → confirm proposed ids → `python3 -m agent_colony project doctor` and `project status`
+3. **Board shell** — create the required views/columns in the GitHub UI (coach: `/board`) until:
 
 ```bash
-gh auth login -h github.com
-# or add scopes on an existing login:
-gh auth refresh -h github.com -s read:project,project
-```
-
-WSL / no browser: copy the one-time code → [github.com/login/device](https://github.com/login/device) → approve → return to terminal.
-
-#### 3c. Wire `project_ssot` (API slice) — use **`/board`**
-
-After **`contributors validate`** passes, paste **both URLs** in Agent chat (same message):
-
-```text
-/board
-
-Project: https://github.com/users/YOU/projects/N
-Repo:    https://github.com/YOU/your-app
-```
-
-The **`/board`** agent uses `gh project view` / `field-list` to propose **`project_ssot`** (board ids, Status/Priority/Size/Estimate/Start date field ids) and **`default_repo`**. **Confirm before save.**
-
-Day-to-day board protocol lives in the **`board-ssot`** skill; onboarding wiring + shell coach is always **`/board`**.
-
-Then verify the API slice:
-
-```bash
-source .venv/bin/activate
-python3 -m agent_colony project doctor
-python3 -m agent_colony project status
-```
-
-Expect:
-
-```text
-board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
-```
-
-**API slice done ≠ board ready.** Views and column visibility are **human UI only** (§4).
-
-**Expected on a brand-new Project:** `doctor: ok` but `board-bootstrap --check` **FAIL** until you finish §4 — do **not** start `/implementer` yet.
-
-Full checklist: [PLUGIN-USER-GUIDE § Consumer project_ssot onboarding](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#consumer-project_ssot-onboarding-checklist).
-
----
-
-### 4. Prepare the board shell (required when SSOT is on)
-
-> **After §3c.** Skip this and `/implementer` will fight a blank `View 1` board.
-
-**You are here** when `project doctor` is ok but `board-bootstrap --check` prints `FAIL — missing minimum view …` and/or column FAILs.
-
-Choose **one** shell path:
-
-| Path | Views required | When |
-|------|----------------|------|
-| **Minimal 2-view** (recommended for small teams) | **Prioritized backlog** + **Status board** only | Match [AI Project Playground #3](https://github.com/users/SavinRazvan/projects/3) |
-| **Playground default** | Six views (Roadmap, Bugs, In review, My items, …) | Kit default schema — no overlay |
-
-#### Minimal 2-view (matches Playground #3)
-
-**New installs:** activate auto-seeds `.local/user_settings/board-shell.schema.yaml` from the minimal exemplar (consumer repos only). **Existing installs:**
-
-```bash
-python3 -m agent_colony project board-shell init --minimal
-```
-
-Or copy manually:
-
-In GitHub UI, mirror [Playground #3](https://github.com/users/SavinRazvan/projects/3):
-
-| View | Layout |
-|------|--------|
-| **Prioritized backlog** | Table · show Priority, Size, Estimate, Start date |
-| **Status board** | Board · group by **Status** · same Tier-1 columns |
-
-Tab order does not matter — bootstrap matches by **view name**.
-
-#### Playground default (six views)
-
-See table in §4B below — use when you do **not** copy the minimal overlay.
-
-#### What runs where
-
-| Action | Where | Command / prompt |
-|--------|--------|------------------|
-| Check shell | Terminal | `python3 -m agent_colony project board-bootstrap --check` |
-| Create missing **fields** | Terminal (optional) | `… board-bootstrap --check --ensure-fields` |
-| Push Project **README** | Terminal (optional) | `… board-bootstrap --check --apply-readme` |
-| Create/rename **views** + **columns** | Browser + **`/board`** | CONSENT GATE + TURN PROTOCOL — **no view CLI** |
-| Day-to-day cards | After `--check` green | `/implementer` |
-
-#### A. Agent chat (copy/paste)
-
-```text
-/board
-
-Using minimal 2-view overlay (or: Playground six-view default).
-board-bootstrap --check still FAIL — coach CONSENT GATE then TURN PROTOCOL:
-one view per turn, wait for "done", re-run --check after each turn.
-Project: https://github.com/users/YOU/projects/N
-Repo: https://github.com/YOU/your-app
-```
-
-Skill: [board-shell](.cursor/skills/board-shell/SKILL.md) · [views-setup.md](.ai_infra/templates/project-board/views-setup.md)
-
-#### B. GitHub UI — Playground default (six views)
-
-| View | Layout (short) |
-|------|----------------|
-| **Status board** | Board · group by Status |
-| **Prioritized backlog** | Table · Tier-1 columns |
-| **Roadmap** | Roadmap |
-| **Bugs** | Table · filter title contains `[BUG]` |
-| **In review** | Table · Status = In review |
-| **My items** | Table · Assignees = `@me` |
-
-On **Status board** and **Prioritized backlog**, show: **Priority**, **Size**, **Estimate**, **Start date**.
-
-#### C. Prove the shell (repeat until exit 0)
-
-```bash
-source .venv/bin/activate
 python3 -m agent_colony project board-bootstrap --check
-python3 -m agent_colony project status
 ```
 
-Schema path should show `.local/user_settings/board-shell.schema.yaml` when using the minimal overlay.
+exits **0**. Wire-only is not enough.
 
-**Do not** start with `/auditor`. When bootstrap is green → **§5** `/implementer`.
+4. **Build** — `/implementer` (not day-0 `/auditor`)
+
+**Ready when:** `health` passes after activate; **and** (if board SSOT is on) `board-bootstrap --check` exits 0 before day-to-day agents.
 
 ---
 
-### 5. Start building
+## What happens next
 
-| Goal | In Agent chat |
-|------|----------------|
-| Implement a slice | `/implementer` |
-| Tests / coverage | `/test-runner` |
-| Verify a claim | `/verifier` |
-| PR lifecycle | `/review-pr` → `/prepare-pr` → `/merge-pr` |
-| Research a repo | `/researcher` + a GitHub URL |
-| Extend agents/skills/MCP | `/integrator` |
-| Architecture audit *(later)* | `/auditor` — not day-0 onboarding |
-
-**Every session Entry:** if `project_ssot.enabled` → `python3 -m agent_colony project status`; else → `.local/index-and-planning/current/session-pointer.md`.
-
-Shorter path: [consumer-quickstart.md](.ai_infra/docs/operations/consumer-quickstart.md).
-
-### Optional — Update the kit / plugin later
-
-Docs and agents in **your app** come from the plugin payload. Re-reading this README on GitHub does **not** refresh your app until you update the plugin + run the upgrade command.
-
-1. **Ship on the kit repo first** (maintainer): merge the change to `main` (PR workflow).
-2. **In your app**, Agent chat — refresh the plugin from GitHub:
-
-```text
-/add-plugin https://github.com/SavinRazvan/agent-colony
-```
-
-3. **Upgrade** (version-gated heal vs full kit-managed refresh — preferred):
-
-```text
-/update-agent-colony
-```
-
-Or terminal:
-
-```bash
-source .venv/bin/activate
-python3 -m agent_colony update --directory .
-```
-
-Plain `/workflow-activate` / `activate` only **heals** (dashboards, gitignore, STARTER, missing `.venv`) when planes are already ready — it does **not** overwrite agents/skills/scripts unless you use `update` (or advanced `activate --force`).
-
-4. Sanity check:
-
-```bash
-python3 -m agent_colony health
-python3 -m agent_colony project board-bootstrap --check   # still FAIL until you finish step 4 views in GitHub UI
-```
-
-Details: [upgrade-kit.md](.ai_infra/docs/operations/upgrade-kit.md) · skill [update-agent-colony](.cursor/skills/update-agent-colony/SKILL.md).
-
-**Board views are not fixed by a plugin update.** `board-bootstrap --check` FAIL on missing views only clears after you complete **step 4** (`/board` + human UI). Updating the plugin only refreshes docs/coaching text.
+| Topic | Go to |
+|-------|--------|
+| Identity / user settings | [PLUGIN-USER-GUIDE § Personalize](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#10-personalize-settings) |
+| Board wire + shell | [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) · [`board-shell`](.cursor/skills/board-shell/SKILL.md) |
+| MCP (DeepWiki, custom servers) | [connect-external-mcp.md](.ai_infra/docs/operations/connect-external-mcp.md) |
+| Research packs | [`research-corpus`](.cursor/skills/research-corpus/SKILL.md) · Guide [use-case matrix](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#6-use-case-matrix) |
+| Upgrade an existing install | `/update-agent-colony` · [upgrade-kit.md](.ai_infra/docs/operations/upgrade-kit.md) |
+| Three planes (architecture) | [workflow-architecture.md](.ai_infra/docs/architecture/workflow-architecture.md) |
 
 ---
 
-## Work in this repository (kit-dev)
+## Kit maintainers
 
-```bash
-gh repo clone SavinRazvan/agent-colony
-cd agent-colony
-python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev,mcp]"
-```
-
-1. Open the folder in Cursor.
-2. Read **[AGENTS.md](AGENTS.md)** first.
-3. Confirm collaboration YAML under `.local/user_settings/` (owner + `project_ssot`).
-4. Start:
-
-```bash
-python3 -m agent_colony project status
-python3 -m agent_colony project list --status ready
-# create / claim — see: python3 -m agent_colony project guide
-```
-
-Maintainer gates: `make gates` · `make drift-validate` · `make doc-validate` · shipped matrix: [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md). Kit canvases: **15** files under `canvases/` (**11** agent/roster hubs + 4 concept hubs — see IMPLEMENTATION-STATUS § Kit canvases). Canvas/plan local artifacts: [ADR-010](.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md) · [canvas-artifacts](.cursor/skills/canvas-artifacts/SKILL.md).
+Developing **this** repository? See **[CONTRIBUTING.md](CONTRIBUTING.md)** (clone, venv, gates), then **[AGENTS.md](AGENTS.md)** for agent doctrine.
 
 ---
 
@@ -317,12 +137,13 @@ Maintainer gates: `make gates` · `make drift-validate` · `make doc-validate` �
 
 | Doc | Audience |
 |-----|----------|
-| [AGENTS.md](AGENTS.md) | Kit-dev front door — identity, north star, execution roster |
-| [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md) | Consumers — install, activate, board onboarding |
-| [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) | 5-minute consumer path |
+| [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) | Consumers — 5-step install |
+| [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md) | Consumers — full manual |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Kit-dev setup |
+| [AGENTS.md](AGENTS.md) | Kit-dev agent doctrine |
 | [Docs index](.ai_infra/docs/README.md) | Full `.ai_infra/docs/` navigation |
 | [repository-map](.ai_infra/docs/handoff/repository-map.md) | Kit vs payload vs consumer install |
-| [assets/](assets/README.md) | Logo + install screenshot |
+| [assets/](assets/README.md) | Logo, video, install screenshot |
 
 ---
 

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -16,6 +16,8 @@ Notes:
 
 # Agent Colony · Plugin User Guide
 
+> **From the [kit README](https://github.com/SavinRazvan/agent-colony):** public landing lives on GitHub. Prefer the short path? [consumer-quickstart.md](consumer-quickstart.md). This guide is the full consumer manual.
+
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.
 
 ---
@@ -474,10 +476,14 @@ More: [consumer-quickstart.md](consumer-quickstart.md) § Troubleshooting.
 
 | Topic | Doc |
 |-------|-----|
+| 5-step cheat sheet | [consumer-quickstart.md](consumer-quickstart.md) |
 | All runbooks | [operations README](README.md) |
 | Three-plane architecture | [workflow-architecture.md](../architecture/workflow-architecture.md) |
+| Board day-to-day | skill `board-ssot` · shell coach `board-shell` |
+| MCP (DeepWiki, custom) | [connect-external-mcp.md](connect-external-mcp.md) |
+| Research packs | skill `research-corpus` |
 | Why plugin + payload | [ADR-001](../decisions/ADR-001-distribution-activation.md) |
 | Upgrade / semver | [upgrade-kit.md](upgrade-kit.md) |
 | Optional project metadata | [project-config.md](project-config.md) |
 
-**Kit maintainers** (not copied to your project): `PLUGIN-ARCHITECTURE.md` and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/agent-colony/tree/main/.ai_infra/docs/handoff).
+**Kit maintainers** (not copied to your project): [CONTRIBUTING.md](https://github.com/SavinRazvan/agent-colony/blob/main/CONTRIBUTING.md), `PLUGIN-ARCHITECTURE.md`, and `IMPLEMENTATION-STATUS.md` in the [GitHub kit repo](https://github.com/SavinRazvan/agent-colony/tree/main/.ai_infra/docs/handoff).

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -15,11 +15,13 @@ Notes:
 
 # Consumer quickstart
 
+> **From the [kit README](https://github.com/SavinRazvan/agent-colony#install-consumers):** this is the 5-step install path after `/add-plugin` + `/workflow-activate`. Full manual: [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md).
+
 Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No special git setup required.
 
 **Product promise:** Install the plugin → open **your app repo** → **`/workflow-activate`** installs the **full kit**. Customize identity in `github.collaboration.yaml`, then **`/board`** wires board ids from Project + repo URLs. **Ready for agents** requires `board-bootstrap --check` **exit 0** — either **two views** (minimal overlay, matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)) or **six Playground views** (kit default). Wire-only is not enough. Details: [PLUGIN-USER-GUIDE § Product promise](PLUGIN-USER-GUIDE.md#product-promise).
 
-> **Full manual:** [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) — plugin vs activate, complete file tree, use-case matrix, PR and audit chapters.
+> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · skill `research-corpus` · skill `board-shell`
 
 ---
 


### PR DESCRIPTION
## Summary
- Slim public README into a landing page (video, outcome pitch, optional board SSOT wording, two-speed install CTA)
- Add root `CONTRIBUTING.md` for kit-dev setup; route consumers to quickstart/PLUGIN-USER-GUIDE
- Align `plugin.json` + marketplace Description; polish consumer doc entry blurbs; keep counts factual (0.6.1 / 1484 / 8 / 14 / 7)

## Test plan
- [x] `make doc-validate` green
- [x] `check_debrand.py` green
- [x] Version lockstep SSOT at 0.6.1
- [ ] `prepare.py` gates on PR