### PR TITLE
docs: mark v0.6.3 release published

### DIFF
--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -40,7 +40,7 @@ Use the kit venv interpreter (`.venv/bin/python`) or `python3` — bare `python`
 
 ## Versioning
 
-**Current release:** `0.6.3` (git tag `v0.6.3` pending until release).
+**Current release:** `0.6.3` (git tag [`v0.6.3`](https://github.com/SavinRazvan/agent-colony/releases/tag/v0.6.3)).
 
 **Superseded:** `v0.3.0` (`1f16af1`) predates `PLUGIN-FLATTEN` (#15) — its tagged tree has **zero**
 files under `agents/`, `rules/`, `skills/`, `payload/` (the gitignore bug #15 fixed). Do not


### PR DESCRIPTION
## Summary
- Clear marketplace-publish “pending until release” now that [`v0.6.3`](https://github.com/SavinRazvan/agent-colony/releases/tag/v0.6.3) is live.

## Test plan
- [x] Tag/release already published
- [ ] Doc link resolves

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: merge-pr