### PR TITLE
docs: align agent blurbs and link abbreviations glossary

### DIFF
--- a/.ai_infra/docs/README.md
+++ b/.ai_infra/docs/README.md
@@ -7,8 +7,8 @@
 | You are | Read first |
 |---------|------------|
 | **Visitor / public** | Root [README.md](../../README.md) (landing) → [consumer-quickstart](operations/consumer-quickstart.md) |
-| **New consumer** | [consumer-quickstart](operations/consumer-quickstart.md) → [PLUGIN-USER-GUIDE](operations/PLUGIN-USER-GUIDE.md) |
-| **Kit maintainer** | [CONTRIBUTING.md](../../CONTRIBUTING.md) → [AGENTS.md](../../AGENTS.md) → [repository-map](handoff/repository-map.md) → [PLUGIN-ARCHITECTURE](handoff/PLUGIN-ARCHITECTURE.md) → [IMPLEMENTATION-STATUS](handoff/IMPLEMENTATION-STATUS.md) |
+| **New consumer** | [consumer-quickstart](operations/consumer-quickstart.md) → [PLUGIN-USER-GUIDE](operations/PLUGIN-USER-GUIDE.md) · glossary: [abbreviations-notepad](operations/abbreviations-notepad.md) |
+| **Kit maintainer** | [CONTRIBUTING.md](../../CONTRIBUTING.md) → [AGENTS.md](../../AGENTS.md) → [repository-map](handoff/repository-map.md) → [PLUGIN-ARCHITECTURE](handoff/PLUGIN-ARCHITECTURE.md) → [IMPLEMENTATION-STATUS](handoff/IMPLEMENTATION-STATUS.md) · glossary: [abbreviations-notepad](operations/abbreviations-notepad.md) |
 | **Governance / policy** | [governance/README](governance/README.md) |
 
 ## Folders
@@ -39,6 +39,7 @@
 | [workflow-architecture.md](architecture/workflow-architecture.md) | Three planes (C4-lite) — copied on activate |
 | [PLUGIN-USER-GUIDE.md](operations/PLUGIN-USER-GUIDE.md) | Plugin manual — copied on activate |
 | [consumer-quickstart.md](operations/consumer-quickstart.md) | Install + verify cheat sheet — copied on activate |
+| [abbreviations-notepad.md](operations/abbreviations-notepad.md) | Glossary (SSOT, DRIFT, Pattern A, agents) — copied on activate |
 
 ## UI templates
 

--- a/.ai_infra/docs/governance/drift-prevention.md
+++ b/.ai_infra/docs/governance/drift-prevention.md
@@ -58,7 +58,7 @@ Script-first checks for plan ↔ tracker ↔ session-pointer coherence, handoff 
 | Canonical doc facts (roster, counts) | `check_doc_facts.py` / INT-013 | Path/brand scans |
 | test-plan/index existence | `check_testing_artifacts.py` | File exists checks |
 | Plugin/payload SHA drift | `sync_plugin_bundle.py --check` | Bundle sync |
-| Slice claim verification | `verifier` | Subjective verification |
+| Slice claim verification | `verifier` | Evidence-based claim verification (Verified\|Partial\|Not verified) |
 | Architecture / security / perf scorecard (CHK-*) | `auditor` | Module deep-dive / EA phases |
 
 **Command:** `python -m agent_colony drift validate --directory .` or `make drift-validate`.

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -346,9 +346,9 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **First-run board shell** *(SSOT on)* | `/board` | paste Project+repo URLs → wire YAML → `project doctor` → `board-bootstrap --check` | [board-shell](../../.cursor/skills/board-shell/SKILL.md) · checklist §3b–4 |
 | **Implement a feature slice** | `/implementer` | — | [implementer-loop](../../.cursor/skills/implementer-loop/SKILL.md) |
 | **Run tests / coverage** | `/test-runner` | `pytest -q` | [workflow-complete.md](workflow-complete.md) §C |
