### PR TITLE
fix: ephemeral consumer VERIFY (no smoke file left)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1484
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1486
 
 ## Shipped (confirmed in repo)
 
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1484 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1486 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-07 (MCP package agent_colony_mcp; kit 0.6.1)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1486
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.1 · **Tests:** 1487
 
 ## Shipped (confirmed in repo)
 
@@ -55,7 +55,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.1 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1486 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1487 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -125,7 +125,7 @@ python3 -m agent_colony integrate validate
 python3 -m agent_colony gates
 ```
 
-Pass: `VERIFY PASS` on activate; `contributors validate: PASS` (after editing placeholders); `integrate validate` P0 = 0 (plugin parity skipped on consumer); `gates` green. Kit smoke alone: `pytest -q tests/modules/smoke/` → **1 passed**; full `gates` runs **your app tests + smoke** (e.g. 120 on Smart-Notes).
+Pass: `VERIFY PASS` on activate; `contributors validate: PASS` (after editing placeholders); `integrate validate` P0 = 0 (plugin parity skipped on consumer); `gates` green. Layout is checked in-process (no `tests/modules/smoke/` by default); full `gates` runs **your app tests** when present (e.g. 120 on Smart-Notes).
 
 **Drift on consumer apps:** auto profile may read `kit-dev` unless `work-tracker.md` contains `STARTER-001`. Use explicit consumer profile (no agent required):
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1486; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1487; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1486; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1487; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1484; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1486; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1484; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1486; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -235,7 +235,7 @@ your-project/
 │   └── agents-control-center/
 ├── agent_colony/               # python3 -m agent_colony shim
 ├── .venv/                         # created on activate
-└── tests/modules/smoke/           # install smoke test only
+└── (your app tests under tests/ — kit does not leave a smoke pytest by default)
 ```
 
 **Not installed:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs. Those exist only in the [kit repository](https://github.com/SavinRazvan/agent-colony).
@@ -279,7 +279,7 @@ source .venv/bin/activate
 | `python3 -m agent_colony integrate validate` | Integration checks |
 | `python3 -m agent_colony gates` | Full smoke gates |
 | `python3 -m agent_colony drift validate --profile consumer` | Consumer drift (no agent required) — see [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
-| `python3 -m pytest -q tests/modules/smoke/` | Install smoke |
+| `python3 -m agent_colony health` | Layout check (activate VERIFY; no kit smoke pytest by default) |
 
 Full list: [consumer-quickstart.md](consumer-quickstart.md) § Terminal commands cheat sheet.
 

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -322,13 +322,12 @@ source .venv/bin/activate          # recommended; gates auto-use `.venv/bin/pyth
 |---------|------|
 | `python3 -m agent_colony activate --directory .` | First install, re-activate, or refresh dashboards |
 | `python3 -m agent_colony contributors validate` | After editing `github.collaboration.yaml` — must PASS before PR |
-| `python3 -m agent_colony health` | Quick layout + `kit_version` check |
+| `python3 -m agent_colony health` | Quick layout + `kit_version` (no kit smoke pytest under `tests/` by default) |
 | `python3 -m agent_colony integrate validate` | Agent/skill/MCP integration sanity (P0 = 0) |
-| `python3 -m agent_colony gates` | Full smoke gates (4 checks on consumer) |
+| `python3 -m agent_colony gates` | Full smoke gates (pytest skipped when consumer has no tests/) |
 | `python3 -m agent_colony drift validate` | Plan ↔ tracker coherence |
 | `python3 -m agent_colony drift validate --profile consumer` | **Use on consumer apps** — no agent required; see [Drift on consumer apps](#drift-on-consumer-apps) |
 | `python3 -m agent_colony mcp validate` | MCP config after edits |
-| `python3 -m pytest -q tests/modules/smoke/` | Install smoke test |
 | `python3 -m http.server 8000` | Serve dashboards — open http://localhost:8000/.local/agents-control-center/dashboards/index.html |
 
 Commit trailer preview: `python3 -m agent_colony contributors commit-trailers`
@@ -528,7 +527,7 @@ your-project/
 ├── .ai_infra/     scripts + docs
 ├── .local/        trackers (gitignored)
 ├── agent_colony/
-└── tests/modules/smoke/
+└── (app tests optional — kit leaves no tests/modules/smoke/ by default)
 ```
 
 **CLI:** `source .venv/bin/activate && python3 -m agent_colony` from your project root.

--- a/.ai_infra/docs/operations/install-dry-run.md
+++ b/.ai_infra/docs/operations/install-dry-run.md
@@ -102,10 +102,11 @@ python3 -m venv .venv
 .venv/bin/pip install -r requirements-mcp.txt
 ```
 
-Copy kit tests only for kit-dev installs (`--with-tests`). Consumer default scaffolds `tests/modules/smoke/test_kit_installed.py`:
+Copy kit tests only for kit-dev installs (`--with-tests`). Consumer default does **not** write a smoke pytest file — layout is checked in-process at CHECK/VERIFY (`--keep-smoke-test` to opt in):
 
 ```bash
-# Default consumer install — no copy needed (scaffold writes smoke test)
+# Default consumer install — no tests/modules/smoke/ left in the app
+# Optional: --keep-smoke-test
 # Kit dev:
 cp -r "$SOURCE/tests" "$TARGET/"
 ```

--- a/.ai_infra/install-contract.json
+++ b/.ai_infra/install-contract.json
@@ -10,7 +10,6 @@
         ".ai_infra/paths.py",
         ".ai_infra/manifest.yaml",
         ".local/index-and-planning/current/session-pointer.md",
-        "tests/modules/smoke/test_kit_installed.py",
         "AGENTS.md",
         "agent_colony/__main__.py",
         ".ai_infra/install/agent_colony/cli.py"

--- a/.ai_infra/install/agent_colony/activate_cli.py
+++ b/.ai_infra/install/agent_colony/activate_cli.py
@@ -358,6 +358,8 @@ def cmd_activate(args: argparse.Namespace) -> int:
         cmd.append("--with-mcp-json")
     if args.verify:
         cmd.append("--verify")
+    if getattr(args, "keep_smoke_test", False):
+        cmd.append("--keep-smoke-test")
     proc = subprocess.run(cmd, cwd=kit_root())
     code = int(proc.returncode)
     if code != 0:
@@ -411,6 +413,11 @@ def register_activate_subparser(sub: argparse._SubParsersAction) -> None:
     activate.add_argument("--no-mcp-json", action="store_false", dest="with_mcp_json")
     activate.add_argument("--verify", action="store_true", default=True)
     activate.add_argument("--no-verify", action="store_false", dest="verify")
+    activate.add_argument(
+        "--keep-smoke-test",
+        action="store_true",
+        help="Opt-in: leave tests/modules/smoke/test_kit_installed.py (default: omit)",
+    )
     activate.add_argument(
         "--force",
         action="store_true",

--- a/.ai_infra/install/agent_colony/board_shell.py
+++ b/.ai_infra/install/agent_colony/board_shell.py
@@ -224,7 +224,7 @@ def consumer_overlay_path(root: Path) -> Path:
 
 
 def is_kit_dev_install(root: Path) -> bool:
-    """Kit product repo ships install test marker; consumer smoke layout does not."""
+    """Kit product repo ships install test marker; consumer installs do not."""
     return (
         Path(root).resolve() / "tests" / "modules" / "install" / "test_scaffold.py"
     ).is_file()

--- a/.ai_infra/install/agent_colony/cli.py
+++ b/.ai_infra/install/agent_colony/cli.py
@@ -102,6 +102,8 @@ def cmd_install(args: argparse.Namespace) -> int:
         cmd.append("--with-readme")
     if args.with_tests:
         cmd.append("--with-tests")
+    if getattr(args, "keep_smoke_test", False):
+        cmd.append("--keep-smoke-test")
     if args.with_venv:
         cmd.append("--with-venv")
     if args.with_mcp_json:
@@ -121,11 +123,22 @@ def cmd_gates(args: argparse.Namespace) -> int:
         arch = scripts_dir("architecture", root)
     steps = [
         [py, str(pr / "check_testing_artifacts.py")],
-        [py, "-m", "pytest", "-q"],
-        [py, str(arch / "check_governance_consistency.py")],
-        [py, str(arch / "check_debrand.py")],
-        [py, str(arch / "check_doc_facts.py")],
     ]
+    tests_dir = root / "tests"
+    has_tests = tests_dir.is_dir() and (
+        any(tests_dir.rglob("test_*.py")) or any(tests_dir.rglob("*_test.py"))
+    )
+    if has_tests:
+        steps.append([py, "-m", "pytest", "-q"])
+    else:
+        print("gates: SKIP pytest (no tests under tests/)")
+    steps.extend(
+        [
+            [py, str(arch / "check_governance_consistency.py")],
+            [py, str(arch / "check_debrand.py")],
+            [py, str(arch / "check_doc_facts.py")],
+        ]
+    )
     for cmd in steps:
         code = _run(cmd, root)
         if code != 0:
@@ -223,6 +236,11 @@ def build_parser() -> argparse.ArgumentParser:
     install.add_argument("--dry-run", action="store_true")
     install.add_argument("--with-readme", action="store_true")
     install.add_argument("--with-tests", action="store_true")
+    install.add_argument(
+        "--keep-smoke-test",
+        action="store_true",
+        help="Opt-in: write tests/modules/smoke/test_kit_installed.py",
+    )
     install.add_argument("--with-venv", action="store_true")
     install.add_argument("--with-mcp-json", action="store_true")
     install.add_argument("--verify", action="store_true")

--- a/.ai_infra/scripts/install/README.md
+++ b/.ai_infra/scripts/install/README.md
@@ -10,7 +10,7 @@ From the **agent-colony** product repo root:
 # Preview
 python .ai_infra/scripts/install/scaffold.py --target /path/to/new-project --dry-run
 
-# Consumer install (minimal smoke test scaffolded automatically)
+# Consumer install (layout verified in-process; no tests/ smoke file by default)
 python .ai_infra/scripts/install/scaffold.py \
   --target /path/to/new-project \
   --with-venv \
@@ -35,7 +35,8 @@ Copies `project.config.yaml.example` to the target (rename to `project.config.ya
 | `--source` | Kit root (default: auto-detect) |
 | `--dry-run` | Print copy plan only |
 | `--with-readme` | Copy kit `README.md` |
-| `--with-tests` | Copy full kit `tests/` (kit dev only; consumer default uses minimal smoke scaffold) |
+| `--with-tests` | Copy full kit `tests/` (kit dev only) |
+| `--keep-smoke-test` | Opt-in: write `tests/modules/smoke/test_kit_installed.py` (default: omit; layout checked in-process) |
 | `--with-venv` | Create `.venv`, install pytest + mcp |
 | `--with-mcp-json` | Merge `mcp.json.kit.example` (+ `mcp.user.json` if present) → `mcp.json` |
 | `--verify` | Run `check_testing_artifacts`, `pytest -q`, governance + debrand |

--- a/.ai_infra/scripts/install/plane_status.py
+++ b/.ai_infra/scripts/install/plane_status.py
@@ -75,13 +75,6 @@ def is_kit_dev_repo(root: Path) -> bool:
     return (root / "tests" / "modules" / "install" / "test_scaffold.py").is_file()
 
 
-CONSUMER_ONLY_PATHS = frozenset(
-    {
-        "tests/modules/smoke/test_kit_installed.py",
-    }
-)
-
-
 def assess_planes(
     root: Path, *, profile: str = "with_mcp", require_venv: bool = False
 ) -> PlaneStatus:
@@ -94,8 +87,6 @@ def assess_planes(
         ".local/index-and-planning/current/session-pointer.md",
         "AGENTS.md",
     ])
-    if is_kit_dev_repo(project_root):
-        required = [rel for rel in required if rel not in CONSUMER_ONLY_PATHS]
 
     missing: list[str] = []
     plane_hits = {"cursor": True, "infrastructure": True, "runtime": True}

--- a/.ai_infra/scripts/install/scaffold.py
+++ b/.ai_infra/scripts/install/scaffold.py
@@ -92,15 +92,17 @@ KIT_TESTS_MARKER = Path("tests") / "modules" / "install" / "test_scaffold.py"
 SMOKE_TEST_REL = Path("tests") / "modules" / "smoke" / "test_kit_installed.py"
 # Live MCP files stay local to kit-dev / consumer; only examples ship via copy.
 CURSOR_LIVE_MCP_IGNORE = ("mcp.user.json", "mcp.json", "mcp.registry.yaml")
+# Opt-in only (--keep-smoke-test). Default consumers get in-process layout VERIFY — no tests/ smoke file.
 SMOKE_TEST_BODY = '''"""
 File: test_kit_installed.py
 Path: tests/modules/smoke/test_kit_installed.py
-Role: Smoke test that core kit paths exist after consumer install.
+Role: Optional smoke test that core kit paths exist after consumer install.
 Used By:
- - pytest (consumer default scaffold)
+ - pytest when scaffold --keep-smoke-test (opt-in)
 Depends On:
- - scaffold minimal test layout
+ - scaffold optional smoke layout
 Notes:
+ - Default consumer install does not write this file; layout is checked in-process.
  - Replaced when install uses --with-tests (kit dev only).
 """
 from pathlib import Path
@@ -113,6 +115,15 @@ def test_core_layout_installed() -> None:
     assert Path(".local/index-and-planning/current/session-pointer.md").is_file()
     assert Path(".local/workflow-artifacts/drift").is_dir()
 '''
+
+# Same paths the optional smoke pytest asserts — checked in _sanity_check for all consumers.
+CONSUMER_LAYOUT_RELS: tuple[tuple[str, str], ...] = (
+    (".cursor/agents/implementer.md", "file"),
+    (".ai_infra/scripts/pr/prepare.py", "file"),
+    ("AGENTS.md", "file"),
+    (".local/index-and-planning/current/session-pointer.md", "file"),
+    (".local/workflow-artifacts/drift", "dir"),
+)
 
 
 def _log(messages: list[str], line: str) -> None:
@@ -486,14 +497,34 @@ def _scaffold_board_shell_overlay(source: Path, target: Path, dry_run: bool, log
     _copy_file_if_missing(minimal, dest, dry_run, log)
 
 
-def _scaffold_minimal_tests(target: Path, dry_run: bool, log: list[str]) -> None:
+def _scaffold_minimal_tests(
+    target: Path,
+    dry_run: bool,
+    log: list[str],
+    *,
+    keep_smoke_test: bool = False,
+) -> None:
+    """Default: do not leave kit smoke under tests/. Opt-in via keep_smoke_test."""
+    if not keep_smoke_test:
+        _log(
+            log,
+            "SKIP consumer smoke test file (layout verified in-process at CHECK/VERIFY)",
+        )
+        return
     smoke_file = target / SMOKE_TEST_REL
     if dry_run:
-        _log(log, f"DRY-RUN write minimal smoke {smoke_file}")
+        _log(log, f"DRY-RUN write optional smoke {smoke_file}")
         return
     smoke_file.parent.mkdir(parents=True, exist_ok=True)
     smoke_file.write_text(SMOKE_TEST_BODY, encoding="utf-8")
     _log(log, f"WRITE {smoke_file}")
+
+
+def _has_pytest_targets(target: Path) -> bool:
+    tests = target / "tests"
+    if not tests.is_dir():
+        return False
+    return any(tests.rglob("test_*.py")) or any(tests.rglob("*_test.py"))
 
 
 def _apply_overlay_rules(source: Path, target: Path, rel_overlay: str, dry_run: bool, log: list[str]) -> None:
@@ -532,23 +563,22 @@ def _sanity_check(target: Path, log: list[str], *, with_tests: bool = False) -> 
     errors: list[str] = []
     agents = target / ".cursor" / "agents"
     rules = target / ".cursor" / "rules"
-    if not (agents / "implementer.md").is_file():
-        errors.append("missing .cursor/agents/implementer.md")
+    for rel, kind in CONSUMER_LAYOUT_RELS:
+        path = target / rel
+        if kind == "dir":
+            if not path.is_dir():
+                errors.append(f"missing {rel}/")
+        elif not path.is_file():
+            errors.append(f"missing {rel}")
     if (rules / ADAPTER_WALL_RULE).is_file():
         errors.append(f"adapter wall must not be in core rules: {ADAPTER_WALL_RULE}")
     mapper = agents / "workflow-intelligence-mapper.md"
     if mapper.is_file():
         errors.append("workflow-intelligence-mapper should not ship in core")
-    session = target / ".local" / "index-and-planning" / "current" / "session-pointer.md"
-    if not session.is_file():
-        errors.append("missing session-pointer.md")
     if (target / "examples").exists():
         errors.append("forbidden in slim install: examples")
     if not with_tests and (target / KIT_TESTS_MARKER).is_file():
         errors.append("forbidden in slim install: full kit tests tree")
-    smoke = target / SMOKE_TEST_REL
-    if not with_tests and not smoke.is_file():
-        errors.append(f"missing consumer smoke test: {SMOKE_TEST_REL}")
     for err in errors:
         _log(log, f"CHECK FAIL: {err}")
     if not errors:
@@ -570,12 +600,20 @@ def _verify_retry_hint(target: Path) -> str:
 def _run_verify(target: Path, log: list[str]) -> int:
     py = Path(resolve_project_python(target))
     infra = target / ".ai_infra"
-    cmds = [
+    # Layout already asserted in _sanity_check (ephemeral consumer VERIFY — no smoke file required).
+    cmds: list[list[str]] = [
         [str(py), str(infra / "scripts" / "pr" / "check_testing_artifacts.py")],
-        [str(py), "-m", "pytest", "-q"],
-        [str(py), str(infra / "scripts" / "architecture" / "check_governance_consistency.py")],
-        [str(py), str(infra / "scripts" / "architecture" / "check_debrand.py")],
     ]
+    if _has_pytest_targets(target):
+        cmds.append([str(py), "-m", "pytest", "-q"])
+    else:
+        _log(log, "VERIFY SKIP pytest (no tests under tests/ — layout checked in-process)")
+    cmds.extend(
+        [
+            [str(py), str(infra / "scripts" / "architecture" / "check_governance_consistency.py")],
+            [str(py), str(infra / "scripts" / "architecture" / "check_debrand.py")],
+        ]
+    )
     for cmd in cmds:
         _log(log, f"RUN {' '.join(cmd)}")
         proc = subprocess.run(cmd, cwd=target, check=False)
@@ -619,6 +657,7 @@ def scaffold(
     with_venv: bool = False,
     with_mcp_json: bool = False,
     verify: bool = False,
+    keep_smoke_test: bool = False,
 ) -> list[str]:
     log: list[str] = []
     target = target.resolve()
@@ -678,7 +717,9 @@ def scaffold(
     if with_tests:
         _copy_tree(source / "tests", target / "tests", dry_run, log)
     else:
-        _scaffold_minimal_tests(target, dry_run, log)
+        _scaffold_minimal_tests(
+            target, dry_run, log, keep_smoke_test=keep_smoke_test
+        )
 
     if spec.get("scaffold_local"):
         _scaffold_local(source, target, dry_run, log)
@@ -748,6 +789,11 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Print actions only")
     parser.add_argument("--with-readme", action="store_true", help="Copy kit README.md")
     parser.add_argument("--with-tests", action="store_true", help="Copy tests/ (kit dev only)")
+    parser.add_argument(
+        "--keep-smoke-test",
+        action="store_true",
+        help="Opt-in: write tests/modules/smoke/test_kit_installed.py (default: omit)",
+    )
     parser.add_argument("--with-venv", action="store_true", help="Create .venv and install deps")
     parser.add_argument("--with-mcp-json", action="store_true", help="Use with_mcp profile + mcp.json")
     parser.add_argument("--verify", action="store_true", help="Run gates after install")
@@ -772,6 +818,7 @@ def main() -> int:
             with_venv=args.with_venv,
             with_mcp_json=args.with_mcp_json,
             verify=args.verify,
+            keep_smoke_test=args.keep_smoke_test,
         )
     except (FileNotFoundError, ValueError, RuntimeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/.ai_infra/scripts/install/smoke_marketplace.sh
+++ b/.ai_infra/scripts/install/smoke_marketplace.sh
@@ -66,7 +66,8 @@ for page in pages["pages"]:
 PY
 
 "$SMOKE/.venv/bin/python" -m agent_colony gates --directory "$SMOKE"
-"$SMOKE/.venv/bin/python" -m pytest -q "$SMOKE/tests/modules/smoke/"
+"$SMOKE/.venv/bin/python" -m agent_colony health --directory "$SMOKE"
+test ! -f "$SMOKE/tests/modules/smoke/test_kit_installed.py"
 
 echo
 echo "=== TRACK A: user_settings idempotency ==="

--- a/.ai_infra/scripts/pr/check_testing_artifacts.py
+++ b/.ai_infra/scripts/pr/check_testing_artifacts.py
@@ -42,6 +42,19 @@ def _check_test_index_structure(path: Path) -> tuple[bool, str]:
     return False, f"FAIL: expected markers not found (`Module:` and `Coverage status:`) -> {path}"
 
 
+def _check_tests_dir(path: Path) -> tuple[bool, str]:
+    """Require tests/modules on kit-dev; optional on consumer until product tests exist."""
+    if path.exists():
+        return True, f"PASS: exists -> {path}"
+    kit_dev_marker = Path("tests") / "modules" / "install" / "test_scaffold.py"
+    if kit_dev_marker.is_file():
+        return False, f"FAIL: missing -> {path}"
+    return True, (
+        f"PASS: optional on consumer — missing {path} "
+        "(add tests/modules/<name>/ when you ship product tests)"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Validate required testing artifacts for PR prepare.")
     parser.add_argument(
@@ -71,7 +84,7 @@ def main() -> int:
 
     checks = [
         _check_exists(control_center),
-        _check_exists(tests_dir),
+        _check_tests_dir(tests_dir),
         _check_nonempty(test_plan),
         _check_nonempty(test_index),
         _check_test_index_structure(test_index),

--- a/.ai_infra/templates/local-workspace/exemplars/test-index.md
+++ b/.ai_infra/templates/local-workspace/exemplars/test-index.md
@@ -24,9 +24,9 @@ Notes:
 ## Current index
 
 - Module: `_project_`
-  - Owned tests: `tests/modules/smoke/`
+  - Owned tests: `(none yet — add tests/modules/<name>/ as you ship product tests)`
   - Coverage status: `gap`
-  - Notes: rename module; add paths as you add product tests
+  - Notes: kit activate does not leave a smoke pytest; rename module when known
 
 ## Template row (copy per module)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | | |
 |--|--|
-| **Version** | [`0.6.1`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1486 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
+| **Version** | [`0.6.1`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1487 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
 | **Reference board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 
 ---
@@ -27,7 +27,7 @@ Agent chats lose Status. Trackers and docs drift. Teams re-explain the same slic
 
 **Agent Colony** installs a full Cursor kit into *your* app repo (not this kit repo). When Project SSOT is on, the **GitHub Project** is the only writable place for backlog and Status — agents **enter** by reading the board and **exit** by updating Status and Notes. Local `.local/` holds gates, audits, and evidence — not a second Status writer.
 
-**Proof:** 1486 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
+**Proof:** 1487 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | | |
 |--|--|
-| **Version** | [`0.6.1`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1484 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
+| **Version** | [`0.6.1`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1486 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
 | **Reference board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 
 ---
@@ -27,7 +27,7 @@ Agent chats lose Status. Trackers and docs drift. Teams re-explain the same slic
 
 **Agent Colony** installs a full Cursor kit into *your* app repo (not this kit repo). When Project SSOT is on, the **GitHub Project** is the only writable place for backlog and Status — agents **enter** by reading the board and **exit** by updating Status and Notes. Local `.local/` holds gates, audits, and evidence — not a second Status writer.
 
-**Proof:** 1484 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
+**Proof:** 1486 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
 
 ---
 

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -235,7 +235,7 @@ your-project/
 │   └── agents-control-center/
 ├── agent_colony/               # python3 -m agent_colony shim
 ├── .venv/                         # created on activate
-└── tests/modules/smoke/           # install smoke test only
+└── (your app tests under tests/ — kit does not leave a smoke pytest by default)
 ```
 
 **Not installed:** kit full `tests/`, `Makefile`, `docs/handoff/`, CI/release scripts, maintainer megadocs. Those exist only in the [kit repository](https://github.com/SavinRazvan/agent-colony).
@@ -279,7 +279,7 @@ source .venv/bin/activate
 | `python3 -m agent_colony integrate validate` | Integration checks |
 | `python3 -m agent_colony gates` | Full smoke gates |
 | `python3 -m agent_colony drift validate --profile consumer` | Consumer drift (no agent required) — see [consumer-quickstart](consumer-quickstart.md#drift-on-consumer-apps) |
-| `python3 -m pytest -q tests/modules/smoke/` | Install smoke |
+| `python3 -m agent_colony health` | Layout check (activate VERIFY; no kit smoke pytest by default) |
 
 Full list: [consumer-quickstart.md](consumer-quickstart.md) § Terminal commands cheat sheet.
 

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -322,13 +322,12 @@ source .venv/bin/activate          # recommended; gates auto-use `.venv/bin/pyth
 |---------|------|
 | `python3 -m agent_colony activate --directory .` | First install, re-activate, or refresh dashboards |
 | `python3 -m agent_colony contributors validate` | After editing `github.collaboration.yaml` — must PASS before PR |
-| `python3 -m agent_colony health` | Quick layout + `kit_version` check |
+| `python3 -m agent_colony health` | Quick layout + `kit_version` (no kit smoke pytest under `tests/` by default) |
 | `python3 -m agent_colony integrate validate` | Agent/skill/MCP integration sanity (P0 = 0) |
-| `python3 -m agent_colony gates` | Full smoke gates (4 checks on consumer) |
+| `python3 -m agent_colony gates` | Full smoke gates (pytest skipped when consumer has no tests/) |
 | `python3 -m agent_colony drift validate` | Plan ↔ tracker coherence |
 | `python3 -m agent_colony drift validate --profile consumer` | **Use on consumer apps** — no agent required; see [Drift on consumer apps](#drift-on-consumer-apps) |
 | `python3 -m agent_colony mcp validate` | MCP config after edits |
-| `python3 -m pytest -q tests/modules/smoke/` | Install smoke test |
 | `python3 -m http.server 8000` | Serve dashboards — open http://localhost:8000/.local/agents-control-center/dashboards/index.html |
 
 Commit trailer preview: `python3 -m agent_colony contributors commit-trailers`
@@ -528,7 +527,7 @@ your-project/
 ├── .ai_infra/     scripts + docs
 ├── .local/        trackers (gitignored)
 ├── agent_colony/
-└── tests/modules/smoke/
+└── (app tests optional — kit leaves no tests/modules/smoke/ by default)
 ```
 
 **CLI:** `source .venv/bin/activate && python3 -m agent_colony` from your project root.

--- a/payload/.ai_infra/docs/operations/install-dry-run.md
+++ b/payload/.ai_infra/docs/operations/install-dry-run.md
@@ -102,10 +102,11 @@ python3 -m venv .venv
 .venv/bin/pip install -r requirements-mcp.txt
 ```
 
-Copy kit tests only for kit-dev installs (`--with-tests`). Consumer default scaffolds `tests/modules/smoke/test_kit_installed.py`:
+Copy kit tests only for kit-dev installs (`--with-tests`). Consumer default does **not** write a smoke pytest file — layout is checked in-process at CHECK/VERIFY (`--keep-smoke-test` to opt in):
 
 ```bash
-# Default consumer install — no copy needed (scaffold writes smoke test)
+# Default consumer install — no tests/modules/smoke/ left in the app
+# Optional: --keep-smoke-test
 # Kit dev:
 cp -r "$SOURCE/tests" "$TARGET/"
 ```

--- a/payload/.ai_infra/install-contract.json
+++ b/payload/.ai_infra/install-contract.json
@@ -10,7 +10,6 @@
         ".ai_infra/paths.py",
         ".ai_infra/manifest.yaml",
         ".local/index-and-planning/current/session-pointer.md",
-        "tests/modules/smoke/test_kit_installed.py",
         "AGENTS.md",
         "agent_colony/__main__.py",
         ".ai_infra/install/agent_colony/cli.py"

--- a/payload/.ai_infra/install/agent_colony/activate_cli.py
+++ b/payload/.ai_infra/install/agent_colony/activate_cli.py
@@ -358,6 +358,8 @@ def cmd_activate(args: argparse.Namespace) -> int:
         cmd.append("--with-mcp-json")
     if args.verify:
         cmd.append("--verify")
+    if getattr(args, "keep_smoke_test", False):
+        cmd.append("--keep-smoke-test")
     proc = subprocess.run(cmd, cwd=kit_root())
     code = int(proc.returncode)
     if code != 0:
@@ -411,6 +413,11 @@ def register_activate_subparser(sub: argparse._SubParsersAction) -> None:
     activate.add_argument("--no-mcp-json", action="store_false", dest="with_mcp_json")
     activate.add_argument("--verify", action="store_true", default=True)
     activate.add_argument("--no-verify", action="store_false", dest="verify")
+    activate.add_argument(
+        "--keep-smoke-test",
+        action="store_true",
+        help="Opt-in: leave tests/modules/smoke/test_kit_installed.py (default: omit)",
+    )
     activate.add_argument(
         "--force",
         action="store_true",

--- a/payload/.ai_infra/install/agent_colony/board_shell.py
+++ b/payload/.ai_infra/install/agent_colony/board_shell.py
@@ -224,7 +224,7 @@ def consumer_overlay_path(root: Path) -> Path:
 
 
 def is_kit_dev_install(root: Path) -> bool:
-    """Kit product repo ships install test marker; consumer smoke layout does not."""
+    """Kit product repo ships install test marker; consumer installs do not."""
     return (
         Path(root).resolve() / "tests" / "modules" / "install" / "test_scaffold.py"
     ).is_file()

--- a/payload/.ai_infra/install/agent_colony/cli.py
+++ b/payload/.ai_infra/install/agent_colony/cli.py
@@ -102,6 +102,8 @@ def cmd_install(args: argparse.Namespace) -> int:
         cmd.append("--with-readme")
     if args.with_tests:
         cmd.append("--with-tests")
+    if getattr(args, "keep_smoke_test", False):
+        cmd.append("--keep-smoke-test")
     if args.with_venv:
         cmd.append("--with-venv")
     if args.with_mcp_json:
@@ -121,11 +123,22 @@ def cmd_gates(args: argparse.Namespace) -> int:
         arch = scripts_dir("architecture", root)
     steps = [
         [py, str(pr / "check_testing_artifacts.py")],
-        [py, "-m", "pytest", "-q"],
-        [py, str(arch / "check_governance_consistency.py")],
-        [py, str(arch / "check_debrand.py")],
-        [py, str(arch / "check_doc_facts.py")],
     ]
+    tests_dir = root / "tests"
+    has_tests = tests_dir.is_dir() and (
+        any(tests_dir.rglob("test_*.py")) or any(tests_dir.rglob("*_test.py"))
+    )
+    if has_tests:
+        steps.append([py, "-m", "pytest", "-q"])
+    else:
+        print("gates: SKIP pytest (no tests under tests/)")
+    steps.extend(
+        [
+            [py, str(arch / "check_governance_consistency.py")],
+            [py, str(arch / "check_debrand.py")],
+            [py, str(arch / "check_doc_facts.py")],
+        ]
+    )
     for cmd in steps:
         code = _run(cmd, root)
         if code != 0:
@@ -223,6 +236,11 @@ def build_parser() -> argparse.ArgumentParser:
     install.add_argument("--dry-run", action="store_true")
     install.add_argument("--with-readme", action="store_true")
     install.add_argument("--with-tests", action="store_true")
+    install.add_argument(
+        "--keep-smoke-test",
+        action="store_true",
+        help="Opt-in: write tests/modules/smoke/test_kit_installed.py",
+    )
     install.add_argument("--with-venv", action="store_true")
     install.add_argument("--with-mcp-json", action="store_true")
     install.add_argument("--verify", action="store_true")

--- a/payload/.ai_infra/scripts/install/README.md
+++ b/payload/.ai_infra/scripts/install/README.md
@@ -10,7 +10,7 @@ From the **agent-colony** product repo root:
 # Preview
 python .ai_infra/scripts/install/scaffold.py --target /path/to/new-project --dry-run
 
-# Consumer install (minimal smoke test scaffolded automatically)
+# Consumer install (layout verified in-process; no tests/ smoke file by default)
 python .ai_infra/scripts/install/scaffold.py \
   --target /path/to/new-project \
   --with-venv \
@@ -35,7 +35,8 @@ Copies `project.config.yaml.example` to the target (rename to `project.config.ya
 | `--source` | Kit root (default: auto-detect) |
 | `--dry-run` | Print copy plan only |
 | `--with-readme` | Copy kit `README.md` |
-| `--with-tests` | Copy full kit `tests/` (kit dev only; consumer default uses minimal smoke scaffold) |
+| `--with-tests` | Copy full kit `tests/` (kit dev only) |
+| `--keep-smoke-test` | Opt-in: write `tests/modules/smoke/test_kit_installed.py` (default: omit; layout checked in-process) |
 | `--with-venv` | Create `.venv`, install pytest + mcp |
 | `--with-mcp-json` | Merge `mcp.json.kit.example` (+ `mcp.user.json` if present) → `mcp.json` |
 | `--verify` | Run `check_testing_artifacts`, `pytest -q`, governance + debrand |

--- a/payload/.ai_infra/scripts/install/plane_status.py
+++ b/payload/.ai_infra/scripts/install/plane_status.py
@@ -75,13 +75,6 @@ def is_kit_dev_repo(root: Path) -> bool:
     return (root / "tests" / "modules" / "install" / "test_scaffold.py").is_file()
 
 
-CONSUMER_ONLY_PATHS = frozenset(
-    {
-        "tests/modules/smoke/test_kit_installed.py",
-    }
-)
-
-
 def assess_planes(
     root: Path, *, profile: str = "with_mcp", require_venv: bool = False
 ) -> PlaneStatus:
@@ -94,8 +87,6 @@ def assess_planes(
         ".local/index-and-planning/current/session-pointer.md",
         "AGENTS.md",
     ])
-    if is_kit_dev_repo(project_root):
-        required = [rel for rel in required if rel not in CONSUMER_ONLY_PATHS]
 
     missing: list[str] = []
     plane_hits = {"cursor": True, "infrastructure": True, "runtime": True}

--- a/payload/.ai_infra/scripts/install/scaffold.py
+++ b/payload/.ai_infra/scripts/install/scaffold.py
@@ -92,15 +92,17 @@ KIT_TESTS_MARKER = Path("tests") / "modules" / "install" / "test_scaffold.py"
 SMOKE_TEST_REL = Path("tests") / "modules" / "smoke" / "test_kit_installed.py"
 # Live MCP files stay local to kit-dev / consumer; only examples ship via copy.
 CURSOR_LIVE_MCP_IGNORE = ("mcp.user.json", "mcp.json", "mcp.registry.yaml")
+# Opt-in only (--keep-smoke-test). Default consumers get in-process layout VERIFY — no tests/ smoke file.
 SMOKE_TEST_BODY = '''"""
 File: test_kit_installed.py
 Path: tests/modules/smoke/test_kit_installed.py
-Role: Smoke test that core kit paths exist after consumer install.
+Role: Optional smoke test that core kit paths exist after consumer install.
 Used By:
- - pytest (consumer default scaffold)
+ - pytest when scaffold --keep-smoke-test (opt-in)
 Depends On:
- - scaffold minimal test layout
+ - scaffold optional smoke layout
 Notes:
+ - Default consumer install does not write this file; layout is checked in-process.
  - Replaced when install uses --with-tests (kit dev only).
 """
 from pathlib import Path
@@ -113,6 +115,15 @@ def test_core_layout_installed() -> None:
     assert Path(".local/index-and-planning/current/session-pointer.md").is_file()
     assert Path(".local/workflow-artifacts/drift").is_dir()
 '''
+
+# Same paths the optional smoke pytest asserts — checked in _sanity_check for all consumers.
+CONSUMER_LAYOUT_RELS: tuple[tuple[str, str], ...] = (
+    (".cursor/agents/implementer.md", "file"),
+    (".ai_infra/scripts/pr/prepare.py", "file"),
+    ("AGENTS.md", "file"),
+    (".local/index-and-planning/current/session-pointer.md", "file"),
+    (".local/workflow-artifacts/drift", "dir"),
+)
 
 
 def _log(messages: list[str], line: str) -> None:
@@ -486,14 +497,34 @@ def _scaffold_board_shell_overlay(source: Path, target: Path, dry_run: bool, log
     _copy_file_if_missing(minimal, dest, dry_run, log)
 
 
-def _scaffold_minimal_tests(target: Path, dry_run: bool, log: list[str]) -> None:
+def _scaffold_minimal_tests(
+    target: Path,
+    dry_run: bool,
+    log: list[str],
+    *,
+    keep_smoke_test: bool = False,
+) -> None:
+    """Default: do not leave kit smoke under tests/. Opt-in via keep_smoke_test."""
+    if not keep_smoke_test:
+        _log(
+            log,
+            "SKIP consumer smoke test file (layout verified in-process at CHECK/VERIFY)",
+        )
+        return
     smoke_file = target / SMOKE_TEST_REL
     if dry_run:
-        _log(log, f"DRY-RUN write minimal smoke {smoke_file}")
+        _log(log, f"DRY-RUN write optional smoke {smoke_file}")
         return
     smoke_file.parent.mkdir(parents=True, exist_ok=True)
     smoke_file.write_text(SMOKE_TEST_BODY, encoding="utf-8")
     _log(log, f"WRITE {smoke_file}")
+
+
+def _has_pytest_targets(target: Path) -> bool:
+    tests = target / "tests"
+    if not tests.is_dir():
+        return False
+    return any(tests.rglob("test_*.py")) or any(tests.rglob("*_test.py"))
 
 
 def _apply_overlay_rules(source: Path, target: Path, rel_overlay: str, dry_run: bool, log: list[str]) -> None:
@@ -532,23 +563,22 @@ def _sanity_check(target: Path, log: list[str], *, with_tests: bool = False) -> 
     errors: list[str] = []
     agents = target / ".cursor" / "agents"
     rules = target / ".cursor" / "rules"
-    if not (agents / "implementer.md").is_file():
-        errors.append("missing .cursor/agents/implementer.md")
+    for rel, kind in CONSUMER_LAYOUT_RELS:
+        path = target / rel
+        if kind == "dir":
+            if not path.is_dir():
+                errors.append(f"missing {rel}/")
+        elif not path.is_file():
+            errors.append(f"missing {rel}")
     if (rules / ADAPTER_WALL_RULE).is_file():
         errors.append(f"adapter wall must not be in core rules: {ADAPTER_WALL_RULE}")
     mapper = agents / "workflow-intelligence-mapper.md"
     if mapper.is_file():
         errors.append("workflow-intelligence-mapper should not ship in core")
-    session = target / ".local" / "index-and-planning" / "current" / "session-pointer.md"
-    if not session.is_file():
-        errors.append("missing session-pointer.md")
     if (target / "examples").exists():
         errors.append("forbidden in slim install: examples")
     if not with_tests and (target / KIT_TESTS_MARKER).is_file():
         errors.append("forbidden in slim install: full kit tests tree")
-    smoke = target / SMOKE_TEST_REL
-    if not with_tests and not smoke.is_file():
-        errors.append(f"missing consumer smoke test: {SMOKE_TEST_REL}")
     for err in errors:
         _log(log, f"CHECK FAIL: {err}")
     if not errors:
@@ -570,12 +600,20 @@ def _verify_retry_hint(target: Path) -> str:
 def _run_verify(target: Path, log: list[str]) -> int:
     py = Path(resolve_project_python(target))
     infra = target / ".ai_infra"
-    cmds = [
+    # Layout already asserted in _sanity_check (ephemeral consumer VERIFY — no smoke file required).
+    cmds: list[list[str]] = [
         [str(py), str(infra / "scripts" / "pr" / "check_testing_artifacts.py")],
-        [str(py), "-m", "pytest", "-q"],
-        [str(py), str(infra / "scripts" / "architecture" / "check_governance_consistency.py")],
-        [str(py), str(infra / "scripts" / "architecture" / "check_debrand.py")],
     ]
+    if _has_pytest_targets(target):
+        cmds.append([str(py), "-m", "pytest", "-q"])
+    else:
+        _log(log, "VERIFY SKIP pytest (no tests under tests/ — layout checked in-process)")
+    cmds.extend(
+        [
+            [str(py), str(infra / "scripts" / "architecture" / "check_governance_consistency.py")],
+            [str(py), str(infra / "scripts" / "architecture" / "check_debrand.py")],
+        ]
+    )
     for cmd in cmds:
         _log(log, f"RUN {' '.join(cmd)}")
         proc = subprocess.run(cmd, cwd=target, check=False)
@@ -619,6 +657,7 @@ def scaffold(
     with_venv: bool = False,
     with_mcp_json: bool = False,
     verify: bool = False,
+    keep_smoke_test: bool = False,
 ) -> list[str]:
     log: list[str] = []
     target = target.resolve()
@@ -678,7 +717,9 @@ def scaffold(
     if with_tests:
         _copy_tree(source / "tests", target / "tests", dry_run, log)
     else:
-        _scaffold_minimal_tests(target, dry_run, log)
+        _scaffold_minimal_tests(
+            target, dry_run, log, keep_smoke_test=keep_smoke_test
+        )
 
     if spec.get("scaffold_local"):
         _scaffold_local(source, target, dry_run, log)
@@ -748,6 +789,11 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Print actions only")
     parser.add_argument("--with-readme", action="store_true", help="Copy kit README.md")
     parser.add_argument("--with-tests", action="store_true", help="Copy tests/ (kit dev only)")
+    parser.add_argument(
+        "--keep-smoke-test",
+        action="store_true",
+        help="Opt-in: write tests/modules/smoke/test_kit_installed.py (default: omit)",
+    )
     parser.add_argument("--with-venv", action="store_true", help="Create .venv and install deps")
     parser.add_argument("--with-mcp-json", action="store_true", help="Use with_mcp profile + mcp.json")
     parser.add_argument("--verify", action="store_true", help="Run gates after install")
@@ -772,6 +818,7 @@ def main() -> int:
             with_venv=args.with_venv,
             with_mcp_json=args.with_mcp_json,
             verify=args.verify,
+            keep_smoke_test=args.keep_smoke_test,
         )
     except (FileNotFoundError, ValueError, RuntimeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/payload/.ai_infra/scripts/install/smoke_marketplace.sh
+++ b/payload/.ai_infra/scripts/install/smoke_marketplace.sh
@@ -66,7 +66,8 @@ for page in pages["pages"]:
 PY
 
 "$SMOKE/.venv/bin/python" -m agent_colony gates --directory "$SMOKE"
-"$SMOKE/.venv/bin/python" -m pytest -q "$SMOKE/tests/modules/smoke/"
+"$SMOKE/.venv/bin/python" -m agent_colony health --directory "$SMOKE"
+test ! -f "$SMOKE/tests/modules/smoke/test_kit_installed.py"
 
 echo
 echo "=== TRACK A: user_settings idempotency ==="

--- a/payload/.ai_infra/scripts/pr/check_testing_artifacts.py
+++ b/payload/.ai_infra/scripts/pr/check_testing_artifacts.py
@@ -42,6 +42,19 @@ def _check_test_index_structure(path: Path) -> tuple[bool, str]:
     return False, f"FAIL: expected markers not found (`Module:` and `Coverage status:`) -> {path}"
 
 
+def _check_tests_dir(path: Path) -> tuple[bool, str]:
+    """Require tests/modules on kit-dev; optional on consumer until product tests exist."""
+    if path.exists():
+        return True, f"PASS: exists -> {path}"
+    kit_dev_marker = Path("tests") / "modules" / "install" / "test_scaffold.py"
+    if kit_dev_marker.is_file():
+        return False, f"FAIL: missing -> {path}"
+    return True, (
+        f"PASS: optional on consumer — missing {path} "
+        "(add tests/modules/<name>/ when you ship product tests)"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Validate required testing artifacts for PR prepare.")
     parser.add_argument(
@@ -71,7 +84,7 @@ def main() -> int:
 
     checks = [
         _check_exists(control_center),
-        _check_exists(tests_dir),
+        _check_tests_dir(tests_dir),
         _check_nonempty(test_plan),
         _check_nonempty(test_index),
         _check_test_index_structure(test_index),

--- a/payload/.ai_infra/templates/local-workspace/exemplars/test-index.md
+++ b/payload/.ai_infra/templates/local-workspace/exemplars/test-index.md
@@ -24,9 +24,9 @@ Notes:
 ## Current index
 
 - Module: `_project_`
-  - Owned tests: `tests/modules/smoke/`
+  - Owned tests: `(none yet — add tests/modules/<name>/ as you ship product tests)`
   - Coverage status: `gap`
-  - Notes: rename module; add paths as you add product tests
+  - Notes: kit activate does not leave a smoke pytest; rename module when known
 
 ## Template row (copy per module)
 

--- a/tests/modules/install/test_agent_colony_cli_full.py
+++ b/tests/modules/install/test_agent_colony_cli_full.py
@@ -183,7 +183,8 @@ def test_cmd_gates_uses_resolve_project_python(monkeypatch: pytest.MonkeyPatch, 
     args = argparse.Namespace(directory=tmp_path)
     assert cli.cmd_gates(args) == 0
     assert resolved_roots == [tmp_path.resolve()]
-    assert seen_interpreters == ["/tmp/fake-project-python"] * 5
+    # No tests/ under tmp_path → pytest step skipped (4 remaining gates).
+    assert seen_interpreters == ["/tmp/fake-project-python"] * 4
 
 
 def test_cmd_gates_fallback_scripts_dir_raises_when_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/modules/install/test_plane_status.py
+++ b/tests/modules/install/test_plane_status.py
@@ -51,7 +51,6 @@ def test_assess_planes_require_venv_missing_runtime(tmp_path: Path) -> None:
         ".ai_infra/bootstrap.py",
         ".ai_infra/paths.py",
         ".ai_infra/manifest.yaml",
-        "tests/modules/smoke/test_kit_installed.py",
         "agent_colony/__main__.py",
         ".ai_infra/install/agent_colony/cli.py",
         ".ai_infra/scripts/architecture/check_governance_consistency.py",

--- a/tests/modules/install/test_scaffold.py
+++ b/tests/modules/install/test_scaffold.py
@@ -41,7 +41,7 @@ def test_scaffold_dry_run_lists_copies(tmp_path: Path) -> None:
     assert ".cursor" in joined
     assert "session-pointer.md" in joined
     assert "project.config.yaml.example" in joined
-    assert "minimal smoke" in joined
+    assert "SKIP consumer smoke test file" in joined
     assert "examples" not in joined
 
 
@@ -56,12 +56,17 @@ def test_scaffold_creates_core_layout(tmp_path: Path) -> None:
     assert not (target / ".cursor" / "agents" / "workflow-intelligence-mapper.md").exists()
     assert not (target / ".cursor" / "rules" / mod.ADAPTER_WALL_RULE).exists()
     assert not (target / "examples").exists()
-    assert (target / "tests" / "modules" / "smoke" / "test_kit_installed.py").is_file()
+    assert not (target / "tests" / "modules" / "smoke" / "test_kit_installed.py").exists()
     assert not (target / "tests" / "modules" / "install" / "test_scaffold.py").exists()
-    smoke = (target / "tests" / "modules" / "smoke" / "test_kit_installed.py").read_text(
-        encoding="utf-8"
-    )
-    assert "workflow-artifacts/drift" in smoke
+
+
+def test_scaffold_keep_smoke_test_opt_in(tmp_path: Path) -> None:
+    mod = _load_scaffold()
+    target = tmp_path / "project"
+    mod.scaffold(target, REPO_ROOT, keep_smoke_test=True)
+    smoke = target / "tests" / "modules" / "smoke" / "test_kit_installed.py"
+    assert smoke.is_file()
+    assert "workflow-artifacts/drift" in smoke.read_text(encoding="utf-8")
 
 
 def test_scaffold_writes_runtime_gitignore_and_starter(tmp_path: Path) -> None:

--- a/tests/modules/install/test_scaffold_full.py
+++ b/tests/modules/install/test_scaffold_full.py
@@ -154,7 +154,9 @@ def test_sanity_check_reports_all_failure_branches(tmp_path: Path) -> None:
     assert any("CHECK FAIL" in line for line in log)
 
 
-def test_run_verify_uses_sys_executable_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_verify_skips_pytest_when_no_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     mod = _load_scaffold()
     target = tmp_path / "project"
     (target / ".ai_infra" / "scripts" / "pr").mkdir(parents=True)
@@ -167,7 +169,6 @@ def test_run_verify_uses_sys_executable_fallback(tmp_path: Path, monkeypatch: py
             "import sys\nsys.exit(0)\n", encoding="utf-8"
         )
     log: list[str] = []
-    monkeypatch.chdir(target)
     calls: list[list[str]] = []
 
     def _fake_run(cmd, cwd=None, check=False):  # noqa: ANN001
@@ -177,7 +178,39 @@ def test_run_verify_uses_sys_executable_fallback(tmp_path: Path, monkeypatch: py
     monkeypatch.setattr(mod.subprocess, "run", _fake_run)
     code = mod._run_verify(target, log)
     assert code == 0
-    assert calls[0][0] == sys.executable
+    assert any("VERIFY SKIP pytest" in line for line in log)
+    assert not any(len(c) >= 3 and c[1] == "-m" and c[2] == "pytest" for c in calls)
+
+
+def test_run_verify_runs_pytest_when_tests_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mod = _load_scaffold()
+    target = tmp_path / "project"
+    (target / ".ai_infra" / "scripts" / "pr").mkdir(parents=True)
+    (target / ".ai_infra" / "scripts" / "pr" / "check_testing_artifacts.py").write_text(
+        "import sys\nsys.exit(0)\n", encoding="utf-8"
+    )
+    (target / ".ai_infra" / "scripts" / "architecture").mkdir(parents=True)
+    for name in ("check_governance_consistency.py", "check_debrand.py"):
+        (target / ".ai_infra" / "scripts" / "architecture" / name).write_text(
+            "import sys\nsys.exit(0)\n", encoding="utf-8"
+        )
+    (target / "tests" / "modules" / "app").mkdir(parents=True)
+    (target / "tests" / "modules" / "app" / "test_ok.py").write_text(
+        "def test_ok():\n    assert True\n", encoding="utf-8"
+    )
+    log: list[str] = []
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, cwd=None, check=False):  # noqa: ANN001
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    code = mod._run_verify(target, log)
+    assert code == 0
+    assert any(len(c) >= 3 and c[1] == "-m" and c[2] == "pytest" for c in calls)
 
 
 def test_run_verify_returns_first_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/modules/pr_workflow/test_user_settings_full.py
+++ b/tests/modules/pr_workflow/test_user_settings_full.py
@@ -580,6 +580,29 @@ def test_check_testing_artifacts_all_pass(tmp_path: Path, monkeypatch: pytest.Mo
     assert cta.main() == 0
 
 
+def test_check_testing_artifacts_consumer_optional_tests_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Consumers without product tests yet may omit tests/modules/."""
+    planning = tmp_path / "planning"
+    _write(planning, "test-plan.md", "plan content")
+    _write(planning, "test-index.md", "Module: foo\nCoverage status: gap\n")
+    monkeypatch.chdir(tmp_path)
+    missing = tmp_path / "tests" / "modules"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_testing_artifacts.py",
+            "--planning-dir",
+            str(planning),
+            "--tests-dir",
+            str(missing),
+        ],
+    )
+    assert cta.main() == 0
+
+
 def test_check_testing_artifacts_legacy_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     planning = tmp_path / "legacy"
     tests_dir = tmp_path / "tests" / "modules"


### PR DESCRIPTION
## Summary
## Summary
- New consumer installs no longer leave \`tests/modules/smoke/test_kit_installed.py\`
- Layout checked in-process at scaffold CHECK; VERIFY/gates skip pytest when \`tests/\` is empty
- Opt-in: \`--keep-smoke-test\` on activate/install/scaffold
- install-contract + plane_status updated; docs + test count 1486

## Test plan
- [x] Targeted install/scaffold/plane/cli tests
- [x] Manual scaffold to tmp: smoke file absent + CHECK PASS
- [x] doc validate (1486)
- [ ] prepare.py gates on PR

## Test plan
- [ ] pytest -q
- [ ] make gates (or project equivalent)

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: implementer | (none) | review-pr | prepare-pr | merge-pr

## Collaboration
- Board-Item: PVTI_lAHOBl46-84A9KZxzg127Ic
- Closes: #214
