### PR TITLE
docs: add permissions-and-prerequisites consumer checklist

### DIFF
--- a/.ai_infra/docs/README.md
+++ b/.ai_infra/docs/README.md
@@ -7,7 +7,7 @@
 | You are | Read first |
 |---------|------------|
 | **Visitor / public** | Root [README.md](../../README.md) (landing) → [consumer-quickstart](operations/consumer-quickstart.md) |
-| **New consumer** | [consumer-quickstart](operations/consumer-quickstart.md) → [PLUGIN-USER-GUIDE](operations/PLUGIN-USER-GUIDE.md) · glossary: [abbreviations-notepad](operations/abbreviations-notepad.md) |
+| **New consumer** | [permissions-and-prerequisites](operations/permissions-and-prerequisites.md) → [consumer-quickstart](operations/consumer-quickstart.md) → [PLUGIN-USER-GUIDE](operations/PLUGIN-USER-GUIDE.md) · glossary: [abbreviations-notepad](operations/abbreviations-notepad.md) |
 | **Kit maintainer** | [CONTRIBUTING.md](../../CONTRIBUTING.md) → [AGENTS.md](../../AGENTS.md) → [repository-map](handoff/repository-map.md) → [PLUGIN-ARCHITECTURE](handoff/PLUGIN-ARCHITECTURE.md) → [IMPLEMENTATION-STATUS](handoff/IMPLEMENTATION-STATUS.md) · glossary: [abbreviations-notepad](operations/abbreviations-notepad.md) |
 | **Governance / policy** | [governance/README](governance/README.md) |
 
@@ -37,6 +37,7 @@
 | File | Role |
 |------|------|
 | [workflow-architecture.md](architecture/workflow-architecture.md) | Three planes (C4-lite) — copied on activate |
+| [permissions-and-prerequisites.md](operations/permissions-and-prerequisites.md) | Cursor, `gh`, git, board SSOT, MCP — copied on activate |
 | [PLUGIN-USER-GUIDE.md](operations/PLUGIN-USER-GUIDE.md) | Plugin manual — copied on activate |
 | [consumer-quickstart.md](operations/consumer-quickstart.md) | Install + verify cheat sheet — copied on activate |
 | [abbreviations-notepad.md](operations/abbreviations-notepad.md) | Glossary (SSOT, DRIFT, Pattern A, agents) — copied on activate |

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -20,6 +20,8 @@ Notes:
 
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.
 
+> **Before `/implementer`:** read [What you need — permissions & prerequisites](permissions-and-prerequisites.md) (Cursor, `gh` scopes, git, board SSOT, MCP).
+
 ---
 
 ## 1. Plugin vs activate vs three planes
@@ -88,7 +90,7 @@ This loads agents, skills, and rules into Cursor. Your project may only get `.cu
 
 ## 2. Quick start (5 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project** open (not the kit product repo `agent-colony`).
+**Need:** Cursor · Python 3.11+ · **your project** open (not the kit product repo `agent-colony`). Full checklist: [permissions-and-prerequisites.md](permissions-and-prerequisites.md).
 
 | Step | Action |
 |------|--------|
@@ -156,7 +158,7 @@ Discover ids: manually via `gh project view <N> --owner <login>` / `gh project f
 |------|--------|
 | 1. Install / activate | Agent chat: `/add-plugin …` then **`/workflow-activate`** in **your app repo** — wait for **`VERIFY PASS`**. |
 | 2. Collaboration YAML (identity) | Edit `.local/user_settings/github.collaboration.yaml`: set `owner.display_name`, `owner.github_user`, and (if using board SSOT) `project_ssot.enabled: true` + `sync_policy: board_only`. Board ids may stay empty until step 3b. |