-| **Verify a claim** | `/verifier` | — | Evidence-only checks |
+| **Verify a claim** | `/verifier` | — | Check done claims vs evidence (no code fixes) |
 | **Architecture audit** *(not day-0)* | `/auditor` | — (subagent only; no dedicated MCP tool) | [agent-workflow-procedures.md](agent-workflow-procedures.md) §1 — after board shell |
-| **Operational drift** (plan ↔ tracker) | `/drift-guard` (optional) | `python3 -m agent_colony drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
+| **Operational drift** (goal/plan/doctrine/docs + DRIFT; board-first when SSOT on) | `/drift-guard` (optional) | `python3 -m agent_colony drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
 | **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [integrator-protocol skill](../../.cursor/skills/integrator-protocol/SKILL.md) · [mas-infrastructure-integration.md](mas-infrastructure-integration.md) (ops filename kept) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
@@ -477,6 +477,7 @@ More: [consumer-quickstart.md](consumer-quickstart.md) § Troubleshooting.
 | Topic | Doc |
 |-------|-----|
 | 5-step cheat sheet | [consumer-quickstart.md](consumer-quickstart.md) |
+| Glossary / abbreviations | [abbreviations-notepad.md](abbreviations-notepad.md) |
 | All runbooks | [operations README](README.md) |
 | Three-plane architecture | [workflow-architecture.md](../architecture/workflow-architecture.md) |
 | Board day-to-day | skill `board-ssot` · shell coach `board-shell` |

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -3,19 +3,25 @@ File: abbreviations-notepad.md
 Path: .ai_infra/docs/operations/abbreviations-notepad.md
 Role: Glossary for Agent Colony workflow terminology.
 Used By:
- - README.md
+ - README.md (Documentation map)
+ - CONTRIBUTING.md
  - AGENTS.md
+ - .ai_infra/docs/README.md
+ - PLUGIN-USER-GUIDE.md
+ - consumer-quickstart.md
+ - operations/README.md
 Depends On:
  - .ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
  - .ai_infra/docs/decisions/README.md
 Notes:
  - Keep definitions short for newcomers.
  - Numbered catalogs (ADR-NNN, DRIFT-NNN, EA-NNN, INT-NNN, DOC-NNN) live in their index docs — list stems here only.
+ - Linked for both consumers (activate payload) and kit-dev onboarding.
 -->
 
 # Abbreviations Notepad
 
-Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
+Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **consumers** (after activate) and **kit-dev**.
 
 ## Agent Colony flow (plain language)
 
@@ -98,11 +104,11 @@ High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `i
 
 | Agent | Role |
 |-------|------|
-| board | Board triage, Status, Tier-1 fields; hand off to implementer |
+| board | Wire Project SSOT, triage, Tier-1; coach board shell; hand off to implementer |
 | implementer | Slice implementation |
 | integrator | Extend agents/skills/MCP into kit infrastructure |
 | test-runner | Module tests and coverage |
-| verifier | Evidence-based verification |
+| verifier | Check done claims vs evidence (no code fixes) |
 | auditor | Architecture audits (alignment / scorecard artifacts) |
 | drift-guard | Operational drift audit + board Exit for drift-pass cards |
 | researcher | Brief-driven research packs; CLI `research init\|fetch\|validate` |

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -21,7 +21,7 @@ Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No
 
 **Product promise:** Install the plugin → open **your app repo** → **`/workflow-activate`** installs the **full kit**. Customize identity in `github.collaboration.yaml`, then **`/board`** wires board ids from Project + repo URLs. **Ready for agents** requires `board-bootstrap --check` **exit 0** — either **two views** (minimal overlay, matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)) or **six Playground views** (kit default). Wire-only is not enough. Details: [PLUGIN-USER-GUIDE § Product promise](PLUGIN-USER-GUIDE.md#product-promise).
 
-> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · skill `research-corpus` · skill `board-shell`
+> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · [abbreviations](abbreviations-notepad.md) · skill `research-corpus` · skill `board-shell`
 
 ---
 

--- a/.cursor/agents/board.md
+++ b/.cursor/agents/board.md
@@ -1,7 +1,7 @@
 ---
 name: board
 model: auto
-description: board Agent Colony — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
+description: board Agent Colony — Wire Project SSOT, triage cards, and coach first-run board shell via project_ssot CLI.
 ---
 
 # Board

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 model: auto
-description: verifier Agent Colony — Claims vs evidence; minimal high-signal checks.
+description: verifier Agent Colony — Check “done” claims against fresh evidence (try to disprove; no code fixes).
 ---
 
 # Verifier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. Staged `/
 | Board shell first-run | `/board` + `.cursor/skills/board-shell/SKILL.md` + `board-shell.schema.yaml` |
 | Integrate infrastructure | `.cursor/agents/integrator.md` + `.cursor/skills/integrator-protocol/SKILL.md` — validate with `python3 -m agent_colony integrate validate` |
 | Tests / coverage | `.cursor/agents/test-runner.md` + `.cursor/skills/test-coverage/SKILL.md` |
