### PR TITLE
docs: clean Project board README (brief, no CLI dump)

### DIFF
--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -27,7 +27,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Status drifts from reality | Status column = truth (DRIFT-009 watches dual-write) |
 | Humans cannot see progress | Project UI is the shared dashboard |
 
-**Rule:** Entry = read board. Exit = update Status and **attributed Notes** for the card you touched. `validate-item` checks the card body, Tier-1 fields (including Assignee when present on the snapshot), and status-scoped Notes; it is not just a section-presence check. **Enforcement:** `handoff` and `set-status` to `in_review`|`done` call the same checks and return EXIT_VALIDATION (5) while Acceptance/Rollback are empty or `(TBD)` (including `- (TBD)` list form). Fill via `create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last`. Prefer Pattern A recipes: `project claim` / `project handoff` (one command each). Atomics (`append-notes --agent`, `set-section`) remain for power use. **Never** paste Project settings UI text into a shell — humans **follow** `.ai_infra/templates/project-board/views-setup.md` and paste **contents of** `project-readme.md` into Project README settings (or opt-in `board-bootstrap --check --apply-readme`).
+**Rule:** Entry = read board. Exit = update Status and **attributed Notes** for the card you touched. `validate-item` checks the card body, Tier-1 fields (including Assignee when present on the snapshot), and status-scoped Notes; it is not just a section-presence check. **Enforcement:** `handoff` and `set-status` to `in_review`|`done` call the same checks and return EXIT_VALIDATION (5) while Acceptance/Rollback are empty or `(TBD)` (including `- (TBD)` list form). Fill via `create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last`. Prefer Pattern A recipes: `project claim` / `project handoff` (one command each). Atomics (`append-notes --agent`, `set-section`) remain for power use. **Never** paste Project settings UI text into a shell — humans **follow** `.ai_infra/templates/project-board/views-setup.md` and paste **contents of** `project-readme.md` (board brief — not a CLI dump) into Project README settings (or opt-in `board-bootstrap --check --apply-readme`). Day-to-day CLI: `project guide`.
 
 ### Board shell starter (first-run)
 
@@ -195,4 +195,4 @@ Do **not** add this to default PR gates — it mutates the live board.
 
 ## Human-only
 
-Views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap. Paste README from `.ai_infra/templates/project-board/project-readme.md` in the GitHub UI only.
+Views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap. Paste the board brief from `.ai_infra/templates/project-board/project-readme.md` in the GitHub UI only (or `--apply-readme`). CLI recipes: `project guide` — not the Project README.