-| 3. GitHub auth | `gh auth status` first — refresh only if Project scopes missing. See **§ GitHub CLI auth (Projects)** below. |
+| 3. GitHub auth | `gh auth status` first — refresh only if Project scopes missing. Canon: [permissions-and-prerequisites.md § GitHub CLI](permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization). |
 | 3b. Wire board ids (agent-assisted) | Paste **Project URL** (`https://github.com/users/YOU/projects/N` or `…/orgs/ORG/projects/N`) **and** this **repo URL** in Agent chat → **`/board`** fills `name` / `number` / `owner` / `project_id` / `fields.*` / `default_repo` via `gh` (or you copy from `gh project view` / `field-list` yourself). Human confirms YAML before save. |
 | 4. Doctor + board shell | `project doctor` → optional **minimal overlay** (`board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`) for **2 views** matching [Playground #3](https://github.com/users/SavinRazvan/projects/3), **or** six-view default without overlay. → **`/board`** CONSENT GATE + TURN PROTOCOL → `board-bootstrap --check` until **exit 0** → `project status`. |
 | 5. First card | `python3 -m agent_colony project create-from-template --template slice --title "…" --priority p1 --size s --estimate 1 --agent implementer` (assigns `owner.github_user` on Issues) → `claim --last --agent implementer` (sets Start date). Prefer `project guide`. |
@@ -164,6 +166,8 @@ Discover ids: manually via `gh project view <N> --owner <login>` / `gh project f
 | 7. Incomplete cards | `project doctor` WARNs empty Status / CLOSED-not-Done counts. Repair: `project heal-cards --check` then `heal-cards --apply` (optional `--fill-tier1`). |
 
 #### GitHub CLI auth (Projects)
+
+> **Canonical checklist:** [permissions-and-prerequisites.md](permissions-and-prerequisites.md) — Profile A (no board) vs Profile B (board SSOT), token types, verify commands.
 
 Board SSOT needs the **GitHub CLI** (`gh`) with **repository** access **and** **Projects** read/write. Without Project scopes, `project status` / `claim` / `outbox flush` fail with “missing required scopes”.
 

--- a/.ai_infra/docs/operations/README.md
+++ b/.ai_infra/docs/operations/README.md
@@ -22,6 +22,7 @@ Depends On:
 
 ## Universal runbooks
 
+- [`permissions-and-prerequisites.md`](permissions-and-prerequisites.md) — **what you need** — Cursor, `gh` scopes, git, board SSOT, MCP (read before `/implementer`)
 - [`PLUGIN-USER-GUIDE.md`](PLUGIN-USER-GUIDE.md) — **start here** — plugin vs activate, file tree, use-case matrix
 - [`consumer-quickstart.md`](consumer-quickstart.md) — adopt the kit in under five minutes (includes [tutorial screenshots](../../../assets/img/tutorials_img/) for `/add-plugin` → board)
 - [`install-dry-run.md`](install-dry-run.md) — detailed install verification checklist

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -48,7 +48,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **con
 | CI / CD | Continuous integration / delivery — GitHub Actions + release evidence |
 | RC | Release candidate — needs CI/CD evidence bundles before ship |
 | UI | GitHub Project / settings UI (humans); agents prefer CLI |
-| PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes |
+| PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes — see [permissions-and-prerequisites](permissions-and-prerequisites.md) |
 | GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
 | KISS | Keep It Simple — incremental, reversible slices |
 | DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |

--- a/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/.ai_infra/docs/operations/consumer-quickstart.md
@@ -21,20 +21,20 @@ Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No
 
 **Product promise:** Install the plugin → open **your app repo** → **`/workflow-activate`** installs the **full kit**. Customize identity in `github.collaboration.yaml`, then **`/board`** wires board ids from Project + repo URLs. **Ready for agents** requires `board-bootstrap --check` **exit 0** — either **two views** (minimal overlay, matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)) or **six Playground views** (kit default). Wire-only is not enough. Details: [PLUGIN-USER-GUIDE § Product promise](PLUGIN-USER-GUIDE.md#product-promise).
 
-> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · [abbreviations](abbreviations-notepad.md) · skill `research-corpus` · skill `board-shell`
+> **Also:** [What you need — permissions & prerequisites](permissions-and-prerequisites.md) · [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · [abbreviations](abbreviations-notepad.md) · skill `research-corpus` · skill `board-shell`
 
 ---
 
 ## First run (5 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit product repo `agent-colony`).
+**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit product repo `agent-colony`). Full checklist: [permissions-and-prerequisites.md](permissions-and-prerequisites.md).
 
 | Step | Action |
 |------|--------|
 | **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/agent-colony` — or **Cursor → Marketplace** when listed |
 | **2. Activate** | Open **your app folder** → Agent chat: **`/workflow-activate`** → wait for **`VERIFY PASS`** |
 | **3. Identity** | Edit `github.collaboration.yaml` → `display_name` + `github_user` → `source .venv/bin/activate && python3 -m agent_colony contributors validate` |
-| **3b. GitHub auth** *(board SSOT)* | `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project`. Device flow: [github.com/login/device](https://github.com/login/device). [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects). |
+| **3b. GitHub auth** *(board SSOT)* | `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project`. Device flow: [github.com/login/device](https://github.com/login/device). Canon: [permissions-and-prerequisites.md § GitHub CLI](permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization). |
 | **3c. Wire board** *(board SSOT)* | Agent chat **`/board`** + paste **Project URL + repo URL** → agent proposes `project_ssot` + `default_repo` (confirm) → `project doctor` + `project status` |
 | **4. Board shell** *(when SSOT on)* | **Minimal 2-view** (recommended): copy overlay → Prioritized backlog + Status board in UI ([Playground #3](https://github.com/users/SavinRazvan/projects/3)). **Or** six-view Playground default. **`/board`**: CONSENT GATE + TURN PROTOCOL → `--check` exit **0**. |
 | **5. Build** | **`/implementer`** · Entry = `python3 -m agent_colony project status` when board SSOT on |

--- a/.ai_infra/docs/operations/permissions-and-prerequisites.md
+++ b/.ai_infra/docs/operations/permissions-and-prerequisites.md
@@ -1,0 +1,274 @@
+<!--
+File: permissions-and-prerequisites.md
+Path: .ai_infra/docs/operations/permissions-and-prerequisites.md
+Role: Canonical checklist — what users must install, authorize, and configure before Agent Colony agents and the plugin work as documented.
+Used By:
+ - README.md
+ - PLUGIN-USER-GUIDE.md
+ - consumer-quickstart.md
+ - AGENTS.md
+ - workflow-activate skill
+Depends On:
+ - PLUGIN-USER-GUIDE.md
+ - consumer-quickstart.md
+ - connect-external-mcp.md
+ - project-board-collaboration.md
+Notes:
+ - Copied to consumer projects via manifest copy_ai_infra: docs/operations.
+ - Agent Colony does not ship a GitHub OAuth app; auth uses gh CLI + git on the user's machine.
+-->
+
+# What you need — permissions & prerequisites
+
+> **Read this before `/implementer`.** It lists everything you must have on your machine and what you must approve on GitHub so the **Cursor plugin**, **agents**, and **board SSOT** behave as documented.
+>
+> Install path: [consumer-quickstart](consumer-quickstart.md) · Full manual: [PLUGIN-USER-GUIDE](PLUGIN-USER-GUIDE.md)
+
+---
+
+## At a glance
+
+| Layer | Required for | What you give / install |
+|-------|----------------|-------------------------|
+| **Cursor IDE** | Plugin + agents | Open your app folder; allow terminal, workspace read/write, network |
+| **Python 3.11+** | Activate + CLI | Local venv (`.venv`) created by `/workflow-activate` |
+| **GitHub CLI (`gh`)** | PR workflow; board SSOT when enabled | **`repo`** (PRs/issues); **`read:project`** + **`project`** (board SSOT only) |
+| **Git credentials** | Push branches, open PRs | SSH key or HTTPS — standard git setup (not stored by the kit) |
+| **GitHub account access** | Board + repo operations | Write access to your **code repo** and **GitHub Project** |
+| **MCP** (optional) | Extra tools (DeepWiki, custom APIs) | Per-server tokens only when you opt in |
+
+**Agent Colony does not ask for a separate GitHub app or a token pasted into chat.** Agents call `gh` and git using **your** logged-in session.
+
+---
+
+## Two setup profiles
+
+Pick the profile that matches how you use the kit.
+
+### Profile A — Plugin + agents (no board SSOT)
+
+Use when `project_ssot.enabled: false` — local trackers only.
+
+| # | Requirement |
+|---|-------------|
+| 1 | [Cursor](https://cursor.com) with your **app repo** open (not the kit product repo `agent-colony`) |
+| 2 | Python **3.11+** |
+| 3 | Plugin: `/add-plugin https://github.com/SavinRazvan/agent-colony` |
+| 4 | Activate: `/workflow-activate` → wait for **`VERIFY PASS`** |
+| 5 | Identity: edit `.local/user_settings/github.collaboration.yaml` → `contributors validate` |
+| 6 | **`gh auth login`** with **`repo`** scope (for `/review-pr` → `/merge-pr`) |
+| 7 | **Git push/pull** to your remote |
+
+### Profile B — Full kit (GitHub Project board SSOT) — recommended
+
+Use when `project_ssot.enabled: true` and `sync_policy: board_only`.
+
+Everything in **Profile A**, plus:
+
+| # | Requirement |
+|---|-------------|
+| 8 | **`gh auth refresh -h github.com -s read:project,project`** (keep existing `repo`) |
+| 9 | A **GitHub Project** with **write access** for your user (org Projects need membership + Project access) |
+| 10 | **Default repository** on the Project set to your app repo (human UI when creating the Project) |
+| 11 | **`/board`** — paste Project URL + repo URL; confirm proposed YAML |
+| 12 | **Human UI:** Project views (minimal **2-view** or kit default **6-view**) — agents cannot API-create views today |
+| 13 | **`project doctor`** + **`board-bootstrap --check` exit 0** before `/implementer` |
+
+---
+
+## 1. Cursor IDE (plugin + agents)
+
+The plugin loads agents, skills, and rules into Cursor. **Activate** copies infrastructure into **your project folder**.
+
+| Capability | Why agents need it |
+|------------|-------------------|
+| **Your app folder open** | Activate and agents write `.cursor/`, `.ai_infra/`, `.local/` under your repo |
+| **Agent chat** (`/` menu) | `/workflow-activate`, `/implementer`, `/board`, PR slash skills |
+| **Terminal / shell** | `python3 -m agent_colony …`, `gh …`, `pytest` |
+| **Workspace read/write** | Code edits, trackers, workflow artifacts under `.local/` |
+| **Network** | Plugin install from GitHub, `gh` API, optional MCP servers |
+| **MCP enabled** (recommended) | Built-in `agent-colony-mcp`; DeepWiki seeded on consumer activate |
+| **Browser MCP** (optional) | Only if **you explicitly ask** for help clicking GitHub Project UI during board shell setup |
+
+**Cursor does not replace `gh auth login`.** GitHub permissions are configured on your machine via the GitHub CLI (§2).
+
+---
+
+## 2. GitHub CLI (`gh`) — main GitHub authorization
+
+When board SSOT is on, agents read and write the **GitHub Project** via `gh project …` GraphQL. PR skills use `gh pr …`.
+
+### Required OAuth scopes
+
+| Scope | Required? | Used for |
+|-------|-----------|----------|
+| **`repo`** | **Yes** | Issues, PRs, repo reads/writes, link PRs to board cards |
+| **`read:project`** | **Yes** (board SSOT) | Read Project, fields, items |
+| **`project`** | **Yes** (board SSOT) | Write Status, Notes, Priority/Size/Estimate, claim/handoff |
+| **`workflow`** | Optional | CI / Actions checks when driven via `gh` |
+
+### Setup
+
+**First login (new machine):**
+
+```bash
+gh auth login -h github.com
+```
+
+Choose HTTPS, authenticate via browser or device code, and allow access to the repos you use.
+
+**Add Project scopes to an existing login:**
+
+```bash
+gh auth refresh -h github.com -s read:project,project
+# Keeps existing repo (and workflow) scopes — refresh adds Project access.
+```
+
+**No browser (WSL, headless, SSH — `xdg-open: no method available`):**
+
+1. Run `gh auth login` or `gh auth refresh …` and leave the terminal open.
+2. Copy the **one-time code** from the terminal.
+3. Open **[https://github.com/login/device](https://github.com/login/device)** in any browser.
+4. Paste the code → sign in → **approve GitHub + Project permissions**.
+5. Return to the terminal — expect `✓ Authentication complete.`
+
+**Verify:**
+
+```bash
+gh auth status
+# Token scopes should include: repo, project
+# (read:project may show separately or be covered when project is present)
+
+python3 -m agent_colony project doctor    # when board SSOT on
+python3 -m agent_colony project status
+```
+
+If `gh` reports **missing required scopes `[read:project]` / `[project]`**, re-run `gh auth refresh -h github.com -s read:project,project` and complete the device link again.
+
+### Token type: classic vs fine-grained PAT
+
+| Method | Recommendation |
+|--------|----------------|
+| **`gh auth login` (OAuth via `gh`)** | **Preferred** — simplest for Projects |
+| **Classic PAT** | Works — needs `repo` + `project` (+ `read:project`) |
+| **Fine-grained PAT** | **Partial** — some Project mutations fail (e.g. Draft→Issue `promote-to-issue`) |
+
+If you see `Resource not accessible by fine-grained personal access token`, use **`gh auth login`** or a **classic PAT** with `project` + `repo`. `project doctor` notes this when relevant.
+
+---
+
+## 3. GitHub account & org access (beyond scopes)
+
+OAuth scopes are necessary but not sufficient. Your **GitHub user** must be able to reach the resources:
+
+| Access | Why |
+|--------|-----|
+| **Read/write on your code repo** | Create Issues, open/merge PRs, push feature branches |
+| **Read/write on the GitHub Project** | Board is the coordination SSOT when enabled |
+| **Org Projects** (if org-owned) | Account must be a member with Project access |
+| **Merge rights** (for `/merge-pr`) | Repo policy must allow your user to merge |
+
+### Human-only in GitHub UI (not API-automated today)
+
+- Project **views** (2-view minimal or 6-view default)
+- Column visibility on **Status board** and **Prioritized backlog**
+- Filters, layout, view rename
+
+See [board-shell skill](../../../.cursor/skills/board-shell/SKILL.md) and [project-board-collaboration](project-board-collaboration.md).
+
+---
+
+## 4. Git (separate from `gh`)
+
+| What | Required? | Notes |
+|------|-----------|-------|
+| **Push/pull to remote** | Yes (PR workflow) | SSH key or HTTPS credentials — standard git |
+| **Private repo clone** (researcher) | If researching private repos | Machine must already authenticate for `git clone` |
+
+The kit **does not store** git credentials. Research agent: no kit-side GitHub token — clone uses your local auth.
+
+---
+
+## 5. What the kit stores locally (secrets)
+
+| Path | Contains | Gitignored? |
+|------|----------|-------------|
+| `.local/user_settings/github.collaboration.yaml` | Name, `@handle`, board field ids — **no token** | Yes |
+| `.local/user_settings/mcp.secrets.yaml` | Optional MCP tokens (`mcp auth`) | Yes |
+| `.cursor/mcp.user.json` | MCP server transport config | Yes |
+
+Never commit tokens or paste them into Agent chat.
+
+---
+
+## 6. MCP servers (optional)
+
+| Server | Auth |
+|--------|------|
+| **`agent-colony-mcp`** (built-in, `with_mcp` profile) | None extra — uses local CLI |
+| **DeepWiki** (default seed on consumer activate) | **None** — public remote server |
+| **GitHub remote MCP** (stretch / opt-in) | Copilot OAuth seat **or** PAT with `repo` |
+| **Custom MCP** (Slack, DB, browser, …) | Per server — env vars / `mcp auth --token-env …` |
+
+Guide: [connect-external-mcp.md](connect-external-mcp.md) · Worksheet: `.local/user_settings/mcp.agents.yaml`
+
+---
+
+## 7. PR workflow permissions (`/review-pr` → `/merge-pr`)
+
+Uses the same **`gh` + `repo`** session:
+
+| Action | Permission |
+|--------|------------|
+| `gh pr view`, `gh pr create` | `repo` |
+| `gh pr merge` | `repo` + merge rights on the repo |
+| `project mention-pr` (board SSOT) | `repo` + `project` |
+| Post-merge board → Done (`merge.py`) | `project` write |
+
+Optional: **`workflow`** scope to inspect CI via `gh`.
+
+---
+
+## 8. What you do **not** need
+
+- No Agent Colony GitHub App install
+- No org-wide admin (unless your org policy requires it for Projects)
+- No token pasted into chat or committed to git
+- No Cursor-specific GitHub OAuth (beyond normal `gh` on your machine)
+- No browser automation unless you explicitly request it for board shell UI help
+
+---
+
+## Quick verification checklist
+
+### Profile A (no board)
+
+```bash
+python3 -m agent_colony contributors validate
+python3 -m agent_colony health
+gh auth status    # expect repo
+```
+
+### Profile B (board SSOT)
+
+```bash
+python3 -m agent_colony contributors validate
+gh auth status    # expect repo + project
+python3 -m agent_colony project doctor
+python3 -m agent_colony project board-bootstrap --check
+python3 -m agent_colony project status
+```
+
+Expect **`board-bootstrap --check` exit 0** before day-to-day `/implementer`.
+
+---
+
+## Related docs
+
+| Doc | Topic |
+|-----|-------|
+| [consumer-quickstart.md](consumer-quickstart.md) | 5-step install with screenshots |
+| [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) | Full plugin manual |
+| [project-board-collaboration.md](project-board-collaboration.md) | Board Entry/Exit, Tier-1 fields, outbox |
+| [connect-external-mcp.md](connect-external-mcp.md) | Optional MCP servers |
+| [abbreviations-notepad.md](abbreviations-notepad.md) | SSOT, Pattern A, DRIFT glossary |

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -185,7 +185,7 @@ Optional end-to-end check against the real Project (skipped in default CI).
 
 **Last PASS:** 2026-07-19 — `make live-board-smoke` (evidence: `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`).
 
-1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes). If `xdg-open` fails, open **https://github.com/login/device**, paste the one-time code, and approve **Project** permissions — see [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
+1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes). If `xdg-open` fails, open **https://github.com/login/device**, paste the one-time code, and approve **Project** permissions — see [permissions-and-prerequisites.md § GitHub CLI](permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization).
 2. Confirm: `python3 -m agent_colony project doctor` and `project status`.
 3. Clear any other card **In progress** for the same assignee (claim enforces `one_in_progress_per_assignee`).
 4. Run: `make live-board-smoke`  

--- a/.ai_infra/templates/AGENTS.stub.md
+++ b/.ai_infra/templates/AGENTS.stub.md
@@ -30,7 +30,7 @@ Details: [consumer-quickstart § First activate troubleshooting](.ai_infra/docs/
 1. Edit `.local/user_settings/github.collaboration.yaml` → your name + `@handle`
 2. `source .venv/bin/activate && python3 -m agent_colony contributors validate` (**must PASS**)
 3. If `project_ssot.enabled: true`:
-   - `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project` ([PLUGIN-USER-GUIDE § GitHub CLI auth](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#github-cli-auth-projects))
+   - `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project` ([permissions-and-prerequisites](.ai_infra/docs/operations/permissions-and-prerequisites.md))
    - Agent chat **`/board`** + paste **Project URL** + **repo URL** → agent wires `project_ssot` ids + `default_repo` (confirm before save)
    - `source .venv/bin/activate && python3 -m agent_colony project doctor` (expect **ok**)
    - **Minimal 2-view shell** (recommended — matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)):

--- a/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -10,7 +10,7 @@
 # Kit default: AI uses Assisted-by (not Co-authored-by: cursoragent@...).
 # Opt-in legacy mode below if your org requires Git co-author trailers for tools.
 # Project SSOT: set enabled: true and fill board ids; requires gh scopes read:project + project (+ repo).
-# Onboarding: gh auth login|refresh -s read:project,project — if no browser, https://github.com/login/device (see PLUGIN-USER-GUIDE § GitHub CLI auth).
+# Onboarding: gh auth login|refresh -s read:project,project — if no browser, https://github.com/login/device (see permissions-and-prerequisites.md § GitHub CLI).
 
 version: 1
 

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -117,7 +117,7 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 
 1. Open `.local/user_settings/github.collaboration.yaml` — set **display_name**, **github_user**. For Project SSOT: enable + `board_only`.
 2. Terminal: `source .venv/bin/activate && python3 -m agent_colony contributors validate` (must PASS).
-3. **`gh auth status`** — refresh Project scopes only if missing — [PLUGIN-USER-GUIDE § GitHub CLI auth](../../.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
+3. **`gh auth status`** — refresh Project scopes only if missing — [permissions-and-prerequisites.md § GitHub CLI](../../.ai_infra/docs/operations/permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization).
 4. Paste **Project URL + repo URL** in chat → **`/board`** wires `project_ssot` + `default_repo` (confirm before save) → `project doctor` + `project status`.
 5. When board SSOT enabled: optional **minimal 2-view overlay** ([Playground #3](https://github.com/users/SavinRazvan/projects/3)) → **`/board`** + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) → `board-bootstrap --check` until **exit 0** → `project status`. See [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md).
 6. **`/implementer`** to start · each session Entry: **`source .venv/bin/activate && python3 -m agent_colony project status`** when board SSOT on; else read `session-pointer.md` first. Audit (`/auditor`) is later — not day-0.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 
 ## First reads (onboarding)
 
-1. [`README.md`](README.md) — public landing · [`CONTRIBUTING.md`](CONTRIBUTING.md) — kit-dev setup · consumer install → [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md)
+1. [`README.md`](README.md) — public landing · [`CONTRIBUTING.md`](CONTRIBUTING.md) — kit-dev setup · consumer install → [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) · **permissions** → [permissions-and-prerequisites](.ai_infra/docs/operations/permissions-and-prerequisites.md)
 2. [`.ai_infra/docs/README.md`](.ai_infra/docs/README.md) — docs index (linked navigation)
 3. [`.ai_infra/docs/handoff/repository-map.md`](.ai_infra/docs/handoff/repository-map.md) — **kit repo only** — SSOT vs generated vs consumer install (not shipped to consumers)
 4. [`.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md`](.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md) — plugin bundle, install profiles

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Slash skills cover activate, update, board protocols, PR lifecycle (`/review-pr`
 
 [Cursor](https://cursor.com) · Python 3.11+ · open **your app folder** (not this kit repo) · for board SSOT: [GitHub CLI](https://cli.github.com/) with Project access
 
+**Full checklist:** [What you need — permissions & prerequisites](.ai_infra/docs/operations/permissions-and-prerequisites.md) (Cursor, `gh` scopes, git, MCP)
+
 ---
 
 ## Install (consumers)

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -20,6 +20,8 @@ Notes:
 
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.
 
+> **Before `/implementer`:** read [What you need — permissions & prerequisites](permissions-and-prerequisites.md) (Cursor, `gh` scopes, git, board SSOT, MCP).
+
 ---
 
 ## 1. Plugin vs activate vs three planes
@@ -88,7 +90,7 @@ This loads agents, skills, and rules into Cursor. Your project may only get `.cu
 
 ## 2. Quick start (5 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project** open (not the kit product repo `agent-colony`).
+**Need:** Cursor · Python 3.11+ · **your project** open (not the kit product repo `agent-colony`). Full checklist: [permissions-and-prerequisites.md](permissions-and-prerequisites.md).
 
 | Step | Action |
 |------|--------|
@@ -156,7 +158,7 @@ Discover ids: manually via `gh project view <N> --owner <login>` / `gh project f
 |------|--------|
 | 1. Install / activate | Agent chat: `/add-plugin …` then **`/workflow-activate`** in **your app repo** — wait for **`VERIFY PASS`**. |
 | 2. Collaboration YAML (identity) | Edit `.local/user_settings/github.collaboration.yaml`: set `owner.display_name`, `owner.github_user`, and (if using board SSOT) `project_ssot.enabled: true` + `sync_policy: board_only`. Board ids may stay empty until step 3b. |
-| 3. GitHub auth | `gh auth status` first — refresh only if Project scopes missing. See **§ GitHub CLI auth (Projects)** below. |
+| 3. GitHub auth | `gh auth status` first — refresh only if Project scopes missing. Canon: [permissions-and-prerequisites.md § GitHub CLI](permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization). |
 | 3b. Wire board ids (agent-assisted) | Paste **Project URL** (`https://github.com/users/YOU/projects/N` or `…/orgs/ORG/projects/N`) **and** this **repo URL** in Agent chat → **`/board`** fills `name` / `number` / `owner` / `project_id` / `fields.*` / `default_repo` via `gh` (or you copy from `gh project view` / `field-list` yourself). Human confirms YAML before save. |
 | 4. Doctor + board shell | `project doctor` → optional **minimal overlay** (`board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`) for **2 views** matching [Playground #3](https://github.com/users/SavinRazvan/projects/3), **or** six-view default without overlay. → **`/board`** CONSENT GATE + TURN PROTOCOL → `board-bootstrap --check` until **exit 0** → `project status`. |
 | 5. First card | `python3 -m agent_colony project create-from-template --template slice --title "…" --priority p1 --size s --estimate 1 --agent implementer` (assigns `owner.github_user` on Issues) → `claim --last --agent implementer` (sets Start date). Prefer `project guide`. |
@@ -164,6 +166,8 @@ Discover ids: manually via `gh project view <N> --owner <login>` / `gh project f
 | 7. Incomplete cards | `project doctor` WARNs empty Status / CLOSED-not-Done counts. Repair: `project heal-cards --check` then `heal-cards --apply` (optional `--fill-tier1`). |
 
 #### GitHub CLI auth (Projects)
+
+> **Canonical checklist:** [permissions-and-prerequisites.md](permissions-and-prerequisites.md) — Profile A (no board) vs Profile B (board SSOT), token types, verify commands.
 
 Board SSOT needs the **GitHub CLI** (`gh`) with **repository** access **and** **Projects** read/write. Without Project scopes, `project status` / `claim` / `outbox flush` fail with “missing required scopes”.
 

--- a/payload/.ai_infra/docs/operations/README.md
+++ b/payload/.ai_infra/docs/operations/README.md
@@ -22,6 +22,7 @@ Depends On:
 
 ## Universal runbooks
 
+- [`permissions-and-prerequisites.md`](permissions-and-prerequisites.md) — **what you need** — Cursor, `gh` scopes, git, board SSOT, MCP (read before `/implementer`)
 - [`PLUGIN-USER-GUIDE.md`](PLUGIN-USER-GUIDE.md) — **start here** — plugin vs activate, file tree, use-case matrix
 - [`consumer-quickstart.md`](consumer-quickstart.md) — adopt the kit in under five minutes (includes [tutorial screenshots](../../../assets/img/tutorials_img/) for `/add-plugin` → board)
 - [`install-dry-run.md`](install-dry-run.md) — detailed install verification checklist

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -48,7 +48,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **con
 | CI / CD | Continuous integration / delivery — GitHub Actions + release evidence |
 | RC | Release candidate — needs CI/CD evidence bundles before ship |
 | UI | GitHub Project / settings UI (humans); agents prefer CLI |
-| PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes |
+| PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes — see [permissions-and-prerequisites](permissions-and-prerequisites.md) |
 | GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
 | KISS | Keep It Simple — incremental, reversible slices |
 | DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |

--- a/payload/.ai_infra/docs/operations/consumer-quickstart.md
+++ b/payload/.ai_infra/docs/operations/consumer-quickstart.md
@@ -21,20 +21,20 @@ Install **Agent Colony** (`agent-colony`) into your project in a few minutes. No
 
 **Product promise:** Install the plugin → open **your app repo** → **`/workflow-activate`** installs the **full kit**. Customize identity in `github.collaboration.yaml`, then **`/board`** wires board ids from Project + repo URLs. **Ready for agents** requires `board-bootstrap --check` **exit 0** — either **two views** (minimal overlay, matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)) or **six Playground views** (kit default). Wire-only is not enough. Details: [PLUGIN-USER-GUIDE § Product promise](PLUGIN-USER-GUIDE.md#product-promise).
 
-> **Also:** [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · [abbreviations](abbreviations-notepad.md) · skill `research-corpus` · skill `board-shell`
+> **Also:** [What you need — permissions & prerequisites](permissions-and-prerequisites.md) · [MCP](connect-external-mcp.md) · [upgrade](upgrade-kit.md) · [abbreviations](abbreviations-notepad.md) · skill `research-corpus` · skill `board-shell`
 
 ---
 
 ## First run (5 steps)
 
-**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit product repo `agent-colony`).
+**Need:** Cursor · Python 3.11+ · **your project folder open in Cursor** (not the kit product repo `agent-colony`). Full checklist: [permissions-and-prerequisites.md](permissions-and-prerequisites.md).
 
 | Step | Action |
 |------|--------|
 | **1. Plugin** | In **Agent chat** (not terminal): `/add-plugin https://github.com/SavinRazvan/agent-colony` — or **Cursor → Marketplace** when listed |
 | **2. Activate** | Open **your app folder** → Agent chat: **`/workflow-activate`** → wait for **`VERIFY PASS`** |
 | **3. Identity** | Edit `github.collaboration.yaml` → `display_name` + `github_user` → `source .venv/bin/activate && python3 -m agent_colony contributors validate` |
-| **3b. GitHub auth** *(board SSOT)* | `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project`. Device flow: [github.com/login/device](https://github.com/login/device). [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects). |
+| **3b. GitHub auth** *(board SSOT)* | `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project`. Device flow: [github.com/login/device](https://github.com/login/device). Canon: [permissions-and-prerequisites.md § GitHub CLI](permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization). |
 | **3c. Wire board** *(board SSOT)* | Agent chat **`/board`** + paste **Project URL + repo URL** → agent proposes `project_ssot` + `default_repo` (confirm) → `project doctor` + `project status` |
 | **4. Board shell** *(when SSOT on)* | **Minimal 2-view** (recommended): copy overlay → Prioritized backlog + Status board in UI ([Playground #3](https://github.com/users/SavinRazvan/projects/3)). **Or** six-view Playground default. **`/board`**: CONSENT GATE + TURN PROTOCOL → `--check` exit **0**. |
 | **5. Build** | **`/implementer`** · Entry = `python3 -m agent_colony project status` when board SSOT on |

--- a/payload/.ai_infra/docs/operations/permissions-and-prerequisites.md
+++ b/payload/.ai_infra/docs/operations/permissions-and-prerequisites.md
@@ -32,7 +32,7 @@ Notes:
 |-------|----------------|-------------------------|
 | **Cursor IDE** | Plugin + agents | Open your app folder; allow terminal, workspace read/write, network |
 | **Python 3.11+** | Activate + CLI | Local venv (`.venv`) created by `/workflow-activate` |
-| **GitHub CLI (`gh`)** | Board SSOT + PR workflow | OAuth scopes: `repo`, `read:project`, `project` |
+| **GitHub CLI (`gh`)** | PR workflow; board SSOT when enabled | **`repo`** (PRs/issues); **`read:project`** + **`project`** (board SSOT only) |
 | **Git credentials** | Push branches, open PRs | SSH key or HTTPS — standard git setup (not stored by the kit) |
 | **GitHub account access** | Board + repo operations | Write access to your **code repo** and **GitHub Project** |
 | **MCP** (optional) | Extra tools (DeepWiki, custom APIs) | Per-server tokens only when you opt in |

--- a/payload/.ai_infra/docs/operations/permissions-and-prerequisites.md
+++ b/payload/.ai_infra/docs/operations/permissions-and-prerequisites.md
@@ -1,0 +1,274 @@
+<!--
+File: permissions-and-prerequisites.md
+Path: .ai_infra/docs/operations/permissions-and-prerequisites.md
+Role: Canonical checklist — what users must install, authorize, and configure before Agent Colony agents and the plugin work as documented.
+Used By:
+ - README.md
+ - PLUGIN-USER-GUIDE.md
+ - consumer-quickstart.md
+ - AGENTS.md
+ - workflow-activate skill
+Depends On:
+ - PLUGIN-USER-GUIDE.md
+ - consumer-quickstart.md
+ - connect-external-mcp.md
+ - project-board-collaboration.md
+Notes:
+ - Copied to consumer projects via manifest copy_ai_infra: docs/operations.
+ - Agent Colony does not ship a GitHub OAuth app; auth uses gh CLI + git on the user's machine.
+-->
+
+# What you need — permissions & prerequisites
+
+> **Read this before `/implementer`.** It lists everything you must have on your machine and what you must approve on GitHub so the **Cursor plugin**, **agents**, and **board SSOT** behave as documented.
+>
+> Install path: [consumer-quickstart](consumer-quickstart.md) · Full manual: [PLUGIN-USER-GUIDE](PLUGIN-USER-GUIDE.md)
+
+---
+
+## At a glance
+
+| Layer | Required for | What you give / install |
+|-------|----------------|-------------------------|
+| **Cursor IDE** | Plugin + agents | Open your app folder; allow terminal, workspace read/write, network |
+| **Python 3.11+** | Activate + CLI | Local venv (`.venv`) created by `/workflow-activate` |
+| **GitHub CLI (`gh`)** | Board SSOT + PR workflow | OAuth scopes: `repo`, `read:project`, `project` |
+| **Git credentials** | Push branches, open PRs | SSH key or HTTPS — standard git setup (not stored by the kit) |
+| **GitHub account access** | Board + repo operations | Write access to your **code repo** and **GitHub Project** |
+| **MCP** (optional) | Extra tools (DeepWiki, custom APIs) | Per-server tokens only when you opt in |
+
+**Agent Colony does not ask for a separate GitHub app or a token pasted into chat.** Agents call `gh` and git using **your** logged-in session.
+
+---
+
+## Two setup profiles
+
+Pick the profile that matches how you use the kit.
+
+### Profile A — Plugin + agents (no board SSOT)
+
+Use when `project_ssot.enabled: false` — local trackers only.
+
+| # | Requirement |
+|---|-------------|
+| 1 | [Cursor](https://cursor.com) with your **app repo** open (not the kit product repo `agent-colony`) |
+| 2 | Python **3.11+** |
+| 3 | Plugin: `/add-plugin https://github.com/SavinRazvan/agent-colony` |
+| 4 | Activate: `/workflow-activate` → wait for **`VERIFY PASS`** |
+| 5 | Identity: edit `.local/user_settings/github.collaboration.yaml` → `contributors validate` |
+| 6 | **`gh auth login`** with **`repo`** scope (for `/review-pr` → `/merge-pr`) |
+| 7 | **Git push/pull** to your remote |
+
+### Profile B — Full kit (GitHub Project board SSOT) — recommended
+
+Use when `project_ssot.enabled: true` and `sync_policy: board_only`.
+
+Everything in **Profile A**, plus:
+
+| # | Requirement |
+|---|-------------|
+| 8 | **`gh auth refresh -h github.com -s read:project,project`** (keep existing `repo`) |
+| 9 | A **GitHub Project** with **write access** for your user (org Projects need membership + Project access) |
+| 10 | **Default repository** on the Project set to your app repo (human UI when creating the Project) |
+| 11 | **`/board`** — paste Project URL + repo URL; confirm proposed YAML |
+| 12 | **Human UI:** Project views (minimal **2-view** or kit default **6-view**) — agents cannot API-create views today |
+| 13 | **`project doctor`** + **`board-bootstrap --check` exit 0** before `/implementer` |
+
+---
+
+## 1. Cursor IDE (plugin + agents)
+
+The plugin loads agents, skills, and rules into Cursor. **Activate** copies infrastructure into **your project folder**.
+
+| Capability | Why agents need it |
+|------------|-------------------|
+| **Your app folder open** | Activate and agents write `.cursor/`, `.ai_infra/`, `.local/` under your repo |
+| **Agent chat** (`/` menu) | `/workflow-activate`, `/implementer`, `/board`, PR slash skills |
+| **Terminal / shell** | `python3 -m agent_colony …`, `gh …`, `pytest` |
+| **Workspace read/write** | Code edits, trackers, workflow artifacts under `.local/` |
+| **Network** | Plugin install from GitHub, `gh` API, optional MCP servers |
+| **MCP enabled** (recommended) | Built-in `agent-colony-mcp`; DeepWiki seeded on consumer activate |
+| **Browser MCP** (optional) | Only if **you explicitly ask** for help clicking GitHub Project UI during board shell setup |
+
+**Cursor does not replace `gh auth login`.** GitHub permissions are configured on your machine via the GitHub CLI (§2).
+
+---
+
+## 2. GitHub CLI (`gh`) — main GitHub authorization
+
+When board SSOT is on, agents read and write the **GitHub Project** via `gh project …` GraphQL. PR skills use `gh pr …`.
+
+### Required OAuth scopes
+
+| Scope | Required? | Used for |
+|-------|-----------|----------|
+| **`repo`** | **Yes** | Issues, PRs, repo reads/writes, link PRs to board cards |
+| **`read:project`** | **Yes** (board SSOT) | Read Project, fields, items |
+| **`project`** | **Yes** (board SSOT) | Write Status, Notes, Priority/Size/Estimate, claim/handoff |
+| **`workflow`** | Optional | CI / Actions checks when driven via `gh` |
+
+### Setup
+
+**First login (new machine):**
+
+```bash
+gh auth login -h github.com
+```
+
+Choose HTTPS, authenticate via browser or device code, and allow access to the repos you use.
+
+**Add Project scopes to an existing login:**
+
+```bash
+gh auth refresh -h github.com -s read:project,project
+# Keeps existing repo (and workflow) scopes — refresh adds Project access.
+```
+
+**No browser (WSL, headless, SSH — `xdg-open: no method available`):**
+
+1. Run `gh auth login` or `gh auth refresh …` and leave the terminal open.
+2. Copy the **one-time code** from the terminal.
+3. Open **[https://github.com/login/device](https://github.com/login/device)** in any browser.
+4. Paste the code → sign in → **approve GitHub + Project permissions**.
+5. Return to the terminal — expect `✓ Authentication complete.`
+
+**Verify:**
+
+```bash
+gh auth status
+# Token scopes should include: repo, project
+# (read:project may show separately or be covered when project is present)
+
+python3 -m agent_colony project doctor    # when board SSOT on
+python3 -m agent_colony project status
+```
+
+If `gh` reports **missing required scopes `[read:project]` / `[project]`**, re-run `gh auth refresh -h github.com -s read:project,project` and complete the device link again.
+
+### Token type: classic vs fine-grained PAT
+
+| Method | Recommendation |
+|--------|----------------|
+| **`gh auth login` (OAuth via `gh`)** | **Preferred** — simplest for Projects |
+| **Classic PAT** | Works — needs `repo` + `project` (+ `read:project`) |
+| **Fine-grained PAT** | **Partial** — some Project mutations fail (e.g. Draft→Issue `promote-to-issue`) |
+
+If you see `Resource not accessible by fine-grained personal access token`, use **`gh auth login`** or a **classic PAT** with `project` + `repo`. `project doctor` notes this when relevant.
+
+---
+
+## 3. GitHub account & org access (beyond scopes)
+
+OAuth scopes are necessary but not sufficient. Your **GitHub user** must be able to reach the resources:
+
+| Access | Why |
+|--------|-----|
+| **Read/write on your code repo** | Create Issues, open/merge PRs, push feature branches |
+| **Read/write on the GitHub Project** | Board is the coordination SSOT when enabled |
+| **Org Projects** (if org-owned) | Account must be a member with Project access |
+| **Merge rights** (for `/merge-pr`) | Repo policy must allow your user to merge |
+
+### Human-only in GitHub UI (not API-automated today)
+
+- Project **views** (2-view minimal or 6-view default)
+- Column visibility on **Status board** and **Prioritized backlog**
+- Filters, layout, view rename
+
+See [board-shell skill](../../../.cursor/skills/board-shell/SKILL.md) and [project-board-collaboration](project-board-collaboration.md).
+
+---
+
+## 4. Git (separate from `gh`)
+
+| What | Required? | Notes |
+|------|-----------|-------|
+| **Push/pull to remote** | Yes (PR workflow) | SSH key or HTTPS credentials — standard git |
+| **Private repo clone** (researcher) | If researching private repos | Machine must already authenticate for `git clone` |
+
+The kit **does not store** git credentials. Research agent: no kit-side GitHub token — clone uses your local auth.
+
+---
+
+## 5. What the kit stores locally (secrets)
+
+| Path | Contains | Gitignored? |
+|------|----------|-------------|
+| `.local/user_settings/github.collaboration.yaml` | Name, `@handle`, board field ids — **no token** | Yes |
+| `.local/user_settings/mcp.secrets.yaml` | Optional MCP tokens (`mcp auth`) | Yes |
+| `.cursor/mcp.user.json` | MCP server transport config | Yes |
+
+Never commit tokens or paste them into Agent chat.
+
+---
+
+## 6. MCP servers (optional)
+
+| Server | Auth |
+|--------|------|
+| **`agent-colony-mcp`** (built-in, `with_mcp` profile) | None extra — uses local CLI |
+| **DeepWiki** (default seed on consumer activate) | **None** — public remote server |
+| **GitHub remote MCP** (stretch / opt-in) | Copilot OAuth seat **or** PAT with `repo` |
+| **Custom MCP** (Slack, DB, browser, …) | Per server — env vars / `mcp auth --token-env …` |
+
+Guide: [connect-external-mcp.md](connect-external-mcp.md) · Worksheet: `.local/user_settings/mcp.agents.yaml`
+
+---
+
+## 7. PR workflow permissions (`/review-pr` → `/merge-pr`)
+
+Uses the same **`gh` + `repo`** session:
+
+| Action | Permission |
+|--------|------------|
+| `gh pr view`, `gh pr create` | `repo` |
+| `gh pr merge` | `repo` + merge rights on the repo |
+| `project mention-pr` (board SSOT) | `repo` + `project` |
+| Post-merge board → Done (`merge.py`) | `project` write |
+
+Optional: **`workflow`** scope to inspect CI via `gh`.
+
+---
+
+## 8. What you do **not** need
+
+- No Agent Colony GitHub App install
+- No org-wide admin (unless your org policy requires it for Projects)
+- No token pasted into chat or committed to git
+- No Cursor-specific GitHub OAuth (beyond normal `gh` on your machine)
+- No browser automation unless you explicitly request it for board shell UI help
+
+---
+
+## Quick verification checklist
+
+### Profile A (no board)
+
+```bash
+python3 -m agent_colony contributors validate
+python3 -m agent_colony health
+gh auth status    # expect repo
+```
+
+### Profile B (board SSOT)
+
+```bash
+python3 -m agent_colony contributors validate
+gh auth status    # expect repo + project
+python3 -m agent_colony project doctor
+python3 -m agent_colony project board-bootstrap --check
+python3 -m agent_colony project status
+```
+
+Expect **`board-bootstrap --check` exit 0** before day-to-day `/implementer`.
+
+---
+
+## Related docs
+
+| Doc | Topic |
+|-----|-------|
+| [consumer-quickstart.md](consumer-quickstart.md) | 5-step install with screenshots |
+| [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) | Full plugin manual |
+| [project-board-collaboration.md](project-board-collaboration.md) | Board Entry/Exit, Tier-1 fields, outbox |
+| [connect-external-mcp.md](connect-external-mcp.md) | Optional MCP servers |
+| [abbreviations-notepad.md](abbreviations-notepad.md) | SSOT, Pattern A, DRIFT glossary |

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -185,7 +185,7 @@ Optional end-to-end check against the real Project (skipped in default CI).
 
 **Last PASS:** 2026-07-19 — `make live-board-smoke` (evidence: `.local/workflow-artifacts/release/live-board-smoke-2026-07-19.md`).
 
-1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes). If `xdg-open` fails, open **https://github.com/login/device**, paste the one-time code, and approve **Project** permissions — see [PLUGIN-USER-GUIDE § GitHub CLI auth](PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
+1. Auth with Project scopes: `gh auth refresh -h github.com -s read:project,project` (plus existing `repo` scopes). If `xdg-open` fails, open **https://github.com/login/device**, paste the one-time code, and approve **Project** permissions — see [permissions-and-prerequisites.md § GitHub CLI](permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization).
 2. Confirm: `python3 -m agent_colony project doctor` and `project status`.
 3. Clear any other card **In progress** for the same assignee (claim enforces `one_in_progress_per_assignee`).
 4. Run: `make live-board-smoke`  

--- a/payload/.ai_infra/templates/AGENTS.stub.md
+++ b/payload/.ai_infra/templates/AGENTS.stub.md
@@ -30,7 +30,7 @@ Details: [consumer-quickstart § First activate troubleshooting](.ai_infra/docs/
 1. Edit `.local/user_settings/github.collaboration.yaml` → your name + `@handle`
 2. `source .venv/bin/activate && python3 -m agent_colony contributors validate` (**must PASS**)
 3. If `project_ssot.enabled: true`:
-   - `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project` ([PLUGIN-USER-GUIDE § GitHub CLI auth](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#github-cli-auth-projects))
+   - `gh auth status` — if Project scopes missing: `gh auth refresh -h github.com -s read:project,project` ([permissions-and-prerequisites](.ai_infra/docs/operations/permissions-and-prerequisites.md))
    - Agent chat **`/board`** + paste **Project URL** + **repo URL** → agent wires `project_ssot` ids + `default_repo` (confirm before save)
    - `source .venv/bin/activate && python3 -m agent_colony project doctor` (expect **ok**)
    - **Minimal 2-view shell** (recommended — matches [Playground #3](https://github.com/users/SavinRazvan/projects/3)):

--- a/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
+++ b/payload/.ai_infra/templates/user-settings/exemplars/github.collaboration.yaml
@@ -10,7 +10,7 @@
 # Kit default: AI uses Assisted-by (not Co-authored-by: cursoragent@...).
 # Opt-in legacy mode below if your org requires Git co-author trailers for tools.
 # Project SSOT: set enabled: true and fill board ids; requires gh scopes read:project + project (+ repo).
-# Onboarding: gh auth login|refresh -s read:project,project — if no browser, https://github.com/login/device (see PLUGIN-USER-GUIDE § GitHub CLI auth).
+# Onboarding: gh auth login|refresh -s read:project,project — if no browser, https://github.com/login/device (see permissions-and-prerequisites.md § GitHub CLI).
 
 version: 1
 

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -117,7 +117,7 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 
 1. Open `.local/user_settings/github.collaboration.yaml` — set **display_name**, **github_user**. For Project SSOT: enable + `board_only`.
 2. Terminal: `source .venv/bin/activate && python3 -m agent_colony contributors validate` (must PASS).
-3. **`gh auth status`** — refresh Project scopes only if missing — [PLUGIN-USER-GUIDE § GitHub CLI auth](../../.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
+3. **`gh auth status`** — refresh Project scopes only if missing — [permissions-and-prerequisites.md § GitHub CLI](../../.ai_infra/docs/operations/permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization).
 4. Paste **Project URL + repo URL** in chat → **`/board`** wires `project_ssot` + `default_repo` (confirm before save) → `project doctor` + `project status`.
 5. When board SSOT enabled: optional **minimal 2-view overlay** ([Playground #3](https://github.com/users/SavinRazvan/projects/3)) → **`/board`** + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) → `board-bootstrap --check` until **exit 0** → `project status`. See [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md).
 6. **`/implementer`** to start · each session Entry: **`source .venv/bin/activate && python3 -m agent_colony project status`** when board SSOT on; else read `session-pointer.md` first. Audit (`/auditor`) is later — not day-0.

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -117,7 +117,7 @@ Tier 1 paths are created on first install; Tier 2 runtime `.md` files appear whe
 
 1. Open `.local/user_settings/github.collaboration.yaml` — set **display_name**, **github_user**. For Project SSOT: enable + `board_only`.
 2. Terminal: `source .venv/bin/activate && python3 -m agent_colony contributors validate` (must PASS).
-3. **`gh auth status`** — refresh Project scopes only if missing — [PLUGIN-USER-GUIDE § GitHub CLI auth](../../.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#github-cli-auth-projects).
+3. **`gh auth status`** — refresh Project scopes only if missing — [permissions-and-prerequisites.md § GitHub CLI](../../.ai_infra/docs/operations/permissions-and-prerequisites.md#2-github-cli-gh--main-github-authorization).
 4. Paste **Project URL + repo URL** in chat → **`/board`** wires `project_ssot` + `default_repo` (confirm before save) → `project doctor` + `project status`.
 5. When board SSOT enabled: optional **minimal 2-view overlay** ([Playground #3](https://github.com/users/SavinRazvan/projects/3)) → **`/board`** + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) → `board-bootstrap --check` until **exit 0** → `project status`. See [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md).
 6. **`/implementer`** to start · each session Entry: **`source .venv/bin/activate && python3 -m agent_colony project status`** when board SSOT on; else read `session-pointer.md` first. Audit (`/auditor`) is later — not day-0.


### PR DESCRIPTION
## Summary

- Add canonical doc **What you need — permissions & prerequisites** (`permissions-and-prerequisites.md`) covering Cursor IDE, `gh` OAuth scopes, git, GitHub Project access, MCP, and PR workflow expectations
- Link from README, consumer-quickstart, PLUGIN-USER-GUIDE, operations index, AGENTS.md, workflow-activate skill, and related onboarding surfaces
- Sync payload bundle copy for consumer activate

## Test plan

- [x] `make doc-validate` — all 8 checks PASS
- [x] `check_governance_consistency.py` — PASS
- [x] Verified all linked doc paths exist
- [x] Factual review against PLUGIN-USER-GUIDE, gh_project_adapter fine-grained PAT caveat, pyproject `requires-python >=3.11`