-| Verify claims | `.cursor/agents/verifier.md` |
+| Verify claims (evidence-only; no code fixes) | `.cursor/agents/verifier.md` |
 | Continuous goal/plan/agent-doctrine coherence + DRIFT scripts | **`drift-guard`** — `.cursor/agents/drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — `python3 -m agent_colony drift validate` (incl. DRIFT-011, DRIFT-012) |
 | Deep / periodic architecture + CHK-* (security/perf/granularity/docs) | **`auditor`** — `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md` — not continuous plan pulse |
 | Audit orchestration | `.cursor/skills/audit-orchestration/SKILL.md` — parent runs verify-all + Task delegation (no dedicated agent) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ Do **not** run `agent_colony update --force` against this kit-dev tree — use `
 | Doc | Role |
 |-----|------|
 | [AGENTS.md](AGENTS.md) | Agent doctrine, continuation, commit trailers |
+| [abbreviations-notepad.md](.ai_infra/docs/operations/abbreviations-notepad.md) | Glossary for kit terms (SSOT, DRIFT, Pattern A, agents) |
 | [repository-map.md](.ai_infra/docs/handoff/repository-map.md) | SSOT vs generated vs consumer install |
 | [PLUGIN-ARCHITECTURE.md](.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md) | Plugin bundle, three planes |
 | [IMPLEMENTATION-STATUS.md](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) | Shipped vs spec, test counts, canvases |

--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ Agent chats lose Status. Trackers and docs drift. Teams re-explain the same slic
 
 | Agent | Job |
 |-------|-----|
-| `implementer` | Ship disciplined slices |
-| `test-runner` | Module tests and coverage evidence |
-| `verifier` | Falsify claims with fresh evidence |
-| `auditor` | Deep / periodic architecture audit |
-| `researcher` | Brief-driven research packs |
-| `integrator` | Add agents, skills, MCP, kit expansions |
-| `drift-guard` | Goal/plan/doctrine + DRIFT scripts |
-| `board` | Wire Project SSOT and coach the board shell |
+| `implementer` | Disciplined implementation slices with trackers and Pattern A gates |
+| `test-runner` | Module-focused tests, regressions, and coverage |
+| `verifier` | Check “done” claims against fresh evidence (try to disprove; no code fixes) |
+| `auditor` | Deep/periodic evidence architecture audit (CHK-*; not plan pulse) |
+| `researcher` | Brief-driven multi-round research packs; no product code |
+| `integrator` | Integrate agents, skills, MCP expansions (procedural, Pattern A) |
+| `drift-guard` | Continuous goal/plan/doctrine coherence + DRIFT scripts (handoff remediations only) |
+| `board` | Wire Project SSOT, triage cards, and coach first-run board shell |
+
+When `project_ssot.enabled`, agents **enter** by reading the board and **exit** by updating Status and Notes — see [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md).
 
 Slash skills cover activate, update, board protocols, PR lifecycle (`/review-pr` → `/prepare-pr` → `/merge-pr`), and more — see the [Plugin User Guide](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md).
 