--- a/.ai_infra/install/agent_colony/project_cli.py
+++ b/.ai_infra/install/agent_colony/project_cli.py
@@ -769,9 +769,17 @@ def apply_board_shell_readme(
     body = path.read_text(encoding="utf-8")
     title = str(ssot.get("name") or "Board SSOT").strip()
     repo = str(ssot.get("default_repo") or "owner/repo").strip()
-    body = body.replace("Your Board Name (board SSOT)", f"{title} (board SSOT)")
+    heading = title if title.endswith("(board SSOT)") else f"{title} (board SSOT)"
+    body = body.replace("Your Board Name (board SSOT)", heading)
     body = body.replace("`owner/repo`", f"`{repo}`")
-    # Strip HTML comment guide lines at top for cleaner Project README (keep placeholders notes)
+    # Strip HTML comments for a cleaner Project README (UI paste / --apply-readme).
+    while "<!--" in body:
+        start = body.find("<!--")
+        end = body.find("-->", start)
+        if end < 0:
+            break
+        body = body[:start] + body[end + 3 :]
+    body = "\n".join(line for line in body.splitlines() if line.strip() or line == "").strip() + "\n"
     mutation = (
         "mutation($input:UpdateProjectV2Input!){"
         "updateProjectV2(input:$input){projectV2{id}}}"

--- a/.ai_infra/templates/project-board/README.md
+++ b/.ai_infra/templates/project-board/README.md
@@ -23,7 +23,7 @@ Notes:
 | `board-shell.schema.yaml` | Coach / CLI | Desired-state Playground parity; overlay `.local/user_settings/board-shell.schema.yaml` |
 | `outbox-entry.schema.json` | Agents / CLI | Validate lines in `.local/generated-data/board-outbox.jsonl` |
 | `outbox-entry.example.json` | Docs | Exemplar outbox line (never paste fake `item_id` as `--id`) |
-| `project-readme.md` | **Humans** (or `--apply-readme`) | Paste **contents** into Project settings → README (edit placeholders). Do **not** paste into a terminal. |
+| `project-readme.md` | **Humans** (or `--apply-readme`) | Board brief for Project settings → README (what/who/how). **Not** a CLI cheat sheet — use `project guide` for commands. Do **not** paste into a terminal. |
 | `views-setup.md` | **Humans** | **Follow** in GitHub UI (rename views / add columns). Do **not** paste this file into Project README. |
 | `views-checklist.md` | **Humans** | Checkbox checklist for the Playground default shell + Tier-1 columns. |
 
@@ -39,7 +39,7 @@ Card bodies always include `## Acceptance`, `## Rollback`, and `## Notes` so `va
 | bug fix | `create-from-template --template bug --priority p1` |
 | external / corpus research | `create-from-template --template research --priority p2` |
 | Project board bootstrap | `project doctor` → `/board` first-run (`board-shell`) → follow `views-setup.md` → paste `project-readme.md` → `project board-bootstrap --check` → `project status` |
-| Project README | **Humans** paste **contents of** `project-readme.md`, or opt-in `board-bootstrap --check --apply-readme` |
+| Project README | **Humans** paste **contents of** `project-readme.md` (board brief), or opt-in `board-bootstrap --check --apply-readme`. CLI: `project guide` |
 
 **Do not** paste Project settings labels (`Project name`, `Short description`, `README`, …) into bash — use `agent_colony project` recipes instead.
 

--- a/.ai_infra/templates/project-board/project-readme.md
+++ b/.ai_infra/templates/project-board/project-readme.md
@@ -1,53 +1,42 @@
 <!--
   Human paste pack — Project settings → README (GitHub UI only).
-  Edit placeholders below, then paste this file's contents into the Project README field.
-  Do not paste this into a shell. Agents never mutate Project README (ADR-008).
+  Board brief: what this Project is, who operates it, how Status moves.
+  CLI cheat sheets belong in `project guide` and project-board-collaboration.md — not here.
+  Do not paste this into a shell. Prefer `board-bootstrap --check --apply-readme` after edit.
 -->
 
 <!-- PROJECT_TITLE: Your Board Name (board SSOT) -->
 # Your Board Name (board SSOT)
 
-This GitHub Project is the **only writable SSOT** for backlog, Status, and multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only`.
+**Agent Colony** coordination board for <!-- DEFAULT_REPO: owner/repo --> `owner/repo`.
+
+When Project SSOT is on (`project_ssot.enabled` + `sync_policy: board_only`), this Project is the **only writable** place for backlog and Status. Chat executes work; it is not the Status source of truth. Local `.local/` holds evidence (gates, audits) — not a second Status writer.
+
+## Who operates this board
+
+| Who | Owns |
+|-----|------|
+| **Humans** | Views, workflows, Insights, this README, Ready ordering / roadmap, status updates in the UI |
+| **Agents** (Cursor + `agent_colony project`) | Claim cards, update Status + Notes, Tier-1 fields on cards they touch, handoffs |
+
+Agents never paste this README into a shell. Day-to-day commands live in the app repo: `python3 -m agent_colony project guide` and `.ai_infra/docs/operations/project-board-collaboration.md`.
+
+## How work moves
+
+- Status: **Ready → In progress → In review → Done**
+- Card body (Acceptance / Rollback / Notes) = continuation between agents — not chat alone
+- Notes: `@github_user/agent · UTC · text`
+- Agents set Priority / Size / Estimate (points), Assignee on Issue create, Start date on first In progress; open PRs via `mention-pr`. They do **not** set Iteration, Labels, Reviewers, or End date by default.
+
+## Links
 
 | | |
 |--|--|
-| **App / product repo** | <!-- DEFAULT_REPO: owner/repo --> `owner/repo` |
-| **Agents guide** | `AGENTS.md` in the app repo (after `/workflow-activate`) |
-| **Board ops** | `.ai_infra/docs/operations/project-board-collaboration.md` (kit install) |
-| **Views setup** | Follow `.ai_infra/templates/project-board/views-setup.md` (do not paste that file here) |
-
-## What this board is for
-
-- Shared backlog for humans and Cursor agents
-- Status path: **Ready → In progress → In review → Done**
-- Card body (Acceptance / Rollback / Notes) = continuation index — not chat alone
-- Notes attributed as `@github_user/agent · UTC timestamp · text`
-- **Tier-1 fields (agents):** Priority/Size/Estimate on create (Size↔Estimate **points** table in kit skill); **Assignee** = human owner on Issue create; **Start date** (UTC) on first In progress via `claim` / `set-status` / `handoff --to in_progress`; promote Draft→Issue; open PR → `mention-pr`. Agents do not set Iteration, Labels, Reviewers, or End date by default.
-
-## Agents (CLI — never paste this README into a shell)
-
-```bash
-python3 -m agent_colony project doctor
-python3 -m agent_colony project board-bootstrap --check
-python3 -m agent_colony project guide --agent implementer
-python3 -m agent_colony project outbox status
-python3 -m agent_colony project create-from-template --title "[SLICE] short-name" --template slice --status ready --priority p1 --size s --estimate 1 --agent implementer
-python3 -m agent_colony project claim --last --agent implementer   # + Start date (UTC) when configured
-python3 -m agent_colony project promote-to-issue --last --agent implementer   # Draft→Issue; same PVTI_; before PR if not using mention-pr auto
-python3 -m agent_colony project mention-pr --pr <n> --last --agent implementer   # auto-promotes Draft when promote_to_issue_on_pr (default true)
-python3 -m agent_colony project handoff --last --agent implementer --next verifier --to in_review
-```
-
-Use `--last` after create (saved under `.local/generated-data/project-last-item.json`). Do **not** invent or paste placeholder ids from docs.
-
-If writes return EXIT_QUEUED (6) / rate-limit: `project outbox flush` after GraphQL quota recovers — do not retry in a loop.
-
-## Humans only (this UI)
-
-- Views, workflows, Insights, **this README**, status updates, Ready prioritization / product roadmap
-- Standard shell first (`views-setup.md` minimum), then customize
-- Paste updates here in the Project settings UI — do not run Project settings text as shell commands
+| **App repo** | `owner/repo` |
+| **Agents guide** | `AGENTS.md` in the app (after `/workflow-activate`) |
+| **Board ops + CLI** | `.ai_infra/docs/operations/project-board-collaboration.md` |
+| **First-run views** | `.ai_infra/templates/project-board/views-setup.md` (follow in UI — do not paste here) |
 
 ## Default repo
 
-Set `project_ssot.default_repo` in `.local/user_settings/github.collaboration.yaml` to match <!-- DEFAULT_REPO --> above.
+`project_ssot.default_repo` in `.local/user_settings/github.collaboration.yaml` must match the app repo above.

--- a/.cursor/skills/board-shell/SKILL.md
+++ b/.cursor/skills/board-shell/SKILL.md
@@ -53,7 +53,7 @@ What short description should appear on this Project board?
 ```
 
 - If they give text → keep it for README placeholders / `--apply-readme` body merge.
-- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (title/repo filled from YAML).
+- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (board brief; title/repo filled from YAML).
 - If README already non-empty and they say keep it → record that; skip overwrite unless they ask.
 
 ### Q2 — Proceed to create / coach the default shell?

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -249,7 +249,7 @@ Ready → In progress → In review → Done
 
 **Never paste docs placeholders as `--id`.** After create, use `--last`. Print recipes: `project guide`.
 
-Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (not into a shell).
+Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (board brief only — not into a shell). CLI recipes stay in `project guide` and `project-board-collaboration.md`.
 
 ### Template routing
 
@@ -260,7 +260,7 @@ Human Project README: paste `.ai_infra/templates/project-board/project-readme.md
 | external / corpus research | researcher, board | `create-from-template --template research` |
 | audit pass | auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
 | consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
-| Project README | **Humans only** | paste `project-readme.md` in Project settings UI |
+| Project README | **Humans only** | paste `project-readme.md` (board brief) in Project settings UI — or `--apply-readme` |
 
 Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
 

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -27,7 +27,7 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 | Status drifts from reality | Status column = truth (DRIFT-009 watches dual-write) |
 | Humans cannot see progress | Project UI is the shared dashboard |
 
-**Rule:** Entry = read board. Exit = update Status and **attributed Notes** for the card you touched. `validate-item` checks the card body, Tier-1 fields (including Assignee when present on the snapshot), and status-scoped Notes; it is not just a section-presence check. **Enforcement:** `handoff` and `set-status` to `in_review`|`done` call the same checks and return EXIT_VALIDATION (5) while Acceptance/Rollback are empty or `(TBD)` (including `- (TBD)` list form). Fill via `create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last`. Prefer Pattern A recipes: `project claim` / `project handoff` (one command each). Atomics (`append-notes --agent`, `set-section`) remain for power use. **Never** paste Project settings UI text into a shell — humans **follow** `.ai_infra/templates/project-board/views-setup.md` and paste **contents of** `project-readme.md` into Project README settings (or opt-in `board-bootstrap --check --apply-readme`).
+**Rule:** Entry = read board. Exit = update Status and **attributed Notes** for the card you touched. `validate-item` checks the card body, Tier-1 fields (including Assignee when present on the snapshot), and status-scoped Notes; it is not just a section-presence check. **Enforcement:** `handoff` and `set-status` to `in_review`|`done` call the same checks and return EXIT_VALIDATION (5) while Acceptance/Rollback are empty or `(TBD)` (including `- (TBD)` list form). Fill via `create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last`. Prefer Pattern A recipes: `project claim` / `project handoff` (one command each). Atomics (`append-notes --agent`, `set-section`) remain for power use. **Never** paste Project settings UI text into a shell — humans **follow** `.ai_infra/templates/project-board/views-setup.md` and paste **contents of** `project-readme.md` (board brief — not a CLI dump) into Project README settings (or opt-in `board-bootstrap --check --apply-readme`). Day-to-day CLI: `project guide`.
 
 ### Board shell starter (first-run)
 
@@ -195,4 +195,4 @@ Do **not** add this to default PR gates — it mutates the live board.
 
 ## Human-only
 
-Views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap. Paste README from `.ai_infra/templates/project-board/project-readme.md` in the GitHub UI only.
+Views, workflows, Insights, Project README, status updates, Ready prioritization / product roadmap. Paste the board brief from `.ai_infra/templates/project-board/project-readme.md` in the GitHub UI only (or `--apply-readme`). CLI recipes: `project guide` — not the Project README.

--- a/payload/.ai_infra/install/agent_colony/project_cli.py
+++ b/payload/.ai_infra/install/agent_colony/project_cli.py
@@ -769,9 +769,17 @@ def apply_board_shell_readme(
     body = path.read_text(encoding="utf-8")
     title = str(ssot.get("name") or "Board SSOT").strip()
     repo = str(ssot.get("default_repo") or "owner/repo").strip()
-    body = body.replace("Your Board Name (board SSOT)", f"{title} (board SSOT)")
+    heading = title if title.endswith("(board SSOT)") else f"{title} (board SSOT)"
+    body = body.replace("Your Board Name (board SSOT)", heading)
     body = body.replace("`owner/repo`", f"`{repo}`")
-    # Strip HTML comment guide lines at top for cleaner Project README (keep placeholders notes)
+    # Strip HTML comments for a cleaner Project README (UI paste / --apply-readme).
+    while "<!--" in body:
+        start = body.find("<!--")
+        end = body.find("-->", start)
+        if end < 0:
+            break
+        body = body[:start] + body[end + 3 :]
+    body = "\n".join(line for line in body.splitlines() if line.strip() or line == "").strip() + "\n"
     mutation = (
         "mutation($input:UpdateProjectV2Input!){"
         "updateProjectV2(input:$input){projectV2{id}}}"

--- a/payload/.ai_infra/templates/project-board/README.md
+++ b/payload/.ai_infra/templates/project-board/README.md
@@ -23,7 +23,7 @@ Notes:
 | `board-shell.schema.yaml` | Coach / CLI | Desired-state Playground parity; overlay `.local/user_settings/board-shell.schema.yaml` |
 | `outbox-entry.schema.json` | Agents / CLI | Validate lines in `.local/generated-data/board-outbox.jsonl` |
 | `outbox-entry.example.json` | Docs | Exemplar outbox line (never paste fake `item_id` as `--id`) |
-| `project-readme.md` | **Humans** (or `--apply-readme`) | Paste **contents** into Project settings → README (edit placeholders). Do **not** paste into a terminal. |
+| `project-readme.md` | **Humans** (or `--apply-readme`) | Board brief for Project settings → README (what/who/how). **Not** a CLI cheat sheet — use `project guide` for commands. Do **not** paste into a terminal. |
 | `views-setup.md` | **Humans** | **Follow** in GitHub UI (rename views / add columns). Do **not** paste this file into Project README. |
 | `views-checklist.md` | **Humans** | Checkbox checklist for the Playground default shell + Tier-1 columns. |
 
@@ -39,7 +39,7 @@ Card bodies always include `## Acceptance`, `## Rollback`, and `## Notes` so `va
 | bug fix | `create-from-template --template bug --priority p1` |
 | external / corpus research | `create-from-template --template research --priority p2` |
 | Project board bootstrap | `project doctor` → `/board` first-run (`board-shell`) → follow `views-setup.md` → paste `project-readme.md` → `project board-bootstrap --check` → `project status` |
-| Project README | **Humans** paste **contents of** `project-readme.md`, or opt-in `board-bootstrap --check --apply-readme` |
+| Project README | **Humans** paste **contents of** `project-readme.md` (board brief), or opt-in `board-bootstrap --check --apply-readme`. CLI: `project guide` |
 
 **Do not** paste Project settings labels (`Project name`, `Short description`, `README`, …) into bash — use `agent_colony project` recipes instead.
 

--- a/payload/.ai_infra/templates/project-board/project-readme.md
+++ b/payload/.ai_infra/templates/project-board/project-readme.md
@@ -1,53 +1,42 @@
 <!--
   Human paste pack — Project settings → README (GitHub UI only).
-  Edit placeholders below, then paste this file's contents into the Project README field.
-  Do not paste this into a shell. Agents never mutate Project README (ADR-008).
+  Board brief: what this Project is, who operates it, how Status moves.
+  CLI cheat sheets belong in `project guide` and project-board-collaboration.md — not here.
+  Do not paste this into a shell. Prefer `board-bootstrap --check --apply-readme` after edit.
 -->
 
 <!-- PROJECT_TITLE: Your Board Name (board SSOT) -->
 # Your Board Name (board SSOT)
 
-This GitHub Project is the **only writable SSOT** for backlog, Status, and multi-agent continuation when `project_ssot.enabled` and `sync_policy: board_only`.
+**Agent Colony** coordination board for <!-- DEFAULT_REPO: owner/repo --> `owner/repo`.
+
+When Project SSOT is on (`project_ssot.enabled` + `sync_policy: board_only`), this Project is the **only writable** place for backlog and Status. Chat executes work; it is not the Status source of truth. Local `.local/` holds evidence (gates, audits) — not a second Status writer.
+
+## Who operates this board
+
+| Who | Owns |
+|-----|------|
+| **Humans** | Views, workflows, Insights, this README, Ready ordering / roadmap, status updates in the UI |
+| **Agents** (Cursor + `agent_colony project`) | Claim cards, update Status + Notes, Tier-1 fields on cards they touch, handoffs |
+
+Agents never paste this README into a shell. Day-to-day commands live in the app repo: `python3 -m agent_colony project guide` and `.ai_infra/docs/operations/project-board-collaboration.md`.
+
+## How work moves
+
+- Status: **Ready → In progress → In review → Done**
+- Card body (Acceptance / Rollback / Notes) = continuation between agents — not chat alone
+- Notes: `@github_user/agent · UTC · text`
+- Agents set Priority / Size / Estimate (points), Assignee on Issue create, Start date on first In progress; open PRs via `mention-pr`. They do **not** set Iteration, Labels, Reviewers, or End date by default.
+
+## Links
 
 | | |
 |--|--|
-| **App / product repo** | <!-- DEFAULT_REPO: owner/repo --> `owner/repo` |
-| **Agents guide** | `AGENTS.md` in the app repo (after `/workflow-activate`) |
-| **Board ops** | `.ai_infra/docs/operations/project-board-collaboration.md` (kit install) |
-| **Views setup** | Follow `.ai_infra/templates/project-board/views-setup.md` (do not paste that file here) |
-
-## What this board is for
-
-- Shared backlog for humans and Cursor agents
-- Status path: **Ready → In progress → In review → Done**
-- Card body (Acceptance / Rollback / Notes) = continuation index — not chat alone
-- Notes attributed as `@github_user/agent · UTC timestamp · text`
-- **Tier-1 fields (agents):** Priority/Size/Estimate on create (Size↔Estimate **points** table in kit skill); **Assignee** = human owner on Issue create; **Start date** (UTC) on first In progress via `claim` / `set-status` / `handoff --to in_progress`; promote Draft→Issue; open PR → `mention-pr`. Agents do not set Iteration, Labels, Reviewers, or End date by default.
-
-## Agents (CLI — never paste this README into a shell)
-
-```bash
-python3 -m agent_colony project doctor
-python3 -m agent_colony project board-bootstrap --check
-python3 -m agent_colony project guide --agent implementer
-python3 -m agent_colony project outbox status
-python3 -m agent_colony project create-from-template --title "[SLICE] short-name" --template slice --status ready --priority p1 --size s --estimate 1 --agent implementer
-python3 -m agent_colony project claim --last --agent implementer   # + Start date (UTC) when configured
-python3 -m agent_colony project promote-to-issue --last --agent implementer   # Draft→Issue; same PVTI_; before PR if not using mention-pr auto
-python3 -m agent_colony project mention-pr --pr <n> --last --agent implementer   # auto-promotes Draft when promote_to_issue_on_pr (default true)
-python3 -m agent_colony project handoff --last --agent implementer --next verifier --to in_review
-```
-
-Use `--last` after create (saved under `.local/generated-data/project-last-item.json`). Do **not** invent or paste placeholder ids from docs.
-
-If writes return EXIT_QUEUED (6) / rate-limit: `project outbox flush` after GraphQL quota recovers — do not retry in a loop.
-
-## Humans only (this UI)
-
-- Views, workflows, Insights, **this README**, status updates, Ready prioritization / product roadmap
-- Standard shell first (`views-setup.md` minimum), then customize
-- Paste updates here in the Project settings UI — do not run Project settings text as shell commands
+| **App repo** | `owner/repo` |
+| **Agents guide** | `AGENTS.md` in the app (after `/workflow-activate`) |
+| **Board ops + CLI** | `.ai_infra/docs/operations/project-board-collaboration.md` |
+| **First-run views** | `.ai_infra/templates/project-board/views-setup.md` (follow in UI — do not paste here) |
 
 ## Default repo
 
-Set `project_ssot.default_repo` in `.local/user_settings/github.collaboration.yaml` to match <!-- DEFAULT_REPO --> above.
+`project_ssot.default_repo` in `.local/user_settings/github.collaboration.yaml` must match the app repo above.

--- a/payload/.cursor/skills/board-shell/SKILL.md
+++ b/payload/.cursor/skills/board-shell/SKILL.md
@@ -53,7 +53,7 @@ What short description should appear on this Project board?
 ```
 
 - If they give text → keep it for README placeholders / `--apply-readme` body merge.
-- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (title/repo filled from YAML).
+- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (board brief; title/repo filled from YAML).
 - If README already non-empty and they say keep it → record that; skip overwrite unless they ask.
 
 ### Q2 — Proceed to create / coach the default shell?

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -249,7 +249,7 @@ Ready → In progress → In review → Done
 
 **Never paste docs placeholders as `--id`.** After create, use `--last`. Print recipes: `project guide`.
 
-Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (not into a shell).
+Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (board brief only — not into a shell). CLI recipes stay in `project guide` and `project-board-collaboration.md`.
 
 ### Template routing
 
@@ -260,7 +260,7 @@ Human Project README: paste `.ai_infra/templates/project-board/project-readme.md
 | external / corpus research | researcher, board | `create-from-template --template research` |
 | audit pass | auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
 | consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
-| Project README | **Humans only** | paste `project-readme.md` in Project settings UI |
+| Project README | **Humans only** | paste `project-readme.md` (board brief) in Project settings UI — or `--apply-readme` |
 
 Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
 

--- a/skills/board-shell/SKILL.md
+++ b/skills/board-shell/SKILL.md
@@ -53,7 +53,7 @@ What short description should appear on this Project board?
 ```
 
 - If they give text → keep it for README placeholders / `--apply-readme` body merge.
-- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (title/repo filled from YAML).
+- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (board brief; title/repo filled from YAML).
 - If README already non-empty and they say keep it → record that; skip overwrite unless they ask.
 
 ### Q2 — Proceed to create / coach the default shell?

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -249,7 +249,7 @@ Ready → In progress → In review → Done
 
 **Never paste docs placeholders as `--id`.** After create, use `--last`. Print recipes: `project guide`.
 
-Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (not into a shell).
+Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (board brief only — not into a shell). CLI recipes stay in `project guide` and `project-board-collaboration.md`.
 
 ### Template routing
 
@@ -260,7 +260,7 @@ Human Project README: paste `.ai_infra/templates/project-board/project-readme.md
 | external / corpus research | researcher, board | `create-from-template --template research` |
 | audit pass | auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
 | consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
-| Project README | **Humans only** | paste `project-readme.md` in Project settings UI |
+| Project README | **Humans only** | paste `project-readme.md` (board brief) in Project settings UI — or `--apply-readme` |
 
 Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
 


### PR DESCRIPTION
## Summary
- Rewrite `project-readme.md` as a short board brief (what Agent Colony’s board is, who operates it, how Status moves) — remove the CLI cheat sheet.
- Point day-to-day commands to `project guide` + project-board-collaboration.md.
- Fix `--apply-readme` title suffix doubling and strip HTML comments; pushed to live Project #3.

## Test plan
- [ ] prepare.py gates green
- [ ] Spot-check Project #3 README has no bash block
- [ ] `board-bootstrap --check` still passes

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: implementer | review-pr | prepare-pr | merge-pr