@@ -139,6 +141,7 @@ Developing **this** repository? See **[CONTRIBUTING.md](CONTRIBUTING.md)** (clon
 |-----|----------|
 | [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) | Consumers — 5-step install |
 | [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md) | Consumers — full manual |
+| [Abbreviations notepad](.ai_infra/docs/operations/abbreviations-notepad.md) | Consumers + kit-dev — glossary (SSOT, DRIFT, Pattern A, agents) |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Kit-dev setup |
 | [AGENTS.md](AGENTS.md) | Kit-dev agent doctrine |
 | [Docs index](.ai_infra/docs/README.md) | Full `.ai_infra/docs/` navigation |

--- a/agents/board.md
+++ b/agents/board.md
@@ -1,7 +1,7 @@
 ---
 name: board
 model: auto
-description: board Agent Colony — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
+description: board Agent Colony — Wire Project SSOT, triage cards, and coach first-run board shell via project_ssot CLI.
 ---
 
 # Board

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 model: auto
-description: verifier Agent Colony — Claims vs evidence; minimal high-signal checks.
+description: verifier Agent Colony — Check “done” claims against fresh evidence (try to disprove; no code fixes).
 ---
 
 # Verifier

--- a/canvases/agent-auditor.canvas.tsx
+++ b/canvases/agent-auditor.canvas.tsx
@@ -232,8 +232,8 @@ export default function AgentAuditorCanvas() {
         </Row>
         <Text tone="secondary">
           auditor Agent Colony — Deep/periodic evidence architecture audit
-          (CHK-* security/perf/granularity/docs); continuous plan pulse is
-          drift-guard. Writes workflow artifacts for other agents.
+          (CHK-* security/perf/granularity/docs); not continuous plan pulse.
+          Writes workflow artifacts for other agents.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agent-board.canvas.tsx
+++ b/canvases/agent-board.canvas.tsx
@@ -209,8 +209,8 @@ export default function AgentBoardCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          board Agent Colony — Independent-governed helper — list/create/move
-          GitHub Project SSOT cards via project_ssot CLI.
+          board Agent Colony — Wire Project SSOT, triage cards, and coach
+          first-run board shell via project_ssot CLI.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agent-drift-guard.canvas.tsx
+++ b/canvases/agent-drift-guard.canvas.tsx
@@ -208,8 +208,7 @@ export default function AgentDriftGuardCanvas() {
         </Row>
         <Text tone="secondary">
           drift-guard Agent Colony — Continuous goal/plan/agent-doctrine/docs
-          coherence + DRIFT-001…012; remediations via Notes/Ready (not auditor
-          deep scorecard).
+          coherence plus operational DRIFT scripts; handoff remediations only.
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agent-relations.canvas.tsx
+++ b/canvases/agent-relations.canvas.tsx
@@ -41,7 +41,7 @@ type AgentId =
 const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   {
     id: "board",
-    role: "board Agent Colony · skill board-ssot (+ board-shell)",
+    role: "board Agent Colony · wire SSOT + coach board-shell · skill board-ssot",
     lane: "Coordination",
   },
   {
@@ -56,7 +56,7 @@ const AGENTS: { id: Exclude<AgentId, "all">; role: string; lane: string }[] = [
   },
   {
     id: "verifier",
-    role: "verifier Agent Colony · claims vs evidence (no primary skill folder)",
+    role: "verifier Agent Colony · check done claims vs evidence; no code fixes (no primary skill folder)",
     lane: "Delivery",
   },
   {
@@ -176,7 +176,7 @@ const RELATIONS: {
 
 const RESEARCHER_REDIRECTS: [string, string][] = [
   ["implementer", "Product code / commits"],
-  ["verifier", "Claims vs evidence"],
+  ["verifier", "Claims vs evidence (no code fixes)"],
   ["auditor", "Architecture audits"],
   ["drift-guard", "Drift / tracker coherence"],
   ["integrator", "Kit surface integration"],

--- a/canvases/agent-researcher.canvas.tsx
+++ b/canvases/agent-researcher.canvas.tsx
@@ -137,7 +137,7 @@ const ARTIFACTS = [
 
 const PEERS = [
   ["Use instead", "implementer", "Product code / commits"],
-  ["Use instead", "verifier", "Claims vs evidence"],
+  ["Use instead", "verifier", "Claims vs evidence (no code fixes)"],
   ["Use instead", "auditor", "Architecture audits"],
   ["Use instead", "drift-guard", "Drift / tracker coherence"],
   ["Use instead", "integrator", "Kit surface integration"],

--- a/canvases/agent-roster.canvas.tsx
+++ b/canvases/agent-roster.canvas.tsx
@@ -28,7 +28,8 @@ const AGENTS = [
   },
   {
     id: "verifier",
-    description: "verifier Agent Colony — Claims vs evidence; minimal high-signal checks.",
+    description:
+      "verifier Agent Colony — Check “done” claims against fresh evidence (try to disprove; no code fixes).",
   },
   {
     id: "test-runner",
@@ -47,7 +48,7 @@ const AGENTS = [
   {
     id: "board",
     description:
-      "board Agent Colony — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.",
+      "board Agent Colony — Wire Project SSOT, triage cards, and coach first-run board shell via project_ssot CLI.",
   },
   {
     id: "integrator",
@@ -181,7 +182,7 @@ const ROSTER_EDGES: RosterEdge[] = [
 
 const RESEARCHER_REDIRECTS = [
   ["implementer", "Product code / commits"],
-  ["verifier", "Claims vs evidence"],
+  ["verifier", "Claims vs evidence (no code fixes)"],
   ["auditor", "Architecture audits"],
   ["drift-guard", "Drift / tracker coherence"],
   ["integrator", "Kit surface integration"],

--- a/canvases/agent-verifier.canvas.tsx
+++ b/canvases/agent-verifier.canvas.tsx
@@ -27,7 +27,7 @@ const VERIFIED = "2026-08-06";
 const SOURCES = ".cursor/agents/verifier.md · board-ssot/SKILL.md § Continuation";
 
 const GOALS = [
-  "Claims vs evidence; minimal high-signal checks",
+  "Check “done” claims against fresh evidence (try to disprove; no code fixes)",
   "Restate claim, gather evidence, run smallest decisive checks",
   "Verdict: Verified | Partial | Not verified with one next action",
 ];
@@ -211,8 +211,9 @@ export default function AgentVerifierCanvas() {
           </Pill>
         </Row>
         <Text tone="secondary">
-          verifier Agent Colony — Claims vs evidence; minimal high-signal checks.
-          No primary skill folder (agent card is canon).
+          verifier Agent Colony — Check “done” claims against fresh evidence
+          (try to disprove; no code fixes). No primary skill folder (agent card is
+          canon).
         </Text>
         <Text tone="tertiary" size="small">
           Source: {SOURCES} · verified {VERIFIED} · facts only

--- a/canvases/agents-artifacts-board.canvas.tsx
+++ b/canvases/agents-artifacts-board.canvas.tsx
@@ -116,7 +116,7 @@ const WHO_WRITES: string[][] = [
     "verifier",
     "Done or In review + failure Notes",
     ".local/workflow-artifacts/pr/ (claims vs evidence Notes)",
-    "Claims vs evidence",
+    "Claims vs evidence (no code fixes)",
   ],
   [
     "auditor",

--- a/payload/.ai_infra/docs/governance/drift-prevention.md
+++ b/payload/.ai_infra/docs/governance/drift-prevention.md
@@ -58,7 +58,7 @@ Script-first checks for plan ↔ tracker ↔ session-pointer coherence, handoff 
 | Canonical doc facts (roster, counts) | `check_doc_facts.py` / INT-013 | Path/brand scans |
 | test-plan/index existence | `check_testing_artifacts.py` | File exists checks |
 | Plugin/payload SHA drift | `sync_plugin_bundle.py --check` | Bundle sync |
-| Slice claim verification | `verifier` | Subjective verification |
+| Slice claim verification | `verifier` | Evidence-based claim verification (Verified\|Partial\|Not verified) |
 | Architecture / security / perf scorecard (CHK-*) | `auditor` | Module deep-dive / EA phases |
 
 **Command:** `python -m agent_colony drift validate --directory .` or `make drift-validate`.

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -346,9 +346,9 @@ Details: [consumer-quickstart.md](consumer-quickstart.md) § Control Center dash
 | **First-run board shell** *(SSOT on)* | `/board` | paste Project+repo URLs → wire YAML → `project doctor` → `board-bootstrap --check` | [board-shell](../../.cursor/skills/board-shell/SKILL.md) · checklist §3b–4 |
 | **Implement a feature slice** | `/implementer` | — | [implementer-loop](../../.cursor/skills/implementer-loop/SKILL.md) |
 | **Run tests / coverage** | `/test-runner` | `pytest -q` | [workflow-complete.md](workflow-complete.md) §C |
-| **Verify a claim** | `/verifier` | — | Evidence-only checks |
+| **Verify a claim** | `/verifier` | — | Check done claims vs evidence (no code fixes) |
 | **Architecture audit** *(not day-0)* | `/auditor` | — (subagent only; no dedicated MCP tool) | [agent-workflow-procedures.md](agent-workflow-procedures.md) §1 — after board shell |
-| **Operational drift** (plan ↔ tracker) | `/drift-guard` (optional) | `python3 -m agent_colony drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
+| **Operational drift** (goal/plan/doctrine/docs + DRIFT; board-first when SSOT on) | `/drift-guard` (optional) | `python3 -m agent_colony drift validate --profile consumer` on app projects | [ADR-007](../decisions/ADR-007-workflow-drift-guard.md) · [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
 | **PR: review → prepare → merge** | `/review-pr` → `/prepare-pr` → `/merge-pr` | `prepare.py` `resolve_gates()` | [workflow-complete.md](workflow-complete.md) §A · [PR_WORKFLOW](../../.agents/skills/PR_WORKFLOW.md) |
 | **Add agents / skills / MCP** | `/integrator` + `/integrator-protocol` | `integrate validate` | [integrator-protocol skill](../../.cursor/skills/integrator-protocol/SKILL.md) · [mas-infrastructure-integration.md](mas-infrastructure-integration.md) (ops filename kept) |
 | **Connect external MCP** | `/mcp-connect` | edit `mcp.agents.yaml` | [connect-external-mcp.md](connect-external-mcp.md) |
@@ -477,6 +477,7 @@ More: [consumer-quickstart.md](consumer-quickstart.md) § Troubleshooting.
 | Topic | Doc |
 |-------|-----|
 | 5-step cheat sheet | [consumer-quickstart.md](consumer-quickstart.md) |
+| Glossary / abbreviations | [abbreviations-notepad.md](abbreviations-notepad.md) |
 | All runbooks | [operations README](README.md) |
 | Three-plane architecture | [workflow-architecture.md](../architecture/workflow-architecture.md) |
 | Board day-to-day | skill `board-ssot` · shell coach `board-shell` |

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -3,19 +3,25 @@ File: abbreviations-notepad.md
 Path: .ai_infra/docs/operations/abbreviations-notepad.md
 Role: Glossary for Agent Colony workflow terminology.
 Used By:
- - README.md
+ - README.md (Documentation map)
+ - CONTRIBUTING.md
  - AGENTS.md
+ - .ai_infra/docs/README.md
+ - PLUGIN-USER-GUIDE.md
+ - consumer-quickstart.md
+ - operations/README.md
 Depends On:
  - .ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md
  - .ai_infra/docs/decisions/README.md
 Notes:
  - Keep definitions short for newcomers.
  - Numbered catalogs (ADR-NNN, DRIFT-NNN, EA-NNN, INT-NNN, DOC-NNN) live in their index docs — list stems here only.
+ - Linked for both consumers (activate payload) and kit-dev onboarding.
 -->
 
 # Abbreviations Notepad
 
-Quick reference for reading `README.md`, `AGENTS.md`, and kit docs.
+Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **consumers** (after activate) and **kit-dev**.
 
 ## Agent Colony flow (plain language)
 
@@ -98,11 +104,11 @@ High-signal drift ids you will see often: **DRIFT-009** (no competing tracker `i
 
 | Agent | Role |
 |-------|------|
-| board | Board triage, Status, Tier-1 fields; hand off to implementer |
+| board | Wire Project SSOT, triage, Tier-1; coach board shell; hand off to implementer |
 | implementer | Slice implementation |
 | integrator | Extend agents/skills/MCP into kit infrastructure |
 | test-runner | Module tests and coverage |
-| verifier | Evidence-based verification |
+| verifier | Check done claims vs evidence (no code fixes) |
 | auditor | Architecture audits (alignment / scorecard artifacts) |
 | drift-guard | Operational drift audit + board Exit for drift-pass cards |
 | researcher | Brief-driven research packs; CLI `research init\|fetch\|validate` |

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -21,7 +21,7 @@ Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No
 
 **Product promise:** Install the plugin → open **your app repo** → **`/workflow-activate`** installs the **full kit**. Customize identity in `github.collaboration.yaml`, then **`/board`** wires board ids from Project + repo URLs. **Ready for agents** requires `board-bootstrap --check` **exit 0** — either **two views** (minimal overlay, matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)) or **six Playground views** (kit default). Wire-only is not enough. Details: [PLUGIN-USER-GUIDE § Product promise](PLUGIN-USER-GUIDE.md#product-promise).
 
-> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · skill `research-corpus` · skill `board-shell`
+> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · [abbreviations](abbreviations-notepad.md) · skill `research-corpus` · skill `board-shell`
 
 ---
 

--- a/payload/.cursor/agents/board.md
+++ b/payload/.cursor/agents/board.md
@@ -1,7 +1,7 @@
 ---
 name: board
 model: auto
-description: board Agent Colony — Independent-governed helper — list/create/move GitHub Project SSOT cards via project_ssot CLI.
+description: board Agent Colony — Wire Project SSOT, triage cards, and coach first-run board shell via project_ssot CLI.
 ---
 
 # Board

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 model: auto
-description: verifier Agent Colony — Claims vs evidence; minimal high-signal checks.
+description: verifier Agent Colony — Check “done” claims against fresh evidence (try to disprove; no code fixes).
 ---
 
 # Verifier


### PR DESCRIPTION
## Summary
- Align agent job blurbs (especially verifier and board) across README, agent cards, canvases, and payload mirrors so marketing matches doctrine.
- Link abbreviations-notepad for consumers and kit-dev (README, CONTRIBUTING, docs index, PLUGIN-USER-GUIDE, consumer-quickstart).
- Fix PLUGIN-USER-GUIDE drift-guard label and drift-prevention verifier wording.

## Test plan
- [ ] prepare.py gates green (pytest, drift, doc validate, check-plugin)
- [ ] Spot-check README Agents table vs `.cursor/agents/*.md` frontmatter
- [ ] Confirm abbreviations links resolve in README and PLUGIN-USER-GUIDE

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: implementer | auditor | drift-guard | verifier | review-pr | prepare-pr | merge-pr
- Board-Item: PVTI_lAHOBl46-84A9KZxzg11-sA