### PR TITLE
feat: Use ASD-STE100 token efficiency (all slices)

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -16,7 +16,7 @@ Notes:
 # Implementation status (Agent Colony)
 
 **Last updated:** 2026-08-09 (board End date on Done; kit 0.6.3)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.3 · **Tests:** 1504
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.3 · **Tests:** 1510
 
 ## Shipped (confirmed in repo)
 
@@ -57,7 +57,7 @@ Notes:
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.3 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1504 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1510 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -237,7 +237,7 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 
 **Listing copy refresh (2026-08-09 board Status + Tier-1 / heal-cards):** `project heal-cards`, create Status default `ready`, validate empty Status + Tier-1, close-linked-issue Done gate, merge outbox queue, ephemeral consumer smoke; **1496** tests; **8** / **14** / **7**; kit version **0.6.2**.
 
-**Listing copy refresh (2026-08-09 board End date on Done):** Agents set End date (UTC) on Status→Done; validate/heal/board-shell Tier-1; `set_end_date_on_done`; **1504** tests; **8** / **14** / **7**; kit version **0.6.3**.
+**Listing copy refresh (2026-08-09 board End date on Done):** Agents set End date (UTC) on Status→Done; validate/heal/board-shell Tier-1; `set_end_date_on_done`; **1510** tests; **8** / **14** / **7**; kit version **0.6.3**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1504; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1510; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1504; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1510; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/README.md
+++ b/.ai_infra/docs/operations/README.md
@@ -31,6 +31,7 @@ Depends On:
 - [`upgrade-kit.md`](upgrade-kit.md) — reinstall / semver upgrade
 - [`project-config.md`](project-config.md) — optional `project.config.yaml` metadata
 - [`token-efficiency.md`](token-efficiency.md) — agent read/write contract
+- [`asd-ste100-prose.md`](asd-ste100-prose.md) — **Use ASD-STE100** (free prose guide; token-efficiency research)
 - [`logging-and-errors.md`](logging-and-errors.md) — logging baseline
 - [`abbreviations-notepad.md`](abbreviations-notepad.md) — shared abbreviations
 

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -49,6 +49,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **con
 | RC | Release candidate — needs CI/CD evidence bundles before ship |
 | UI | GitHub Project / settings UI (humans); agents prefer CLI |
 | PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes — see [permissions-and-prerequisites](permissions-and-prerequisites.md) |
+| ASD-STE100 | Simplified Technical English (ASD). Kit: **Use ASD-STE100** → [asd-ste100-prose.md](asd-ste100-prose.md) (free principles; no dictionary; not compliance) |
 | GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
 | KISS | Keep It Simple — incremental, reversible slices |
 | DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |

--- a/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -1,0 +1,66 @@
+<!--
+File: asd-ste100-prose.md
+Path: .ai_infra/docs/operations/asd-ste100-prose.md
+Role: Free-path Use ASD-STE100 prose guide for agent-facing instructions (token efficiency research).
+Used By:
+ - .cursor/agents/*.md
+ - .cursor/skills/*
+ - token-efficiency.md
+ - AGENTS.md
+Depends On:
+ - token-efficiency.md
+Notes:
+ - Inspired by ASD-STE100 writing principles. No ASD dictionary. No purchase. Not a compliance claim.
+-->
+
+# Use ASD-STE100
+
+**Mandatory for agents.** Write instructions, Notes, and handoffs with this guide.
+
+Inspired by [ASD-STE100](https://asd-ste100.org/) writing principles. This kit ships a **free** guide only.
+
+| Do | Do not |
+|----|--------|
+| Follow this file | Buy or license ASD materials for this kit |
+| Use **kit vocabulary** below | Embed ASD’s dictionary in the repo |
+| Say *inspired by ASD-STE100* | Claim *ASD-STE100 compliant* |
+
+Research goal: clearer prose → fewer tokens → measure before/after byte and line counts.
+
+## Writing rules (free principles)
+
+1. Use short sentences. Prefer under 20 words.
+2. Put one instruction in each bullet.
+3. Use active voice. Prefer imperatives: `Run project entry.`
+4. Give each word one meaning in this kit (see vocabulary).
+5. Link to skills or CLI. Do not paste long procedures.
+6. Prefer tables for commands.
+7. Say *prepare gates green* or paste failing stderr only. Do not paste full gate lists.
+
+## Kit vocabulary (ours — not ASD’s dictionary)
+
+| Term | Meaning | Do not also say |
+|------|---------|-----------------|
+| **Use ASD-STE100** | Follow this file | “STE style” without this link |
+| Entry | `python -m agent_colony project entry` | Unfiltered `list` / full `export` as default |
+| Claim | `project claim --last --agent <id>` | Vague “take the card” |
+| Handoff | `project handoff --last …` | Separate Status + Notes as the default recipe |
+| Gates green | `prepare.py` passed | Pasting full `GATES` / gate subprocess lists |
+| Board SSOT | GitHub Project writable Status when enabled | Local tracker Status under `board_only` |
+| Tier-1 | Status, Priority, Size, Estimate, dates, Assignee, PR link | “All the fields” without the skill |
+| EXIT_QUEUED | Exit code 6 — outbox; flush later | Retry loops on GraphQL throttle |
+
+## When agents write
+
+| Surface | Rule |
+|---------|------|
+| Agent cards | Keep Anchors short. Point here + `token-efficiency.md`. |
+| Skills | Procedure lives in the skill. Cards link to sections. |
+| Board Notes | Attributed one-liners. No gate dumps. |
+| Chat handoff | One line: Status · next · Tasks `[P…]` |
+
+## Related
+
+- [token-efficiency.md](token-efficiency.md) — read/write contract
+- [board-ssot skill](../../../.cursor/skills/board-ssot/SKILL.md) — Tier-1 and Continuation
+- Official standard (reference only): [asd-ste100.org](https://asd-ste100.org/)

--- a/.ai_infra/docs/operations/token-efficiency.md
+++ b/.ai_infra/docs/operations/token-efficiency.md
@@ -7,12 +7,28 @@ Used By:
 Depends On:
  - .ai_infra/scripts/pr/prepare.py
  - docs/governance/workflow-source-owners.md
+ - asd-ste100-prose.md
 Notes:
  - When project_ssot.enabled: pair with board Status + card Notes for resume-without-chat.
  - Else: session-pointer.md + change-index.md.
+ - Use ASD-STE100: see asd-ste100-prose.md (free principles; no ASD dictionary).
 -->
 
 # Token efficiency (agent contract)
+
+**Use ASD-STE100** for agent-facing prose: [asd-ste100-prose.md](asd-ste100-prose.md).
+
+## Skill thin-index (intent)
+
+Load the section you need. Do not load whole skills by default.
+
+| Skill | Read when | Prefer |
+|-------|-----------|--------|
+| `board-ssot` | Mutating Status / Tier-1 | § Continuation · § Tier-1 |
+| `implementer-loop` | Implement slice | Full skill (short) |
+| `drift-audit` | drift-guard pass | Steps 1–3 |
+| `auditor-protocol` | Audit task | Evidence contract + current phase |
+| `workflow-activate` | Consumer install | “When user just installed” |
 
 ## Read set (default)
 
@@ -40,6 +56,15 @@ Notes:
 | 5 | `workflow-artifacts/pr/*.md` | Only when phase = review \| prepare \| merge |
 
 **Skip:** `.local/generated-data/**`, `history/archive/**`, full `updates-log.md` body, full `AGENTS.md` unless explicitly tasked.
+
+**Prefer CLI digests (token-efficient):**
+
+| Need | Command |
+|------|---------|
+| Entry summary | `python -m agent_colony project entry --digest` (or `--json`) |
+| Agent roster | `python -m agent_colony doc roster-digest` |
+| Doc head | `python -m agent_colony doc summarize --path …` |
+| Prepare gates | `python .ai_infra/scripts/pr/prepare.py … --summary` |
 
 ## Write set (slice close)
 

--- a/.ai_infra/install/agent_colony/doc_cli.py
+++ b/.ai_infra/install/agent_colony/doc_cli.py
@@ -1,18 +1,20 @@
 """
 File: doc_cli.py
 Path: .ai_infra/install/agent_colony/doc_cli.py
-Role: CLI handlers for doc subcommands (canonical doc fact validation).
+Role: CLI handlers for doc subcommands (canonical doc fact validation + digests).
 Used By:
  - .ai_infra/install/agent_colony/cli.py
 Depends On:
  - .ai_infra/scripts/architecture/check_doc_facts.py
 Notes:
  - Adds scripts/architecture to sys.path for consumer installs.
+ - roster-digest / summarize support token-efficient agent Entry.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -51,8 +53,6 @@ def cmd_doc_validate(args: argparse.Namespace) -> int:
     if preflight is not None:
         check_doc_facts.write_preflight_json(results, preflight)
     if args.json:
-        import json
-
         payload = {
             "results": [
                 {
@@ -69,6 +69,77 @@ def cmd_doc_validate(args: argparse.Namespace) -> int:
     else:
         print(check_doc_facts.format_report(results))
     return check_doc_facts.exit_code_for(results)
+
+
+def cmd_doc_roster_digest(args: argparse.Namespace) -> int:
+    """Print agent id + one-line description (token-efficient roster)."""
+    root = Path(args.directory).resolve()
+    agents_dir = root / ".cursor" / "agents"
+    if not agents_dir.is_dir():
+        print(f"doc roster-digest: FAIL — missing {agents_dir}", file=sys.stderr)
+        return 1
+    rows: list[dict[str, str]] = []
+    for path in sorted(agents_dir.glob("*.md")):
+        agent_id = path.stem
+        desc = ""
+        text = path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if line.startswith("description:"):
+                desc = line.split(":", 1)[1].strip()
+                break
+        rows.append({"id": agent_id, "description": desc})
+    if args.json:
+        print(json.dumps({"agents": rows, "count": len(rows)}, indent=2))
+    else:
+        print(f"agents={len(rows)}")
+        for row in rows:
+            short = row["description"]
+            if len(short) > 72:
+                short = short[:69] + "…"
+            print(f"{row['id']}\t{short}")
+    return 0
+
+
+def cmd_doc_summarize(args: argparse.Namespace) -> int:
+    """Print first N non-empty lines of a markdown/doc path (token-efficient)."""
+    root = Path(args.directory).resolve()
+    path = Path(args.path)
+    if not path.is_absolute():
+        path = (root / path).resolve()
+    if not path.is_file():
+        print(f"doc summarize: FAIL — missing {path}", file=sys.stderr)
+        return 1
+    max_lines = int(args.lines)
+    lines_out: list[str] = []
+    in_comment = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if in_comment:
+            if "-->" in stripped:
+                in_comment = False
+            continue
+        if stripped.startswith("<!--"):
+            if "-->" not in stripped:
+                in_comment = True
+            continue
+        if not stripped:
+            continue
+        lines_out.append(line.rstrip())
+        if len(lines_out) >= max_lines:
+            break
+    payload = {
+        "path": str(path.relative_to(root) if path.is_relative_to(root) else path),
+        "lines": lines_out,
+        "truncated": len(lines_out) >= max_lines,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"path={payload['path']} · lines={len(lines_out)}"
+              f"{' · truncated' if payload['truncated'] else ''}")
+        for line in lines_out:
+            print(line)
+    return 0
 
 
 def register_doc_subparser(sub: argparse._SubParsersAction) -> None:
@@ -93,3 +164,21 @@ def register_doc_subparser(sub: argparse._SubParsersAction) -> None:
         help="Custom preflight JSON path",
     )
     validate_cmd.set_defaults(func=cmd_doc_validate)
+
+    roster_cmd = doc_sub.add_parser(
+        "roster-digest",
+        help="Token-efficient agent roster (id + description)",
+    )
+    roster_cmd.add_argument("--directory", type=Path, default=".")
+    roster_cmd.add_argument("--json", action="store_true")
+    roster_cmd.set_defaults(func=cmd_doc_roster_digest)
+
+    summarize_cmd = doc_sub.add_parser(
+        "summarize",
+        help="First N non-empty lines of a doc (token-efficient)",
+    )
+    summarize_cmd.add_argument("--directory", type=Path, default=".")
+    summarize_cmd.add_argument("--path", required=True, help="Repo-relative or absolute path")
+    summarize_cmd.add_argument("--lines", type=int, default=40, help="Max non-empty lines")
+    summarize_cmd.add_argument("--json", action="store_true")
+    summarize_cmd.set_defaults(func=cmd_doc_summarize)

--- a/.ai_infra/install/agent_colony/project_cli.py
+++ b/.ai_infra/install/agent_colony/project_cli.py
@@ -1492,22 +1492,73 @@ def cmd_export(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def _print_entry_rows(items: list[dict[str, Any]], *, statuses: set[str]) -> int:
-    """Print TSV rows matching normalized statuses; return count printed."""
-    printed = 0
+def _filter_entry_items(
+    items: list[dict[str, Any]], *, statuses: set[str]
+) -> list[dict[str, Any]]:
+    """Return items matching normalized statuses."""
+    out: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, dict):
             continue
         status = _normalize_status(str(item.get("status") or item.get("status_normalized") or ""))
         if status not in statuses:
             continue
-        printed += 1
+        out.append(item)
+    return out
+
+
+def _print_entry_rows(items: list[dict[str, Any]], *, statuses: set[str]) -> int:
+    """Print TSV rows matching normalized statuses; return count printed."""
+    matched = _filter_entry_items(items, statuses=statuses)
+    for item in matched:
         print(
             f"{item.get('id')}\t{item.get('status')}\t{item.get('priority') or ''}\t"
             f"{item.get('size') or ''}\t{item.get('estimate') or item.get('Estimate') or ''}\t"
             f"{item.get('title')}"
         )
-    return printed
+    return len(matched)
+
+
+def _emit_entry_digest(
+    *,
+    mode: str,
+    rem_disp: str,
+    next_cmd: str,
+    matched: list[dict[str, Any]],
+    as_json: bool,
+    digest: bool,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Print token-efficient entry summary (--digest / --json)."""
+    payload: dict[str, Any] = {
+        "mode": mode,
+        "graphql_remaining": rem_disp,
+        "item_count": len(matched),
+        "next": next_cmd,
+        "items": [
+            {
+                "id": it.get("id"),
+                "status": it.get("status"),
+                "title": it.get("title"),
+                "priority": it.get("priority") or "",
+            }
+            for it in matched[:20]
+        ],
+    }
+    if extra:
+        payload.update(extra)
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return
+    if digest:
+        print(
+            f"mode={mode} · graphql_remaining={rem_disp} · "
+            f"items={len(matched)} · next={next_cmd}"
+        )
+        for it in matched[:5]:
+            print(f"  {it.get('id')}\t{it.get('status')}\t{it.get('title')}")
+        if len(matched) > 5:
+            print(f"  … +{len(matched) - 5} more")
 
 
 def cmd_entry(args: argparse.Namespace) -> int:
@@ -1521,20 +1572,36 @@ def cmd_entry(args: argparse.Namespace) -> int:
     if errs or ssot is None:
         return fail("entry", EXIT_USAGE, errs[0] if errs else "project_ssot missing")
     enabled = bool(ssot.get("enabled"))
-    print(f"enabled: {enabled}")
-    print(f"operational: {enabled}")
-    print(f"name: {ssot.get('name')}")
-    print(f"owner: {ssot.get('owner')}")
-    print(f"number: {ssot.get('number')}")
-    print(f"url: {ssot.get('url')}")
-    print(f"project_id: {ssot.get('project_id')}")
-    print(f"sync_policy: {ssot.get('sync_policy')}")
-    print(f"fallback: {ssot.get('fallback')}")
+    compact = bool(getattr(args, "digest", False) or getattr(args, "json", False))
+    as_json = bool(getattr(args, "json", False))
+    digest = bool(getattr(args, "digest", False)) and not as_json
+
+    if not compact:
+        print(f"enabled: {enabled}")
+        print(f"operational: {enabled}")
+        print(f"name: {ssot.get('name')}")
+        print(f"owner: {ssot.get('owner')}")
+        print(f"number: {ssot.get('number')}")
+        print(f"url: {ssot.get('url')}")
+        print(f"project_id: {ssot.get('project_id')}")
+        print(f"sync_policy: {ssot.get('sync_policy')}")
+        print(f"fallback: {ssot.get('fallback')}")
     if not enabled:
-        print(
-            "mode=offline_artifacts · graphql_remaining=? · "
-            "next=local_trackers|enable project_ssot"
-        )
+        if compact:
+            _emit_entry_digest(
+                mode="offline_artifacts",
+                rem_disp="?",
+                next_cmd="local_trackers|enable project_ssot",
+                matched=[],
+                as_json=as_json,
+                digest=digest or True,
+                extra={"enabled": False},
+            )
+        else:
+            print(
+                "mode=offline_artifacts · graphql_remaining=? · "
+                "next=local_trackers|enable project_ssot"
+            )
         return EXIT_OK
 
     eff = load_efficiency_config(ssot)
@@ -1572,23 +1639,37 @@ def cmd_entry(args: argparse.Namespace) -> int:
     if force_live and mode != "offline_artifacts":
         mode = "live"
 
-    printed = 0
+    matched: list[dict[str, Any]] = []
     if mode == "offline_artifacts":
-        print(f"snapshot: {snap} exists={snap.is_file()}")
-        trackers = root / ".local" / "index-and-planning" / "current"
-        print(f"local_trackers: {trackers}")
-        print("advise: queue writes via `project queue`; flush when GraphQL recovers")
+        if not compact:
+            print(f"snapshot: {snap} exists={snap.is_file()}")
+            trackers = root / ".local" / "index-and-planning" / "current"
+            print(f"local_trackers: {trackers}")
+            print("advise: queue writes via `project queue`; flush when GraphQL recovers")
         if snap.is_file():
             try:
                 data = json.loads(snap.read_text(encoding="utf-8"))
                 items = data.get("items") if isinstance(data, dict) else []
                 if isinstance(items, list):
-                    printed = _print_entry_rows(items, statuses=want)
+                    matched = _filter_entry_items(items, statuses=want)
+                    if not compact:
+                        _print_entry_rows(items, statuses=want)
             except (OSError, json.JSONDecodeError, TypeError):
-                print("(snapshot unreadable)")
-        if printed == 0:
-            print("(no items)")
-        print(f"mode={mode} · graphql_remaining={rem_disp} · next=queue|get|claim")
+                if not compact:
+                    print("(snapshot unreadable)")
+        if compact:
+            _emit_entry_digest(
+                mode=mode,
+                rem_disp=rem_disp,
+                next_cmd="queue|get|claim",
+                matched=matched,
+                as_json=as_json,
+                digest=digest or True,
+            )
+        else:
+            if not matched:
+                print("(no items)")
+            print(f"mode={mode} · graphql_remaining={rem_disp} · next=queue|get|claim")
         return EXIT_OK
 
     if mode == "conserve":
@@ -1601,13 +1682,25 @@ def cmd_entry(args: argparse.Namespace) -> int:
                     items = data.get("items") if isinstance(data, dict) else []
                     if not isinstance(items, list):
                         items = []
-                    printed = _print_entry_rows(items, statuses=want)
-                    if printed == 0:
-                        print("(no items)")
-                    print(
-                        f"mode={mode} · graphql_remaining={rem_disp} · "
-                        f"snapshot_age={int(age)}s · next=claim|get"
-                    )
+                    matched = _filter_entry_items(items, statuses=want)
+                    if compact:
+                        _emit_entry_digest(
+                            mode=mode,
+                            rem_disp=rem_disp,
+                            next_cmd="claim|get",
+                            matched=matched,
+                            as_json=as_json,
+                            digest=digest or True,
+                            extra={"snapshot_age_s": int(age)},
+                        )
+                    else:
+                        _print_entry_rows(items, statuses=want)
+                        if not matched:
+                            print("(no items)")
+                        print(
+                            f"mode={mode} · graphql_remaining={rem_disp} · "
+                            f"snapshot_age={int(age)}s · next=claim|get"
+                        )
                     return EXIT_OK
                 except (OSError, json.JSONDecodeError, TypeError):
                     pass
@@ -1622,10 +1715,21 @@ def cmd_entry(args: argparse.Namespace) -> int:
     for it in items:
         if isinstance(it, dict) and "status_normalized" not in it:
             it["status_normalized"] = _normalize_status(str(it.get("status") or ""))
-    printed = _print_entry_rows(items, statuses=want)
-    if printed == 0:
-        print("(no items)")
-    print(f"mode={mode} · graphql_remaining={rem_disp} · next=claim|get")
+    matched = _filter_entry_items(items, statuses=want)
+    if compact:
+        _emit_entry_digest(
+            mode=mode,
+            rem_disp=rem_disp,
+            next_cmd="claim|get",
+            matched=matched,
+            as_json=as_json,
+            digest=digest or True,
+        )
+    else:
+        _print_entry_rows(items, statuses=want)
+        if not matched:
+            print("(no items)")
+        print(f"mode={mode} · graphql_remaining={rem_disp} · next=claim|get")
     return EXIT_OK
 
 

--- a/.ai_infra/install/agent_colony/project_parser.py
+++ b/.ai_infra/install/agent_colony/project_parser.py
@@ -55,6 +55,16 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Override efficiency.entry_list_limit for live mode",
     )
+    entry_cmd.add_argument(
+        "--digest",
+        action="store_true",
+        help="One-line mode + item count + next command (token-efficient)",
+    )
+    entry_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON digest (mode, remaining, items, next)",
+    )
     entry_cmd.set_defaults(func=pc.cmd_entry)
 
     list_cmd = project_sub.add_parser("list", help="List project items (optional status filter)")

--- a/.ai_infra/scripts/pr/prepare.py
+++ b/.ai_infra/scripts/pr/prepare.py
@@ -107,6 +107,11 @@ def main() -> int:
             "verified all gates; the artifact will record gates as externally verified."
         ),
     )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print one-line PASS/FAIL per gate (token-efficient); still writes prep.md",
+    )
     args = parser.parse_args()
 
     try:
@@ -142,13 +147,17 @@ def main() -> int:
     ]
 
     failed = False
+    summary_rows: list[str] = []
     if args.skip_gates:
         lines.append("- gates: externally verified by agent before this script call")
+        summary_rows.append("gates: externally verified")
     else:
         for gate in resolve_gates(Path.cwd()):
             code, output = _run(gate)
             label = "PASS" if code == 0 else "FAIL"
-            lines.append(f"- `{ ' '.join(_resolve_gate_cmd(gate)) }` -> {label}")
+            cmd_disp = " ".join(_resolve_gate_cmd(gate))
+            lines.append(f"- `{cmd_disp}` -> {label}")
+            summary_rows.append(f"{label}\t{cmd_disp}")
             if code != 0:
                 failed = True
                 lines.append("")
@@ -167,7 +176,13 @@ def main() -> int:
         ]
     )
     prep_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"Created {prep_file}")
+    if args.summary:
+        verdict = "FAIL" if failed else "PASS"
+        print(f"prepare: {verdict} · pr={args.pr} · artifact={prep_file}")
+        for row in summary_rows:
+            print(row)
+    else:
+        print(f"Created {prep_file}")
     return 1 if failed else 0
 
 

--- a/.cursor/agents/auditor.md
+++ b/.cursor/agents/auditor.md
@@ -6,61 +6,37 @@ description: auditor Agent Colony — Deep/periodic evidence architecture audit 
 
 # Auditor
 
-## What we own (deep / periodic)
+## Own
 
-**Own:** Evidence-only enterprise architecture and engineering audit — architecture, security (code + agent contracts), performance, granularity/boundaries, documentation quality — via `auditor-protocol` CHK-* checklists. Full scorecard or focused alignment for architecture-impacting PRs.
-
-**Do not own:** Continuous goal/plan/agent-doctrine coherence when plans change — that is **`drift-guard`** (script + goal pulse). Do not auto-fix product code unless the user explicitly asks.
+Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is `drift-guard`. No product-code auto-fix unless user asks.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + board context. If no audit card: `create-from-template --template slice --title "[AUDIT] …" --status ready --priority p1 --size s --estimate 1 --agent auditor` then `claim --last --agent auditor`. Else `session-pointer.md` + `change-index.md`.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+**Entry:** If SSOT on: `project status`. If no audit card: `create-from-template` `[AUDIT]` → `claim --last --agent auditor`. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent auditor` (→ `@owner.github_user/auditor`); atomics `append-notes --agent auditor` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Write audit artifacts. Status → `in_review`/`done`. Put paths in Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. When proposing Ready cards, recommend Priority/Size/Estimate alongside Severity.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent auditor`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …" --priority p1 --size s --estimate 1 --agent auditor` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `auditor-protocol` skill.
 
-Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
+## Read first
 
-**Write scope:** `.local/workflow-artifacts/` (paths in `.ai_infra/scripts/pr/local_workflow_paths.py`) and tracker hooks only — **no product-code auto-remediation** unless the user explicitly asks. (`readonly` is not set so Task delegation can write audit artifacts per Cursor subagent semantics.)
+- `.cursor/skills/auditor-protocol/SKILL.md` — Evidence contract + current phase
+- `audit-orchestration` / `audit-module-map` when tasked
+- Plan/work-tracker read-only if present
 
-**Evidence-backed deliverables:** follow the **Evidence contract** in `.cursor/skills/auditor-protocol/SKILL.md` — every **Confirmed** repo claim cites paths; **Probable risk** separates facts from inference; **Unknown** states what was not verifiable.
+## Write (full audit)
 
-## Read first (scope + workflow)
+1. `enterprise-architecture-audit/enterprise-architecture-audit.md`
+2. `enterprise-architecture-audit/enterprise-audit-actions.md`
+3. Alignment files when schema applies (advisory)
 
-- `.cursor/skills/auditor-protocol/SKILL.md` — **full operating protocol, phases, scorecard, and output contract**
-- `.ai_infra/templates/project-board/README.md` — when creating audit cards
-- `AGENTS.md`, `README.md`
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` (if present — do not assume content)
-- Project `docs/architecture/` (local stub: `.local/.../current/architecture.md`)
-- `.ai_infra/docs/operations/local-workspace-layout.md` — where artifacts live under `.local/`
-
-**Deep module topology:** when the user wants a generated module map + HTML export, run `.cursor/skills/audit-module-map/SKILL.md` first or in parallel, then fold summarized evidence into the enterprise audit.
-
-**Full audit orchestration:** when running a phased audit with script preflight and Task delegation, follow `.cursor/skills/audit-orchestration/SKILL.md`.
-
-## Write (mandatory for a full audit)
-
-1. **Primary report:** `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md`
-2. **Action backlog:** `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md`
-3. **Optional — governance drift:** if findings match `.ai_infra/docs/roadmap/alignment-audit-schema.md`, add or reference them in `.local/workflow-artifacts/alignment/alignment-audit.md` / `alignment-todos.md` (advisory; do not auto-remediate).
-
-## Tracker etiquette
-
-- Do **not** silently overwrite `plan.md` / `work-tracker.md`. Propose concrete tracker edits (gate counts, closed EA IDs, dates) in `enterprise-audit-actions.md`; **implementer** applies them so Plan / Work Tracker ICC tabs match audit reality.
-- Log a short entry in `.local/index-and-planning/history/updates-log.md` when the audit completes.
-
-## Architecture cross-check
-
-When project overlays exist (`overlays/rules/*.mdc`), cross-check claims against those boundaries. Universal rules always apply from `.cursor/rules/`.
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -70,13 +46,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** When producing audit or alignment artifacts, persist session evidence via `canvas save` / `plan snapshot` under `.local/canvases/` and `.local/plans/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/board.md
+++ b/.cursor/agents/board.md
@@ -8,82 +8,45 @@ description: board Agent Colony — Wire Project SSOT, triage cards, and coach f
 
 ## Anchor (mandatory)
 
-**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/board-ssot/SKILL.md`. Run `python -m agent_colony project entry` (quota-aware). **Wire-from-URLs (day-0):** if the human pastes a **Project URL** + **repo URL** after `gh` auth, use `gh project view` / `field-list` to propose YAML updates — human confirms before save (discovery only — **no** `--ensure-fields` until CONSENT GATE). **First-run / shell setup:** load `.cursor/skills/board-shell/SKILL.md` — **CONSENT GATE is mandatory** (ask board description + “may I proceed to create the default shell?”) before TURN PROTOCOL or `--apply-readme` / `--ensure-fields`. Then `project board-bootstrap --check` against `board-shell.schema.yaml` — refuse “ready” until the **default** Playground shell (six views + Tier-1 columns on Status board / Prioritized backlog) and README pass.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+**Entry:** Read `github.collaboration.yaml` → `project_ssot`. Run `project entry`. Wire-from-URLs: propose YAML; human confirms. First-run: `board-shell` **CONSENT GATE** before TURN PROTOCOL / `--apply-readme` / `--ensure-fields`. Refuse ready until `board-bootstrap --check` exit 0.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `project claim` / `project handoff --agent board` (→ `@owner.github_user/board`); atomics `append-notes --agent board` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Update Status via CLI. Append `change-index.md`. One line in `updates-log.md`. Print handoff. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. On triage/create: **must** set Priority, Size, and Estimate (not optional).
+**Board rights:** Status + Notes on the card you touch. Prefer `claim` / `handoff --agent board`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards **must** set Priority/Size/Estimate via `set-field` (Tier-1 contract). Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
-
-**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`. **Board shell:** first-run = **CONSENT GATE** (description + proceed) then `board-shell` + human `views-setup.md` / TURN PROTOCOL; optional `board-bootstrap --apply-readme` / `--ensure-fields` only after `proceed=yes`. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** On triage/create **must** set Priority, Size, Estimate. Canon: `board-ssot` § Tier-1.
 
 ## Role
 
-Own **board triage and Status transitions** for the product Project SSOT (`agent-colony`). Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines. **Also** coach first-run board shell (schema check + human views) via `board-shell`.
+Triage and Status. Hand code to implementer. Coach board shell via `board-shell`.
 
 ## Read first
 
-- `.cursor/skills/board-ssot/SKILL.md`
-- `.cursor/skills/board-shell/SKILL.md` — when first-time / `board-bootstrap --check` fails vs `board-shell.schema.yaml`
-- `.ai_infra/templates/project-board/board-shell.schema.yaml` — kit **default** desired state (six Playground views)
-- `.ai_infra/templates/project-board/README.md` — when creating cards
-- `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `AGENTS.md` (STANDALONE product + board SSOT north star)
-- `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation · § Tier-1
+- `.cursor/skills/board-shell/SKILL.md` when bootstrap fails
+- `board-shell.schema.yaml` · project-board README · ADR-008
 
 ## Loop
 
-### First-run (shell)
+**Wire-only exit:** `board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN`
 
-0. If YAML board ids are missing and the human pasted **Project URL + repo URL**: resolve with `gh`, propose `project_ssot` + `default_repo`, wait for human confirm, then continue.
+| Automated | Human UI |
+|-----------|----------|
+| YAML, fields, README | Views / columns / filters |
 
-**Exit (wire-only):** After YAML save + `contributors validate` / `project doctor` pass, print:
+**First-run:** CONSENT → TURN PROTOCOL one turn at a time → `--check` exit 0.
 
-```text
-board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
-```
-
-Then print the **automation boundary** (never say “ready for `/implementer`” or “same API path for views”):
-
-| Automated (CLI/API) | Human UI only |
-|---------------------|---------------|
-| YAML ids, field definitions, README (`--apply-readme`) | Views (kit default: six Playground; **minimal overlay: two views**) |
-| `contributors validate`, `project doctor` | Column visibility on Status board + Prioritized backlog |
-| `--ensure-fields` | Filters, layout, rename View 1 |
-
-**Minimal 2-view path:** when the user wants a simple board, offer copy of `board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml` and coach Turn A + Turn B only (see `board-shell` § Customization).
-
-Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 0.
-
-1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the board shell?` (Playground default **or** minimal 2-view overlay if user asked) — wait for `yes` before any shell work. If `no`, stop.
-2. Follow `.cursor/skills/board-shell/SKILL.md` — especially **TURN PROTOCOL** when `board-bootstrap --check` FAILs missing views.
-3. **Do not** dump “follow views-setup.md” and stop. One view/column turn at a time; wait for human `done`; re-run `--check` after each turn.
-4. Optional smoke `create-from-template` then cleanup only after `board-bootstrap --check` exit 0 (no view FAIL, no Tier-1 column FAIL).
-
-### Day-to-day (cards)
-
-1. `python -m agent_colony project entry --directory .` (or `status` + scoped `list` when already live)
-2. Prefer Pattern A: `create-from-template --template slice|bug` then `claim --last --agent board` (or `claim --id <real PVTI_>`). Use `--template bug` for defect/`fix/` work. Avoid raw multi-step claim unless atomics are required.
-3. Print handoff line for implementer: item id, title, next Status target
-4. **Verify:** CLI exit 0 + board list reflects change
+**Day-to-day:** `project entry` → `create-from-template` → `claim --last` → handoff to implementer.
 
 ## Boundaries
 
-| Do | Do not |
-|----|--------|
-| Drive board via `agent_colony project` | Bypass `prepare.py` gates |
-| Coach shell via schema + human UI | Create/rename Project **views** via API |
-| Use YAML field/option ids | Dual-write board + tracker SSOT |
-| Hand off code slices to implementer | Mutate unrelated repositories |
-| Fall back to local trackers when disabled | Invent MCP tools |
-| One TURN PROTOCOL turn → wait `done` → re-check | Bulk-dump all views from `views-setup.md` in one message |
-| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn; follow **Browser assist map** in `board-shell` / `views-setup.md` | Open browser MCP for views unprompted; invent GraphQL view mutations |
-| | Say “ready for `/implementer`” after wire-only (API slice) |
+Do: CLI board + shell coach. Do not: invent view GraphQL; say ready for `/implementer` after wire-only; open browser MCP unprompted.
 
-## Handoff format
+If the user asks for browser help on views/columns, use browser MCP for that turn only — follow **Browser assist map** in `board-shell` / `views-setup.md`.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -93,13 +56,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | Trackers/gates if needed — prefer `agent_colony project` for board |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `board` |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Live plan SSOT on the board card (`board_only`) or `plan.md` offline — `.local/plans/` is snapshot-only; `plan snapshot|list|open` for history / human Build bridge — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/drift-guard.md
+++ b/.cursor/agents/drift-guard.md
@@ -6,49 +6,38 @@ description: drift-guard Agent Colony — Continuous goal/plan/agent-doctrine/do
 
 # Drift guard
 
-## What we guard (continuous)
+## Own
 
-**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…012 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
-
-**Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
+Goal/plan/agent-doctrine/docs coherence + DRIFT-001…012 (script-first). Not deep architecture — that is `auditor`. No product-code auto-fix.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → **must** `python -m agent_colony project entry` (and `list --status in_progress` only when Entry mode is `live` and you need a fresh filter). Cite board Status in findings. Else `session-pointer.md`. Prefer `project export --reuse-if-fresh` before drift validate when a snapshot is needed.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+**Entry:** If SSOT on: `project entry` (must). Prefer `export --reuse-if-fresh` before drift validate. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent drift-guard` (→ `@owner.github_user/drift-guard`); atomics `append-notes --agent drift-guard` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Write `.local/workflow-artifacts/drift/`. Set drift-pass card → `done` or `in_review`. Remediations via Notes/Ready — never silent tracker dual-write. One line in `updates-log.md`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. When seeding Ready remediations, set or recommend Priority/Size/Estimate.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent drift-guard`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
+**Write scope:** drift artifacts only (`drift-audit.md`, `drift-todos.md`).
 
-**Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
+## Loop
 
-1. Run `python -m agent_colony drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when applicable; prefer a fresh `project export` snapshot for DRIFT-010; **DRIFT-012** guards `.local/plans/` snapshot-only under `board_only`).
-3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
-4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
-5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
-6. Do not duplicate governance, integrate, or auditor deep scorecard scope (ADR-007 / ADR-008).
+1. `python -m agent_colony drift validate --directory .` first.
+2. Map to drift-audit / drift-todos (incl. DRIFT-009…012 when applicable).
+3. Goal pulse: board vs plan vs AGENTS — hand off gaps.
+4. P0 blocks prepare; P1 same slice; P2 backlog.
 
 ## Read first
 
-- `.cursor/skills/drift-audit/SKILL.md` — full protocol
-- `.cursor/skills/board-ssot/SKILL.md` — when `project_ssot.enabled`
-- `.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md`
-- `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md` (when project_ssot enabled)
-- Fallback only: `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only)
+- `.cursor/skills/drift-audit/SKILL.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation (when SSOT on)
+- ADR-007 · ADR-008
 
-## Write (mandatory)
-
-1. `.local/workflow-artifacts/drift/drift-audit.md`
-2. `.local/workflow-artifacts/drift/drift-todos.md`
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -58,13 +47,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Under `board_only`, `.local/plans/` is snapshot-only (**DRIFT-012**); live plan stays on the board card — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -8,63 +8,36 @@ description: implementer Agent Colony — Disciplined implementation slices with
 
 ## Anchor (mandatory)
 
-**Entry (board-first when enabled):**
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-1. Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`.
-2. If `project_ssot.enabled`: run `python -m agent_colony project entry`, then claim existing In progress / Ready (or create). Skill: `.cursor/skills/board-ssot/SKILL.md`. Acceptance/Rollback live on the **card body** (`body_sections`).
-3. If disabled or CLI exit non-zero with `fallback: local_trackers`: read `.local/index-and-planning/current/session-pointer.md`, then files it lists (offline path only).
+**Entry:** Read `github.collaboration.yaml` → `project_ssot`. If enabled: `project entry`, then claim or create. Skill: `board-ssot` § Continuation. Else: `session-pointer.md`.
 
-**Exit (board-first when enabled):**
+**Exit:** Fill Acceptance/Rollback, then `handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Promote or `mention-pr` before shippable PR. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`. Say *prepare gates green*.
 
-1. Prefer recipe: fill Acceptance/Rollback (`create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last --agent implementer`) then `python3 -m agent_colony project handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Handoff/`set-status` to `in_review`|`done` returns **EXIT_VALIDATION (5)** while placeholders remain — fix with `set-section`, then retry.
-2. Claim with `project claim --last --agent implementer` (after create-from-template; never paste docs placeholder ids).
-3. Before opening a shippable PR: `promote-to-issue --last` **or** `mention-pr --pr N` (auto-promotes when `promote_to_issue_on_pr`). Claim does **not** promote.
-4. Append `change-index.md`; one line in `history/updates-log.md`.
-5. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-6. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent implementer`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Lifecycle:** May `create-from-template` → `claim --last`. Set Priority/Size/Estimate on own card. Day-0: `board-bootstrap --check`; on exit 5 hand human to `/board` + `board-shell`.
 
-**Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card **must** set Priority/Size/Estimate via `set-field` (Tier-1). Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
+Deliver small reversible slices. New sources: module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 
-**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+## Read first
 
-**Board shell gate (SSOT on):** Day-0 requires the kit **default** board shell (`.ai_infra/templates/project-board/board-shell.schema.yaml`: six Playground views; Priority/Size/Estimate/Start date/End date on Status board + Prioritized backlog). Run `project board-bootstrap --check`. On **exit 5** (view or Tier-1 column FAIL), do **not** claim work — hand the human to **`/board`** + `board-shell` (**CONSENT GATE** then **TURN PROTOCOL**; human UI per `views-setup.md`). Do not treat `/auditor` as day-0 setup.
-
-**STANDALONE:** this product lives only in `agent-colony` as a standalone product.
-
-**Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
-
-Deliver **small, reversible** slices with production quality: clear module boundaries, tests, and **board Status** (or fallback trackers).
-
-## Read first (do not load the whole `.local/` tree)
-
-- `.cursor/skills/implementer-loop/SKILL.md` — slice lifecycle protocol
-- `.cursor/skills/board-ssot/SKILL.md` — when `project_ssot.enabled`
-- `.ai_infra/templates/project-board/README.md` — when creating cards
-- `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `.local/index-and-planning/current/architecture.md` (architecture stub)
-- Fallback only: `session-pointer.md`, `plan.md`, `work-tracker.md`
-- If board Notes or the user cite `_research_results/sources/<slug>/AGENT_BRIEF.md`, **read that brief** before coding (researcher packs are input, not a second SSOT)
-
-When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. After meaningful coverage runs: run **`make coverage-index`** when coverage mattered.  
-**Skip** `.local/generated-data/**` unless the task is coverage or metrics. **Do not** edit `.local/agents-control-center/audits/module-audit.html` except deliberate audit refresh.
+- `.cursor/skills/implementer-loop/SKILL.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation · § Tier-1 (when SSOT on)
+- `github.collaboration.yaml` · fallback: `session-pointer.md`, `plan.md`, `work-tracker.md`
+- Research brief path from Notes when cited
 
 ## Loop
 
-1. One primary claimed board card (`in_progress`) when SSOT enabled; else one `in_progress` in `work-tracker.md`. Scope on card body or `plan.md` (fallback).
-2. Contracts → implementation → tests. **New sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
-3. **Gates:** run `python .ai_infra/scripts/pr/prepare.py` (executes `resolve_gates()`; `GATES` is the 2-gate back-compat alias). Add `python .ai_infra/scripts/architecture/check_governance_consistency.py` if governance/workflows/policy docs changed.
-4. **Commits:** trailers via `python -m agent_colony contributors commit-trailers` (`.cursor/rules/commit-trailer-format.mdc`). Optional `Assisted-by:`. No tool-generated human sign-off.
-5. **Close:** board Status via CLI; `change-index.md` + `updates-log.md`; fallback tracker close only if offline. Run **`make drift-validate`**; hand off to **`drift-guard`** when P0/P1 findings need artifacts.
+1. One claimed `in_progress` card (or offline tracker).
+2. Contracts → code → tests.
+3. Gates: `prepare.py`. Add governance consistency when policy changes.
+4. Commits: `contributors commit-trailers`.
+5. Close: board Status; `make drift-validate`; hand off to `drift-guard` on P0/P1.
 
-## Architecture
-
-Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Board SSOT precedence: `overlays/rules/project-ssot-precedence.mdc`.
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -74,13 +47,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, gates — prefer `agent_colony project` for board |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/integrator.md
+++ b/.cursor/agents/integrator.md
@@ -8,79 +8,40 @@ description: integrator Agent Colony — Integrates new agents, skills, MCP, and
 
 ## Role
 
-You **extend the multi-agent system** without breaking planes, gates, or procedural discipline. You do **not** invent workflow steps — you wire new capability into the existing kit using **templates, scripts, and facts**.
-
-**Product intent:** the plugin unpacks the full consumer infrastructure (agents, scripts, `.local/`, optional MCP); the human completes **`.local/user_settings/`**; you keep everything else aligned when they add agents, skills, or tools.
+Wire new agents, skills, MCP, and kit surfaces. Do not invent workflow steps. Use templates and scripts.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + skill `.cursor/skills/integrator-protocol/SKILL.md` (and `board-ssot` when touching board wiring). Claim/create integration card (`claim --last` after create). Else `session-pointer.md` then integration skill.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` + `integrator-protocol`. Claim/create integration card. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator` (→ `@owner.github_user/integrator`); atomics `append-notes --agent integrator` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Status → `done` or `in_review`. Notes with validate outcomes. `change-index.md` + `updates-log.md`. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent integrator`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+## Read first
 
-**STANDALONE:** this product lives only in `agent-colony` as a standalone product.
+1. `.cursor/skills/integrator-protocol/SKILL.md`
+2. `mas-infrastructure-integration.md` · workflow-architecture · folder-charter · module-boundaries
+3. `manifest.yaml` · `github.collaboration.yaml` · `mcp.agents.yaml`
 
-## Read first (evidence before edits)
+## Loop
 
-| Order | Path | Why |
-|-------|------|-----|
-| 1 | `.cursor/skills/integrator-protocol/SKILL.md` | Integration procedure (canonical) |
-| 2 | `.ai_infra/templates/project-board/README.md` | When creating board cards |
-| 3 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
-| 4 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
-| 5 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
-| 6 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
-| 7 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
-| 8 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
-| 9 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
-| 10 | `_research_results/sources/<slug>/AGENT_BRIEF.md` | When board Notes / user cite a research pack — read before intake edits |
-
-**Skip** `.local/generated-data/**` unless validating coverage exports.
-
-## Integration modes (pick one per request)
-
-| Mode | When | Must still follow |
-|------|------|-------------------|
-| **MAS-integrated** | Agent joins PR workflow, trackers, MCP registry, pipelines | All universal rules + Anchor blocks + script commands |
-| **Independent contract** | Standalone agent (e.g. one-off tool); no PR slice ownership | Universal `.cursor/rules/*`, commit/PR attribution if it touches git, no bypass of `prepare.py` `resolve_gates()` |
-
-Independent agents **never** skip governance scanners, file headers, or Pattern A for maintainer actions they perform.
-
-## Loop (one integration slice)
-
-1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
-3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
-4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
-5. **Verify** — `python -m agent_colony contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
-6. **Handoff** — implementer owns product code; test-runner owns tests; auditor if architecture-impacting.
+1. Intake: agent | skill | MCP | script | doc.
+2. Plan on board card (or offline trackers).
+3. Apply `.ai_infra/templates/agent-integration/`.
+4. Wire registry / pipelines / sync.
+5. Verify: `contributors validate`, gates, governance when `.cursor/` changes.
+6. Handoff: implementer / test-runner / auditor as needed.
 
 ## Non-negotiables
 
-- **Pattern A:** one script command per maintainer action; merge gates only via `prepare.py` `resolve_gates()` (`GATES` = alias).
-- **No duplicated gate lists** in prose — point to `prepare.py` or `gate-matrix.md`.
-- **Facts only** — cite paths; label `Unknown` when not verified.
-- **No bullshit** — no fake certifications, no `Made-with:` trailers, no invented MCP tools.
-- **Token efficiency** — run scripts; do not re-implement `prepare.py` logic in chat.
+Pattern A. No duplicated gate lists. Facts only. No invented MCP tools.
 
-## When to escalate
-
-| Situation | Agent |
-|-----------|--------|
-| Architecture audit / alignment | `auditor` |
-| Test coverage slice | `test-runner` |
-| Product `src/` implementation | `implementer` |
-| PR merge path | maintainer skills `review-pr` → `prepare-pr` → `merge-pr` |
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -90,13 +51,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -4,89 +4,39 @@ model: auto
 description: researcher Agent Colony — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
-# Researcher (shipped; opt-in corpus)
+# Researcher
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Research packs under `_research_results/sources/<slug>/`. When a **research board card** exists: **must** `set-status --to done` and put pack paths (`AGENT_BRIEF.md`, `INDEX.json`) in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` (+ research card). Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Packs under `_research_results/sources/<slug>/`. Research card → `done` + paths in Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent researcher`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Create research cards with `create-from-template --template research`. If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.
+**Lifecycle:** `--template research`. Write only under `_research_results/` unless user expands scope. No product PRs.
 
-Build and maintain a **local research corpus** of verified packs. **Agent is shipped/proven** (live E2E + verifier PASS 2026-07-19); corpus packs remain **opt-in** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
+## Adaptive intake
 
-## Adaptive intake (mandatory before research)
+Build a Brief from chat, board, or handoff. Normalize `https://github.com/…` → `github:owner/repo`. Defaults when terse: architecture/cli/agents lenses; `rounds_max` 6. Refuse only when no source and not `mode: self`.
 
-Normalize a **Research Brief** from whatever channel started you — do **not** refuse a usable chat/handoff just because fields are informal.
+## Anti-loop
 
-| Source | What to read | How to adapt |
-|--------|--------------|--------------|
-| **User chat** | Current message (+ prior turns in thread) | Extract URL / `github:owner/repo` / local path; question from prose; lenses if named else defaults |
-| **Other agents** | Board Notes, handoff line, `AGENT_BRIEF` / pack path, implementer/integrator request | Treat their question + source as Brief; name them in `consumers` |
-| **Board research card** | Card body Brief table + Notes | Prefer card fields; fill gaps from chat |
-| **Explicit Brief** | `BRIEF.md` or pasted contract | Use as-is |
+One pack per slug. One fetch. Cap `rounds_max`. Close after validate PASS. No retry storms.
 
-**Normalize sources** before CLI:
+## Hard stop
 
-- `https://github.com/owner/repo` → acceptable (CLI accepts HTTPS); prefer also recording `github:owner/repo`
-- `github:owner/repo[@ref]` → canonical
-- Absolute/relative local path → `path:…` or bare path
-
-**Defaults when user is terse** (e.g. `/researcher https://github.com/owner/repo`):
-
-- `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
-- `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
-- `slug`: repo name lowercased (`grok-build`)
-- `consumers`: implementer, integrator
-- `rounds_max`: 6
-
-**Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
-
-Then write `BRIEF.md` via `research init` and proceed with the skill loop.
-
-## GitHub access (public + private)
-
-| Repo visibility | How fetch works |
-|-----------------|-----------------|
-| **Public** | `research fetch` clones via `gh repo clone` (preferred) or `git clone https://…` |
-| **Private** | Same CLI — requires the **consumer machine** to already authenticate (`gh auth login` and/or git credentials) so a normal local clone of that URL would succeed |
-
-No kit-side GitHub token is stored. If clone fails, report the error and stop (do not retry in a loop).
-
-## Anti-loop (mandatory stop rules)
-
-1. **One pack per slug** — do not `research init` again without user `--force` / explicit redo.
-2. **One fetch** — if `SOURCE.md` exists, do not re-fetch without `--force`.
-3. **Hard cap** — deepen at most `rounds_max` (default **6**). Never invent round-7+.
-4. **Close then exit** — after `INDEX.json` `status: complete` + `research validate` PASS → handoff/Done and **stop**. Do not start another deepen cycle in the same session unless the user explicitly asks to reopen.
-5. **Gaps OK** — if questions remain at cap, write them under gaps / `status: blocked` or complete with “open gaps”; do not keep reading forever.
-6. **No retry storms** — clone/API failures: one attempt, surface stderr, exit (outbox only for board writes).
-
-## Hard stop (when enabled)
-
-1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
-2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files without explicit user request.
-3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External mode requires a Brief** — derive it from chat/agents/card (see Adaptive intake); then persist as `BRIEF.md`.
-
-**Read-only** on the rest of the repo (and on foreign sources) unless the user directs otherwise.
+No edits to product `src/` / `tests/` / scripts without explicit ask. No git commit/push for research-only.
 
 ## Read first
 
-1. `.cursor/skills/research-corpus/SKILL.md` (intake + rounds)
-2. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
-3. `.agents/skills/RESEARCH_WORKFLOW.md`
-4. Pack `BRIEF.md` + `SOURCE.md` when continuing a slug
-5. Any pack path or handoff cited by another agent / board Notes
+`.cursor/skills/research-corpus/SKILL.md` · `RESEARCH_BOUNDARIES.md` · pack `BRIEF.md`
 
-## CLI (procedural)
+## CLI
 
 ```bash
 python3 -m agent_colony research init --slug <slug> --source '…' --question '…'
@@ -94,28 +44,16 @@ python3 -m agent_colony research fetch --slug <slug> --source '…'
 python3 -m agent_colony research validate --slug <slug>
 ```
 
-`--source` accepts `github:owner/repo[@ref]`, `https://github.com/owner/repo[/tree/ref]`, `path:…`, or bare local path.
-
-Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, and INDEX validation.
-
 ## Modes
 
-| Mode | Trigger | Output |
-|------|---------|--------|
-| `external` | Source found in chat/card/handoff (default) | Multi-round pack + `AGENT_BRIEF.md` |
-| `self` | User asks host deepening / DEPTH_BACKLOG | Same write root; no foreign fetch |
+| Mode | Output |
+|------|--------|
+| external | Pack + `AGENT_BRIEF.md` |
+| self | Host deepen; no foreign fetch |
 
-## Not this agent
+GitHub clone uses machine auth. DeepWiki MCP uses `repoName` — does not replace `research fetch`.
 
-| Need | Use |
-|------|-----|
-| Implement features | `implementer` (consume `AGENT_BRIEF.md`) |
-| Integrate kit surfaces | `integrator` |
-| PR merge | `pr-workflow/SKILL.md` |
-| Full enterprise audit | `auditor` |
-| Verify a claim | `verifier` |
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -125,26 +63,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | `deepwiki` (worked example, zero-auth) — see `.cursor/mcp.registry.yaml` | Indexed wiki Q&A (`read_wiki_structure`, `read_wiki_contents`, `ask_question`); other listed servers only if connected for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-### Two sources (do not mix)
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-| Need | Use | Example |
-|------|-----|---------|
-| Clone / pack corpus (`research init\|fetch`) | **GitHub** URL or `github:owner/repo` | `https://github.com/karpathy/nanochat` |
-| Wiki Q&A via MCP | **DeepWiki** MCP · arg **`repoName`** (not `repo`) | `repoName":"karpathy/nanochat"` — wiki must exist at [deepwiki.com/…](https://deepwiki.com/karpathy/nanochat) |
-
-Same `owner/repo` string in both places; different transports. DeepWiki does **not** replace `research fetch` — it answers questions about an already-indexed wiki. If DeepWiki returns “Repository not found,” index the repo on deepwiki.com (or pick an indexed example) — do not invent a `repo` arg.
-
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
-
-```bash
-python3 -m agent_colony mcp call --server deepwiki --tool ask_question \
-  --args-json '{"repoName":"karpathy/nanochat","question":"What is nanochat in one sentence?"}'
-```
-
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names or arg keys.
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Ephemeral analysis → persist via `canvas save`; not git SSOT — research packs stay under `_research_results/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -8,27 +8,28 @@ description: test-runner Agent Colony — Module-focused tests, regressions, cov
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/board-ssot/SKILL.md` when board SSOT is on.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` / claim; read Acceptance/Notes. Else `session-pointer.md`. Read `test-index.md` when tests change.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent test-runner` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** `handoff --last` / claim. Status → `in_review` if tests gate PR, else `done`. Update `change-index.md`, `test-index.md` / `test-plan.md`. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent test-runner`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.
+**Lifecycle:** Consume only — do not `create-from-template`. Claim existing slice card.
 
-- Map changes → `tests/modules/<module>/`; one clear responsibility per file.
-- Cover happy, failure, edge, and regression cases for touched behavior.
-- Run **smallest** pytest scope first; widen when needed. For risky kit-dev slices: `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q` (see `.cursor/skills/test-coverage/SKILL.md`).
-- Before PR handoff path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (first entry in `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
-- Strategy detail: `.cursor/skills/test-coverage/SKILL.md`.
+## Work
 
-Report: tests added/updated • scope run • gaps • `test-index.md` / `test-plan.md` updates if any.
+- Map changes → `tests/modules/<module>/`.
+- Cover happy, failure, edge, regression.
+- Smallest pytest first. Risky kit-dev: see `test-coverage` skill.
+- Before PR path: `check_testing_artifacts.py` (in `prepare.py` `resolve_gates()`).
 
-## Handoff format
+Report: tests · scope · gaps · tracker updates.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -38,13 +39,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Test evidence stays under `.local/`; board/card Notes may pointer-only cite paths — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -8,31 +8,29 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project entry` + related board card (read **Acceptance / Rollback / Notes** for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Before Status → `done`, run `project validate-item --last` and refuse close while Acceptance/Rollback are placeholders (CLI also gates `handoff`/`set-status` → `done`). Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project entry` + card Acceptance/Rollback/Notes. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent verifier` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** `validate-item --last` before `done`. Refuse placeholder Acceptance/Rollback. Status → `done` or leave `in_review` with failure Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. On closure, spot-check Status/Priority/Size/Estimate/Start date/End date on Done; Assignee when Issue-backed; Linked PR when a PR was opened; **Acceptance/Rollback must not be `(TBD)`**.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent verifier`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Spot-check on close. Canon: `board-ssot` § Tier-1.
 
-**Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes. If Acceptance/Rollback still placeholders, leave `in_review` with Notes naming the gap (implementer remediates via `set-section`).
+**Lifecycle:** Consume only. Evidence only — do not implement fixes.
 
-1. Restate what was claimed done.
-2. Point to files/lines or command output as evidence.
-3. Run the **smallest** checks that disprove the claim; expand if still uncertain:
-   - targeted `pytest` → full `pytest -q` when scope warrants
-   - same **category** of checks as `.ai_infra/scripts/pr/prepare.py` **`resolve_gates()`** (see that file; `GATES` is the 2-gate back-compat alias)
-   - `python .ai_infra/scripts/architecture/check_governance_consistency.py` when governance/workflows/policy docs changed
-   - `verify_publish.py --branch <branch>` when validating PR linkage
-4. Label each claim: Verified | Partial | Not verified.
-5. Output: passed • failed • missing • **one** next action.
+## Work
 
-Do not approve merge readiness without artifacts under `.local/workflow-artifacts/pr/` when the maintainer workflow is in play (`.ai_infra/scripts/pr/local_workflow_paths.py`). Flag drift vs `AGENTS.md` and `.cursor/rules/*`.
+1. Restate the claim.
+2. Cite files or command output.
+3. Smallest disproof checks first (`pytest`, `resolve_gates()` category, governance when needed, `verify_publish.py` for PR link).
+4. Label: Verified | Partial | Not verified.
+5. Output: passed · failed · missing · one next action.
 
-## Handoff format
+Do not approve merge without `.local/workflow-artifacts/pr/` when maintainer workflow applies.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -42,13 +40,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Claims may cite `.local/plans/` snapshots and `.local/canvases/` evidence; live plan remains board card / `plan.md` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/.cursor/rules/advisory-audit-alignment-enforcement.mdc
+++ b/.cursor/rules/advisory-audit-alignment-enforcement.mdc
@@ -3,13 +3,13 @@ description: Architecture-impacting advisory audits before prepare/merge (author
 alwaysApply: true
 ---
 
-# Architecture-impacting advisory audit (alignment artifacts)
+# Alignment audit (architecture-impacting)
 
-- **Canonical audit agent:** `.cursor/agents/auditor.md` with `.cursor/skills/auditor-protocol/SKILL.md` (Evidence contract applies to all audit outputs).
-- For **merge workflow only**, architecture-impacting work may use a **focused alignment pass** (same agent/skill; outputs limited to alignment files — see skill § “Focused alignment pass”).
-- Audits are **advisory**: findings and recommendations only; do not auto-apply fixes during the audit step.
-- Run before `/prepare-pr` when scope touches: module boundaries, workflow/rule/skill policy, test/CI layout, roadmap/research source of truth.
+- **Agent:** `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md`.
+- Merge workflow may use **focused alignment pass** (skill § Focused alignment pass).
+- Audits are advisory. Do not auto-apply fixes in the audit step.
+- Run before `/prepare-pr` when scope touches: boundaries, workflow/rule/skill policy, test/CI, roadmap/research SSOT.
 - **Outputs:** `.local/workflow-artifacts/alignment/alignment-audit.md`, `.local/workflow-artifacts/alignment/alignment-todos.md`.
 - **Schema:** `.ai_infra/docs/roadmap/alignment-audit-schema.md`.
 - Each finding: evidence path, mismatch category, recommended fix, status (`open` | `accepted_divergence` | `fixed` | `deferred`).
-- **P0:** block merge prep until fixed or accepted with rationale. **P1:** fix in-slice or defer with owner and slice. **P2:** batch but track in reconciliation TODOs.
+- **P0:** block merge prep until fixed or accepted with rationale. **P1:** fix in-slice or defer with owner. **P2:** batch; track in reconciliation TODOs.

--- a/.cursor/rules/commit-trailer-format.mdc
+++ b/.cursor/rules/commit-trailer-format.mdc
@@ -5,28 +5,26 @@ alwaysApply: true
 
 # Commit trailer format
 
-## Required (git commits)
+## Required
 
-- Every commit message body **must** include these two lines **in this order**, with **no other lines between them**:
+- Every commit body **must** include, in order, with no lines between:
   - `Author: <Your Full Name>`
   - `GitHub-User: @<yourhandle>`
-- Values **must** match `.local/user_settings/github.collaboration.yaml` (`owner.display_name`, `owner.github_user`).
+- Values match `.local/user_settings/github.collaboration.yaml` (`owner.display_name`, `owner.github_user`).
 
-## Optional provenance (after the required pair)
+## Optional (after required pair)
 
-- `Assisted-by: <tool>[:<model>]` — repeat on separate lines when AI **materially** shaped code, tests, docs, or migration logic. Skip for trivial autocomplete, formatting-only, or mechanical boilerplate.
-- **Render from config:** `python -m agent_colony contributors commit-trailers` reads **`.local/user_settings/github.collaboration.yaml`** (copied at install).
-- **Do not use `Made-with:`** — human accountability is already expressed by **`Author:`** / **`GitHub-User:`**; an extra editor/tool line is redundant with that contract.
-- `Co-authored-by:` — optional; only for real human co-authors (Git convention).
+- `Assisted-by: <tool>[:<model>]` when AI materially shaped code, tests, docs, or migrations. Skip trivial autocomplete or formatting.
+- Render: `python -m agent_colony contributors commit-trailers`.
+- No `Made-with:` — use `Author:` / `GitHub-User:` only.
+- `Co-authored-by:` — real human co-authors only.
 
 ## Responsibility
 
-- The human author remains responsible for reviewing and validating the change.
-- **Do not** use AI or scripts to insert human certification, approval, or DCO-style assertions the person did not explicitly intend.
+- Human author reviews and validates the change.
+- Do not insert certification or DCO assertions the person did not intend.
 
-## Order
-
-Typical tail (required lines first, then optional):
+## Example tail
 
 ```text
 Author: Your Full Name

--- a/.cursor/rules/file-docstring-header-relations.mdc
+++ b/.cursor/rules/file-docstring-header-relations.mdc
@@ -5,8 +5,8 @@ alwaysApply: true
 
 # File header (docstring / comment block)
 
-- New sources must start with a module header; keep it accurate when responsibilities change.
-- Required fields: `File:`, `Path:` (repo-relative), `Role:`, `Used By:`, `Depends On:`, `Notes:` (optional). Factual only; unknown relations → `TBD`.
+- New sources need a module header. Update when responsibilities change.
+- Required: `File:`, `Path:` (repo-relative), `Role:`, `Used By:`, `Depends On:`, `Notes:` (optional). Unknown → `TBD`.
 
 ## Python example
 
@@ -14,14 +14,12 @@ alwaysApply: true
 """
 File: example_module.py
 Path: src/example/example_module.py
-Role: Short description of responsibilities.
+Role: Short description.
 Used By:
   - src/core/orchestrator.py
 Depends On:
   - src/schemas/events.py
-Notes:
-  - Keep deterministic behavior for retry paths.
 """
 ```
 
-- Non-Python: same fields in a top comment block using that language’s comment syntax.
+- Non-Python: same fields in a top comment block.

--- a/.cursor/rules/implementation-workflow-governance.mdc
+++ b/.cursor/rules/implementation-workflow-governance.mdc
@@ -8,33 +8,33 @@ alwaysApply: true
 ## Lifecycle
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.
-- Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
-- When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m agent_colony project status` / claim card); local trackers are offline fallback only.
-- Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
-- Exactly one primary `in_progress` **Status on the Project** when `board_only`; `work-tracker.md` `in_progress` only when SSOT disabled or offline fallback. Do not implement without scope on the board card body (or `plan.md` when fallback).
-- Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.
+- Before coding: read `session-pointer.md`, then `plan.md`, `work-tracker.md`, architecture stub, `test-plan.md`, `test-index.md`. Confirm boundary, acceptance, rollback in `plan.md`.
+- When `board_only`: board Entry wins (`project status` / claim); local trackers are offline fallback only.
+- `.local/index-and-planning/current/*`, `history/*`, `audits/*` = live state. Doctrine: `.ai_infra/docs/operations/*`.
+- One `in_progress` on Project when `board_only`. Do not implement without board card scope (or `plan.md` when fallback).
+- Incremental slices; KISS. Block release on P0. RCs need CI/CD evidence.
 
 ## Tests
 
-- Place tests under `tests/modules/<module>/` matching source boundaries.
-- Cover happy, failure, and edge cases; add retry/timeout/replay where high-risk or state-changing.
-- Run targeted module tests first, then full suite before merge.
-- For medium/high-risk slices, run `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q`; record gaps in `work-tracker.md` and `updates-log.md`.
-- If modules/tests move or drop, update/remove tests in the same slice; note rationale in `updates-log.md`.
+- Tests under `tests/modules/<module>/` match source boundaries.
+- Cover happy, failure, edge; add retry/timeout/replay for high-risk paths.
+- Run module tests first, then full suite before merge.
+- Medium/high-risk: `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q`; record gaps in trackers.
+- Module/test moves in the same slice; note in `updates-log.md`.
 
-## Planning index updates
+## Planning index
 
-- After substantive code change: `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when tests or risk change; `updates-log.md` (one line — see `.ai_infra/docs/operations/token-efficiency.md`).
-- Planning-only scope changes: update `plan.md` / `work-tracker.md` + at least one `updates-log.md` entry.
-- Blocked: mark blocker and unblock action in `work-tracker.md`.
-- **ADR-010:** `.local/plans/` is snapshot history only — live plan SSOT stays on the board card (`board_only`) or `plan.md` offline; see `canvas-artifacts` skill.
-- **Slice closure** (before handoff): regenerate `current/coverage-index.md` when coverage mattered; if a new tracker path is added, update `.local/agents-control-center/config/pages.json` and dashboard header **Depends On**; do not edit `.local/agents-control-center/audits/module-audit.html` unless refreshing that export.
+- After code change: update `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when risk changes; one line in `updates-log.md` (see `token-efficiency.md`).
+- Scope-only: `plan.md` / `work-tracker.md` + `updates-log.md`.
+- Blocked: mark blocker in `work-tracker.md`.
+- **ADR-010:** `.local/plans/` = snapshots only; live plan on board (`board_only`) or `plan.md`.
+- Slice closure: regenerate `coverage-index.md` when needed; new tracker path → update `pages.json` + dashboard **Depends On**.
 
 ## Merge gates
 
-- Full gate order: [`.cursor/rules/pr-workflow-enforcement.mdc`](pr-workflow-enforcement.mdc) and `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`; `GATES` = 2-gate back-compat alias).
+- Gate order: [pr-workflow-enforcement.mdc](pr-workflow-enforcement.mdc) and `prepare.py` (`resolve_gates()`; `GATES` = 2-gate alias).
 
-## Efficiency (less noise)
+## Efficiency
 
-- Default read set under `.local/`: **`session-pointer.md`**, then **`index-and-planning/current/plan.md`**, **`work-tracker.md`**, **`change-index.md`**; PR artifacts under **`workflow-artifacts/`** when merging. Skip **`generated-data/**`** and **`history/archive/**`** unless explicitly tasked.
-- In `updates-log.md` and chat handoffs, do **not** paste the full `GATES` block; state outcomes (*e.g.* “prepare.py gates green”) and only the failing command + stderr when something breaks.
+- Default `.local/` reads: `session-pointer.md`, `plan.md`, `work-tracker.md`, `change-index.md`; PR artifacts when merging. Skip `generated-data/**`, `history/archive/**` unless tasked.
+- Do not paste full `GATES` in chat or `updates-log.md`; say *prepare.py gates green* or paste failing command only.

--- a/.cursor/rules/local-artifact-protection.mdc
+++ b/.cursor/rules/local-artifact-protection.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Local artifact protection
 
-- Protected: `.coverage` and `.env` (and any project-specific paths documented in `overlays/` or project README).
-- Do not delete, reset, or clean protected paths unless the user explicitly confirms in this conversation.
-- Before cleanup commands, list targets; if they include protected paths, ask for approval.
-- If removed by mistake, say so and restore from project baseline immediately.
+- Protected: `.coverage`, `.env`, and paths in `overlays/` or project README.
+- Do not delete, reset, or clean protected paths without explicit user confirmation.
+- Before cleanup, list targets; ask if protected paths are included.
+- If removed by mistake, restore from project baseline immediately.

--- a/.cursor/rules/pr-workflow-enforcement.mdc
+++ b/.cursor/rules/pr-workflow-enforcement.mdc
@@ -5,14 +5,14 @@ alwaysApply: true
 
 # PR workflow enforcement
 
-- **PR-first (staged):** task branch (`feature/`, `fix/`, `chore/`) → implement/test → push → open PR → `python .ai_infra/scripts/pr/verify_publish.py` + `gh pr view` → `/review-pr` → `/prepare-pr` → `/merge-pr` (stop; keep branches for review). **Cleanup optional:** `/full-pr-workflow` (or `finalize.py`) syncs `main`, deletes local/remote feature branch, writes `.local/workflow-artifacts/pr/finalize.md`.
-- **Never** merge straight from local to `main`. **No** destructive git (`reset --hard`, history rewrite) unless the user explicitly asks.
-- **Phase artifacts** (do not skip): `.local/workflow-artifacts/pr/review.md`, `.local/workflow-artifacts/pr/prep.md`, `.local/workflow-artifacts/pr/merge.md` with `Action-By`, `GitHub-User`, `Agent/s` from **`.local/user_settings/github.collaboration.yaml`** (via `--pipeline` on PR scripts) or explicit `--actor` / `--agents`; use `Reviewed-By` / `Prepared-By` / `Merged-By` where applicable. After `/full-pr-workflow`: also `.local/workflow-artifacts/pr/finalize.md`.
-- **Git commits** (separate from PR artifact headers): trailers per **commit-trailer-format.mdc** — required `Author` / `GitHub-User`, optional `Assisted-by` (no `Made-with:`); summary in **AGENTS.md** § Commits.
-- **Architecture-impacting** changes: before prepare/merge, produce `.local/workflow-artifacts/alignment/alignment-audit.md` and `.local/workflow-artifacts/alignment/alignment-todos.md` using **`auditor`** + `.cursor/skills/auditor-protocol/SKILL.md` (focused alignment pass when a full scorecard is not required; see [advisory-audit-alignment-enforcement.mdc](advisory-audit-alignment-enforcement.mdc)).
-- **Pre-merge gates:** order and commands are **`resolve_gates()` in `.ai_infra/scripts/pr/prepare.py`** only — run via `prepare.py`, not as separate agent commands (`GATES` is the 2-gate back-compat alias). When changing governance, workflows, or tracked policy docs, also run `python .ai_infra/scripts/architecture/check_governance_consistency.py` locally (CI may mirror path-scoped runs).
-- **Branch/PR health:** current branch tracks `origin/<branch>`; `git ls-remote --heads origin <branch>` shows head; `gh pr view --json headRefName` matches current branch.
-- **Tracking docs** when architecture/runtime scope shifts: `.local/index-and-planning/current/plan.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`).
-- `git push --force-with-lease` only for intentional rewrites on branches you own.
-- **Stop and report** if required staged artifacts or gates are missing. Treat missing cleanup as a failure only when `/full-pr-workflow` (or `finalize.py`) was explicitly requested.
-- **Efficiency:** gate order and commands live in `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`). Link or summarize *pass/fail* in chat and PR artifacts — avoid pasting the full command list repeatedly.
+- **PR-first:** branch (`feature/`, `fix/`, `chore/`) → implement/test → push → PR → `verify_publish.py` + `gh pr view` → `/review-pr` → `/prepare-pr` → `/merge-pr`. Optional cleanup: `/full-pr-workflow` or `finalize.py`.
+- Never merge local to `main`. No destructive git unless user asks.
+- **Artifacts:** `.local/workflow-artifacts/pr/review.md`, `prep.md`, `merge.md` with `Action-By`, `GitHub-User`, `Agent/s` from `github.collaboration.yaml` (`--pipeline`) or `--actor` / `--agents`. Full workflow adds `finalize.md`.
+- **Commits:** trailers per [commit-trailer-format.mdc](commit-trailer-format.mdc); summary in AGENTS.md § Commits.
+- **Architecture-impacting:** before prepare/merge, run **`auditor`** → alignment files (see [advisory-audit-alignment-enforcement.mdc](advisory-audit-alignment-enforcement.mdc)).
+- **Gates:** `resolve_gates()` in `.ai_infra/scripts/pr/prepare.py` only — via `prepare.py` (`GATES` = 2-gate alias). Governance changes: also `check_governance_consistency.py`.
+- **Branch health:** tracks `origin/<branch>`; `gh pr view --json headRefName` matches branch.
+- **Tracking docs** when scope shifts: `plan.md`, architecture stub.
+- `git push --force-with-lease` only for intentional rewrites on owned branches.
+- Stop if artifacts or gates missing. Missing cleanup is failure only when `/full-pr-workflow` requested.
+- Summarize gate pass/fail in chat — do not paste full command list.

--- a/.cursor/rules/project-ssot-precedence.mdc
+++ b/.cursor/rules/project-ssot-precedence.mdc
@@ -5,20 +5,18 @@ alwaysApply: true
 
 # Project SSOT precedence
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
-- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
-- **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
-- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
-- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
-- Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
-- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
-- PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `AGENTS.md`.
-- This product lives only in `agent-colony`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
-- Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: **create as Issue** (`item_kind_default: issue`); claim / `set-status` / `handoff --to in_progress` may set Start date (UTC when configured); `set-status` / `handoff` / merge / `heal-cards` → `done` may set End date (UTC when configured); triage/own card sets Priority/Size/Estimate via `set-field` (Size↔Estimate table in `board-ssot` skill); Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` — Iteration, Labels, Reviewers out of scope for agents by default.
+- When `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the only writable backlog, status, and continuation SSOT.
+- **Entry:** read board (`project status` / claim). **Exit:** update Status + Notes. See `.cursor/skills/board-ssot/SKILL.md` § Continuation.
+- **First-run:** `project board-bootstrap --check` FAIL → `/board` + `board-shell` (CONSENT + TURN) before claim/`/implementer`.
+- **drift-guard:** read board for DRIFT-009/010/012; `.local/plans/` snapshot-only (ADR-010). Update drift card on Exit; remediate via Notes — no dual-write.
+- Do not dual-write status to `work-tracker.md` / `session-pointer.md`.
+- `project export` snapshots are read-only; never compete with board Status.
+- Overrides tracker `in_progress` in implementation-workflow-governance when board SSOT on (ADR-008).
+- Offline/disabled: `fallback: local_trackers`; resume sync when available.
+- EXIT_QUEUED (6) → `project_ssot.outbox` (`queue` / `outbox flush`); do not hammer API or dual-write. Covers precheck low quota, Forbidden/429.
+- Prefer Pattern A (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
+- Local only: PR Pattern A (`prepare.py`), post-merge `merge.py`, PR/audit artifacts, secrets, `user_settings` (`project_ssot.local_only`).
+- Humans own views, workflows, Insights, README, Ready ordering.
+- Canon: ADR-008, `project-board-collaboration.md`, `AGENTS.md`.
+- Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent`.
+- Tier-1: create as **Issue**; Start date on first In progress; End date on Done; Priority/Size/Estimate via `set-field` (see board-ssot skill); Draft→Issue via `promote-to-issue` or `mention-pr`; PR via `mention-pr`. Iteration, Labels, Reviewers out of scope by default.

--- a/.cursor/skills/auditor-protocol/SKILL.md
+++ b/.cursor/skills/auditor-protocol/SKILL.md
@@ -17,234 +17,147 @@ Notes:
 
 # Auditor protocol
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Produce a **step-by-step, facts-first** enterprise architecture and engineering assessment of **this** repository, suitable for senior technical and executive decisions. **No invented architecture.** Every significant claim is tied to repository evidence or labeled **Unknown**.
+Produce a **step-by-step, facts-first** enterprise architecture assessment of **this** repository. **No invented architecture.** Every significant claim is tied to repository evidence or labeled **Unknown**.
 
 ## Evidence contract (mandatory)
 
-Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in the written deliverables.
+Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in written deliverables.
 
-**What counts as evidence (in priority order)**
+**What counts as evidence (priority order)**
 
-1. **Repository paths** — repo-relative file or directory paths you actually opened or searched (e.g. `src/core/foo.py`, `pyproject.toml`, `.github/workflows/`).
-2. **Quoted fragments** — short, faithful quotes from files (configs, docstrings, key symbols) when the claim is non-obvious; add line reference when practical (e.g. `path:42-48` or “see `symbol` in `path`”).
-3. **Command output** — only when run during the audit (e.g. `pytest`, `rg`, `python scripts/...`); record the **exact command** and **outcome** in §2 Audit Method, not vague “tests pass.”
-4. **User context** — label as **`Context:`** (field name); use for business/deployment intent **only**; never treat as **Confirmed** for claims about what the **code** does.
+1. **Repository paths** — repo-relative paths actually opened or searched.
+2. **Quoted fragments** — short faithful quotes when non-obvious; line ref when practical (`path:42-48`).
+3. **Command output** — only when run during the audit; record **exact command** and **outcome** in §2 Audit Method.
+4. **User context** — label **`Context:`**; never treat as **Confirmed** for what the **code** does.
 
 **Per classification**
 
 | Label | Requirement |
 |--------|-------------|
-| **Confirmed** | At least one repo path (or command + output) that directly supports the statement. |
-| **Probable risk** | (a) **Observed:** path + fact; (b) **Inference:** explicitly labeled; (c) **Falsify:** what evidence would confirm or refute. |
-| **Unknown** | State **what was not inspected** or **why** the repo cannot answer (e.g. no deployment manifests in tree, secrets not in repo). |
+| **Confirmed** | At least one repo path (or command + output) directly supports the statement. |
+| **Probable risk** | (a) **Observed:** path + fact; (b) **Inference:** labeled; (c) **Falsify:** what would confirm/refute. |
+| **Unknown** | What was not inspected or why the repo cannot answer. |
 
-**Scorecard (§9)** — For **each** category, the **Evidence** subsection must be a **bulleted list of paths** (and optional line/symbol refs) representing what was actually reviewed for that score. If the list is empty or only generic (“reviewed the codebase”), **cap the score at 3** and set scoring confidence to **Low** unless the gap is explicitly **Unknown**.
+**Scorecard (§9)** — Each category **Evidence** = bulleted paths reviewed. Empty/generic list → **cap score at 3**, confidence **Low** unless explicitly **Unknown**.
 
-**Findings (§7) and actions file** — **Evidence** is mandatory. If you cannot cite a path or command output, rephrase as **Unknown** or omit the finding.
+**Findings (§7) and actions file** — **Evidence** mandatory; else rephrase as **Unknown** or omit.
 
-**§2 Audit Method** — Must list: **sources read** (paths), **searches or scans** (e.g. patterns, tools), **commands run** (if any), and **scope limits** (what was out of scope or time-boxed). Readers must be able to **reproduce** how conclusions were reached.
+**§2 Audit Method** — List: sources read, searches/scans, commands run, scope limits. Readers must reproduce how conclusions were reached.
 
-**Contradictions** — When docs and code disagree, cite **both** sides (paths) and state the conflict before recommending.
+**Contradictions** — When docs and code disagree, cite **both** paths and state the conflict.
 
 ## When to use
 
-- Pre- or post-major refactor, platform review, or diligence-style read of the codebase.
-- When documentation and implementation may diverge (challenge documented architecture with code and config evidence).
-- When you need **module-level** findings, a **weighted scorecard**, and a **prioritized action list** for implementers.
+- Pre/post major refactor, platform review, diligence-style read.
+- Docs vs implementation may diverge.
+- Need module-level findings, weighted scorecard, prioritized actions.
 
 ## Project workflow integration
 
-**Read (do not load all of `.local/` blindly):**
+**Read (targeted, not all of `.local/`):** `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md`, project `docs/architecture/`, `AGENTS.md`, `README.md`, overlay rules, `prepare.py` (`resolve_gates()`).
 
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` — current slice context (if missing, say so).
-- `test-plan.md`, `test-index.md` when assessing test architecture.
-- Project `docs/architecture/`, `AGENTS.md`, `README.md` for stated intent vs implementation.
-- Overlay rules (`overlays/rules/*.mdc`) when installed.
-- `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`; `GATES` = 2-gate alias) for quality-gate reality.
-
-**Write — create directory if needed:**
+**Write:**
 
 | Output | Path |
 |--------|------|
-| Full audit (all sections below) | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md` |
-| Prioritized actions for implementers | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md` |
+| Full audit | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md` |
+| Actions | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md` |
 
-**Report frontmatter (top of `enterprise-architecture-audit.md`):**
+**Frontmatter:**
 
 ```text
 Audit-Type: enterprise-architecture-python
-Audited-By: <agent name or human>
+Audited-By: <agent or human>
 Action-By: <name>
 GitHub-User: <handle>
-Date: <ISO-8601 date>
+Date: <ISO-8601>
 Evidence-Standard: repository + user context only
 ```
 
-**Downstream agents:**
-
-- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items onto **board Ready cards** when `project_ssot.enabled` (Acceptance/Rollback in body); else `work-tracker.md` (one primary `in_progress`). Follow `.cursor/skills/implementer-loop/SKILL.md` + `board-ssot` Continuation contract.
-- **Alignment / maintainer:** if findings are doc-policy-roadmap drift, also record P0/P1 items per `.ai_infra/docs/roadmap/alignment-audit-schema.md` in `.local/workflow-artifacts/alignment/alignment-audit.md` and `alignment-todos.md` (advisory).
-- **Module map depth:** optionally run `.cursor/skills/audit-module-map/SKILL.md` for `module-map` / HTML export; cite those paths as evidence in the enterprise report.
-
-**After the audit:** add a brief entry to `.local/index-and-planning/history/updates-log.md` (artifacts written, no gate laundry lists).
+**Downstream:** **Implementer** → `enterprise-audit-actions.md`; board Ready cards when SSOT on. **Alignment** → `alignment-audit.md` + `alignment-todos.md` per schema. **Module map** → optional `audit-module-map` skill. Brief `updates-log.md` entry after audit.
 
 ### Focused alignment pass (architecture-impacting PRs)
 
-When the **maintainer workflow** requires alignment files for `--arch-impacting` but a **full** `enterprise-architecture-audit.md` is not requested:
+When maintainer workflow requires alignment files but not full enterprise report:
 
-- Stay on **`auditor`** and keep the **Evidence contract** (paths for every Confirmed finding; §2 Audit Method lists what you read/searched).
-- **Write only** (unless the user also wants the full report):
-  - `.local/workflow-artifacts/alignment/alignment-audit.md`
-  - `.local/workflow-artifacts/alignment/alignment-todos.md`
-- Use **`.ai_infra/docs/roadmap/alignment-audit-schema.md`** for finding shape and P0/P1/P2 handling.
-- Scope: compare **touched** roadmap/plan/strategy docs, rules/skills/agents, `src/` + `tests/modules/` relevant to the PR — not a whole-repo scorecard.
-- Include a short **CHK-*** tick table (below) for dimensions that touch the PR; mark N/A for untouched dimensions.
-- **Optional:** note in `alignment-audit.md` that a full enterprise scorecard was deferred.
-- Continuous plan/agent-doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 prose here.
+- Stay on **`auditor`**; keep **Evidence contract**.
+- **Write only:** `alignment-audit.md`, `alignment-todos.md` (schema: `.ai_infra/docs/roadmap/alignment-audit-schema.md`).
+- Scope: **touched** roadmap/plan/rules/skills/agents + relevant `src/` / `tests/modules/` — not whole-repo scorecard.
+- Short **CHK-*** tick table for PR-touching dimensions; N/A elsewhere.
+- Plan/doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 here.
 
----
-
-## Context block (required from user — paste at start of engagement)
+## Context block (paste at start)
 
 ```text
-Context:
-- Business type:
-- Product type:
-- Current users/customers:
-- Expected growth over next 12–24 months:
-- Team size and structure:
-- Deployment platform:
-- Compliance/security requirements:
-- Uptime/SLA expectations:
-- Main business goals:
-- Main roadmap items:
-- Main engineering goals:
-- Main pain points today:
-- Known constraints:
-- Intended future architecture direction:
-- Known incidents or operational failures:
-- Performance concerns already suspected:
-- Areas we especially want challenged:
+Context: Business type · Product · Users/growth · Team · Deployment · Compliance · SLA ·
+Goals · Roadmap · Engineering goals · Pain points · Constraints · Future direction ·
+Incidents · Performance concerns · Areas to challenge
 ```
 
-If the user leaves fields blank, label gaps **Unknown – not provided in context** and lower scoring confidence.
+Blank fields → **Unknown – not provided**; lower scoring confidence.
 
----
+## Operating mode
 
-## Operating mode (non-negotiable)
+Facts-first: inventory → quality → risks → recommendations (never reverse). **Strict / evidence-only / no speculation / step-by-step / Python-specific: ON.**
 
-```text
-Do not jump to recommendations before completing repository inventory and implemented architecture assessment.
-
-Facts-first rule:
-- First describe what exists
-- Then assess quality
-- Then identify risks
-- Then recommend changes
-- Never reverse that order
-
-Strict mode: ON
-Evidence-only mode: ON
-No speculation mode: ON
-Step-by-step mode: ON
-Python-specific analysis mode: ON
-```
-
-**Rules:**
-
-- Do not invent facts. If not verifiable from the repo (and provided context), say: **Unknown – not verifiable from repository evidence**.
+- No invented facts; label **Unknown – not verifiable from repository evidence** when needed.
 - Separate **Confirmed** / **Probable risk** / **Unknown** for material statements.
-- Do not describe architecture as confirmed unless supported by evidence (paths, configs, imports, entrypoints).
-- Be critical and precise. Prefer **insufficient evidence** over assumptions.
-- If evidence conflicts (e.g. docs vs code), call out the conflict.
+- Challenge docs vs code; **documented architecture ≠ real** without verification.
+- No vague likelihood unless explicit **hypothesis** + **evidence gap**.
 
-**Anti-hallucination:** Do not use vague likelihood language (“likely”, “probably intended”) unless framed as an explicit **hypothesis** with the **evidence gap** stated.
+## Mandatory phases (execute in order; show boundaries in report)
 
-**Challenge assumptions:** Actively look for contradictions between folder structure, import graph, runtime entrypoints, and deployment clues. **Documented architecture is not assumed to be real architecture** without verification.
-
-**Review discipline:**
-
-1. Inventory before judgment  
-2. Evidence before interpretation  
-3. Interpretation before recommendation  
-4. Recommendation before roadmap  
-5. Unknowns explicitly called out  
-
----
-
-## Mandatory phases (execute in order; show phase boundaries in the written report)
-
-### Named checklists (CHK-*) — mandatory coverage
-
-Map each checklist into the matching phase. In the written report (or focused alignment), include a **CHK tick table**: id · status (Pass / Gap / N/A / Unknown) · evidence paths. **Do not** invent new skill folders for these dimensions.
+### CHK-* checklists
 
 | Id | Phase | Must cite |
 |----|-------|-----------|
 | `CHK-ARCH` | 2 | Style, dependency direction, cycles |
-| `CHK-GRANULARITY` | 2 / 4 | God modules, blurred boundaries vs `.ai_infra/docs/governance/module-boundaries.md` (kit planes) or consumer `src/` modules |
-| `CHK-PERF` | 3 | Hot paths, N+1/queue clues; **Unknown** if none observable |
-| `CHK-SEC-CODE` | 3 | Secrets handling, injection/trust boundaries in kit scripts / app code in scope |
-| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, hard-stops, MCP `.cursor/mcp.registry.yaml` allowlists, no product auto-fix — **contract compliance**, not LLM jailbreak proof |
-| `CHK-INFRA-KIT` | 1 / 3 | Three planes, install/activate, `integrate validate` clues — **not** consumer cloud infra product |
-| `CHK-DOCS` | 5 | Stated goals vs docs; stale AGENTS / IMPLEMENTATION-STATUS |
+| `CHK-GRANULARITY` | 2 / 4 | God modules vs module-boundaries.md or consumer `src/` |
+| `CHK-PERF` | 3 | Hot paths; **Unknown** if none observable |
+| `CHK-SEC-CODE` | 3 | Secrets, injection/trust boundaries in scope |
+| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, MCP allowlists — contract compliance |
+| `CHK-INFRA-KIT` | 1 / 3 | Three planes, activate, `integrate validate` |
+| `CHK-DOCS` | 5 | Goals vs docs; stale AGENTS / IMPLEMENTATION-STATUS |
 
-### PHASE 1 — Repository inventory (descriptive only)
+Report includes **CHK tick table**: id · Pass/Gap/N/A/Unknown · evidence paths.
 
-Establish facts: Python version(s), dependency tooling, frameworks, entry points, main packages, workers/jobs, APIs/CLI/scripts, data stores, messaging, infra/deployment clues, test layout, docs/ADRs/config.  
-**Output:** inventory table, architecture map sketch (text), confirmed technologies, unknowns.
+### PHASE 1 — Repository inventory
+
+Facts only: Python version, deps, frameworks, entry points, packages, jobs, APIs/CLI, data stores, infra clues, tests, docs/ADRs. **Output:** inventory table, architecture sketch, confirmed tech, unknowns.
 
 ### PHASE 2 — Implemented architecture
 
-Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles. Complete **CHK-ARCH** and start **CHK-GRANULARITY**.  
-**Output:** detected profile, boundary analysis, layering assessment, risks visible from structure.
+Actual style, boundaries, dependency direction, layering, leakage, god modules/cycles. **CHK-ARCH**, start **CHK-GRANULARITY**. **Output:** profile, boundary analysis, structural risks.
 
 ### PHASE 3 — Python engineering and runtime
 
-Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security. Complete **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**.  
-**Output:** evidence-backed findings only; label Confirmed / Probable risk / Unknown.
+Packaging, imports, typing, data access, async/jobs, config/secrets, perf/scaling, reliability, security. **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**. **Output:** evidence-backed findings only.
 
 ### PHASE 4 — Module-by-module audit
 
-For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later). Finish **CHK-GRANULARITY**.  
-Use **Unknown** where needed. **Do not skip** module-level sections for major roots.
+Each **major** module: purpose, surfaces, dependencies, boundary (Clear/Blurred/Violated), coupling, layer, leakage, data ownership, perf/security/test clues, recommendation (Keep/Refactor/Split/Merge/Extract/Defer), effort, priority. Finish **CHK-GRANULARITY**. Do not skip major roots.
 
 ### PHASE 5 — Goal and plan alignment
 
-For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice. Complete **CHK-DOCS**. Continuous plan pulse when plans change is **`drift-guard`** — reference drift artifacts if present; do not re-run DRIFT scripts as a substitute for this phase.
+Per stated goal in docs: alignment (Strong/Partial/Weak), evidence, gaps, action (Preserve/Improve/Simplify/Postpone/Redesign). **CHK-DOCS**. Plan pulse when plans change = **`drift-guard`** — reference drift artifacts; do not substitute DRIFT scripts here.
 
 ### PHASE 6 — Recommended direction
 
-Acceptable for now; what breaks under growth; fix immediately vs intentional deferral; target direction; evolution vs redesign; migration risks; **top 5 highest-ROI** improvements (30–60 days), each repo-specific.
-
----
+What holds now; what breaks at scale; fix now vs defer; target direction; migration risks; **top 5 highest-ROI** improvements (30–60 days), repo-specific.
 
 ## Recommendation standard
 
-Every meaningful recommendation must include: **Problem**, **Evidence**, **Why it matters**, **Recommendation**, **Tradeoffs**, **Implementation approach**, **Effort estimate**, **Priority**, **Affected modules**.  
-Avoid generic bullets (“improve modularity”, “add observability”) without repo ties.
-
-**Migration difficulty** (for each major recommendation): Low / Moderate / High / Very High.
-
-**Optional:** **Top 10 modules by architectural risk** (ranked, with evidence).
-
-**Optional closing section — “Potential dissent from a second architect”:** what a reviewer might dispute, weak evidence, decisions needing human validation.
-
----
+Each recommendation: **Problem**, **Evidence**, **Why it matters**, **Recommendation**, **Tradeoffs**, **Implementation**, **Effort**, **Priority**, **Affected modules**. Migration difficulty: Low / Moderate / High / Very High. No generic bullets without repo ties.
 
 ## Scoring framework
 
-**Scoring rules:**
+Scores need concrete evidence; limited evidence → lower confidence. High scores need **positive** evidence; lack of evidence ≠ quality.
 
-- Do not assign scores from intuition alone.  
-- Every score references concrete evidence.  
-- If evidence is limited, **lower confidence**.  
-- **High scores require positive evidence**, not absence of problems.  
-- **Lack of evidence is not evidence of quality.**  
-- Do not reward absence of visible issues with high scores.
-
-**Categories (1–5):** 1 = materially inadequate for enterprise; 2 = weak/high-risk; 3 = workable/moderate risk; 4 = strong with manageable gaps; 5 = enterprise-strong/low risk.
+**Categories (1–5):** 1 materially inadequate … 5 enterprise-strong.
 
 | Category | Weight |
 |----------|--------|
@@ -263,23 +176,20 @@ Avoid generic bullets (“improve modularity”, “add observability”) withou
 | Documentation and governance | 5% |
 | Strategic alignment | 10% |
 
-For **each** category: Score, Why, Evidence, What is needed to reach the next level.  
-Then: **weighted overall score**, **enterprise readiness level** (Early-stage / Growing / Scaling / Enterprise-capable), **scoring confidence** (High / Medium / Low).
-
----
+Per category: Score, Why, Evidence (paths), path to next level. Then weighted overall, enterprise readiness (Early-stage / Growing / Scaling / Enterprise-capable), confidence (High / Medium / Low).
 
 ## Required report structure
 
-Write `enterprise-architecture-audit.md` with these sections:
+`enterprise-architecture-audit.md`:
 
 1. Executive Summary  
-2. Audit Method (must satisfy the **Evidence contract**: sources, searches, commands, scope limits)  
-2b. **CHK-* tick table** (all seven ids: Pass / Gap / N/A / Unknown + evidence)  
+2. Audit Method (Evidence contract: sources, searches, commands, scope)  
+2b. CHK-* tick table  
 3. Repository Inventory  
 4. Detected Architecture Profile  
 5. Python-Specific Engineering Assessment  
 6. Module-by-Module Deep Dive  
-7. Findings by Severity (Critical / High / Medium / Low — each with Classification, Confidence, Why it matters, Evidence, Recommendation, Tradeoffs, Effort, Priority, Affected areas)  
+7. Findings by Severity (each: Classification, Confidence, Evidence, Recommendation, Effort, Priority)  
 8. Performance & Scalability Risk Table  
 9. Architecture Scorecard (+ weighted overall + readiness + confidence)  
 10. Goal and Plan Alignment  
@@ -288,70 +198,22 @@ Write `enterprise-architecture-audit.md` with these sections:
 13. Top 5 Highest-ROI Changes  
 14. Risks, Unknowns, and Assumptions  
 15. Human Validation Required  
-16. Final Verdict (Acceptable / Acceptable with Risks / Major Redesign Recommended) — rationale, biggest blocker, executive takeaway  
+16. Final Verdict (Acceptable / Acceptable with Risks / Major Redesign Recommended)
 
-**Closing quality bar:**
+Quality bar: concrete at module level; lower confidence instead of inventing certainty.
 
-```text
-Do not summarize vaguely. Be concrete at module level.
-If evidence is incomplete, lower confidence instead of inventing certainty.
-The review should help a senior engineering leader decide:
-- what is fine now
-- what becomes dangerous at scale
-- what to fix first
-- what architecture direction best supports the business plan
-```
+## `enterprise-audit-actions.md`
 
----
+Backlog: **ID** (e.g. `EA-001`), **Title**, **Severity** (P0/P1 mapping), **Classification**, **Evidence** (paths), **Recommendation**, **Effort**, **Migration difficulty**, **Priority**, optional owner, link to audit section.
 
-## `enterprise-audit-actions.md` format
+## Shorter invocation (skill already loaded)
 
-Structured backlog for implementers:
-
-- **ID** (e.g. `EA-001`)  
-- **Title**  
-- **Severity** (map enterprise Critical/High to P0/P1 where appropriate for internal tracking)  
-- **Classification:** Confirmed / Probable risk / Unknown  
-- **Evidence** (paths)  
-- **Recommendation** (one concrete step)  
-- **Effort** / **Migration difficulty** / **Priority**  
-- **Suggested owner role** (optional)  
-- **Link** to section in `enterprise-architecture-audit.md`  
-
----
-
-## Shorter invocation prompt (when full skill context is already loaded)
-
-```text
-Audit this Python repository as a Principal Enterprise Architect.
-
-Work step by step. Facts only. No guessing.
-
-Process:
-1. Inventory the repo
-2. Identify the actual implemented architecture
-3. Assess Python-specific engineering quality
-4. Audit each major module/package
-5. Assess risks, scalability, security, reliability, and operability
-6. Compare current architecture to goals and target direction (from docs + context)
-7. Recommend a practical transition path
-
-Rules:
-- Every major claim must include repository evidence (paths)
-- If not verifiable, say "Unknown – not verifiable from repository evidence"
-- Distinguish Confirmed / Probable risk / Unknown
-- Do not jump to recommendations before inventory and architecture assessment
-- Do not provide generic advice
-- Use the weighted scorecard; high scores require positive evidence
-
-Deliverables: full report + enterprise-audit-actions.md under .local/workflow-artifacts/enterprise-architecture-audit/
-```
+Audit as Principal Enterprise Architect: inventory → implemented architecture → Python quality → modules → risks → goals comparison → transition path. Facts only; weighted scorecard; deliverables under `.local/workflow-artifacts/enterprise-architecture-audit/`.
 
 ## Exit criteria
 
-- Phases 1–6 completed in order in the written report; no early recommendation dump.  
-- **CHK-*** tick table present (full audit) or scoped tick table (focused alignment).  
-- **Evidence contract** satisfied: §2 lists reproducible sources/commands; Confirmed claims and scorecard categories cite paths; no finding in §7 or actions file without **Evidence** paths (or explicit **Unknown**).  
-- Scorecard populated with evidence and confidence; no score without justification.  
-- `enterprise-audit-actions.md` exists with prioritized, repo-tied items (full audit).  
-- Unknowns and human-validation items explicitly listed.
+- Phases 1–6 in order; no early recommendation dump.  
+- CHK-* tick table present (full or focused).  
+- Evidence contract: §2 reproducible; Confirmed/scorecard cite paths; §7/actions have Evidence or **Unknown**.  
+- Scorecard with justification; `enterprise-audit-actions.md` with repo-tied items (full audit).  
+- Unknowns and human-validation items listed.

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -13,313 +13,192 @@ Used By:
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/agent_colony/project_cli.py
- - .ai_infra/install/agent_colony/project_atomics.py
- - .ai_infra/install/agent_colony/gh_project_adapter.py
- - .ai_infra/install/agent_colony/project_recipes.py
- - .ai_infra/install/agent_colony/project_outbox.py
  - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:
- - Pattern A: prefer recipes (claim/handoff/create-from-template); atomics for power use; no dual-write when board_only.
- - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
+ - Pattern A: prefer recipes (claim/handoff/create-from-template); no dual-write when board_only.
 -->
 
 # Board SSOT
 
-## Goal
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
-When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Project as the **only writable SSOT** for backlog, Status, and multi-agent continuation. Prefer CLI over inventing `gh` flags. Local trackers are offline fallback only; read-only exports never compete with board Status.
+When `project_ssot.enabled` and `sync_policy: board_only`, the GitHub Project is the **only writable SSOT** for backlog, Status, and continuation. Prefer CLI over inventing `gh` flags. Local trackers = offline fallback only; read-only exports never compete with board Status.
 
-**Agent:** `.cursor/agents/board.md`  
-**Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
-**ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+**Agent:** `.cursor/agents/board.md` · **Ops:** `.ai_infra/docs/operations/project-board-collaboration.md` · **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
 ## Two-tier plans (ADR-010)
 
 | Tier | Location | Role |
 |------|----------|------|
-| **Live** | Board card body (`board_only`) or `.local/index-and-planning/current/plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
-| **History** | `.local/plans/` (`plan snapshot`, `plan list`, `plan open` for human Build) | Dated snapshots + `index.md` — **never** competing Status or live plan under `board_only` (**DRIFT-012**) |
+| **Live** | Board card body (`board_only`) or `plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
+| **History** | `.local/plans/` (`plan snapshot\|list\|open`) | Snapshots only — **never** competing Status under `board_only` (**DRIFT-012**) |
 
 Agents: `plan list` → read snapshot → execute. Exit: `plan snapshot --slug … --board-item …`. See `.cursor/skills/canvas-artifacts/SKILL.md`.
 
-## First-run (board shell) — before day-to-day cards
+## First-run (board shell)
 
-Day-0 requires the kit **default** shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Priority/Size/Estimate/Start date/End date on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.
+Kit default shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Tier-1 columns on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.
 
-0. **Wire YAML from URLs (if ids missing):** after `gh` auth, human pastes Project URL + repo URL → use `gh project view` / `field-list` → propose `project_ssot` + `default_repo` → human confirms before save. Discovery only — **no** `--ensure-fields` until CONSENT.
-1. Load `.cursor/skills/board-shell/SKILL.md` (coach) and the schema above.
-2. **CONSENT GATE (mandatory):** ask board description (or `use template default`) + `May I proceed to set up the kit default shell?` — only continue on `yes`.
-3. Run `python3 -m agent_colony project doctor` → `project board-bootstrap --check`.
-4. On **exit 5** (view FAIL or Tier-1 column FAIL): TURN PROTOCOL (agent coaches one view at a time; human uses `views-setup.md` as click reference). Optional `--ensure-fields` / `--apply-readme` only after consent. **No** `--apply-shell` CLI today.
-5. Refuse “ready for agents” until `board-bootstrap --check` exits **0** (README non-empty, six views, Tier-1 columns on Status board / Prioritized backlog). Then resume day-to-day Pattern A below.
+1. Wire YAML from Project + repo URLs (human confirms before save). Discovery only — **no** `--ensure-fields` until CONSENT.
+2. Load `.cursor/skills/board-shell/SKILL.md`. **CONSENT GATE:** ask description + `May I proceed to set up the kit default shell?` — continue only on `yes`.
+3. `python3 -m agent_colony project doctor` → `project board-bootstrap --check`.
+4. **Exit 5:** TURN PROTOCOL (human UI via `views-setup.md`). Optional `--ensure-fields` / `--apply-readme` only after consent. **No** `--apply-shell` CLI.
+5. Refuse “ready for agents” until `board-bootstrap --check` exits **0**. Then Pattern A below. **`/auditor`** is not day-0.
 
-**Not first-run:** `/auditor` (architecture-impacting / pre-merge later).
+## Continuation contract
 
-## Continuation contract (all agents — non-negotiable when enabled)
-
-Work is **indexed on the Project**, not in chat alone.
+Work is **indexed on the Project**, not chat alone.
 
 | Phase | Required |
 |-------|----------|
-| **Entry** | Prefer `python3 -m agent_colony project entry` (quota-aware: live \| conserve \| offline_artifacts). Then `get` / `claim` **one** card. Read Acceptance / Rollback / Notes on that card body. Avoid unfiltered `project list` / full `export` every turn — use `export --reuse-if-fresh` when a snapshot is enough. Parallel agents may each Entry, but **one export refresh per parent wave**. |
-| **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit / Forbidden throttle / precheck low quota: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
-| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
+| **Entry** | Prefer `python3 -m agent_colony project entry` (live \| conserve \| offline_artifacts). Then `get` / `claim` **one** card. Read Acceptance / Rollback / Notes. Avoid unfiltered `list` / full `export` every turn — use `export --reuse-if-fresh`. One export refresh per parent wave. |
+| **During** | **One** In progress card for your assignee. Mid-slice progress → card Notes. |
+| **Exit** | Update Status → `in_review` / `done`, or stay `in_progress` with **Notes** naming next agent. Notes via `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **EXIT_QUEUED (6)** / rate-limit / Forbidden / precheck low quota: **do not** retry-loop — op in `.local/generated-data/board-outbox.jsonl`; later `project outbox flush`. |
+| **Never** | Chat-only completion with stale Status. No dual-write tracker `in_progress` under `board_only`. No bare `Agent: implementer` without `@user/` namespace. |
 
-Handoff line (chat + card Notes):
+Handoff line (chat + Notes):
 
 ```text
 item_id=<from project last or create> · @User/implementer · Status=before→after · Priority=p1 · Size=s · Estimate=1 · next=@User/verifier
 Tasks: [P1] …; [P2] …; [P3] …
 ```
 
-Prefer `--last` after create so agents never invent ids.
+Prefer `--last` after create. Multi-collaborator: each `owner.github_user` namespaces agents (`@Alice/implementer` vs `@Bob/implementer`).
 
-Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
+## Tier-1 card fields contract
 
-## Tier-1 card fields contract (all agents — mandatory)
+When you **create** or **own** a card, fill Tier-1 fields. Verifier spot-checks on closure.
 
-When you **create** or **own** a Project card, fill the Tier-1 fields below. Do **not** leave them empty and move on. Verifier spot-checks this on closure.
+### Priority
 
-### Priority scale
+| Label | `set-field --field priority --to` | When |
+|-------|-----------------------------------|------|
+| P0 | `p0` | Blocks merge / release / SSOT |
+| P1 | `p1` | Must do next |
+| P2 | `p2` | Hygiene / polish |
+| P3 (deferred) | `p2` + Notes `deferred` | No `p3` option id in YAML |
 
-| Chat / plan label | Board `set-field --field priority --to` | When |
-|-------------------|----------------------------------------|------|
-| **P0** | `p0` | Blocks merge / release / SSOT integrity |
-| **P1** | `p1` | Must do next |
-| **P2** | `p2` | Planned hygiene / polish |
-| **P3** (deferred) | `p2` + Notes line `deferred` | Optional later — **no** `p3` option id in YAML |
+Priority is independent of Size (P0 can be XS).
 
-Priority is **independent** of Size (a P0 can be XS).
-
-### Size ↔ Estimate rubric (points, not hours)
-
-**Estimate** is relative **points**. Do not invent hours unless the consumer’s Project README defines hours→points.
+### Size ↔ Estimate (points, not hours)
 
 | Size | Typical slice | Estimate band | Default if unsure |
 |------|---------------|---------------|-------------------|
-| **xs** | Trivial (&lt; ~1h), one file / one paragraph | **1** | 1 |
+| **xs** | Trivial, one file | **1** | 1 |
 | **s** | Small, clear boundary | **1–2** | **1** |
-| **m** | Multi-file / multi-step, one PR | **3–5** | **3** |
-| **l** | Large or high risk — prefer split | **5–8** | **5** |
-| **xl** | Too big for one agent turn — **split** before coding | **8+** | refuse / split |
+| **m** | Multi-file, one PR | **3–5** | **3** |
+| **l** | Large / high risk — split | **5–8** | **5** |
+| **xl** | Too big — **split** before coding | **8+** | refuse / split |
 
-**Honesty rules**
-
-1. Prefer smaller cards; if Size would be `l`/`xl`, create multiple Ready cards.
-2. If Size and Estimate disagree with the table, explain in Notes.
-3. Unknown → Size=`s`, Estimate=`1`, and Notes: `Size/Estimate guessed (default s/1)`.
-4. Keep Size and Estimate aligned with this table (e.g. Size=`m` → Estimate in 3–5).
+Honesty: prefer smaller cards; if Size=`l`/`xl`, split. If table mismatch, explain in Notes. Unknown → Size=`s`, Estimate=`1`, Notes: `Size/Estimate guessed (default s/1)`.
 
 ### Timing matrix
 
-| Moment | Status | Priority | Size | Estimate | Start date | End date | Assignee | Linked PR |
-|--------|--------|----------|------|----------|------------|----------|----------|-----------|
-| Create (Ready/Backlog) | ✓ | ✓ required | ✓ | ✓ | — | — | ✓ Issue (owner; `--no-assignee` to skip) | — |
-| First In progress | ✓ | confirm | confirm | confirm | **✓ required** | — | ✓ (Issue) | — |
+| Moment | Status | Priority | Size | Estimate | Start | End | Assignee | Linked PR |
+|--------|--------|----------|------|----------|-------|-----|----------|-----------|
+| Create (Ready/Backlog) | ✓ | ✓ | ✓ | ✓ | — | — | ✓ Issue | — |
+| First In progress | ✓ | confirm | confirm | confirm | **✓** | — | ✓ | — |
 | Open PR | — | — | — | — | — | — | — | ✓ `mention-pr` |
-| Exit In review | ✓ | Notes | Notes | Notes | already set | — | — | if PR |
-| Exit Done | ✓ | Notes | Notes | Notes | already set | **✓ required** | — | if PR |
+| Exit In review | ✓ | Notes | Notes | Notes | set | — | — | if PR |
+| Exit Done | ✓ | Notes | Notes | Notes | set | **✓** | — | if PR |
 
-**Start date** = UTC calendar day work began. Set when Status becomes `in_progress` if empty — via `claim`, `set-status --to in_progress`, or `handoff --to in_progress` (master switch: `conventions.set_start_date_on_claim`). Never set on create while Ready/Backlog.
+**Start date:** UTC day work began. Set on first `in_progress` if empty — `claim`, `set-status --to in_progress`, or `handoff --to in_progress` (`conventions.set_start_date_on_claim`). Never on Ready/Backlog create.
 
-**End date** = UTC calendar day work finished. Set when Status becomes `done` if empty — via `set-status --to done`, `handoff --to done`, merge board sync, or `heal-cards --apply` (master switch: `conventions.set_end_date_on_done`). Never set on create or In progress / In review.
+**End date:** UTC day finished. Set on `done` if empty — `set-status --to done`, `handoff --to done`, merge sync, or `heal-cards --apply` (`conventions.set_end_date_on_done`). Never on create or In progress / In review.
 
-### Mandatory field checklist
+### Field checklist
 
-| Field | When | CLI | Rules |
-|-------|------|-----|-------|
-| **Status** | Always | `claim` / `handoff` / `set-status` | Create defaults `--status ready` (overridable); Exit → `in_review` / `done` |
-| **Priority** | Create / claim / own | `create-from-template --priority p0\|p1\|p2` or `set-field` | Required on template create — no silent default |
-| **Size** | Create / claim / own | `--size` / `set-field --field size --to xs\|s\|m\|l\|xl` | Per Size↔Estimate table; default `s` + Notes if guessed |
-| **Estimate** | Create / claim / own | `--estimate` / `set-field --field estimate --to N` | Points per table; default `1` + Notes if guessed |
-| **Start date** | First In progress | `claim` / `set-status --to in_progress` / `handoff --to in_progress` | Auto when `set_start_date_on_claim` + `fields.start_date.field_id`; if WARN, retry — do not ignore |
-| **End date** | Done | `set-status --to done` / `handoff --to done` / merge / `heal-cards` | Auto when `set_end_date_on_done` + `fields.end_date.field_id`; if WARN, retry — do not ignore |
-| **Assignee** | Create (Issue) / claim re-assert | `create-from-template` auto-assigns `owner.github_user`; `claim` / `set-assignee --login …` | **Create as Issue** (`item_kind_default: issue`). Draft is scratch-only; `--no-assignee` escape hatch |
-| **Linked PR** | When a PR exists | `mention-pr --pr N --last --agent <agent>` | Auto-promotes Draft when `promote_to_issue_on_pr` |
+| Field | When | CLI |
+|-------|------|-----|
+| **Status** | Always | `claim` / `handoff` / `set-status` |
+| **Priority** | Create / own | `create-from-template --priority p0\|p1\|p2` or `set-field` |
+| **Size** | Create / own | `--size` / `set-field --field size --to xs\|s\|m\|l\|xl` |
+| **Estimate** | Create / own | `--estimate` / `set-field --field estimate --to N` |
+| **Start date** | First In progress | `claim` / `set-status` / `handoff` → `in_progress` |
+| **End date** | Done | `set-status` / `handoff` / merge / `heal-cards` → `done` |
+| **Assignee** | Create (Issue) | `create-from-template` (default `owner.github_user`); `claim` / `set-assignee` |
+| **Linked PR** | PR exists | `mention-pr --pr N --last --agent <agent>` |
+
+**Create as Issue** (`item_kind_default: issue`). Draft = scratch only (`--no-assignee` escape hatch). `promote-to-issue --last --agent <name>` when still Draft. `mention-pr` auto-promotes when `promote_to_issue_on_pr: true`.
 
 ```bash
-# Pattern A — Tier-1 at create + Start date on claim
 python3 -m agent_colony project create-from-template \
   --template slice --title "[P1] …" --status ready \
   --priority p1 --size s --estimate 1 --agent implementer
 python3 -m agent_colony project claim --last --agent implementer
-# When opening a shippable PR:
 python3 -m agent_colony project mention-pr --pr N --last --agent implementer
 ```
 
-Plain `project create` (non-template) still needs follow-up `set-field` for Priority/Size/Estimate.
-
-Rules:
-
-1. After create: **Priority + Size + Estimate** before coding; on first In progress confirm **Start date** from CLI output.
-2. Exit Notes and chat: `[P0]…; [P1]…; [P2]…; [P3]…` and `Priority=p? · Size=? · Estimate=?`.
-3. `auditor` / `drift-guard`: recommend Priority/Size/Estimate (per table) when seeding Ready cards.
-4. `verifier`: spot-check Status, Priority, Size, Estimate, **Start date on In progress / In review / Done**, **End date on Done**; Assignee when Issue-backed; Linked PR when a PR opened. Missing Start date on active statuses or missing End date on Done = **incomplete Exit**.
-5. Missing Tier-1 fields = incomplete Exit — fill or document blocker in Notes before handoff.
-
-## When to use
-
-- Any session where `project_ssot.enabled: true`
-- Triage, create, claim, Priority/Size, Status transitions
-- Multi-agent handoffs (implementer → test-runner → verifier, etc.)
-
-## Evidence contract
-
-- Cite CLI output or `gh project` JSON for claims.
-- Label **Unknown** when board unreachable → then `fallback: local_trackers` only.
+Plain `project create` needs follow-up `set-field` for Priority/Size/Estimate. Exit Notes: `[P0]…; [P1]…` and `Priority=p? · Size=? · Estimate=?`. Missing Tier-1 or Start on active statuses / End on Done = **incomplete Exit**.
 
 ## Collaboration
 
-### Human vs agent vs GitHub
+| Surface | Human | Agents |
+|---------|-------|--------|
+| Status / Priority / Size / cards | Yes | Yes (rights below) |
+| Ready prioritization / roadmap | **Owner** | Consume Ready; create agreed work |
+| Views, workflows, Insights, README | **Owner only** | **Never** (browser assist only if human asks) |
+| PR gates, audits, secrets | Local | Local (`local_only`) |
 
-| Surface | Human | Agents | Derived |
-|---------|-------|--------|---------|
-| Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
-| Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
-| Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
-| My items | Assign in UI or `project set-assignee` (human login) | Claim = Status In progress + Notes `@user/agent`; assignee = human only | View filter |
-| PR gates, audits, secrets | Local | Local (`local_only`) | — |
+**Issue vs board Status:** independent by default. Opt-in bridge: `conventions.close_linked_issue_on_cleanup` → `finalize.py` closes linked Issue after merge cleanup. CLI: `project close-linked-issue --pr N` (requires Status=Done first).
 
-### Tier-1 board fields (agents)
+**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` flags missing Status/Tier-1 · `outbox flush` if QUEUED.
 
-| Field / action | When | CLI | Notes |
-|----------------|------|-----|-------|
-| **Start date** | First In progress | `claim` / `set-status --to in_progress` / `handoff --to in_progress` | **Mandatory** when empty — UTC today if `conventions.set_start_date_on_claim: true`; see § Tier-1 card fields contract |
-| **End date** | Done | `set-status` / `handoff` / merge / `heal-cards` → `done` | **Mandatory** when empty — UTC today if `conventions.set_end_date_on_done: true` |
-| **Estimate** | Create / claim / own | `project set-field --field estimate --to N` | **Mandatory** — default `1` if unknown |
-| **Size** | Create / claim / own | `project set-field --field size --to xs\|s\|m\|l\|xl` | **Mandatory** — default `s` if unknown |
-| **Priority** | Create / claim / own | `project set-field --field priority --to p0\|p1\|p2` | **Mandatory** — chat P3 → `p2` + Notes `deferred` |
-| **Assignee** | Create Issue (owner) | `create-from-template` (default) / `claim` / `set-assignee` | **Mandatory on Issue create** — `owner.github_user`; Draft cannot hold Assignees |
-| **Linked PR** | PR open | `project mention-pr --pr N --last` | **Mandatory when a PR exists** for the card |
-| **Promote Draft→Issue** | Only if card is still Draft | `project promote-to-issue --last --agent <name>` | Prefer never needing this — create as Issue |
-| **Out of scope (agents default)** | — | — | Iteration, Labels, Reviewers — human / UI only |
+**Rules:** one In progress per human assignee; Acceptance/Rollback/Notes on card body; no dual-mirror under `board_only` (DRIFT-009); read-only `export` never writes Status; post-merge Done via `merge.py`.
 
-### Issue lifecycle (Draft vs Issue)
+| Agent | Exit (must update board) |
+|-------|--------------------------|
+| implementer | In progress → In review (PR) → Done; fields on own card |
+| test-runner / verifier | Stay on card; → In review or Done with Notes |
+| drift-guard | Drift-pass → Done; cite board Status; hand remediation via Notes/Ready — **no** silent tracker edits |
+| auditor | Audit card → In review/Done; Notes → artifact paths |
 
-| Path | CLI / config | Notes |
-|------|--------------|-------|
-| Default create | `create-from-template` + `item_kind_default: issue` | **Issue** on the Project + linked repo (`default_repo`) — Assignees + Linked PRs work from claim |
-| Scratch only | `item_kind_default: draft` (override) | DraftIssue — no Assignees until `promote-to-issue`; do **not** use for shippable work |
-| Explicit promote | `promote-to-issue --last --agent <name>` | Same `PVTI_`; needed only if card was created as Draft |
-| Auto on PR | `mention-pr` | When `promote_to_issue_on_pr: true` (still useful if a Draft slipped through) |
+Status path: `Ready → In progress → In review → Done`
 
-### Issue state vs board Status (they're independent by default)
+## Procedure (Pattern A)
 
-Board `Status=Done` and the linked GitHub Issue's own `open`/`closed` state are **separate signals** — Status is the continuation SSOT; Issue state is GitHub-native (Issues list, notifications). A card can be `Done` while its Issue stays `open` — this is expected, not a bug, unless you opt in below.
+Never paste placeholder `--id`. After create, use `--last`. `project guide --agent <name>`.
 
-- **Opt-in bridge:** `conventions.close_linked_issue_on_cleanup` (default `false`). When `true`, `full-pr-workflow`'s `finalize.py` best-effort closes the Issue linked to the merged PR's board item, **after** branch cleanup succeeds — never on `set-status`/`claim`/`handoff`, so it can't race ahead of merge/cleanup evidence.
-- **CLI:** `project close-linked-issue --pr N [--dry-run]` — resolves the item via `find-by-pr`; **requires board Status=Done** first (else SKIPPED with remediation); skips when there's no linked Issue, the flag is off, or the Issue is already closed; a `gh` error is `DEFERRED` (non-blocking).
-- **Evidence:** outcome recorded in `finalize.md § Linked Issue Closure` (`PASS` / `SKIPPED` / `DEFERRED` / `DRY-RUN` when `finalize.py --dry-run` is used).
+| Need | Template / action |
+|------|-------------------|
+| slice / feature / chore | `create-from-template --template slice` |
+| bug / fix | `create-from-template --template bug` |
+| research | `--template research` |
+| audit pass | `--template slice` + `[AUDIT] …` then `claim --last` |
+| test-runner / verifier | claim/continue only — **no** create |
 
-### Repair incomplete cards
+**Recipes:**
 
-Empty Status (especially with a CLOSED Issue) breaks Status views. Detection and repair:
-
-```bash
-python3 -m agent_colony project doctor          # WARN counts + heal hint
-python3 -m agent_colony project heal-cards --check
-python3 -m agent_colony project heal-cards --apply [--fill-tier1] [--dry-run]
-python3 -m agent_colony project outbox flush    # if QUEUED
-```
-
-`heal-cards --apply` sets Status→Done only when the linked Issue is CLOSED and Status is empty/non-done. `--fill-tier1` optionally fills missing Priority=`p2` / Size=`s` / Estimate=`1`. `validate-item` flags `missing Status` (and Tier-1 when configured) so empty cards never soft-pass.
-
-### Rules
-
-1. One primary **In progress** per **human assignee** — do not steal others'.
-2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (or `claim`/`handoff` recipes).
-4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
-5. Humans own views, workflows, README, Insights, status updates by default (no view API). If the human **asks** for browser help on views/columns, `/board` may use browser MCP for that turn (see `board-shell`).
-6. Read-only `project export` (if used) never writes Status.
-7. Post-merge Done is Pattern A (`merge.py`), Notes prefixed `@user/merge.py`.
-
-### Per-agent rights (what / when / where)
-
-| Agent | Entry (read board) | Exit (must update board) | Local writes |
-|-------|--------------------|--------------------------|--------------|
-| **board** | status + list | create/move any Status; Priority/Size; hand off to implementer | change-index, updates-log |
-| **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
-| **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
-| **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
-| **integrator** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
-| **auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
-| **drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
-| **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |
-
-### Status path
-
-```text
-Ready → In progress → In review → Done
-```
-
-| Moment | Actor | CLI |
-|--------|-------|-----|
-| Start work | implementer / integrator / test-runner / board | `set-status --to in_progress` |
-| PR open / peer handoff | implementer | `set-status --to in_review` |
-| Part verified closed | implementer / verifier / test-runner | `set-status --to done` |
-| Drift / audit pass closed | drift-guard / auditor | `set-status --to done` (their card) |
-| Queue triage | board or human | create / set-status / set-field |
-
-## Procedure (CLI) — prefer Pattern A recipes
-
-**Never paste docs placeholders as `--id`.** After create, use `--last`. Print recipes: `project guide`.
-
-Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (board brief only — not into a shell). CLI recipes stay in `project guide` and `project-board-collaboration.md`.
-
-### Template routing
-
-| Need | Who | Template / action |
-|------|-----|-------------------|
-| slice / feature / `chore/` | implementer, board, integrator | `create-from-template --template slice` |
-| bug / defect / `fix/` | implementer, board | `create-from-template --template bug` |
-| external / corpus research | researcher, board | `create-from-template --template research` |
-| audit pass | auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
-| consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
-| Project README | **Humans only** | paste `project-readme.md` (board brief) in Project settings UI — or `--apply-readme` |
-
-Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
-
-**Notes format:** `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · text` — auto-stamped by CLI on `claim`, `handoff`, and `append-notes --agent`. Idempotent when timestamp already present. Do not hand-forge times.
-
-**Local continuity:** append UTC-prefixed lines to `history/updates-log.md`; optional row in `history/continuity-index.md` (rolling ≥3 days). Board Notes retain full card lifetime.
-
-1. **Doctor / guide:** `project doctor` · `project guide --agent implementer`
-2. **Status / list:** `project status` · `project list [--status ready|in_progress|in_review]`
-3. **Create:** `project create-from-template --title "[SLICE] short-name" --template slice --status ready --priority p1 --size s --estimate 1 --agent <agent>` (prefer `--acceptance` / `--rollback` at create)
+1. `project doctor` · `project guide --agent implementer`
+2. `project status` · `project list [--status ready|in_progress|in_review]`
+3. **Create:** `create-from-template … --priority p1 --size s --estimate 1 --agent <agent>` (prefer `--acceptance` / `--rollback`)
 4. **Claim:** `project claim --last --agent <this-agent>`
-5. **Fill body (if still TBD):** `project set-section --section acceptance|rollback --text '…' --last --agent <this-agent>` — Notes stay append-only
-6. **Handoff:** `project handoff --last --agent <this-agent> --next <agent> [--to in_review|done]` — **EXIT_VALIDATION (5)** when Acceptance/Rollback are still placeholders (also enforced on `set-status --to in_review|done`)
-7. **Validate:** `project validate-item --last` (same checks; handoff/`set-status` already gate closes)
-8. **Atomics (power use):** `set-status` · `set-field` (priority · size · estimate) · `set-section` · `promote-to-issue` · `mention-pr` · `append-notes --agent` · `get --last` · `export`
-9. **Verify:** `project list` + handoff line; `project last` prints saved id
+5. **Body:** `set-section --section acceptance|rollback --text '…' --last --agent <agent>`
+6. **Handoff:** `handoff --last --agent <this-agent> --next <agent> [--to in_review|done]` — **EXIT_VALIDATION (5)** when Acceptance/Rollback are `(TBD)` (also on `set-status --to in_review|done`)
+7. **Validate:** `validate-item --last`
+8. **Atomics:** `set-status` · `set-field` · `set-section` · `promote-to-issue` · `mention-pr` · `append-notes --agent` · `get --last` · `export`
 
-Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation · `6` queued (outbox; soft-success — flush later).
+Exit codes: `0` ok · `2` usage/config · `3` gh · `4` not found · **`5` validation** · **`6` queued** (outbox; flush later).
 
 Rate-limit: `project outbox status` / `project queue` / `project outbox flush` — see `project_ssot.outbox` in collaboration YAML.
 
 ## Dual-write ban
 
-When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local (`local_only`).
+When `board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local.
+
+## Evidence contract
+
+Cite CLI output or `gh project` JSON. Label **Unknown** when board unreachable → `fallback: local_trackers` only.
 
 ## Exit criteria
 
 - [ ] Entry read board (or explicit offline fallback)
-- [ ] Exit updated Status (or Notes + next agent if still In progress)
-- [ ] If EXIT_QUEUED: confirmed via `outbox status`; no API hammering
-- [ ] Handoff line printed with real item_id
-- [ ] Handoff line printed when another agent continues
-- [ ] No dual-write; no unprompted edits to Project views/workflows/Insights (browser assist only if human asked)
+- [ ] Exit updated Status or Notes + next agent
+- [ ] If EXIT_QUEUED: `outbox status`; no API hammering
+- [ ] Handoff line with real `item_id`
+- [ ] No dual-write; no unprompted Project view/workflow edits
 
 ## Anti-patterns
 
-- Chat-only completion with stale board Status
-- Hardcoding field/option ids
-- Reshuffling Ready/P0 without human or board ask
-- Editing Project views/workflows/Insights unprompted (browser assist only when human asks)
-- Pasting Project settings UI text into a terminal
-- Dual-write board + tracker under `board_only`
-- Multi-step claim without `project claim` / bare Notes without `--agent`
-- Do not push to unrelated repositories
+Chat-only completion · hardcoded field ids · dual-write under `board_only` · multi-step claim without `project claim` · bare Notes without `--agent` · reshuffling Ready without human ask · pasting Project UI into terminal

--- a/.cursor/skills/drift-audit/SKILL.md
+++ b/.cursor/skills/drift-audit/SKILL.md
@@ -18,6 +18,8 @@ Notes:
 
 # Drift audit
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
 Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:

--- a/.cursor/skills/implementer-loop/SKILL.md
+++ b/.cursor/skills/implementer-loop/SKILL.md
@@ -5,6 +5,8 @@ description: Disciplined implementation slices with board SSOT continuation and 
 
 # Implementer loop
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slices.

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -17,6 +17,8 @@ Notes:
 
 # Workflow activate
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 User enabled the **Agent Colony** plugin (`agent-colony`) and opened **their app** (not this kit product repo). Run on first use or when planes are missing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,168 +1,109 @@
 # AGENTS.md
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Project intent
 
-**Agent Colony** (`agent-colony`) — this repository **is** the product: installable multi-agent workflow infrastructure with a **GitHub Project** as the only writable coordination SSOT when `project_ssot.enabled` and `sync_policy: board_only`.
+**Agent Colony** (`agent-colony`) — installable multi-agent workflow with **GitHub Project** as the only writable SSOT when `project_ssot.enabled` and `sync_policy: board_only`.
 
 | Surface | Role |
 |---------|------|
-| **GitHub Project** | Backlog, Status, Priority/Size, multi-agent continuation. **Entry** = read board; **Exit** = update Status + Notes. |
-| **Local `.local/`** | Evidence only (PR Pattern A, audits, gates, secrets, coverage, outbox). Never a second Status writer under `board_only`. |
+| **GitHub Project** | Backlog, Status, Priority/Size, continuation. **Entry** = read board; **Exit** = Status + Notes. |
+| **Local `.local/`** | Evidence only (PR Pattern A, audits, gates, secrets, outbox). Never a second Status writer under `board_only`. |
 
 **Non-negotiables**
 
-- **No dual-write** of Status to `work-tracker.md` / `session-pointer.md` when `board_only`.
-- Create shippable cards as **Issues** (`item_kind_default: issue`). Draft is scratch-only.
-- Fill **Tier-1** fields (Status, Priority, Size/Estimate, Start date on first In progress, End date on Done, Assignee, Linked PR via `mention-pr`).
-- GraphQL throttle / Forbidden / precheck low quota → **EXIT_QUEUED (6)** / `project outbox` (do not retry-loop); outbox is not SSOT.
+- No dual-write of Status to `work-tracker.md` / `session-pointer.md` when `board_only`.
+- Shippable cards as **Issues** (`item_kind_default: issue`). Draft is scratch-only.
+- Fill **Tier-1** fields: Status, Priority, Size/Estimate, Start/End dates, Assignee, Linked PR (`mention-pr`).
+- EXIT_QUEUED (6) → `project outbox`; outbox is not SSOT.
 
-**Consumer install:** plugin + `/workflow-activate` in the app repo installs the full kit; consumers wire only identity + board YAML — see [PLUGIN-USER-GUIDE § Product promise](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#product-promise).
+**Consumer install:** plugin + `/workflow-activate` — see [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#product-promise).
 
-**Continuation:** Entry prefers `python3 -m agent_colony project entry` (quota-aware live \| conserve \| offline_artifacts), then claim/get one card; Exit updates Status and Notes (see [board-ssot skill](.cursor/skills/board-ssot/SKILL.md) § Collaboration, [ADR-008](.ai_infra/docs/decisions/ADR-008-project-board-ssot.md), and [project-board-collaboration ops](.ai_infra/docs/operations/project-board-collaboration.md)). Offline fallback trackers only when board unavailable or Entry mode `offline_artifacts`. Rate-limit / precheck / Forbidden throttle: EXIT_QUEUED (6) → `project outbox` (do not retry-loop; local buffer, not a second SSOT).
+## First reads
 
-## First reads (onboarding)
+1. [`README.md`](README.md) · [`CONTRIBUTING.md`](CONTRIBUTING.md) · [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md)
+2. [docs index](.ai_infra/docs/README.md) · [repository-map](.ai_infra/docs/handoff/repository-map.md) · [PLUGIN-ARCHITECTURE](.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md)
+3. [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) · [workflow-architecture](.ai_infra/docs/architecture/workflow-architecture.md)
+4. [ADR index](.ai_infra/docs/decisions/README.md) · [local-workspace-layout](.ai_infra/docs/operations/local-workspace-layout.md) · [workflow-source-owners](.ai_infra/docs/governance/workflow-source-owners.md)
 
-1. [`README.md`](README.md) — public landing · [`CONTRIBUTING.md`](CONTRIBUTING.md) — kit-dev setup · consumer install → [consumer-quickstart](.ai_infra/docs/operations/consumer-quickstart.md) · **permissions** → [permissions-and-prerequisites](.ai_infra/docs/operations/permissions-and-prerequisites.md)
-2. [`.ai_infra/docs/README.md`](.ai_infra/docs/README.md) — docs index (linked navigation)
-3. [`.ai_infra/docs/handoff/repository-map.md`](.ai_infra/docs/handoff/repository-map.md) — **kit repo only** — SSOT vs generated vs consumer install (not shipped to consumers)
-4. [`.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md`](.ai_infra/docs/handoff/PLUGIN-ARCHITECTURE.md) — plugin bundle, install profiles
-5. [`.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md`](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md) — shipped vs spec
-6. [`.ai_infra/docs/architecture/workflow-architecture.md`](.ai_infra/docs/architecture/workflow-architecture.md) — three planes
-7. [`.ai_infra/docs/decisions/README.md`](.ai_infra/docs/decisions/README.md) — ADR index
-8. [`.ai_infra/docs/operations/local-workspace-layout.md`](.ai_infra/docs/operations/local-workspace-layout.md) — `.local/` contract (**Artifact tiers**: base scaffold vs runtime artifacts)
-9. [`.ai_infra/docs/governance/workflow-source-owners.md`](.ai_infra/docs/governance/workflow-source-owners.md) — scripts win over prose
+Token contract: [token-efficiency.md](.ai_infra/docs/operations/token-efficiency.md).
 
-**Optional product overlays:** copy rules from [`overlays/rules/`](overlays/README.md) into the target `.cursor/rules/` at install.
-
-Abbreviations: [`.ai_infra/docs/operations/abbreviations-notepad.md`](.ai_infra/docs/operations/abbreviations-notepad.md)
-
-## Rules (always applied in Cursor)
+## Rules (always applied)
 
 | Rule | Topic |
 |------|--------|
-| `.cursor/rules/implementation-workflow-governance.mdc` | Slice lifecycle, `.local/.../current` trackers, tests |
-| `.cursor/rules/pr-workflow-enforcement.mdc` | PR-first, artifacts, branch safety |
-| `.cursor/rules/commit-trailer-format.mdc` | Commit trailers + optional `Assisted-by` (AI) |
-| `.cursor/rules/file-docstring-header-relations.mdc` | File headers |
-| `.cursor/rules/local-artifact-protection.mdc` | Protected local paths (`.coverage`, `.env`) |
-| `.cursor/rules/advisory-audit-alignment-enforcement.mdc` | Architecture-impacting audits → **`auditor`** + alignment artifacts |
-| `.cursor/rules/project-ssot-precedence.mdc` | Board SSOT precedes local trackers when `project_ssot.enabled` (ADR-008) |
+| `implementation-workflow-governance.mdc` | Slice lifecycle, trackers, tests |
+| `pr-workflow-enforcement.mdc` | PR-first, artifacts, branch safety |
+| `commit-trailer-format.mdc` | Commit trailers + `Assisted-by` |
+| `file-docstring-header-relations.mdc` | File headers |
+| `local-artifact-protection.mdc` | Protected `.coverage`, `.env` |
+| `advisory-audit-alignment-enforcement.mdc` | Alignment audits → `auditor` |
+| `project-ssot-precedence.mdc` | Board SSOT (ADR-008) |
 
-**Product rules** belong in **`overlays/rules/`** at install — see [`overlays/README.md`](overlays/README.md). **Do not duplicate gate lists** in chat or `updates-log.md` — say *prepare gates green* or paste failing command output only.
+Product rules: [`overlays/rules/`](overlays/README.md). Say *prepare gates green* — do not duplicate gate lists.
 
-## Execution workflow
+## Execution
 
-**Resume every session:**
+**Resume:** `project_ssot.enabled` → `python3 -m agent_colony project entry`, claim one card (`.cursor/skills/board-ssot/SKILL.md`). First-run: `board-bootstrap --check` fail → `/board` + `board-shell`. Else: `session-pointer.md` → `plan.md` → `work-tracker.md`.
 
-1. If `project_ssot.enabled` → `python -m agent_colony project entry` (then claim/get one card; `.cursor/skills/board-ssot/SKILL.md` § Continuation contract). Read card Notes for prior handoffs. **First-run only:** if `board-bootstrap --check` exits non-zero (views, Tier-1 columns, README) → `/board` + `board-shell` (**CONSENT GATE** + TURN PROTOCOL) before `/implementer` (audit is not day-0).
-2. Else → `.local/index-and-planning/current/session-pointer.md` → `plan.md` → `work-tracker.md`.
+**After each agent:** update board Status/Notes. Tier-1 on owned cards — see board-ssot skill § Tier-1.
 
-**After every agent part:** update board Status (`in_review` / `done` / Notes + next agent) so continuation is indexed on the Project — not chat-only. **Tier-1 fields are mandatory** on cards you create/own: Status, Priority (`p0|p1|p2`), Size/Estimate per skill **Size↔Estimate** table (points, not hours), Start date on first **In progress** (`claim` / `set-status` / `handoff --to in_progress`), End date on **Done** (`set-status` / `handoff` / merge / `heal-cards` when configured), Assignee (human — **create as Issue** via `item_kind_default: issue`), and Linked PR via `mention-pr` when a PR exists. Exit task lists use `[P0]`…`[P3]`. Notes attribution: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC). Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime. Ops: `.ai_infra/docs/operations/project-board-collaboration.md`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
-
-### Board SSOT (Pattern A + Tier-1)
-
-When `project_ssot.enabled`, prefer CLI recipes over multi-step atomics (`project guide --agent <name>`):
+### Board Pattern A
 
 | Step | Command | Notes |
 |------|---------|--------|
-| Claim | `project claim --last --agent <name>` | In progress; sets **Start date** (UTC) if empty when configured |
-| Done | `project set-status --to done` / `handoff --to done` | Sets **End date** (UTC) if empty when configured |
-| Entry | `project entry` | Quota-aware scoped read (prefer over unfiltered `list`) |
-| Triage | `project set-field --field priority\|size\|estimate --to … --last` | Agents may set on triage/own cards; humans own Ready *ordering* |
-| Promote | `project promote-to-issue --last --agent <name>` | Draft→Issue (same `PVTI_`); claim does **not** auto-promote |
-| PR link | `project mention-pr --pr N --last --agent <name>` | Notes + auto-promote when `promote_to_issue_on_pr` (default true) |
-| Handoff | `project handoff --last --agent <name> --next <peer> --to in_review` | Status + Notes for next agent |
+| Entry | `project entry` | Quota-aware read |
+| Claim | `project claim --last --agent <name>` | In progress; Start date |
+| Done | `project set-status --to done` / `handoff --to done` | End date |
+| Triage | `project set-field --field priority\|size\|estimate --to … --last` | Own/triage cards |
+| Promote | `project promote-to-issue --last --agent <name>` | Draft→Issue |
+| PR link | `project mention-pr --pr N --last --agent <name>` | Notes + auto-promote |
+| Handoff | `project handoff --last --agent <name> --next <peer> --to in_review` | Status + Notes |
 
-Do **not** leave shippable work as Draft through merge. Canon: `.cursor/skills/board-ssot/SKILL.md`; visual hub: `canvases/agent-board-collaboration.canvas.tsx`.
+Do not leave shippable work as Draft. Handoff: [workflow-complete.md](.ai_infra/docs/operations/workflow-complete.md) §F.
 
-Token contract: [`.ai_infra/docs/operations/token-efficiency.md`](.ai_infra/docs/operations/token-efficiency.md).
+Sequence: `plan → interfaces → implementation → tests → evidence → docs`.
 
-Sequence: `plan → interfaces → implementation → tests → evidence → docs update` (plan lives on the **board card body** when SSOT enabled).
+## Quality gates
 
-Full handoff checklist: [`.ai_infra/docs/operations/workflow-complete.md`](.ai_infra/docs/operations/workflow-complete.md) (esp. §F).
+Merge gate order: `resolve_gates()` in `.ai_infra/scripts/pr/prepare.py` — **two** universal + **three** kit-dev append (**five** total). Also run `check_governance_consistency.py` and `check_debrand.py` when changing governance, `.cursor/`, `.agents/`, or policy docs.
 
-## Quality gates (single source of truth)
-
-**Default merge gate order** is `resolve_gates()` in **`.ai_infra/scripts/pr/prepare.py`** — **two** subprocesses in universal core (`check_testing_artifacts.py`, `pytest -q`). Kit-dev repos auto-append drift validate + doc facts + plugin bundle `--check` (**five** / **5** total). Append gates at consumer install as needed. `prepare.py` does **not** run governance consistency by default.
-
-**Additionally** run **`python3 .ai_infra/scripts/architecture/check_governance_consistency.py`** and **`python3 .ai_infra/scripts/architecture/check_debrand.py`** when changing governance, workflows, `.cursor/`, `.agents/`, or tracked policy docs.
-
-When adding or changing agents, skills, pipelines, or integration templates, also run **`python3 -m agent_colony integrate validate`** (included in governance consistency on kit dev repo).
-
-At slice closure, run **`python3 -m agent_colony drift validate`** (or `make drift-validate`) and hand off to **`drift-guard`** when P0/P1 findings need artifacts.
-
-After doc or agent roster changes, run **`make doc-validate`** (included in **`make gates`**). Before full audits, run **`make verify-all`** — see `.cursor/skills/audit-orchestration/SKILL.md`.
+Slice closure: `python3 -m agent_colony drift validate`; hand off `drift-guard` on P0/P1. Doc/agent changes: `make doc-validate`. Audits: `make verify-all` — see `audit-orchestration` skill.
 
 ## Commits
 
-Required in every commit message (see **`.cursor/rules/commit-trailer-format.mdc`**):
+Required: `Author:` + `GitHub-User:` (see `commit-trailer-format.mdc`). Render: `python3 -m agent_colony contributors commit-trailers`. Optional `Assisted-by:` when AI materially shaped work; no `Made-with:`.
 
-- `Author: <Your Name>`
-- `GitHub-User: @<handle>`
+PR artifacts: `Action-By` / `GitHub-User` / `Agent/s` via `--pipeline` (`.agents/skills/pr-workflow/SKILL.md`).
 
-**Render from config:** `.local/user_settings/github.collaboration.yaml` via  
-`python3 -m agent_colony contributors commit-trailers`.
-
-**AI-assisted work:** optional `Assisted-by:` when AI materially shaped the change. Do **not** add **`Made-with:`** (redundant). You stay accountable for the result.
-
-**Cursor IDE attribution (separate):** the kit policy above is **`Assisted-by:`** only. Cursor may optionally add **`Co-authored-by: Cursor <cursoragent@cursor.com>`** via IDE settings or exemplar YAML — that is IDE/opt-in provenance, not a kit commit requirement. Do not treat IDE trailers as substitutes for **`Author:`** / **`GitHub-User:`**.
-
-**PR workflow artifacts** use `Action-By` / `GitHub-User` / `Agent/s` — resolved from the same YAML when scripts run with `--pipeline` (see **`.agents/skills/pr-workflow/SKILL.md`**).
-
-## Skills and agents (Cursor contract)
+## Skills and agents
 
 | Root | Role |
 |------|------|
-| `.cursor/agents/` | Subagent cards (8) — Task delegation; **`model: auto`**; audit agents write `.local/` artifacts only |
-| `.cursor/skills/` | **Canonical protocols** (14 folders: `auditor-protocol`, `audit-orchestration`, `audit-module-map`, `board-ssot`, `board-shell`, `canvas-artifacts`, `drift-audit`, `implementer-loop`, `integrator-protocol`, `mcp-connect`, `research-corpus`, `test-coverage`, `update-agent-colony`, `workflow-activate`) — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
-| `.agents/skills/` | **Maintainer slash skills** (6 folders: `review-pr`, `prepare-pr`, `merge-pr`, `pr-workflow`, `full-pr-workflow`, `audit-alignment` stub → `auditor`) — additive in plugin sync |
-| `.cursor/rules/` | **7** `alwaysApply` rules in this product repo (6 kit + `project-ssot-precedence`) — high context cost by design |
-
-**Plugin sync:** `.cursor/skills/` wins; `.agents/skills/` never overwrites same folder name (`sync_plugin_bundle.py`).
-
-Do not duplicate skill folder names across `.cursor/skills/` and `.agents/skills/`.
-
-### Cursor Task `subagent_type` (human sync)
-
-After agent renames, update the IDE/plugin Task registry so `subagent_type` matches **on-disk** agent ids:
-
-| Use | Retire (legacy) |
-|-----|-----------------|
-| `integrator`, `auditor`, `drift-guard`, `board` | `integrator-mas-agent`, `enterprise-auditor`, `workflow-drift-guard`, `project-board` |
-| Keep: `implementer`, `test-runner`, `researcher`, `verifier` | — |
-
-In-repo cards under `.cursor/agents/<id>.md` are the source of truth; Task enum is Cursor-side and is not updated by git merge.
-
-## Branching
-
-Use `feature/`, `fix/`, or `chore/` branches; keep `main` merge-ready. Staged `/merge-pr` stops at merge (branches may remain for review). Optional cleanup: `/full-pr-workflow` (or `finalize.py`) syncs `main` and removes local + remote feature branch, writing `finalize.md`.
-
-## Skills and agents (where to look)
+| `.cursor/agents/` | 8 agent cards — `auditor`, `board`, `drift-guard`, `implementer`, `integrator`, `researcher`, `test-runner`, `verifier` |
+| `.cursor/skills/` | 14 canonical protocols — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
+| `.agents/skills/` | 6 maintainer slash skills (PR workflow) |
+| `.cursor/rules/` | 7 `alwaysApply` rules |
 
 | Role | Entry |
 |------|--------|
-| Plugin activation | [PLUGIN-USER-GUIDE.md](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md) or `workflow-activate` skill / `python3 -m agent_colony activate --directory .` |
-| Implement | `.cursor/agents/implementer.md` + `.cursor/skills/implementer-loop/SKILL.md` |
-| Project board SSOT | `.cursor/agents/board.md` + `.cursor/skills/board-ssot/SKILL.md` — `python -m agent_colony project …` |
-| Board shell first-run | `/board` + `.cursor/skills/board-shell/SKILL.md` + `board-shell.schema.yaml` |
-| Integrate infrastructure | `.cursor/agents/integrator.md` + `.cursor/skills/integrator-protocol/SKILL.md` — validate with `python3 -m agent_colony integrate validate` |
-| Tests / coverage | `.cursor/agents/test-runner.md` + `.cursor/skills/test-coverage/SKILL.md` |
-| Verify claims (evidence-only; no code fixes) | `.cursor/agents/verifier.md` |
-| Continuous goal/plan/agent-doctrine coherence + DRIFT scripts | **`drift-guard`** — `.cursor/agents/drift-guard.md` + `.cursor/skills/drift-audit/SKILL.md` — `python3 -m agent_colony drift validate` (incl. DRIFT-011, DRIFT-012) |
-| Deep / periodic architecture + CHK-* (security/perf/granularity/docs) | **`auditor`** — `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md` — not continuous plan pulse |
-| Audit orchestration | `.cursor/skills/audit-orchestration/SKILL.md` — parent runs verify-all + Task delegation (no dedicated agent) |
-| Audit module map | `.cursor/skills/audit-module-map/SKILL.md` — optional deep map; invoke via **`auditor`** |
-| Maintainer PR | `.agents/skills/pr-workflow/SKILL.md` → `review-pr` → `prepare-pr` → `merge-pr` (staged) → `full-pr-workflow` → `finalize.py` (cleanup + `finalize.md` evidence) |
-| Research corpus (shipped; opt-in packs) | `.cursor/agents/researcher.md` — adaptive Brief from chat/agents; HTTPS/`github:`/`path:`; `research init\|fetch\|validate`; packs in `_research_results/sources/<slug>/`; live E2E proven 2026-07-19 |
-| MCP | `.ai_infra/mcp_servers/agent_colony_mcp/` — `python -m agent_colony_mcp`; [`.cursor/mcp.json.kit.example`](.cursor/mcp.json.kit.example) + [mcp-connect](.ai_infra/docs/operations/connect-external-mcp.md) |
-| Canvas / plan artifacts | [canvas-artifacts](.cursor/skills/canvas-artifacts/SKILL.md) — `python3 -m agent_colony canvas …` / `plan snapshot|list|open` (ADR-010) |
+| Activate | `workflow-activate` / `python3 -m agent_colony activate --directory .` |
+| Board SSOT | `board` + `board-ssot` skill |
+| Implement | `implementer` + `implementer-loop` |
+| Integrate | `integrator` + `integrator-protocol` |
+| Tests | `test-runner` + `test-coverage` |
+| Verify | `verifier` (evidence only) |
+| Drift | `drift-guard` + `drift-audit` |
+| Audit | `auditor` + `auditor-protocol` |
+| Research | `researcher` + `research-corpus` |
+| MCP | `agent_colony_mcp` + `mcp-connect` |
+| Canvas | `canvas-artifacts` skill |
 
-Scripts:
+**Task `subagent_type`:** use on-disk ids (`integrator`, `auditor`, `drift-guard`, `board`); retire legacy names.
 
-- `python .ai_infra/scripts/pr/verify_publish.py --branch <branch>`
-- `python .ai_infra/scripts/pr/review.py|prepare.py|merge.py --pr <id|url> --actor "<name>" --agents "<pipeline>"`
-- Architecture-impacting PRs: run **`auditor`** before `/prepare-pr` when required
+**Branching:** `feature/`, `fix/`, `chore/` → PR-first workflow. Optional cleanup: `/full-pr-workflow`.
 
 ## Next work
 
-See `.local/index-and-planning/current/plan.md` and [`.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md`](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md).
+`.local/index-and-planning/current/plan.md` · [IMPLEMENTATION-STATUS](.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | | |
 |--|--|
-| **Version** | [`0.6.3`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1504 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
+| **Version** | [`0.6.3`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1510 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
 | **Reference board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 
 ---
@@ -27,7 +27,7 @@ Agent chats lose Status. Trackers and docs drift. Teams re-explain the same slic
 
 **Agent Colony** installs a full Cursor kit into *your* app repo (not this kit repo). When Project SSOT is on, the **GitHub Project** is the only writable place for backlog and Status — agents **enter** by reading the board and **exit** by updating Status and Notes. Local `.local/` holds gates, audits, and evidence — not a second Status writer.
 
-**Proof:** 1504 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
+**Proof:** 1510 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
 
 ---
 

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -6,61 +6,37 @@ description: auditor Agent Colony — Deep/periodic evidence architecture audit 
 
 # Auditor
 
-## What we own (deep / periodic)
+## Own
 
-**Own:** Evidence-only enterprise architecture and engineering audit — architecture, security (code + agent contracts), performance, granularity/boundaries, documentation quality — via `auditor-protocol` CHK-* checklists. Full scorecard or focused alignment for architecture-impacting PRs.
-
-**Do not own:** Continuous goal/plan/agent-doctrine coherence when plans change — that is **`drift-guard`** (script + goal pulse). Do not auto-fix product code unless the user explicitly asks.
+Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is `drift-guard`. No product-code auto-fix unless user asks.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + board context. If no audit card: `create-from-template --template slice --title "[AUDIT] …" --status ready --priority p1 --size s --estimate 1 --agent auditor` then `claim --last --agent auditor`. Else `session-pointer.md` + `change-index.md`.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+**Entry:** If SSOT on: `project status`. If no audit card: `create-from-template` `[AUDIT]` → `claim --last --agent auditor`. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent auditor` (→ `@owner.github_user/auditor`); atomics `append-notes --agent auditor` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Write audit artifacts. Status → `in_review`/`done`. Put paths in Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. When proposing Ready cards, recommend Priority/Size/Estimate alongside Severity.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent auditor`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …" --priority p1 --size s --estimate 1 --agent auditor` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `auditor-protocol` skill.
 
-Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
+## Read first
 
-**Write scope:** `.local/workflow-artifacts/` (paths in `.ai_infra/scripts/pr/local_workflow_paths.py`) and tracker hooks only — **no product-code auto-remediation** unless the user explicitly asks. (`readonly` is not set so Task delegation can write audit artifacts per Cursor subagent semantics.)
+- `.cursor/skills/auditor-protocol/SKILL.md` — Evidence contract + current phase
+- `audit-orchestration` / `audit-module-map` when tasked
+- Plan/work-tracker read-only if present
 
-**Evidence-backed deliverables:** follow the **Evidence contract** in `.cursor/skills/auditor-protocol/SKILL.md` — every **Confirmed** repo claim cites paths; **Probable risk** separates facts from inference; **Unknown** states what was not verifiable.
+## Write (full audit)
 
-## Read first (scope + workflow)
+1. `enterprise-architecture-audit/enterprise-architecture-audit.md`
+2. `enterprise-architecture-audit/enterprise-audit-actions.md`
+3. Alignment files when schema applies (advisory)
 
-- `.cursor/skills/auditor-protocol/SKILL.md` — **full operating protocol, phases, scorecard, and output contract**
-- `.ai_infra/templates/project-board/README.md` — when creating audit cards
-- `AGENTS.md`, `README.md`
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` (if present — do not assume content)
-- Project `docs/architecture/` (local stub: `.local/.../current/architecture.md`)
-- `.ai_infra/docs/operations/local-workspace-layout.md` — where artifacts live under `.local/`
-
-**Deep module topology:** when the user wants a generated module map + HTML export, run `.cursor/skills/audit-module-map/SKILL.md` first or in parallel, then fold summarized evidence into the enterprise audit.
-
-**Full audit orchestration:** when running a phased audit with script preflight and Task delegation, follow `.cursor/skills/audit-orchestration/SKILL.md`.
-
-## Write (mandatory for a full audit)
-
-1. **Primary report:** `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md`
-2. **Action backlog:** `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md`
-3. **Optional — governance drift:** if findings match `.ai_infra/docs/roadmap/alignment-audit-schema.md`, add or reference them in `.local/workflow-artifacts/alignment/alignment-audit.md` / `alignment-todos.md` (advisory; do not auto-remediate).
-
-## Tracker etiquette
-
-- Do **not** silently overwrite `plan.md` / `work-tracker.md`. Propose concrete tracker edits (gate counts, closed EA IDs, dates) in `enterprise-audit-actions.md`; **implementer** applies them so Plan / Work Tracker ICC tabs match audit reality.
-- Log a short entry in `.local/index-and-planning/history/updates-log.md` when the audit completes.
-
-## Architecture cross-check
-
-When project overlays exist (`overlays/rules/*.mdc`), cross-check claims against those boundaries. Universal rules always apply from `.cursor/rules/`.
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -70,13 +46,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** When producing audit or alignment artifacts, persist session evidence via `canvas save` / `plan snapshot` under `.local/canvases/` and `.local/plans/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/board.md
+++ b/agents/board.md
@@ -8,82 +8,45 @@ description: board Agent Colony — Wire Project SSOT, triage cards, and coach f
 
 ## Anchor (mandatory)
 
-**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/board-ssot/SKILL.md`. Run `python -m agent_colony project entry` (quota-aware). **Wire-from-URLs (day-0):** if the human pastes a **Project URL** + **repo URL** after `gh` auth, use `gh project view` / `field-list` to propose YAML updates — human confirms before save (discovery only — **no** `--ensure-fields` until CONSENT GATE). **First-run / shell setup:** load `.cursor/skills/board-shell/SKILL.md` — **CONSENT GATE is mandatory** (ask board description + “may I proceed to create the default shell?”) before TURN PROTOCOL or `--apply-readme` / `--ensure-fields`. Then `project board-bootstrap --check` against `board-shell.schema.yaml` — refuse “ready” until the **default** Playground shell (six views + Tier-1 columns on Status board / Prioritized backlog) and README pass.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+**Entry:** Read `github.collaboration.yaml` → `project_ssot`. Run `project entry`. Wire-from-URLs: propose YAML; human confirms. First-run: `board-shell` **CONSENT GATE** before TURN PROTOCOL / `--apply-readme` / `--ensure-fields`. Refuse ready until `board-bootstrap --check` exit 0.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `project claim` / `project handoff --agent board` (→ `@owner.github_user/board`); atomics `append-notes --agent board` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Update Status via CLI. Append `change-index.md`. One line in `updates-log.md`. Print handoff. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. On triage/create: **must** set Priority, Size, and Estimate (not optional).
+**Board rights:** Status + Notes on the card you touch. Prefer `claim` / `handoff --agent board`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards **must** set Priority/Size/Estimate via `set-field` (Tier-1 contract). Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
-
-**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`. **Board shell:** first-run = **CONSENT GATE** (description + proceed) then `board-shell` + human `views-setup.md` / TURN PROTOCOL; optional `board-bootstrap --apply-readme` / `--ensure-fields` only after `proceed=yes`. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** On triage/create **must** set Priority, Size, Estimate. Canon: `board-ssot` § Tier-1.
 
 ## Role
 
-Own **board triage and Status transitions** for the product Project SSOT (`agent-colony`). Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines. **Also** coach first-run board shell (schema check + human views) via `board-shell`.
+Triage and Status. Hand code to implementer. Coach board shell via `board-shell`.
 
 ## Read first
 
-- `.cursor/skills/board-ssot/SKILL.md`
-- `.cursor/skills/board-shell/SKILL.md` — when first-time / `board-bootstrap --check` fails vs `board-shell.schema.yaml`
-- `.ai_infra/templates/project-board/board-shell.schema.yaml` — kit **default** desired state (six Playground views)
-- `.ai_infra/templates/project-board/README.md` — when creating cards
-- `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `AGENTS.md` (STANDALONE product + board SSOT north star)
-- `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation · § Tier-1
+- `.cursor/skills/board-shell/SKILL.md` when bootstrap fails
+- `board-shell.schema.yaml` · project-board README · ADR-008
 
 ## Loop
 
-### First-run (shell)
+**Wire-only exit:** `board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN`
 
-0. If YAML board ids are missing and the human pasted **Project URL + repo URL**: resolve with `gh`, propose `project_ssot` + `default_repo`, wait for human confirm, then continue.
+| Automated | Human UI |
+|-----------|----------|
+| YAML, fields, README | Views / columns / filters |
 
-**Exit (wire-only):** After YAML save + `contributors validate` / `project doctor` pass, print:
+**First-run:** CONSENT → TURN PROTOCOL one turn at a time → `--check` exit 0.
 
-```text
-board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
-```
-
-Then print the **automation boundary** (never say “ready for `/implementer`” or “same API path for views”):
-
-| Automated (CLI/API) | Human UI only |
-|---------------------|---------------|
-| YAML ids, field definitions, README (`--apply-readme`) | Views (kit default: six Playground; **minimal overlay: two views**) |
-| `contributors validate`, `project doctor` | Column visibility on Status board + Prioritized backlog |
-| `--ensure-fields` | Filters, layout, rename View 1 |
-
-**Minimal 2-view path:** when the user wants a simple board, offer copy of `board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml` and coach Turn A + Turn B only (see `board-shell` § Customization).
-
-Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 0.
-
-1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the board shell?` (Playground default **or** minimal 2-view overlay if user asked) — wait for `yes` before any shell work. If `no`, stop.
-2. Follow `.cursor/skills/board-shell/SKILL.md` — especially **TURN PROTOCOL** when `board-bootstrap --check` FAILs missing views.
-3. **Do not** dump “follow views-setup.md” and stop. One view/column turn at a time; wait for human `done`; re-run `--check` after each turn.
-4. Optional smoke `create-from-template` then cleanup only after `board-bootstrap --check` exit 0 (no view FAIL, no Tier-1 column FAIL).
-
-### Day-to-day (cards)
-
-1. `python -m agent_colony project entry --directory .` (or `status` + scoped `list` when already live)
-2. Prefer Pattern A: `create-from-template --template slice|bug` then `claim --last --agent board` (or `claim --id <real PVTI_>`). Use `--template bug` for defect/`fix/` work. Avoid raw multi-step claim unless atomics are required.
-3. Print handoff line for implementer: item id, title, next Status target
-4. **Verify:** CLI exit 0 + board list reflects change
+**Day-to-day:** `project entry` → `create-from-template` → `claim --last` → handoff to implementer.
 
 ## Boundaries
 
-| Do | Do not |
-|----|--------|
-| Drive board via `agent_colony project` | Bypass `prepare.py` gates |
-| Coach shell via schema + human UI | Create/rename Project **views** via API |
-| Use YAML field/option ids | Dual-write board + tracker SSOT |
-| Hand off code slices to implementer | Mutate unrelated repositories |
-| Fall back to local trackers when disabled | Invent MCP tools |
-| One TURN PROTOCOL turn → wait `done` → re-check | Bulk-dump all views from `views-setup.md` in one message |
-| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn; follow **Browser assist map** in `board-shell` / `views-setup.md` | Open browser MCP for views unprompted; invent GraphQL view mutations |
-| | Say “ready for `/implementer`” after wire-only (API slice) |
+Do: CLI board + shell coach. Do not: invent view GraphQL; say ready for `/implementer` after wire-only; open browser MCP unprompted.
 
-## Handoff format
+If the user asks for browser help on views/columns, use browser MCP for that turn only — follow **Browser assist map** in `board-shell` / `views-setup.md`.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -93,13 +56,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | Trackers/gates if needed — prefer `agent_colony project` for board |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `board` |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Live plan SSOT on the board card (`board_only`) or `plan.md` offline — `.local/plans/` is snapshot-only; `plan snapshot|list|open` for history / human Build bridge — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/drift-guard.md
+++ b/agents/drift-guard.md
@@ -6,49 +6,38 @@ description: drift-guard Agent Colony — Continuous goal/plan/agent-doctrine/do
 
 # Drift guard
 
-## What we guard (continuous)
+## Own
 
-**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…012 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
-
-**Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
+Goal/plan/agent-doctrine/docs coherence + DRIFT-001…012 (script-first). Not deep architecture — that is `auditor`. No product-code auto-fix.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → **must** `python -m agent_colony project entry` (and `list --status in_progress` only when Entry mode is `live` and you need a fresh filter). Cite board Status in findings. Else `session-pointer.md`. Prefer `project export --reuse-if-fresh` before drift validate when a snapshot is needed.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+**Entry:** If SSOT on: `project entry` (must). Prefer `export --reuse-if-fresh` before drift validate. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent drift-guard` (→ `@owner.github_user/drift-guard`); atomics `append-notes --agent drift-guard` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Write `.local/workflow-artifacts/drift/`. Set drift-pass card → `done` or `in_review`. Remediations via Notes/Ready — never silent tracker dual-write. One line in `updates-log.md`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. When seeding Ready remediations, set or recommend Priority/Size/Estimate.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent drift-guard`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
+**Write scope:** drift artifacts only (`drift-audit.md`, `drift-todos.md`).
 
-**Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
+## Loop
 
-1. Run `python -m agent_colony drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when applicable; prefer a fresh `project export` snapshot for DRIFT-010; **DRIFT-012** guards `.local/plans/` snapshot-only under `board_only`).
-3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
-4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
-5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
-6. Do not duplicate governance, integrate, or auditor deep scorecard scope (ADR-007 / ADR-008).
+1. `python -m agent_colony drift validate --directory .` first.
+2. Map to drift-audit / drift-todos (incl. DRIFT-009…012 when applicable).
+3. Goal pulse: board vs plan vs AGENTS — hand off gaps.
+4. P0 blocks prepare; P1 same slice; P2 backlog.
 
 ## Read first
 
-- `.cursor/skills/drift-audit/SKILL.md` — full protocol
-- `.cursor/skills/board-ssot/SKILL.md` — when `project_ssot.enabled`
-- `.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md`
-- `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md` (when project_ssot enabled)
-- Fallback only: `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only)
+- `.cursor/skills/drift-audit/SKILL.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation (when SSOT on)
+- ADR-007 · ADR-008
 
-## Write (mandatory)
-
-1. `.local/workflow-artifacts/drift/drift-audit.md`
-2. `.local/workflow-artifacts/drift/drift-todos.md`
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -58,13 +47,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Under `board_only`, `.local/plans/` is snapshot-only (**DRIFT-012**); live plan stays on the board card — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -8,63 +8,36 @@ description: implementer Agent Colony — Disciplined implementation slices with
 
 ## Anchor (mandatory)
 
-**Entry (board-first when enabled):**
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-1. Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`.
-2. If `project_ssot.enabled`: run `python -m agent_colony project entry`, then claim existing In progress / Ready (or create). Skill: `.cursor/skills/board-ssot/SKILL.md`. Acceptance/Rollback live on the **card body** (`body_sections`).
-3. If disabled or CLI exit non-zero with `fallback: local_trackers`: read `.local/index-and-planning/current/session-pointer.md`, then files it lists (offline path only).
+**Entry:** Read `github.collaboration.yaml` → `project_ssot`. If enabled: `project entry`, then claim or create. Skill: `board-ssot` § Continuation. Else: `session-pointer.md`.
 
-**Exit (board-first when enabled):**
+**Exit:** Fill Acceptance/Rollback, then `handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Promote or `mention-pr` before shippable PR. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`. Say *prepare gates green*.
 
-1. Prefer recipe: fill Acceptance/Rollback (`create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last --agent implementer`) then `python3 -m agent_colony project handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Handoff/`set-status` to `in_review`|`done` returns **EXIT_VALIDATION (5)** while placeholders remain — fix with `set-section`, then retry.
-2. Claim with `project claim --last --agent implementer` (after create-from-template; never paste docs placeholder ids).
-3. Before opening a shippable PR: `promote-to-issue --last` **or** `mention-pr --pr N` (auto-promotes when `promote_to_issue_on_pr`). Claim does **not** promote.
-4. Append `change-index.md`; one line in `history/updates-log.md`.
-5. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-6. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent implementer`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Lifecycle:** May `create-from-template` → `claim --last`. Set Priority/Size/Estimate on own card. Day-0: `board-bootstrap --check`; on exit 5 hand human to `/board` + `board-shell`.
 
-**Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card **must** set Priority/Size/Estimate via `set-field` (Tier-1). Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
+Deliver small reversible slices. New sources: module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 
-**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+## Read first
 
-**Board shell gate (SSOT on):** Day-0 requires the kit **default** board shell (`.ai_infra/templates/project-board/board-shell.schema.yaml`: six Playground views; Priority/Size/Estimate/Start date/End date on Status board + Prioritized backlog). Run `project board-bootstrap --check`. On **exit 5** (view or Tier-1 column FAIL), do **not** claim work — hand the human to **`/board`** + `board-shell` (**CONSENT GATE** then **TURN PROTOCOL**; human UI per `views-setup.md`). Do not treat `/auditor` as day-0 setup.
-
-**STANDALONE:** this product lives only in `agent-colony` as a standalone product.
-
-**Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
-
-Deliver **small, reversible** slices with production quality: clear module boundaries, tests, and **board Status** (or fallback trackers).
-
-## Read first (do not load the whole `.local/` tree)
-
-- `.cursor/skills/implementer-loop/SKILL.md` — slice lifecycle protocol
-- `.cursor/skills/board-ssot/SKILL.md` — when `project_ssot.enabled`
-- `.ai_infra/templates/project-board/README.md` — when creating cards
-- `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `.local/index-and-planning/current/architecture.md` (architecture stub)
-- Fallback only: `session-pointer.md`, `plan.md`, `work-tracker.md`
-- If board Notes or the user cite `_research_results/sources/<slug>/AGENT_BRIEF.md`, **read that brief** before coding (researcher packs are input, not a second SSOT)
-
-When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. After meaningful coverage runs: run **`make coverage-index`** when coverage mattered.  
-**Skip** `.local/generated-data/**` unless the task is coverage or metrics. **Do not** edit `.local/agents-control-center/audits/module-audit.html` except deliberate audit refresh.
+- `.cursor/skills/implementer-loop/SKILL.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation · § Tier-1 (when SSOT on)
+- `github.collaboration.yaml` · fallback: `session-pointer.md`, `plan.md`, `work-tracker.md`
+- Research brief path from Notes when cited
 
 ## Loop
 
-1. One primary claimed board card (`in_progress`) when SSOT enabled; else one `in_progress` in `work-tracker.md`. Scope on card body or `plan.md` (fallback).
-2. Contracts → implementation → tests. **New sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
-3. **Gates:** run `python .ai_infra/scripts/pr/prepare.py` (executes `resolve_gates()`; `GATES` is the 2-gate back-compat alias). Add `python .ai_infra/scripts/architecture/check_governance_consistency.py` if governance/workflows/policy docs changed.
-4. **Commits:** trailers via `python -m agent_colony contributors commit-trailers` (`.cursor/rules/commit-trailer-format.mdc`). Optional `Assisted-by:`. No tool-generated human sign-off.
-5. **Close:** board Status via CLI; `change-index.md` + `updates-log.md`; fallback tracker close only if offline. Run **`make drift-validate`**; hand off to **`drift-guard`** when P0/P1 findings need artifacts.
+1. One claimed `in_progress` card (or offline tracker).
+2. Contracts → code → tests.
+3. Gates: `prepare.py`. Add governance consistency when policy changes.
+4. Commits: `contributors commit-trailers`.
+5. Close: board Status; `make drift-validate`; hand off to `drift-guard` on P0/P1.
 
-## Architecture
-
-Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Board SSOT precedence: `overlays/rules/project-ssot-precedence.mdc`.
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -74,13 +47,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, gates — prefer `agent_colony project` for board |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/integrator.md
+++ b/agents/integrator.md
@@ -8,79 +8,40 @@ description: integrator Agent Colony — Integrates new agents, skills, MCP, and
 
 ## Role
 
-You **extend the multi-agent system** without breaking planes, gates, or procedural discipline. You do **not** invent workflow steps — you wire new capability into the existing kit using **templates, scripts, and facts**.
-
-**Product intent:** the plugin unpacks the full consumer infrastructure (agents, scripts, `.local/`, optional MCP); the human completes **`.local/user_settings/`**; you keep everything else aligned when they add agents, skills, or tools.
+Wire new agents, skills, MCP, and kit surfaces. Do not invent workflow steps. Use templates and scripts.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + skill `.cursor/skills/integrator-protocol/SKILL.md` (and `board-ssot` when touching board wiring). Claim/create integration card (`claim --last` after create). Else `session-pointer.md` then integration skill.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` + `integrator-protocol`. Claim/create integration card. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator` (→ `@owner.github_user/integrator`); atomics `append-notes --agent integrator` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Status → `done` or `in_review`. Notes with validate outcomes. `change-index.md` + `updates-log.md`. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent integrator`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+## Read first
 
-**STANDALONE:** this product lives only in `agent-colony` as a standalone product.
+1. `.cursor/skills/integrator-protocol/SKILL.md`
+2. `mas-infrastructure-integration.md` · workflow-architecture · folder-charter · module-boundaries
+3. `manifest.yaml` · `github.collaboration.yaml` · `mcp.agents.yaml`
 
-## Read first (evidence before edits)
+## Loop
 
-| Order | Path | Why |
-|-------|------|-----|
-| 1 | `.cursor/skills/integrator-protocol/SKILL.md` | Integration procedure (canonical) |
-| 2 | `.ai_infra/templates/project-board/README.md` | When creating board cards |
-| 3 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
-| 4 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
-| 5 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
-| 6 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
-| 7 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
-| 8 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
-| 9 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
-| 10 | `_research_results/sources/<slug>/AGENT_BRIEF.md` | When board Notes / user cite a research pack — read before intake edits |
-
-**Skip** `.local/generated-data/**` unless validating coverage exports.
-
-## Integration modes (pick one per request)
-
-| Mode | When | Must still follow |
-|------|------|-------------------|
-| **MAS-integrated** | Agent joins PR workflow, trackers, MCP registry, pipelines | All universal rules + Anchor blocks + script commands |
-| **Independent contract** | Standalone agent (e.g. one-off tool); no PR slice ownership | Universal `.cursor/rules/*`, commit/PR attribution if it touches git, no bypass of `prepare.py` `resolve_gates()` |
-
-Independent agents **never** skip governance scanners, file headers, or Pattern A for maintainer actions they perform.
-
-## Loop (one integration slice)
-
-1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
-3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
-4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
-5. **Verify** — `python -m agent_colony contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
-6. **Handoff** — implementer owns product code; test-runner owns tests; auditor if architecture-impacting.
+1. Intake: agent | skill | MCP | script | doc.
+2. Plan on board card (or offline trackers).
+3. Apply `.ai_infra/templates/agent-integration/`.
+4. Wire registry / pipelines / sync.
+5. Verify: `contributors validate`, gates, governance when `.cursor/` changes.
+6. Handoff: implementer / test-runner / auditor as needed.
 
 ## Non-negotiables
 
-- **Pattern A:** one script command per maintainer action; merge gates only via `prepare.py` `resolve_gates()` (`GATES` = alias).
-- **No duplicated gate lists** in prose — point to `prepare.py` or `gate-matrix.md`.
-- **Facts only** — cite paths; label `Unknown` when not verified.
-- **No bullshit** — no fake certifications, no `Made-with:` trailers, no invented MCP tools.
-- **Token efficiency** — run scripts; do not re-implement `prepare.py` logic in chat.
+Pattern A. No duplicated gate lists. Facts only. No invented MCP tools.
 
-## When to escalate
-
-| Situation | Agent |
-|-----------|--------|
-| Architecture audit / alignment | `auditor` |
-| Test coverage slice | `test-runner` |
-| Product `src/` implementation | `implementer` |
-| PR merge path | maintainer skills `review-pr` → `prepare-pr` → `merge-pr` |
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -90,13 +51,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -4,89 +4,39 @@ model: auto
 description: researcher Agent Colony — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
-# Researcher (shipped; opt-in corpus)
+# Researcher
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Research packs under `_research_results/sources/<slug>/`. When a **research board card** exists: **must** `set-status --to done` and put pack paths (`AGENT_BRIEF.md`, `INDEX.json`) in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` (+ research card). Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Packs under `_research_results/sources/<slug>/`. Research card → `done` + paths in Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent researcher`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Create research cards with `create-from-template --template research`. If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.
+**Lifecycle:** `--template research`. Write only under `_research_results/` unless user expands scope. No product PRs.
 
-Build and maintain a **local research corpus** of verified packs. **Agent is shipped/proven** (live E2E + verifier PASS 2026-07-19); corpus packs remain **opt-in** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
+## Adaptive intake
 
-## Adaptive intake (mandatory before research)
+Build a Brief from chat, board, or handoff. Normalize `https://github.com/…` → `github:owner/repo`. Defaults when terse: architecture/cli/agents lenses; `rounds_max` 6. Refuse only when no source and not `mode: self`.
 
-Normalize a **Research Brief** from whatever channel started you — do **not** refuse a usable chat/handoff just because fields are informal.
+## Anti-loop
 
-| Source | What to read | How to adapt |
-|--------|--------------|--------------|
-| **User chat** | Current message (+ prior turns in thread) | Extract URL / `github:owner/repo` / local path; question from prose; lenses if named else defaults |
-| **Other agents** | Board Notes, handoff line, `AGENT_BRIEF` / pack path, implementer/integrator request | Treat their question + source as Brief; name them in `consumers` |
-| **Board research card** | Card body Brief table + Notes | Prefer card fields; fill gaps from chat |
-| **Explicit Brief** | `BRIEF.md` or pasted contract | Use as-is |
+One pack per slug. One fetch. Cap `rounds_max`. Close after validate PASS. No retry storms.
 
-**Normalize sources** before CLI:
+## Hard stop
 
-- `https://github.com/owner/repo` → acceptable (CLI accepts HTTPS); prefer also recording `github:owner/repo`
-- `github:owner/repo[@ref]` → canonical
-- Absolute/relative local path → `path:…` or bare path
-
-**Defaults when user is terse** (e.g. `/researcher https://github.com/owner/repo`):
-
-- `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
-- `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
-- `slug`: repo name lowercased (`grok-build`)
-- `consumers`: implementer, integrator
-- `rounds_max`: 6
-
-**Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
-
-Then write `BRIEF.md` via `research init` and proceed with the skill loop.
-
-## GitHub access (public + private)
-
-| Repo visibility | How fetch works |
-|-----------------|-----------------|
-| **Public** | `research fetch` clones via `gh repo clone` (preferred) or `git clone https://…` |
-| **Private** | Same CLI — requires the **consumer machine** to already authenticate (`gh auth login` and/or git credentials) so a normal local clone of that URL would succeed |
-
-No kit-side GitHub token is stored. If clone fails, report the error and stop (do not retry in a loop).
-
-## Anti-loop (mandatory stop rules)
-
-1. **One pack per slug** — do not `research init` again without user `--force` / explicit redo.
-2. **One fetch** — if `SOURCE.md` exists, do not re-fetch without `--force`.
-3. **Hard cap** — deepen at most `rounds_max` (default **6**). Never invent round-7+.
-4. **Close then exit** — after `INDEX.json` `status: complete` + `research validate` PASS → handoff/Done and **stop**. Do not start another deepen cycle in the same session unless the user explicitly asks to reopen.
-5. **Gaps OK** — if questions remain at cap, write them under gaps / `status: blocked` or complete with “open gaps”; do not keep reading forever.
-6. **No retry storms** — clone/API failures: one attempt, surface stderr, exit (outbox only for board writes).
-
-## Hard stop (when enabled)
-
-1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
-2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files without explicit user request.
-3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External mode requires a Brief** — derive it from chat/agents/card (see Adaptive intake); then persist as `BRIEF.md`.
-
-**Read-only** on the rest of the repo (and on foreign sources) unless the user directs otherwise.
+No edits to product `src/` / `tests/` / scripts without explicit ask. No git commit/push for research-only.
 
 ## Read first
 
-1. `.cursor/skills/research-corpus/SKILL.md` (intake + rounds)
-2. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
-3. `.agents/skills/RESEARCH_WORKFLOW.md`
-4. Pack `BRIEF.md` + `SOURCE.md` when continuing a slug
-5. Any pack path or handoff cited by another agent / board Notes
+`.cursor/skills/research-corpus/SKILL.md` · `RESEARCH_BOUNDARIES.md` · pack `BRIEF.md`
 
-## CLI (procedural)
+## CLI
 
 ```bash
 python3 -m agent_colony research init --slug <slug> --source '…' --question '…'
@@ -94,28 +44,16 @@ python3 -m agent_colony research fetch --slug <slug> --source '…'
 python3 -m agent_colony research validate --slug <slug>
 ```
 
-`--source` accepts `github:owner/repo[@ref]`, `https://github.com/owner/repo[/tree/ref]`, `path:…`, or bare local path.
-
-Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, and INDEX validation.
-
 ## Modes
 
-| Mode | Trigger | Output |
-|------|---------|--------|
-| `external` | Source found in chat/card/handoff (default) | Multi-round pack + `AGENT_BRIEF.md` |
-| `self` | User asks host deepening / DEPTH_BACKLOG | Same write root; no foreign fetch |
+| Mode | Output |
+|------|--------|
+| external | Pack + `AGENT_BRIEF.md` |
+| self | Host deepen; no foreign fetch |
 
-## Not this agent
+GitHub clone uses machine auth. DeepWiki MCP uses `repoName` — does not replace `research fetch`.
 
-| Need | Use |
-|------|-----|
-| Implement features | `implementer` (consume `AGENT_BRIEF.md`) |
-| Integrate kit surfaces | `integrator` |
-| PR merge | `pr-workflow/SKILL.md` |
-| Full enterprise audit | `auditor` |
-| Verify a claim | `verifier` |
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -125,26 +63,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | `deepwiki` (worked example, zero-auth) — see `.cursor/mcp.registry.yaml` | Indexed wiki Q&A (`read_wiki_structure`, `read_wiki_contents`, `ask_question`); other listed servers only if connected for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-### Two sources (do not mix)
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-| Need | Use | Example |
-|------|-----|---------|
-| Clone / pack corpus (`research init\|fetch`) | **GitHub** URL or `github:owner/repo` | `https://github.com/karpathy/nanochat` |
-| Wiki Q&A via MCP | **DeepWiki** MCP · arg **`repoName`** (not `repo`) | `repoName":"karpathy/nanochat"` — wiki must exist at [deepwiki.com/…](https://deepwiki.com/karpathy/nanochat) |
-
-Same `owner/repo` string in both places; different transports. DeepWiki does **not** replace `research fetch` — it answers questions about an already-indexed wiki. If DeepWiki returns “Repository not found,” index the repo on deepwiki.com (or pick an indexed example) — do not invent a `repo` arg.
-
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
-
-```bash
-python3 -m agent_colony mcp call --server deepwiki --tool ask_question \
-  --args-json '{"repoName":"karpathy/nanochat","question":"What is nanochat in one sentence?"}'
-```
-
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names or arg keys.
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Ephemeral analysis → persist via `canvas save`; not git SSOT — research packs stay under `_research_results/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -8,27 +8,28 @@ description: test-runner Agent Colony — Module-focused tests, regressions, cov
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/board-ssot/SKILL.md` when board SSOT is on.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` / claim; read Acceptance/Notes. Else `session-pointer.md`. Read `test-index.md` when tests change.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent test-runner` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** `handoff --last` / claim. Status → `in_review` if tests gate PR, else `done`. Update `change-index.md`, `test-index.md` / `test-plan.md`. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent test-runner`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.
+**Lifecycle:** Consume only — do not `create-from-template`. Claim existing slice card.
 
-- Map changes → `tests/modules/<module>/`; one clear responsibility per file.
-- Cover happy, failure, edge, and regression cases for touched behavior.
-- Run **smallest** pytest scope first; widen when needed. For risky kit-dev slices: `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q` (see `.cursor/skills/test-coverage/SKILL.md`).
-- Before PR handoff path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (first entry in `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
-- Strategy detail: `.cursor/skills/test-coverage/SKILL.md`.
+## Work
 
-Report: tests added/updated • scope run • gaps • `test-index.md` / `test-plan.md` updates if any.
+- Map changes → `tests/modules/<module>/`.
+- Cover happy, failure, edge, regression.
+- Smallest pytest first. Risky kit-dev: see `test-coverage` skill.
+- Before PR path: `check_testing_artifacts.py` (in `prepare.py` `resolve_gates()`).
 
-## Handoff format
+Report: tests · scope · gaps · tracker updates.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -38,13 +39,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Test evidence stays under `.local/`; board/card Notes may pointer-only cite paths — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -8,31 +8,29 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project entry` + related board card (read **Acceptance / Rollback / Notes** for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Before Status → `done`, run `project validate-item --last` and refuse close while Acceptance/Rollback are placeholders (CLI also gates `handoff`/`set-status` → `done`). Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project entry` + card Acceptance/Rollback/Notes. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent verifier` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** `validate-item --last` before `done`. Refuse placeholder Acceptance/Rollback. Status → `done` or leave `in_review` with failure Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. On closure, spot-check Status/Priority/Size/Estimate/Start date/End date on Done; Assignee when Issue-backed; Linked PR when a PR was opened; **Acceptance/Rollback must not be `(TBD)`**.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent verifier`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Spot-check on close. Canon: `board-ssot` § Tier-1.
 
-**Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes. If Acceptance/Rollback still placeholders, leave `in_review` with Notes naming the gap (implementer remediates via `set-section`).
+**Lifecycle:** Consume only. Evidence only — do not implement fixes.
 
-1. Restate what was claimed done.
-2. Point to files/lines or command output as evidence.
-3. Run the **smallest** checks that disprove the claim; expand if still uncertain:
-   - targeted `pytest` → full `pytest -q` when scope warrants
-   - same **category** of checks as `.ai_infra/scripts/pr/prepare.py` **`resolve_gates()`** (see that file; `GATES` is the 2-gate back-compat alias)
-   - `python .ai_infra/scripts/architecture/check_governance_consistency.py` when governance/workflows/policy docs changed
-   - `verify_publish.py --branch <branch>` when validating PR linkage
-4. Label each claim: Verified | Partial | Not verified.
-5. Output: passed • failed • missing • **one** next action.
+## Work
 
-Do not approve merge readiness without artifacts under `.local/workflow-artifacts/pr/` when the maintainer workflow is in play (`.ai_infra/scripts/pr/local_workflow_paths.py`). Flag drift vs `AGENTS.md` and `.cursor/rules/*`.
+1. Restate the claim.
+2. Cite files or command output.
+3. Smallest disproof checks first (`pytest`, `resolve_gates()` category, governance when needed, `verify_publish.py` for PR link).
+4. Label: Verified | Partial | Not verified.
+5. Output: passed · failed · missing · one next action.
 
-## Handoff format
+Do not approve merge without `.local/workflow-artifacts/pr/` when maintainer workflow applies.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -42,13 +40,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Claims may cite `.local/plans/` snapshots and `.local/canvases/` evidence; live plan remains board card / `plan.md` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.ai_infra/docs/operations/README.md
+++ b/payload/.ai_infra/docs/operations/README.md
@@ -31,6 +31,7 @@ Depends On:
 - [`upgrade-kit.md`](upgrade-kit.md) — reinstall / semver upgrade
 - [`project-config.md`](project-config.md) — optional `project.config.yaml` metadata
 - [`token-efficiency.md`](token-efficiency.md) — agent read/write contract
+- [`asd-ste100-prose.md`](asd-ste100-prose.md) — **Use ASD-STE100** (free prose guide; token-efficiency research)
 - [`logging-and-errors.md`](logging-and-errors.md) — logging baseline
 - [`abbreviations-notepad.md`](abbreviations-notepad.md) — shared abbreviations
 

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -49,6 +49,7 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **con
 | RC | Release candidate — needs CI/CD evidence bundles before ship |
 | UI | GitHub Project / settings UI (humans); agents prefer CLI |
 | PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes — see [permissions-and-prerequisites](permissions-and-prerequisites.md) |
+| ASD-STE100 | Simplified Technical English (ASD). Kit: **Use ASD-STE100** → [asd-ste100-prose.md](asd-ste100-prose.md) (free principles; no dictionary; not compliance) |
 | GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
 | KISS | Keep It Simple — incremental, reversible slices |
 | DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |

--- a/payload/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/payload/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -1,0 +1,66 @@
+<!--
+File: asd-ste100-prose.md
+Path: .ai_infra/docs/operations/asd-ste100-prose.md
+Role: Free-path Use ASD-STE100 prose guide for agent-facing instructions (token efficiency research).
+Used By:
+ - .cursor/agents/*.md
+ - .cursor/skills/*
+ - token-efficiency.md
+ - AGENTS.md
+Depends On:
+ - token-efficiency.md
+Notes:
+ - Inspired by ASD-STE100 writing principles. No ASD dictionary. No purchase. Not a compliance claim.
+-->
+
+# Use ASD-STE100
+
+**Mandatory for agents.** Write instructions, Notes, and handoffs with this guide.
+
+Inspired by [ASD-STE100](https://asd-ste100.org/) writing principles. This kit ships a **free** guide only.
+
+| Do | Do not |
+|----|--------|
+| Follow this file | Buy or license ASD materials for this kit |
+| Use **kit vocabulary** below | Embed ASD’s dictionary in the repo |
+| Say *inspired by ASD-STE100* | Claim *ASD-STE100 compliant* |
+
+Research goal: clearer prose → fewer tokens → measure before/after byte and line counts.
+
+## Writing rules (free principles)
+
+1. Use short sentences. Prefer under 20 words.
+2. Put one instruction in each bullet.
+3. Use active voice. Prefer imperatives: `Run project entry.`
+4. Give each word one meaning in this kit (see vocabulary).
+5. Link to skills or CLI. Do not paste long procedures.
+6. Prefer tables for commands.
+7. Say *prepare gates green* or paste failing stderr only. Do not paste full gate lists.
+
+## Kit vocabulary (ours — not ASD’s dictionary)
+
+| Term | Meaning | Do not also say |
+|------|---------|-----------------|
+| **Use ASD-STE100** | Follow this file | “STE style” without this link |
+| Entry | `python -m agent_colony project entry` | Unfiltered `list` / full `export` as default |
+| Claim | `project claim --last --agent <id>` | Vague “take the card” |
+| Handoff | `project handoff --last …` | Separate Status + Notes as the default recipe |
+| Gates green | `prepare.py` passed | Pasting full `GATES` / gate subprocess lists |
+| Board SSOT | GitHub Project writable Status when enabled | Local tracker Status under `board_only` |
+| Tier-1 | Status, Priority, Size, Estimate, dates, Assignee, PR link | “All the fields” without the skill |
+| EXIT_QUEUED | Exit code 6 — outbox; flush later | Retry loops on GraphQL throttle |
+
+## When agents write
+
+| Surface | Rule |
+|---------|------|
+| Agent cards | Keep Anchors short. Point here + `token-efficiency.md`. |
+| Skills | Procedure lives in the skill. Cards link to sections. |
+| Board Notes | Attributed one-liners. No gate dumps. |
+| Chat handoff | One line: Status · next · Tasks `[P…]` |
+
+## Related
+
+- [token-efficiency.md](token-efficiency.md) — read/write contract
+- [board-ssot skill](../../../.cursor/skills/board-ssot/SKILL.md) — Tier-1 and Continuation
+- Official standard (reference only): [asd-ste100.org](https://asd-ste100.org/)

--- a/payload/.ai_infra/docs/operations/token-efficiency.md
+++ b/payload/.ai_infra/docs/operations/token-efficiency.md
@@ -7,12 +7,28 @@ Used By:
 Depends On:
  - .ai_infra/scripts/pr/prepare.py
  - docs/governance/workflow-source-owners.md
+ - asd-ste100-prose.md
 Notes:
  - When project_ssot.enabled: pair with board Status + card Notes for resume-without-chat.
  - Else: session-pointer.md + change-index.md.
+ - Use ASD-STE100: see asd-ste100-prose.md (free principles; no ASD dictionary).
 -->
 
 # Token efficiency (agent contract)
+
+**Use ASD-STE100** for agent-facing prose: [asd-ste100-prose.md](asd-ste100-prose.md).
+
+## Skill thin-index (intent)
+
+Load the section you need. Do not load whole skills by default.
+
+| Skill | Read when | Prefer |
+|-------|-----------|--------|
+| `board-ssot` | Mutating Status / Tier-1 | § Continuation · § Tier-1 |
+| `implementer-loop` | Implement slice | Full skill (short) |
+| `drift-audit` | drift-guard pass | Steps 1–3 |
+| `auditor-protocol` | Audit task | Evidence contract + current phase |
+| `workflow-activate` | Consumer install | “When user just installed” |
 
 ## Read set (default)
 
@@ -40,6 +56,15 @@ Notes:
 | 5 | `workflow-artifacts/pr/*.md` | Only when phase = review \| prepare \| merge |
 
 **Skip:** `.local/generated-data/**`, `history/archive/**`, full `updates-log.md` body, full `AGENTS.md` unless explicitly tasked.
+
+**Prefer CLI digests (token-efficient):**
+
+| Need | Command |
+|------|---------|
+| Entry summary | `python -m agent_colony project entry --digest` (or `--json`) |
+| Agent roster | `python -m agent_colony doc roster-digest` |
+| Doc head | `python -m agent_colony doc summarize --path …` |
+| Prepare gates | `python .ai_infra/scripts/pr/prepare.py … --summary` |
 
 ## Write set (slice close)
 

--- a/payload/.ai_infra/install/agent_colony/doc_cli.py
+++ b/payload/.ai_infra/install/agent_colony/doc_cli.py
@@ -1,18 +1,20 @@
 """
 File: doc_cli.py
 Path: .ai_infra/install/agent_colony/doc_cli.py
-Role: CLI handlers for doc subcommands (canonical doc fact validation).
+Role: CLI handlers for doc subcommands (canonical doc fact validation + digests).
 Used By:
  - .ai_infra/install/agent_colony/cli.py
 Depends On:
  - .ai_infra/scripts/architecture/check_doc_facts.py
 Notes:
  - Adds scripts/architecture to sys.path for consumer installs.
+ - roster-digest / summarize support token-efficient agent Entry.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -51,8 +53,6 @@ def cmd_doc_validate(args: argparse.Namespace) -> int:
     if preflight is not None:
         check_doc_facts.write_preflight_json(results, preflight)
     if args.json:
-        import json
-
         payload = {
             "results": [
                 {
@@ -69,6 +69,77 @@ def cmd_doc_validate(args: argparse.Namespace) -> int:
     else:
         print(check_doc_facts.format_report(results))
     return check_doc_facts.exit_code_for(results)
+
+
+def cmd_doc_roster_digest(args: argparse.Namespace) -> int:
+    """Print agent id + one-line description (token-efficient roster)."""
+    root = Path(args.directory).resolve()
+    agents_dir = root / ".cursor" / "agents"
+    if not agents_dir.is_dir():
+        print(f"doc roster-digest: FAIL — missing {agents_dir}", file=sys.stderr)
+        return 1
+    rows: list[dict[str, str]] = []
+    for path in sorted(agents_dir.glob("*.md")):
+        agent_id = path.stem
+        desc = ""
+        text = path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if line.startswith("description:"):
+                desc = line.split(":", 1)[1].strip()
+                break
+        rows.append({"id": agent_id, "description": desc})
+    if args.json:
+        print(json.dumps({"agents": rows, "count": len(rows)}, indent=2))
+    else:
+        print(f"agents={len(rows)}")
+        for row in rows:
+            short = row["description"]
+            if len(short) > 72:
+                short = short[:69] + "…"
+            print(f"{row['id']}\t{short}")
+    return 0
+
+
+def cmd_doc_summarize(args: argparse.Namespace) -> int:
+    """Print first N non-empty lines of a markdown/doc path (token-efficient)."""
+    root = Path(args.directory).resolve()
+    path = Path(args.path)
+    if not path.is_absolute():
+        path = (root / path).resolve()
+    if not path.is_file():
+        print(f"doc summarize: FAIL — missing {path}", file=sys.stderr)
+        return 1
+    max_lines = int(args.lines)
+    lines_out: list[str] = []
+    in_comment = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if in_comment:
+            if "-->" in stripped:
+                in_comment = False
+            continue
+        if stripped.startswith("<!--"):
+            if "-->" not in stripped:
+                in_comment = True
+            continue
+        if not stripped:
+            continue
+        lines_out.append(line.rstrip())
+        if len(lines_out) >= max_lines:
+            break
+    payload = {
+        "path": str(path.relative_to(root) if path.is_relative_to(root) else path),
+        "lines": lines_out,
+        "truncated": len(lines_out) >= max_lines,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"path={payload['path']} · lines={len(lines_out)}"
+              f"{' · truncated' if payload['truncated'] else ''}")
+        for line in lines_out:
+            print(line)
+    return 0
 
 
 def register_doc_subparser(sub: argparse._SubParsersAction) -> None:
@@ -93,3 +164,21 @@ def register_doc_subparser(sub: argparse._SubParsersAction) -> None:
         help="Custom preflight JSON path",
     )
     validate_cmd.set_defaults(func=cmd_doc_validate)
+
+    roster_cmd = doc_sub.add_parser(
+        "roster-digest",
+        help="Token-efficient agent roster (id + description)",
+    )
+    roster_cmd.add_argument("--directory", type=Path, default=".")
+    roster_cmd.add_argument("--json", action="store_true")
+    roster_cmd.set_defaults(func=cmd_doc_roster_digest)
+
+    summarize_cmd = doc_sub.add_parser(
+        "summarize",
+        help="First N non-empty lines of a doc (token-efficient)",
+    )
+    summarize_cmd.add_argument("--directory", type=Path, default=".")
+    summarize_cmd.add_argument("--path", required=True, help="Repo-relative or absolute path")
+    summarize_cmd.add_argument("--lines", type=int, default=40, help="Max non-empty lines")
+    summarize_cmd.add_argument("--json", action="store_true")
+    summarize_cmd.set_defaults(func=cmd_doc_summarize)

--- a/payload/.ai_infra/install/agent_colony/project_cli.py
+++ b/payload/.ai_infra/install/agent_colony/project_cli.py
@@ -1492,22 +1492,73 @@ def cmd_export(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def _print_entry_rows(items: list[dict[str, Any]], *, statuses: set[str]) -> int:
-    """Print TSV rows matching normalized statuses; return count printed."""
-    printed = 0
+def _filter_entry_items(
+    items: list[dict[str, Any]], *, statuses: set[str]
+) -> list[dict[str, Any]]:
+    """Return items matching normalized statuses."""
+    out: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, dict):
             continue
         status = _normalize_status(str(item.get("status") or item.get("status_normalized") or ""))
         if status not in statuses:
             continue
-        printed += 1
+        out.append(item)
+    return out
+
+
+def _print_entry_rows(items: list[dict[str, Any]], *, statuses: set[str]) -> int:
+    """Print TSV rows matching normalized statuses; return count printed."""
+    matched = _filter_entry_items(items, statuses=statuses)
+    for item in matched:
         print(
             f"{item.get('id')}\t{item.get('status')}\t{item.get('priority') or ''}\t"
             f"{item.get('size') or ''}\t{item.get('estimate') or item.get('Estimate') or ''}\t"
             f"{item.get('title')}"
         )
-    return printed
+    return len(matched)
+
+
+def _emit_entry_digest(
+    *,
+    mode: str,
+    rem_disp: str,
+    next_cmd: str,
+    matched: list[dict[str, Any]],
+    as_json: bool,
+    digest: bool,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Print token-efficient entry summary (--digest / --json)."""
+    payload: dict[str, Any] = {
+        "mode": mode,
+        "graphql_remaining": rem_disp,
+        "item_count": len(matched),
+        "next": next_cmd,
+        "items": [
+            {
+                "id": it.get("id"),
+                "status": it.get("status"),
+                "title": it.get("title"),
+                "priority": it.get("priority") or "",
+            }
+            for it in matched[:20]
+        ],
+    }
+    if extra:
+        payload.update(extra)
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return
+    if digest:
+        print(
+            f"mode={mode} · graphql_remaining={rem_disp} · "
+            f"items={len(matched)} · next={next_cmd}"
+        )
+        for it in matched[:5]:
+            print(f"  {it.get('id')}\t{it.get('status')}\t{it.get('title')}")
+        if len(matched) > 5:
+            print(f"  … +{len(matched) - 5} more")
 
 
 def cmd_entry(args: argparse.Namespace) -> int:
@@ -1521,20 +1572,36 @@ def cmd_entry(args: argparse.Namespace) -> int:
     if errs or ssot is None:
         return fail("entry", EXIT_USAGE, errs[0] if errs else "project_ssot missing")
     enabled = bool(ssot.get("enabled"))
-    print(f"enabled: {enabled}")
-    print(f"operational: {enabled}")
-    print(f"name: {ssot.get('name')}")
-    print(f"owner: {ssot.get('owner')}")
-    print(f"number: {ssot.get('number')}")
-    print(f"url: {ssot.get('url')}")
-    print(f"project_id: {ssot.get('project_id')}")
-    print(f"sync_policy: {ssot.get('sync_policy')}")
-    print(f"fallback: {ssot.get('fallback')}")
+    compact = bool(getattr(args, "digest", False) or getattr(args, "json", False))
+    as_json = bool(getattr(args, "json", False))
+    digest = bool(getattr(args, "digest", False)) and not as_json
+
+    if not compact:
+        print(f"enabled: {enabled}")
+        print(f"operational: {enabled}")
+        print(f"name: {ssot.get('name')}")
+        print(f"owner: {ssot.get('owner')}")
+        print(f"number: {ssot.get('number')}")
+        print(f"url: {ssot.get('url')}")
+        print(f"project_id: {ssot.get('project_id')}")
+        print(f"sync_policy: {ssot.get('sync_policy')}")
+        print(f"fallback: {ssot.get('fallback')}")
     if not enabled:
-        print(
-            "mode=offline_artifacts · graphql_remaining=? · "
-            "next=local_trackers|enable project_ssot"
-        )
+        if compact:
+            _emit_entry_digest(
+                mode="offline_artifacts",
+                rem_disp="?",
+                next_cmd="local_trackers|enable project_ssot",
+                matched=[],
+                as_json=as_json,
+                digest=digest or True,
+                extra={"enabled": False},
+            )
+        else:
+            print(
+                "mode=offline_artifacts · graphql_remaining=? · "
+                "next=local_trackers|enable project_ssot"
+            )
         return EXIT_OK
 
     eff = load_efficiency_config(ssot)
@@ -1572,23 +1639,37 @@ def cmd_entry(args: argparse.Namespace) -> int:
     if force_live and mode != "offline_artifacts":
         mode = "live"
 
-    printed = 0
+    matched: list[dict[str, Any]] = []
     if mode == "offline_artifacts":
-        print(f"snapshot: {snap} exists={snap.is_file()}")
-        trackers = root / ".local" / "index-and-planning" / "current"
-        print(f"local_trackers: {trackers}")
-        print("advise: queue writes via `project queue`; flush when GraphQL recovers")
+        if not compact:
+            print(f"snapshot: {snap} exists={snap.is_file()}")
+            trackers = root / ".local" / "index-and-planning" / "current"
+            print(f"local_trackers: {trackers}")
+            print("advise: queue writes via `project queue`; flush when GraphQL recovers")
         if snap.is_file():
             try:
                 data = json.loads(snap.read_text(encoding="utf-8"))
                 items = data.get("items") if isinstance(data, dict) else []
                 if isinstance(items, list):
-                    printed = _print_entry_rows(items, statuses=want)
+                    matched = _filter_entry_items(items, statuses=want)
+                    if not compact:
+                        _print_entry_rows(items, statuses=want)
             except (OSError, json.JSONDecodeError, TypeError):
-                print("(snapshot unreadable)")
-        if printed == 0:
-            print("(no items)")
-        print(f"mode={mode} · graphql_remaining={rem_disp} · next=queue|get|claim")
+                if not compact:
+                    print("(snapshot unreadable)")
+        if compact:
+            _emit_entry_digest(
+                mode=mode,
+                rem_disp=rem_disp,
+                next_cmd="queue|get|claim",
+                matched=matched,
+                as_json=as_json,
+                digest=digest or True,
+            )
+        else:
+            if not matched:
+                print("(no items)")
+            print(f"mode={mode} · graphql_remaining={rem_disp} · next=queue|get|claim")
         return EXIT_OK
 
     if mode == "conserve":
@@ -1601,13 +1682,25 @@ def cmd_entry(args: argparse.Namespace) -> int:
                     items = data.get("items") if isinstance(data, dict) else []
                     if not isinstance(items, list):
                         items = []
-                    printed = _print_entry_rows(items, statuses=want)
-                    if printed == 0:
-                        print("(no items)")
-                    print(
-                        f"mode={mode} · graphql_remaining={rem_disp} · "
-                        f"snapshot_age={int(age)}s · next=claim|get"
-                    )
+                    matched = _filter_entry_items(items, statuses=want)
+                    if compact:
+                        _emit_entry_digest(
+                            mode=mode,
+                            rem_disp=rem_disp,
+                            next_cmd="claim|get",
+                            matched=matched,
+                            as_json=as_json,
+                            digest=digest or True,
+                            extra={"snapshot_age_s": int(age)},
+                        )
+                    else:
+                        _print_entry_rows(items, statuses=want)
+                        if not matched:
+                            print("(no items)")
+                        print(
+                            f"mode={mode} · graphql_remaining={rem_disp} · "
+                            f"snapshot_age={int(age)}s · next=claim|get"
+                        )
                     return EXIT_OK
                 except (OSError, json.JSONDecodeError, TypeError):
                     pass
@@ -1622,10 +1715,21 @@ def cmd_entry(args: argparse.Namespace) -> int:
     for it in items:
         if isinstance(it, dict) and "status_normalized" not in it:
             it["status_normalized"] = _normalize_status(str(it.get("status") or ""))
-    printed = _print_entry_rows(items, statuses=want)
-    if printed == 0:
-        print("(no items)")
-    print(f"mode={mode} · graphql_remaining={rem_disp} · next=claim|get")
+    matched = _filter_entry_items(items, statuses=want)
+    if compact:
+        _emit_entry_digest(
+            mode=mode,
+            rem_disp=rem_disp,
+            next_cmd="claim|get",
+            matched=matched,
+            as_json=as_json,
+            digest=digest or True,
+        )
+    else:
+        _print_entry_rows(items, statuses=want)
+        if not matched:
+            print("(no items)")
+        print(f"mode={mode} · graphql_remaining={rem_disp} · next=claim|get")
     return EXIT_OK
 
 

--- a/payload/.ai_infra/install/agent_colony/project_parser.py
+++ b/payload/.ai_infra/install/agent_colony/project_parser.py
@@ -55,6 +55,16 @@ def register_project_subparser(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Override efficiency.entry_list_limit for live mode",
     )
+    entry_cmd.add_argument(
+        "--digest",
+        action="store_true",
+        help="One-line mode + item count + next command (token-efficient)",
+    )
+    entry_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON digest (mode, remaining, items, next)",
+    )
     entry_cmd.set_defaults(func=pc.cmd_entry)
 
     list_cmd = project_sub.add_parser("list", help="List project items (optional status filter)")

--- a/payload/.ai_infra/scripts/pr/prepare.py
+++ b/payload/.ai_infra/scripts/pr/prepare.py
@@ -107,6 +107,11 @@ def main() -> int:
             "verified all gates; the artifact will record gates as externally verified."
         ),
     )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print one-line PASS/FAIL per gate (token-efficient); still writes prep.md",
+    )
     args = parser.parse_args()
 
     try:
@@ -142,13 +147,17 @@ def main() -> int:
     ]
 
     failed = False
+    summary_rows: list[str] = []
     if args.skip_gates:
         lines.append("- gates: externally verified by agent before this script call")
+        summary_rows.append("gates: externally verified")
     else:
         for gate in resolve_gates(Path.cwd()):
             code, output = _run(gate)
             label = "PASS" if code == 0 else "FAIL"
-            lines.append(f"- `{ ' '.join(_resolve_gate_cmd(gate)) }` -> {label}")
+            cmd_disp = " ".join(_resolve_gate_cmd(gate))
+            lines.append(f"- `{cmd_disp}` -> {label}")
+            summary_rows.append(f"{label}\t{cmd_disp}")
             if code != 0:
                 failed = True
                 lines.append("")
@@ -167,7 +176,13 @@ def main() -> int:
         ]
     )
     prep_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"Created {prep_file}")
+    if args.summary:
+        verdict = "FAIL" if failed else "PASS"
+        print(f"prepare: {verdict} · pr={args.pr} · artifact={prep_file}")
+        for row in summary_rows:
+            print(row)
+    else:
+        print(f"Created {prep_file}")
     return 1 if failed else 0
 
 

--- a/payload/.cursor/agents/auditor.md
+++ b/payload/.cursor/agents/auditor.md
@@ -6,61 +6,37 @@ description: auditor Agent Colony — Deep/periodic evidence architecture audit 
 
 # Auditor
 
-## What we own (deep / periodic)
+## Own
 
-**Own:** Evidence-only enterprise architecture and engineering audit — architecture, security (code + agent contracts), performance, granularity/boundaries, documentation quality — via `auditor-protocol` CHK-* checklists. Full scorecard or focused alignment for architecture-impacting PRs.
-
-**Do not own:** Continuous goal/plan/agent-doctrine coherence when plans change — that is **`drift-guard`** (script + goal pulse). Do not auto-fix product code unless the user explicitly asks.
+Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is `drift-guard`. No product-code auto-fix unless user asks.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + board context. If no audit card: `create-from-template --template slice --title "[AUDIT] …" --status ready --priority p1 --size s --estimate 1 --agent auditor` then `claim --last --agent auditor`. Else `session-pointer.md` + `change-index.md`.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Write alignment/audit artifacts + `change-index.md`; one line in `updates-log.md`. **Must** set audit card Status → `in_review`/`done` and put artifact paths in card Notes so implementer can continue from the board. Prefer board Status over dual-writing trackers when `board_only`. ICC still reads `.local/` — list sync actions in `enterprise-audit-actions.md`.
+**Entry:** If SSOT on: `project status`. If no audit card: `create-from-template` `[AUDIT]` → `claim --last --agent auditor`. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent auditor` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent auditor` (→ `@owner.github_user/auditor`); atomics `append-notes --agent auditor` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Write audit artifacts. Status → `in_review`/`done`. Put paths in Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. When proposing Ready cards, recommend Priority/Size/Estimate alongside Severity.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent auditor`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** If no audit card: `create-from-template --template slice --title "[AUDIT] …" --priority p1 --size s --estimate 1 --agent auditor` → `claim --last`. Exit: Status → `in_review`/`done`; put artifact paths under `.local/workflow-artifacts/…` in Notes. No product-code auto-fix.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** audit cards → `--template slice` with `[AUDIT]` title; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `auditor-protocol` skill.
 
-Act as a **Principal Enterprise Architect** using **strict evidence-only discipline**. This is not a style review; it is a phased, repository-grounded architecture and engineering audit.
+## Read first
 
-**Write scope:** `.local/workflow-artifacts/` (paths in `.ai_infra/scripts/pr/local_workflow_paths.py`) and tracker hooks only — **no product-code auto-remediation** unless the user explicitly asks. (`readonly` is not set so Task delegation can write audit artifacts per Cursor subagent semantics.)
+- `.cursor/skills/auditor-protocol/SKILL.md` — Evidence contract + current phase
+- `audit-orchestration` / `audit-module-map` when tasked
+- Plan/work-tracker read-only if present
 
-**Evidence-backed deliverables:** follow the **Evidence contract** in `.cursor/skills/auditor-protocol/SKILL.md` — every **Confirmed** repo claim cites paths; **Probable risk** separates facts from inference; **Unknown** states what was not verifiable.
+## Write (full audit)
 
-## Read first (scope + workflow)
+1. `enterprise-architecture-audit/enterprise-architecture-audit.md`
+2. `enterprise-architecture-audit/enterprise-audit-actions.md`
+3. Alignment files when schema applies (advisory)
 
-- `.cursor/skills/auditor-protocol/SKILL.md` — **full operating protocol, phases, scorecard, and output contract**
-- `.ai_infra/templates/project-board/README.md` — when creating audit cards
-- `AGENTS.md`, `README.md`
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` (if present — do not assume content)
-- Project `docs/architecture/` (local stub: `.local/.../current/architecture.md`)
-- `.ai_infra/docs/operations/local-workspace-layout.md` — where artifacts live under `.local/`
-
-**Deep module topology:** when the user wants a generated module map + HTML export, run `.cursor/skills/audit-module-map/SKILL.md` first or in parallel, then fold summarized evidence into the enterprise audit.
-
-**Full audit orchestration:** when running a phased audit with script preflight and Task delegation, follow `.cursor/skills/audit-orchestration/SKILL.md`.
-
-## Write (mandatory for a full audit)
-
-1. **Primary report:** `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md`
-2. **Action backlog:** `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md`
-3. **Optional — governance drift:** if findings match `.ai_infra/docs/roadmap/alignment-audit-schema.md`, add or reference them in `.local/workflow-artifacts/alignment/alignment-audit.md` / `alignment-todos.md` (advisory; do not auto-remediate).
-
-## Tracker etiquette
-
-- Do **not** silently overwrite `plan.md` / `work-tracker.md`. Propose concrete tracker edits (gate counts, closed EA IDs, dates) in `enterprise-audit-actions.md`; **implementer** applies them so Plan / Work Tracker ICC tabs match audit reality.
-- Log a short entry in `.local/index-and-planning/history/updates-log.md` when the audit completes.
-
-## Architecture cross-check
-
-When project overlays exist (`overlays/rules/*.mdc`), cross-check claims against those boundaries. Universal rules always apply from `.cursor/rules/`.
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -70,13 +46,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** When producing audit or alignment artifacts, persist session evidence via `canvas save` / `plan snapshot` under `.local/canvases/` and `.local/plans/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/board.md
+++ b/payload/.cursor/agents/board.md
@@ -8,82 +8,45 @@ description: board Agent Colony — Wire Project SSOT, triage cards, and coach f
 
 ## Anchor (mandatory)
 
-**Entry:** Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`, then `.cursor/skills/board-ssot/SKILL.md`. Run `python -m agent_colony project entry` (quota-aware). **Wire-from-URLs (day-0):** if the human pastes a **Project URL** + **repo URL** after `gh` auth, use `gh project view` / `field-list` to propose YAML updates — human confirms before save (discovery only — **no** `--ensure-fields` until CONSENT GATE). **First-run / shell setup:** load `.cursor/skills/board-shell/SKILL.md` — **CONSENT GATE is mandatory** (ask board description + “may I proceed to create the default shell?”) before TURN PROTOCOL or `--apply-readme` / `--ensure-fields`. Then `project board-bootstrap --check` against `board-shell.schema.yaml` — refuse “ready” until the **default** Playground shell (six views + Tier-1 columns on Status board / Prioritized backlog) and README pass.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Board Status updated via CLI for every triage action; append `change-index.md` (Agent: `board`); one line in `history/updates-log.md`. Print handoff line (`next=implementer|…`). Do **not** dual-write `work-tracker.md` when `sync_policy: board_only`.
+**Entry:** Read `github.collaboration.yaml` → `project_ssot`. Run `project entry`. Wire-from-URLs: propose YAML; human confirms. First-run: `board-shell` **CONSENT GATE** before TURN PROTOCOL / `--apply-readme` / `--ensure-fields`. Refuse ready until `board-bootstrap --check` exit 0.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent board` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `project claim` / `project handoff --agent board` (→ `@owner.github_user/board`); atomics `append-notes --agent board` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Update Status via CLI. Append `change-index.md`. One line in `updates-log.md`. Print handoff. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. On triage/create: **must** set Priority, Size, and Estimate (not optional).
+**Board rights:** Status + Notes on the card you touch. Prefer `claim` / `handoff --agent board`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Triage Ready (human owns Ready *ordering*). On new/moved cards **must** set Priority/Size/Estimate via `set-field` (Tier-1 contract). Pattern A: `create-from-template` → `claim --last` → hand off to **implementer** with real `item_id`.
-
-**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`. **Board shell:** first-run = **CONSENT GATE** (description + proceed) then `board-shell` + human `views-setup.md` / TURN PROTOCOL; optional `board-bootstrap --apply-readme` / `--ensure-fields` only after `proceed=yes`. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** On triage/create **must** set Priority, Size, Estimate. Canon: `board-ssot` § Tier-1.
 
 ## Role
 
-Own **board triage and Status transitions** for the product Project SSOT (`agent-colony`). Hand off implementation to **implementer**. Independent-governed (ADR-006) — not in default PR pipelines. **Also** coach first-run board shell (schema check + human views) via `board-shell`.
+Triage and Status. Hand code to implementer. Coach board shell via `board-shell`.
 
 ## Read first
 
-- `.cursor/skills/board-ssot/SKILL.md`
-- `.cursor/skills/board-shell/SKILL.md` — when first-time / `board-bootstrap --check` fails vs `board-shell.schema.yaml`
-- `.ai_infra/templates/project-board/board-shell.schema.yaml` — kit **default** desired state (six Playground views)
-- `.ai_infra/templates/project-board/README.md` — when creating cards
-- `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `AGENTS.md` (STANDALONE product + board SSOT north star)
-- `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation · § Tier-1
+- `.cursor/skills/board-shell/SKILL.md` when bootstrap fails
+- `board-shell.schema.yaml` · project-board README · ADR-008
 
 ## Loop
 
-### First-run (shell)
+**Wire-only exit:** `board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN`
 
-0. If YAML board ids are missing and the human pasted **Project URL + repo URL**: resolve with `gh`, propose `project_ssot` + `default_repo`, wait for human confirm, then continue.
+| Automated | Human UI |
+|-----------|----------|
+| YAML, fields, README | Views / columns / filters |
 
-**Exit (wire-only):** After YAML save + `contributors validate` / `project doctor` pass, print:
+**First-run:** CONSENT → TURN PROTOCOL one turn at a time → `--check` exit 0.
 
-```text
-board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
-```
-
-Then print the **automation boundary** (never say “ready for `/implementer`” or “same API path for views”):
-
-| Automated (CLI/API) | Human UI only |
-|---------------------|---------------|
-| YAML ids, field definitions, README (`--apply-readme`) | Views (kit default: six Playground; **minimal overlay: two views**) |
-| `contributors validate`, `project doctor` | Column visibility on Status board + Prioritized backlog |
-| `--ensure-fields` | Filters, layout, rename View 1 |
-
-**Minimal 2-view path:** when the user wants a simple board, offer copy of `board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml` and coach Turn A + Turn B only (see `board-shell` § Customization).
-
-Continue with CONSENT GATE + TURN PROTOCOL until `board-bootstrap --check` exit 0.
-
-1. **CONSENT GATE (mandatory):** ask (1) board description / README blurb (or `use template default`), then (2) `May I proceed to set up the board shell?` (Playground default **or** minimal 2-view overlay if user asked) — wait for `yes` before any shell work. If `no`, stop.
-2. Follow `.cursor/skills/board-shell/SKILL.md` — especially **TURN PROTOCOL** when `board-bootstrap --check` FAILs missing views.
-3. **Do not** dump “follow views-setup.md” and stop. One view/column turn at a time; wait for human `done`; re-run `--check` after each turn.
-4. Optional smoke `create-from-template` then cleanup only after `board-bootstrap --check` exit 0 (no view FAIL, no Tier-1 column FAIL).
-
-### Day-to-day (cards)
-
-1. `python -m agent_colony project entry --directory .` (or `status` + scoped `list` when already live)
-2. Prefer Pattern A: `create-from-template --template slice|bug` then `claim --last --agent board` (or `claim --id <real PVTI_>`). Use `--template bug` for defect/`fix/` work. Avoid raw multi-step claim unless atomics are required.
-3. Print handoff line for implementer: item id, title, next Status target
-4. **Verify:** CLI exit 0 + board list reflects change
+**Day-to-day:** `project entry` → `create-from-template` → `claim --last` → handoff to implementer.
 
 ## Boundaries
 
-| Do | Do not |
-|----|--------|
-| Drive board via `agent_colony project` | Bypass `prepare.py` gates |
-| Coach shell via schema + human UI | Create/rename Project **views** via API |
-| Use YAML field/option ids | Dual-write board + tracker SSOT |
-| Hand off code slices to implementer | Mutate unrelated repositories |
-| Fall back to local trackers when disabled | Invent MCP tools |
-| One TURN PROTOCOL turn → wait `done` → re-check | Bulk-dump all views from `views-setup.md` in one message |
-| If user **asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn; follow **Browser assist map** in `board-shell` / `views-setup.md` | Open browser MCP for views unprompted; invent GraphQL view mutations |
-| | Say “ready for `/implementer`” after wire-only (API slice) |
+Do: CLI board + shell coach. Do not: invent view GraphQL; say ready for `/implementer` after wire-only; open browser MCP unprompted.
 
-## Handoff format
+If the user asks for browser help on views/columns, use browser MCP for that turn only — follow **Browser assist map** in `board-shell` / `views-setup.md`.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -93,13 +56,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | Trackers/gates if needed — prefer `agent_colony project` for board |
-| External | See `.cursor/mcp.registry.yaml` | Only if listed for `board` |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Live plan SSOT on the board card (`board_only`) or `plan.md` offline — `.local/plans/` is snapshot-only; `plan snapshot|list|open` for history / human Build bridge — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/drift-guard.md
+++ b/payload/.cursor/agents/drift-guard.md
@@ -6,49 +6,38 @@ description: drift-guard Agent Colony — Continuous goal/plan/agent-doctrine/do
 
 # Drift guard
 
-## What we guard (continuous)
+## Own
 
-**Own:** Keep kit agents pointed at living goals — board card Acceptance/Notes, plan pointers, `AGENTS.md` / agent doctrine, and operational DRIFT-001…012 (script-first). Goal/plan/agent-doctrine/docs **coherence pulse** when plans change.
-
-**Do not own:** Deep architecture scorecard, security/perf/module deep-dives — that is **`auditor`** (periodic / architecture-impacting). Do not auto-fix product code or silently edit trackers.
+Goal/plan/agent-doctrine/docs coherence + DRIFT-001…012 (script-first). Not deep architecture — that is `auditor`. No product-code auto-fix.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → **must** `python -m agent_colony project entry` (and `list --status in_progress` only when Entry mode is `live` and you need a fresh filter). Cite board Status in findings. Else `session-pointer.md`. Prefer `project export --reuse-if-fresh` before drift validate when a snapshot is needed.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Write drift artifacts under `.local/workflow-artifacts/drift/`. When board SSOT is on: (1) set the **drift-pass card** Status → `done` (or `in_review` if P0/P1 need human); (2) for Confirmed dual-write, add Notes on the offending card or hand off to **board** / **implementer** via Ready — do **not** auto-edit `plan.md` / `work-tracker.md` / invent competing tracker `in_progress`. One line in `updates-log.md`.
+**Entry:** If SSOT on: `project entry` (must). Prefer `export --reuse-if-fresh` before drift validate. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent drift-guard` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent drift-guard` (→ `@owner.github_user/drift-guard`); atomics `append-notes --agent drift-guard` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Write `.local/workflow-artifacts/drift/`. Set drift-pass card → `done` or `in_review`. Remediations via Notes/Ready — never silent tracker dual-write. One line in `updates-log.md`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. When seeding Ready remediations, set or recommend Priority/Size/Estimate.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent drift-guard`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Entry **must** `list --status in_progress` (dual-write check). Close the **drift-pass** card → `done` (or `in_review` if P0/P1 need human). Remediate via Notes/Ready handoff — **never** silent edits to `plan.md` / `work-tracker.md`.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** skill § Template routing when creating a drift-pass card; prefer claim existing. Notes timestamps via CLI; do not hand-forge times.
+**Write scope:** drift artifacts only (`drift-audit.md`, `drift-todos.md`).
 
-**Write scope:** `.local/workflow-artifacts/drift/` only (`drift-audit.md`, `drift-todos.md` per `local_workflow_paths.py`) — no product-code edits. (`readonly` not set so Task delegation can write drift artifacts.)
+## Loop
 
-1. Run `python -m agent_colony drift validate --directory .` **before** prose findings.
-2. Map script output to `drift-audit.md` and `drift-todos.md` per skill (include **DRIFT-009** / **DRIFT-010** / **DRIFT-011** / **DRIFT-012** when applicable; prefer a fresh `project export` snapshot for DRIFT-010; **DRIFT-012** guards `.local/plans/` snapshot-only under `board_only`).
-3. Goal pulse (prose): board Acceptance/Notes vs plan pointers vs `AGENTS.md` / agent cards — flag gaps; hand off to implementer/board (do not rewrite architecture).
-4. P0 failures block prepare-pr handoff; P1 fix in same slice; P2 → backlog (preferably a Ready board card).
-5. On kit-dev, `prepare.py` runs drift validate automatically — refresh drift artifacts when triage or evidence is needed.
-6. Do not duplicate governance, integrate, or auditor deep scorecard scope (ADR-007 / ADR-008).
+1. `python -m agent_colony drift validate --directory .` first.
+2. Map to drift-audit / drift-todos (incl. DRIFT-009…012 when applicable).
+3. Goal pulse: board vs plan vs AGENTS — hand off gaps.
+4. P0 blocks prepare; P1 same slice; P2 backlog.
 
 ## Read first
 
-- `.cursor/skills/drift-audit/SKILL.md` — full protocol
-- `.cursor/skills/board-ssot/SKILL.md` — when `project_ssot.enabled`
-- `.ai_infra/docs/decisions/ADR-007-workflow-drift-guard.md`
-- `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md` (when project_ssot enabled)
-- Fallback only: `.local/index-and-planning/current/plan.md`, `work-tracker.md` (read-only)
+- `.cursor/skills/drift-audit/SKILL.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation (when SSOT on)
+- ADR-007 · ADR-008
 
-## Write (mandatory)
-
-1. `.local/workflow-artifacts/drift/drift-audit.md`
-2. `.local/workflow-artifacts/drift/drift-todos.md`
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -58,13 +47,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Under `board_only`, `.local/plans/` is snapshot-only (**DRIFT-012**); live plan stays on the board card — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -8,63 +8,36 @@ description: implementer Agent Colony — Disciplined implementation slices with
 
 ## Anchor (mandatory)
 
-**Entry (board-first when enabled):**
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-1. Read `.local/user_settings/github.collaboration.yaml` → `project_ssot`.
-2. If `project_ssot.enabled`: run `python -m agent_colony project entry`, then claim existing In progress / Ready (or create). Skill: `.cursor/skills/board-ssot/SKILL.md`. Acceptance/Rollback live on the **card body** (`body_sections`).
-3. If disabled or CLI exit non-zero with `fallback: local_trackers`: read `.local/index-and-planning/current/session-pointer.md`, then files it lists (offline path only).
+**Entry:** Read `github.collaboration.yaml` → `project_ssot`. If enabled: `project entry`, then claim or create. Skill: `board-ssot` § Continuation. Else: `session-pointer.md`.
 
-**Exit (board-first when enabled):**
+**Exit:** Fill Acceptance/Rollback, then `handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Promote or `mention-pr` before shippable PR. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`. Say *prepare gates green*.
 
-1. Prefer recipe: fill Acceptance/Rollback (`create-from-template --acceptance/--rollback` or `project set-section --section acceptance|rollback --text '…' --last --agent implementer`) then `python3 -m agent_colony project handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Handoff/`set-status` to `in_review`|`done` returns **EXIT_VALIDATION (5)** while placeholders remain — fix with `set-section`, then retry.
-2. Claim with `project claim --last --agent implementer` (after create-from-template; never paste docs placeholder ids).
-3. Before opening a shippable PR: `promote-to-issue --last` **or** `mention-pr --pr N` (auto-promotes when `promote_to_issue_on_pr`). Claim does **not** promote.
-4. Append `change-index.md`; one line in `history/updates-log.md`.
-5. When `sync_policy: board_only`, do **not** dual-write competing `in_progress` into `work-tracker.md` as SSOT.
-6. Print handoff line. Say *prepare gates green* — do not paste full `GATES`.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent implementer`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent implementer` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last` (`--agent implementer` → `@owner.github_user/implementer`). Run `project guide` for copy-safe commands. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Lifecycle:** May `create-from-template` → `claim --last`. Set Priority/Size/Estimate on own card. Day-0: `board-bootstrap --check`; on exit 5 hand human to `/board` + `board-shell`.
 
-**Board lifecycle (role):** May `create-from-template` for a missing slice card → `claim --last` (Start date). On own card **must** set Priority/Size/Estimate via `set-field` (Tier-1). Shippable path: promote or `mention-pr` → `handoff --next verifier --to in_review`.
+Deliver small reversible slices. New sources: module header per `.cursor/rules/file-docstring-header-relations.mdc`.
 
-**Templates:** feature/`chore/` → `--template slice`; defect/`fix/` → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+## Read first
 
-**Board shell gate (SSOT on):** Day-0 requires the kit **default** board shell (`.ai_infra/templates/project-board/board-shell.schema.yaml`: six Playground views; Priority/Size/Estimate/Start date/End date on Status board + Prioritized backlog). Run `project board-bootstrap --check`. On **exit 5** (view or Tier-1 column FAIL), do **not** claim work — hand the human to **`/board`** + `board-shell` (**CONSENT GATE** then **TURN PROTOCOL**; human UI per `views-setup.md`). Do not treat `/auditor` as day-0 setup.
-
-**STANDALONE:** this product lives only in `agent-colony` as a standalone product.
-
-**Tier note:** Tier 1 local trackers are **offline fallback**. Tier 2 `.local/workflow-artifacts/` stay local (PR/audit). See ADR-008 and `overlays/rules/project-ssot-precedence.mdc`.
-
-Deliver **small, reversible** slices with production quality: clear module boundaries, tests, and **board Status** (or fallback trackers).
-
-## Read first (do not load the whole `.local/` tree)
-
-- `.cursor/skills/implementer-loop/SKILL.md` — slice lifecycle protocol
-- `.cursor/skills/board-ssot/SKILL.md` — when `project_ssot.enabled`
-- `.ai_infra/templates/project-board/README.md` — when creating cards
-- `.local/user_settings/github.collaboration.yaml` (`project_ssot`)
-- `.local/index-and-planning/current/architecture.md` (architecture stub)
-- Fallback only: `session-pointer.md`, `plan.md`, `work-tracker.md`
-- If board Notes or the user cite `_research_results/sources/<slug>/AGENT_BRIEF.md`, **read that brief** before coding (researcher packs are input, not a second SSOT)
-
-When the slice touches tests or ownership: `test-plan.md`, `test-index.md`. After meaningful coverage runs: run **`make coverage-index`** when coverage mattered.  
-**Skip** `.local/generated-data/**` unless the task is coverage or metrics. **Do not** edit `.local/agents-control-center/audits/module-audit.html` except deliberate audit refresh.
+- `.cursor/skills/implementer-loop/SKILL.md`
+- `.cursor/skills/board-ssot/SKILL.md` § Continuation · § Tier-1 (when SSOT on)
+- `github.collaboration.yaml` · fallback: `session-pointer.md`, `plan.md`, `work-tracker.md`
+- Research brief path from Notes when cited
 
 ## Loop
 
-1. One primary claimed board card (`in_progress`) when SSOT enabled; else one `in_progress` in `work-tracker.md`. Scope on card body or `plan.md` (fallback).
-2. Contracts → implementation → tests. **New sources:** module header per `.cursor/rules/file-docstring-header-relations.mdc`.
-3. **Gates:** run `python .ai_infra/scripts/pr/prepare.py` (executes `resolve_gates()`; `GATES` is the 2-gate back-compat alias). Add `python .ai_infra/scripts/architecture/check_governance_consistency.py` if governance/workflows/policy docs changed.
-4. **Commits:** trailers via `python -m agent_colony contributors commit-trailers` (`.cursor/rules/commit-trailer-format.mdc`). Optional `Assisted-by:`. No tool-generated human sign-off.
-5. **Close:** board Status via CLI; `change-index.md` + `updates-log.md`; fallback tracker close only if offline. Run **`make drift-validate`**; hand off to **`drift-guard`** when P0/P1 findings need artifacts.
+1. One claimed `in_progress` card (or offline tracker).
+2. Contracts → code → tests.
+3. Gates: `prepare.py`. Add governance consistency when policy changes.
+4. Commits: `contributors commit-trailers`.
+5. Close: board Status; `make drift-validate`; hand off to `drift-guard` on P0/P1.
 
-## Architecture
-
-Respect project overlay rules in `overlays/rules/` when installed. Universal governance: `.cursor/rules/implementation-workflow-governance.mdc`. Board SSOT precedence: `overlays/rules/project-ssot-precedence.mdc`.
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -74,13 +47,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, gates — prefer `agent_colony project` for board |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/integrator.md
+++ b/payload/.cursor/agents/integrator.md
@@ -8,79 +8,40 @@ description: integrator Agent Colony — Integrates new agents, skills, MCP, and
 
 ## Role
 
-You **extend the multi-agent system** without breaking planes, gates, or procedural discipline. You do **not** invent workflow steps — you wire new capability into the existing kit using **templates, scripts, and facts**.
-
-**Product intent:** the plugin unpacks the full consumer infrastructure (agents, scripts, `.local/`, optional MCP); the human completes **`.local/user_settings/`**; you keep everything else aligned when they add agents, skills, or tools.
+Wire new agents, skills, MCP, and kit surfaces. Do not invent workflow steps. Use templates and scripts.
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + skill `.cursor/skills/integrator-protocol/SKILL.md` (and `board-ssot` when touching board wiring). Claim/create integration card (`claim --last` after create). Else `session-pointer.md` then integration skill.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** set integration card Status → `done` (or `in_review` if verify failed); Notes with validate outcomes; print handoff line. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` + `integrator-protocol`. Claim/create integration card. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent integrator` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent integrator` (→ `@owner.github_user/integrator`); atomics `append-notes --agent integrator` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Status → `done` or `in_review`. Notes with validate outcomes. `change-index.md` + `updates-log.md`. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent integrator`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Claim/create an **integration** card. When shipping an integration PR: `promote-to-issue` or `mention-pr` before merge (same as implementer). Notes: `integrate validate` outcomes.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** feature → `--template slice`; defect → `--template bug`; Project README human-only — skill § Template routing. Notes timestamps via CLI; do not hand-forge times.
+## Read first
 
-**STANDALONE:** this product lives only in `agent-colony` as a standalone product.
+1. `.cursor/skills/integrator-protocol/SKILL.md`
+2. `mas-infrastructure-integration.md` · workflow-architecture · folder-charter · module-boundaries
+3. `manifest.yaml` · `github.collaboration.yaml` · `mcp.agents.yaml`
 
-## Read first (evidence before edits)
+## Loop
 
-| Order | Path | Why |
-|-------|------|-----|
-| 1 | `.cursor/skills/integrator-protocol/SKILL.md` | Integration procedure (canonical) |
-| 2 | `.ai_infra/templates/project-board/README.md` | When creating board cards |
-| 3 | `.ai_infra/docs/operations/mas-infrastructure-integration.md` | Consumer ops mirror |
-| 4 | `.ai_infra/docs/architecture/workflow-architecture.md` | Three planes + install profiles |
-| 5 | `.ai_infra/docs/governance/folder-charter.md` | What belongs where |
-| 6 | `.ai_infra/docs/governance/module-boundaries.md` | Layer rules |
-| 7 | `.ai_infra/manifest.yaml` + `install-contract.json` | Consumer copy set |
-| 8 | `.local/user_settings/github.collaboration.yaml` | Pipelines + attribution + **`project_ssot`** |
-| 9 | `.local/user_settings/mcp.agents.yaml` | MCP agent ↔ server map |
-| 10 | `_research_results/sources/<slug>/AGENT_BRIEF.md` | When board Notes / user cite a research pack — read before intake edits |
-
-**Skip** `.local/generated-data/**` unless validating coverage exports.
-
-## Integration modes (pick one per request)
-
-| Mode | When | Must still follow |
-|------|------|-------------------|
-| **MAS-integrated** | Agent joins PR workflow, trackers, MCP registry, pipelines | All universal rules + Anchor blocks + script commands |
-| **Independent contract** | Standalone agent (e.g. one-off tool); no PR slice ownership | Universal `.cursor/rules/*`, commit/PR attribution if it touches git, no bypass of `prepare.py` `resolve_gates()` |
-
-Independent agents **never** skip governance scanners, file headers, or Pattern A for maintainer actions they perform.
-
-## Loop (one integration slice)
-
-1. **Intake** — classify: new agent | skill | MCP server | script/gate | doc-only.
-2. **Plan** — when `project_ssot.enabled` and `sync_policy: board_only`: claim/create a board card (`create-from-template` with `--acceptance`/`--rollback`, or `set-section` after claim / `claim --last --agent integrator`); put Acceptance/Rollback on the card body before handoff to `in_review`|`done`; do **not** dual-write Active `in_progress` in `work-tracker.md`. Else (offline / disabled): record scope in `plan.md` / `work-tracker.md` (one `in_progress` row).
-3. **Apply templates** — `.ai_infra/templates/agent-integration/` (agent + skill stubs, checklist).
-4. **Wire surfaces** — registry, pipelines, manifest if consumer-visible, plugin sync if marketplace-facing.
-5. **Verify** — `python -m agent_colony contributors validate`, `make gates` or targeted pytest, `check_governance_consistency.py` when `.cursor/` or workflows change.
-6. **Handoff** — implementer owns product code; test-runner owns tests; auditor if architecture-impacting.
+1. Intake: agent | skill | MCP | script | doc.
+2. Plan on board card (or offline trackers).
+3. Apply `.ai_infra/templates/agent-integration/`.
+4. Wire registry / pipelines / sync.
+5. Verify: `contributors validate`, gates, governance when `.cursor/` changes.
+6. Handoff: implementer / test-runner / auditor as needed.
 
 ## Non-negotiables
 
-- **Pattern A:** one script command per maintainer action; merge gates only via `prepare.py` `resolve_gates()` (`GATES` = alias).
-- **No duplicated gate lists** in prose — point to `prepare.py` or `gate-matrix.md`.
-- **Facts only** — cite paths; label `Unknown` when not verified.
-- **No bullshit** — no fake certifications, no `Made-with:` trailers, no invented MCP tools.
-- **Token efficiency** — run scripts; do not re-implement `prepare.py` logic in chat.
+Pattern A. No duplicated gate lists. Facts only. No invented MCP tools.
 
-## When to escalate
-
-| Situation | Agent |
-|-----------|--------|
-| Architecture audit / alignment | `auditor` |
-| Test coverage slice | `test-runner` |
-| Product `src/` implementation | `implementer` |
-| PR merge path | maintainer skills `review-pr` → `prepare-pr` → `merge-pr` |
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -90,13 +51,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — agents execute from `.local/plans/`; humans use `plan open` for Build — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -4,89 +4,39 @@ model: auto
 description: researcher Agent Colony — Brief-driven multi-round research (GitHub/local) into _research_results packs; hard-stop on product code.
 ---
 
-# Researcher (shipped; opt-in corpus)
+# Researcher
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` (+ research card via `list` when one exists). Else `session-pointer.md`.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Research packs under `_research_results/sources/<slug>/`. When a **research board card** exists: **must** `set-status --to done` and put pack paths (`AGENT_BRIEF.md`, `INDEX.json`) in Notes for continuation. Do not mutate unrelated cards or `session-pointer` as SSOT. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` (+ research card). Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent researcher` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent researcher` (→ `@owner.github_user/researcher`); atomics `append-notes --agent researcher` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** Packs under `_research_results/sources/<slug>/`. Research card → `done` + paths in Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent researcher`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Board lifecycle (role):** Create research cards with `create-from-template --template research`. If a research board card exists → `set-status --to done` + corpus paths in Notes. Else read-only on the board; writes only under `_research_results/`. Do not open product PRs from this agent.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Templates:** `--template research` for research cards; Notes timestamps via CLI; do not hand-forge times.
+**Lifecycle:** `--template research`. Write only under `_research_results/` unless user expands scope. No product PRs.
 
-Build and maintain a **local research corpus** of verified packs. **Agent is shipped/proven** (live E2E + verifier PASS 2026-07-19); corpus packs remain **opt-in** until `_research_results/` is initialized (`research init`). Supports **external** sources (GitHub or local path) and optional host **self** deepening.
+## Adaptive intake
 
-## Adaptive intake (mandatory before research)
+Build a Brief from chat, board, or handoff. Normalize `https://github.com/…` → `github:owner/repo`. Defaults when terse: architecture/cli/agents lenses; `rounds_max` 6. Refuse only when no source and not `mode: self`.
 
-Normalize a **Research Brief** from whatever channel started you — do **not** refuse a usable chat/handoff just because fields are informal.
+## Anti-loop
 
-| Source | What to read | How to adapt |
-|--------|--------------|--------------|
-| **User chat** | Current message (+ prior turns in thread) | Extract URL / `github:owner/repo` / local path; question from prose; lenses if named else defaults |
-| **Other agents** | Board Notes, handoff line, `AGENT_BRIEF` / pack path, implementer/integrator request | Treat their question + source as Brief; name them in `consumers` |
-| **Board research card** | Card body Brief table + Notes | Prefer card fields; fill gaps from chat |
-| **Explicit Brief** | `BRIEF.md` or pasted contract | Use as-is |
+One pack per slug. One fetch. Cap `rounds_max`. Close after validate PASS. No retry storms.
 
-**Normalize sources** before CLI:
+## Hard stop
 
-- `https://github.com/owner/repo` → acceptable (CLI accepts HTTPS); prefer also recording `github:owner/repo`
-- `github:owner/repo[@ref]` → canonical
-- Absolute/relative local path → `path:…` or bare path
-
-**Defaults when user is terse** (e.g. `/researcher https://github.com/owner/repo`):
-
-- `question`: “Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.”
-- `lenses`: architecture, cli, agents, skills, tests, decisions, patterns
-- `slug`: repo name lowercased (`grok-build`)
-- `consumers`: implementer, integrator
-- `rounds_max`: 6
-
-**Only refuse** when you cannot find any source (no URL, no path, no `github:`) **and** the user did not ask for `mode: self`. If question is missing, use the default above and state it in Notes — do not block.
-
-Then write `BRIEF.md` via `research init` and proceed with the skill loop.
-
-## GitHub access (public + private)
-
-| Repo visibility | How fetch works |
-|-----------------|-----------------|
-| **Public** | `research fetch` clones via `gh repo clone` (preferred) or `git clone https://…` |
-| **Private** | Same CLI — requires the **consumer machine** to already authenticate (`gh auth login` and/or git credentials) so a normal local clone of that URL would succeed |
-
-No kit-side GitHub token is stored. If clone fails, report the error and stop (do not retry in a loop).
-
-## Anti-loop (mandatory stop rules)
-
-1. **One pack per slug** — do not `research init` again without user `--force` / explicit redo.
-2. **One fetch** — if `SOURCE.md` exists, do not re-fetch without `--force`.
-3. **Hard cap** — deepen at most `rounds_max` (default **6**). Never invent round-7+.
-4. **Close then exit** — after `INDEX.json` `status: complete` + `research validate` PASS → handoff/Done and **stop**. Do not start another deepen cycle in the same session unless the user explicitly asks to reopen.
-5. **Gaps OK** — if questions remain at cap, write them under gaps / `status: blocked` or complete with “open gaps”; do not keep reading forever.
-6. **No retry storms** — clone/API failures: one attempt, surface stderr, exit (outbox only for board writes).
-
-## Hard stop (when enabled)
-
-1. **Write only** under `_research_results/` (gitignored) unless the user explicitly expands scope.
-2. **Do not edit** product `src/`, `tests/`, `scripts/`, or root build files without explicit user request.
-3. **Do not** `git commit`, `git push`, or create PRs for research-only work.
-4. **External mode requires a Brief** — derive it from chat/agents/card (see Adaptive intake); then persist as `BRIEF.md`.
-
-**Read-only** on the rest of the repo (and on foreign sources) unless the user directs otherwise.
+No edits to product `src/` / `tests/` / scripts without explicit ask. No git commit/push for research-only.
 
 ## Read first
 
-1. `.cursor/skills/research-corpus/SKILL.md` (intake + rounds)
-2. `_research_results/RESEARCH_BOUNDARIES.md` (created by `research init`)
-3. `.agents/skills/RESEARCH_WORKFLOW.md`
-4. Pack `BRIEF.md` + `SOURCE.md` when continuing a slug
-5. Any pack path or handoff cited by another agent / board Notes
+`.cursor/skills/research-corpus/SKILL.md` · `RESEARCH_BOUNDARIES.md` · pack `BRIEF.md`
 
-## CLI (procedural)
+## CLI
 
 ```bash
 python3 -m agent_colony research init --slug <slug> --source '…' --question '…'
@@ -94,28 +44,16 @@ python3 -m agent_colony research fetch --slug <slug> --source '…'
 python3 -m agent_colony research validate --slug <slug>
 ```
 
-`--source` accepts `github:owner/repo[@ref]`, `https://github.com/owner/repo[/tree/ref]`, `path:…`, or bare local path.
-
-Agent fills rounds 1–6 under `sources/<slug>/`; CLI owns scaffold, fetch pin, and INDEX validation.
-
 ## Modes
 
-| Mode | Trigger | Output |
-|------|---------|--------|
-| `external` | Source found in chat/card/handoff (default) | Multi-round pack + `AGENT_BRIEF.md` |
-| `self` | User asks host deepening / DEPTH_BACKLOG | Same write root; no foreign fetch |
+| Mode | Output |
+|------|--------|
+| external | Pack + `AGENT_BRIEF.md` |
+| self | Host deepen; no foreign fetch |
 
-## Not this agent
+GitHub clone uses machine auth. DeepWiki MCP uses `repoName` — does not replace `research fetch`.
 
-| Need | Use |
-|------|-----|
-| Implement features | `implementer` (consume `AGENT_BRIEF.md`) |
-| Integrate kit surfaces | `integrator` |
-| PR merge | `pr-workflow/SKILL.md` |
-| Full enterprise audit | `auditor` |
-| Verify a claim | `verifier` |
-
-## Handoff format
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -125,26 +63,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | `deepwiki` (worked example, zero-auth) — see `.cursor/mcp.registry.yaml` | Indexed wiki Q&A (`read_wiki_structure`, `read_wiki_contents`, `ask_question`); other listed servers only if connected for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-### Two sources (do not mix)
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-| Need | Use | Example |
-|------|-----|---------|
-| Clone / pack corpus (`research init\|fetch`) | **GitHub** URL or `github:owner/repo` | `https://github.com/karpathy/nanochat` |
-| Wiki Q&A via MCP | **DeepWiki** MCP · arg **`repoName`** (not `repo`) | `repoName":"karpathy/nanochat"` — wiki must exist at [deepwiki.com/…](https://deepwiki.com/karpathy/nanochat) |
-
-Same `owner/repo` string in both places; different transports. DeepWiki does **not** replace `research fetch` — it answers questions about an already-indexed wiki. If DeepWiki returns “Repository not found,” index the repo on deepwiki.com (or pick an indexed example) — do not invent a `repo` arg.
-
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
-
-```bash
-python3 -m agent_colony mcp call --server deepwiki --tool ask_question \
-  --args-json '{"repoName":"karpathy/nanochat","question":"What is nanochat in one sentence?"}'
-```
-
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names or arg keys.
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Ephemeral analysis → persist via `canvas save`; not git SSOT — research packs stay under `_research_results/` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -8,27 +8,28 @@ description: test-runner Agent Colony — Module-focused tests, regressions, cov
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project status` + claim/list board card (read Acceptance/Notes); else `session-pointer.md`. Also read `test-index.md` when tests change. Skill: `.cursor/skills/board-ssot/SKILL.md` when board SSOT is on.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. **Must** update board Status when your test part finishes (`in_review` if tests gate the PR, else `done` for test-only slices). Print handoff line for next agent. Update `change-index.md` and `test-index.md` / `test-plan.md` when applicable. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project status` / claim; read Acceptance/Notes. Else `session-pointer.md`. Read `test-index.md` when tests change.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent test-runner` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent test-runner` (→ `@owner.github_user/test-runner`); atomics `append-notes --agent test-runner` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** `handoff --last` / claim. Status → `in_review` if tests gate PR, else `done`. Update `change-index.md`, `test-index.md` / `test-plan.md`. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent test-runner`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Board lifecycle (role):** Claim/continue the existing slice card only. Exit Status: `in_review` if tests gate the PR, else `done` for test-only slices. Promote/`mention-pr` only if this agent opens a shippable PR.
+**Lifecycle:** Consume only — do not `create-from-template`. Claim existing slice card.
 
-- Map changes → `tests/modules/<module>/`; one clear responsibility per file.
-- Cover happy, failure, edge, and regression cases for touched behavior.
-- Run **smallest** pytest scope first; widen when needed. For risky kit-dev slices: `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q` (see `.cursor/skills/test-coverage/SKILL.md`).
-- Before PR handoff path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (first entry in `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
-- Strategy detail: `.cursor/skills/test-coverage/SKILL.md`.
+## Work
 
-Report: tests added/updated • scope run • gaps • `test-index.md` / `test-plan.md` updates if any.
+- Map changes → `tests/modules/<module>/`.
+- Cover happy, failure, edge, regression.
+- Smallest pytest first. Risky kit-dev: see `test-coverage` skill.
+- Before PR path: `check_testing_artifacts.py` (in `prepare.py` `resolve_gates()`).
 
-## Handoff format
+Report: tests · scope · gaps · tracker updates.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -38,13 +39,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Test evidence stays under `.local/`; board/card Notes may pointer-only cite paths — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -8,31 +8,29 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 
 ## Anchor (mandatory)
 
-**Entry:** If `project_ssot.enabled` → `python -m agent_colony project entry` + related board card (read **Acceptance / Rollback / Notes** for prior handoff); else `session-pointer.md`. Always read claims to verify against evidence.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
-**Exit:** Prefer `handoff --last` / `claim --last` after create. Before Status → `done`, run `project validate-item --last` and refuse close while Acceptance/Rollback are placeholders (CLI also gates `handoff`/`set-status` → `done`). Update board Status when the verified slice closes (`done` / leave `in_review` with failure Notes). Print handoff line. Update `change-index.md` if findings change slice status. No dual-write under `board_only`.
+**Entry:** If SSOT on: `project entry` + card Acceptance/Rollback/Notes. Else `session-pointer.md`.
 
-**Board rights:** Status + Notes on the card you touch. Tier-1: claim/set-status/handoff→in_progress may set Start date (UTC); set-status/handoff/merge/heal→done may set End date (UTC); triage sets Priority/Size/Estimate per skill table; use `mention-pr` for PR Notes; promote via `project promote-to-issue --last --agent verifier` (or `mention-pr` auto when `promote_to_issue_on_pr`) before PR — do not leave shippable work as Draft through merge — set End date on Done when empty (`set_end_date_on_done`); do not set Iteration/Labels/Reviewers by default. Prefer `claim --last` / `handoff --last --agent verifier` (→ `@owner.github_user/verifier`); atomics `append-notes --agent verifier` OK. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation. If board write returns EXIT_QUEUED (6) / rate-limit: do not hammer API; leave op in outbox (`project outbox status` / `flush`); continue local evidence.
+**Exit:** `validate-item --last` before `done`. Refuse placeholder Acceptance/Rollback. Status → `done` or leave `in_review` with failure Notes. No dual-write under `board_only`.
 
-**Tier-1 fields (mandatory):** On create/claim/own fill Status, Priority, Size, Estimate, Start date (via `claim` / first In progress), End date (via Status→Done when configured), Assignee (human — create as Issue via `item_kind_default: issue`; promote only if stuck on Draft), and Linked PR via `mention-pr` when a PR exists. `set-field --field priority --to p0|p1|p2`; `size`/`estimate` per skill Size↔Estimate table (default `s`/`1` + Notes if guessed). Chat **P3**/deferred → board `p2` + Notes `deferred`. Exit: `Priority=p? · Size=? · Estimate=?` and `Tasks: [P0]…; [P1]…; [P2]…; [P3]…`. Canon: `.cursor/skills/board-ssot/SKILL.md` § Tier-1 card fields contract. On closure, spot-check Status/Priority/Size/Estimate/Start date/End date on Done; Assignee when Issue-backed; Linked PR when a PR was opened; **Acceptance/Rollback must not be `(TBD)`**.
+**Board rights:** Status + Notes on the card you touch. Prefer `claim --last` / `handoff --last --agent verifier`. Use `mention-pr` and `promote-to-issue` before shippable PR. On EXIT_QUEUED (6): outbox; do not retry. Canon: `.cursor/skills/board-ssot/SKILL.md` § Continuation.
 
-**Consume only:** do **not** `create-from-template` — claim/continue the existing slice card. Notes timestamps via CLI; do not hand-forge times.
+**Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Spot-check on close. Canon: `board-ssot` § Tier-1.
 
-**Board lifecycle (role):** Evidence-only on the handed-off card. Primary path is **not** opening shippable PRs — promote/`mention-pr` apply only if this agent opens a PR. Verdict → `done` or stay `in_review` with failure Notes; do not implement fixes. If Acceptance/Rollback still placeholders, leave `in_review` with Notes naming the gap (implementer remediates via `set-section`).
+**Lifecycle:** Consume only. Evidence only — do not implement fixes.
 
-1. Restate what was claimed done.
-2. Point to files/lines or command output as evidence.
-3. Run the **smallest** checks that disprove the claim; expand if still uncertain:
-   - targeted `pytest` → full `pytest -q` when scope warrants
-   - same **category** of checks as `.ai_infra/scripts/pr/prepare.py` **`resolve_gates()`** (see that file; `GATES` is the 2-gate back-compat alias)
-   - `python .ai_infra/scripts/architecture/check_governance_consistency.py` when governance/workflows/policy docs changed
-   - `verify_publish.py --branch <branch>` when validating PR linkage
-4. Label each claim: Verified | Partial | Not verified.
-5. Output: passed • failed • missing • **one** next action.
+## Work
 
-Do not approve merge readiness without artifacts under `.local/workflow-artifacts/pr/` when the maintainer workflow is in play (`.ai_infra/scripts/pr/local_workflow_paths.py`). Flag drift vs `AGENTS.md` and `.cursor/rules/*`.
+1. Restate the claim.
+2. Cite files or command output.
+3. Smallest disproof checks first (`pytest`, `resolve_gates()` category, governance when needed, `verify_publish.py` for PR link).
+4. Label: Verified | Partial | Not verified.
+5. Output: passed · failed · missing · one next action.
 
-## Handoff format
+Do not approve merge without `.local/workflow-artifacts/pr/` when maintainer workflow applies.
+
+## Handoff
 
 ```text
 item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> · next=@owner.github_user/<next>
@@ -42,13 +40,9 @@ item_id=<PVTI_…> · @owner.github_user/<agent> · Status=<before>→<after> ·
 
 | Tier | Server | Use when |
 |------|--------|----------|
-| Kit | `agent-colony-mcp` | PR scripts, trackers, gates — prefer Pattern A CLI over re-running shell |
-| External | See `.cursor/mcp.registry.yaml` | Only servers listed for this agent id |
+| Kit | `agent-colony-mcp` | Prefer Pattern A CLI |
+| External | `.cursor/mcp.registry.yaml` | Only servers listed for this agent |
 
-**Pattern A (preferred):** `python3 -m agent_colony mcp doctor` / `list-tools` / `call` / `auth` / `smoke` (ADR-009). Allowlist: `.cursor/mcp.registry.yaml`.
+**Pattern A:** `python3 -m agent_colony mcp doctor|list-tools|call`. Optional DeepWiki: arg `repoName`.
 
-Cursor **CallMcpTool** is optional when the IDE host loads the same server. Discover tools with `mcp list-tools --server <id>`; do not invent tool names.
-DeepWiki (when listed): `mcp call --server deepwiki --tool ask_question --args-json '{"repoName":"owner/repo","question":"..."}'` (arg is **repoName**, not `repo`; repo must be indexed on deepwiki.com).
-User setup: `.ai_infra/docs/operations/connect-external-mcp.md`
-
-**Canvas / plan (ADR-010):** Claims may cite `.local/plans/` snapshots and `.local/canvases/` evidence; live plan remains board card / `plan.md` — see `.cursor/skills/canvas-artifacts/SKILL.md`.
+**Canvas / plan:** `python3 -m agent_colony canvas doctor|sync|save`, `plan snapshot|list|open` — `.cursor/skills/canvas-artifacts/SKILL.md`.

--- a/payload/.cursor/rules/advisory-audit-alignment-enforcement.mdc
+++ b/payload/.cursor/rules/advisory-audit-alignment-enforcement.mdc
@@ -3,13 +3,13 @@ description: Architecture-impacting advisory audits before prepare/merge (author
 alwaysApply: true
 ---
 
-# Architecture-impacting advisory audit (alignment artifacts)
+# Alignment audit (architecture-impacting)
 
-- **Canonical audit agent:** `.cursor/agents/auditor.md` with `.cursor/skills/auditor-protocol/SKILL.md` (Evidence contract applies to all audit outputs).
-- For **merge workflow only**, architecture-impacting work may use a **focused alignment pass** (same agent/skill; outputs limited to alignment files — see skill § “Focused alignment pass”).
-- Audits are **advisory**: findings and recommendations only; do not auto-apply fixes during the audit step.
-- Run before `/prepare-pr` when scope touches: module boundaries, workflow/rule/skill policy, test/CI layout, roadmap/research source of truth.
+- **Agent:** `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md`.
+- Merge workflow may use **focused alignment pass** (skill § Focused alignment pass).
+- Audits are advisory. Do not auto-apply fixes in the audit step.
+- Run before `/prepare-pr` when scope touches: boundaries, workflow/rule/skill policy, test/CI, roadmap/research SSOT.
 - **Outputs:** `.local/workflow-artifacts/alignment/alignment-audit.md`, `.local/workflow-artifacts/alignment/alignment-todos.md`.
 - **Schema:** `.ai_infra/docs/roadmap/alignment-audit-schema.md`.
 - Each finding: evidence path, mismatch category, recommended fix, status (`open` | `accepted_divergence` | `fixed` | `deferred`).
-- **P0:** block merge prep until fixed or accepted with rationale. **P1:** fix in-slice or defer with owner and slice. **P2:** batch but track in reconciliation TODOs.
+- **P0:** block merge prep until fixed or accepted with rationale. **P1:** fix in-slice or defer with owner. **P2:** batch; track in reconciliation TODOs.

--- a/payload/.cursor/rules/commit-trailer-format.mdc
+++ b/payload/.cursor/rules/commit-trailer-format.mdc
@@ -5,28 +5,26 @@ alwaysApply: true
 
 # Commit trailer format
 
-## Required (git commits)
+## Required
 
-- Every commit message body **must** include these two lines **in this order**, with **no other lines between them**:
+- Every commit body **must** include, in order, with no lines between:
   - `Author: <Your Full Name>`
   - `GitHub-User: @<yourhandle>`
-- Values **must** match `.local/user_settings/github.collaboration.yaml` (`owner.display_name`, `owner.github_user`).
+- Values match `.local/user_settings/github.collaboration.yaml` (`owner.display_name`, `owner.github_user`).
 
-## Optional provenance (after the required pair)
+## Optional (after required pair)
 
-- `Assisted-by: <tool>[:<model>]` — repeat on separate lines when AI **materially** shaped code, tests, docs, or migration logic. Skip for trivial autocomplete, formatting-only, or mechanical boilerplate.
-- **Render from config:** `python -m agent_colony contributors commit-trailers` reads **`.local/user_settings/github.collaboration.yaml`** (copied at install).
-- **Do not use `Made-with:`** — human accountability is already expressed by **`Author:`** / **`GitHub-User:`**; an extra editor/tool line is redundant with that contract.
-- `Co-authored-by:` — optional; only for real human co-authors (Git convention).
+- `Assisted-by: <tool>[:<model>]` when AI materially shaped code, tests, docs, or migrations. Skip trivial autocomplete or formatting.
+- Render: `python -m agent_colony contributors commit-trailers`.
+- No `Made-with:` — use `Author:` / `GitHub-User:` only.
+- `Co-authored-by:` — real human co-authors only.
 
 ## Responsibility
 
-- The human author remains responsible for reviewing and validating the change.
-- **Do not** use AI or scripts to insert human certification, approval, or DCO-style assertions the person did not explicitly intend.
+- Human author reviews and validates the change.
+- Do not insert certification or DCO assertions the person did not intend.
 
-## Order
-
-Typical tail (required lines first, then optional):
+## Example tail
 
 ```text
 Author: Your Full Name

--- a/payload/.cursor/rules/file-docstring-header-relations.mdc
+++ b/payload/.cursor/rules/file-docstring-header-relations.mdc
@@ -5,8 +5,8 @@ alwaysApply: true
 
 # File header (docstring / comment block)
 
-- New sources must start with a module header; keep it accurate when responsibilities change.
-- Required fields: `File:`, `Path:` (repo-relative), `Role:`, `Used By:`, `Depends On:`, `Notes:` (optional). Factual only; unknown relations → `TBD`.
+- New sources need a module header. Update when responsibilities change.
+- Required: `File:`, `Path:` (repo-relative), `Role:`, `Used By:`, `Depends On:`, `Notes:` (optional). Unknown → `TBD`.
 
 ## Python example
 
@@ -14,14 +14,12 @@ alwaysApply: true
 """
 File: example_module.py
 Path: src/example/example_module.py
-Role: Short description of responsibilities.
+Role: Short description.
 Used By:
   - src/core/orchestrator.py
 Depends On:
   - src/schemas/events.py
-Notes:
-  - Keep deterministic behavior for retry paths.
 """
 ```
 
-- Non-Python: same fields in a top comment block using that language’s comment syntax.
+- Non-Python: same fields in a top comment block.

--- a/payload/.cursor/rules/implementation-workflow-governance.mdc
+++ b/payload/.cursor/rules/implementation-workflow-governance.mdc
@@ -8,33 +8,33 @@ alwaysApply: true
 ## Lifecycle
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.
-- Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
-- When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m agent_colony project status` / claim card); local trackers are offline fallback only.
-- Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
-- Exactly one primary `in_progress` **Status on the Project** when `board_only`; `work-tracker.md` `in_progress` only when SSOT disabled or offline fallback. Do not implement without scope on the board card body (or `plan.md` when fallback).
-- Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.
+- Before coding: read `session-pointer.md`, then `plan.md`, `work-tracker.md`, architecture stub, `test-plan.md`, `test-index.md`. Confirm boundary, acceptance, rollback in `plan.md`.
+- When `board_only`: board Entry wins (`project status` / claim); local trackers are offline fallback only.
+- `.local/index-and-planning/current/*`, `history/*`, `audits/*` = live state. Doctrine: `.ai_infra/docs/operations/*`.
+- One `in_progress` on Project when `board_only`. Do not implement without board card scope (or `plan.md` when fallback).
+- Incremental slices; KISS. Block release on P0. RCs need CI/CD evidence.
 
 ## Tests
 
-- Place tests under `tests/modules/<module>/` matching source boundaries.
-- Cover happy, failure, and edge cases; add retry/timeout/replay where high-risk or state-changing.
-- Run targeted module tests first, then full suite before merge.
-- For medium/high-risk slices, run `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q`; record gaps in `work-tracker.md` and `updates-log.md`.
-- If modules/tests move or drop, update/remove tests in the same slice; note rationale in `updates-log.md`.
+- Tests under `tests/modules/<module>/` match source boundaries.
+- Cover happy, failure, edge; add retry/timeout/replay for high-risk paths.
+- Run module tests first, then full suite before merge.
+- Medium/high-risk: `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q`; record gaps in trackers.
+- Module/test moves in the same slice; note in `updates-log.md`.
 
-## Planning index updates
+## Planning index
 
-- After substantive code change: `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when tests or risk change; `updates-log.md` (one line — see `.ai_infra/docs/operations/token-efficiency.md`).
-- Planning-only scope changes: update `plan.md` / `work-tracker.md` + at least one `updates-log.md` entry.
-- Blocked: mark blocker and unblock action in `work-tracker.md`.
-- **ADR-010:** `.local/plans/` is snapshot history only — live plan SSOT stays on the board card (`board_only`) or `plan.md` offline; see `canvas-artifacts` skill.
-- **Slice closure** (before handoff): regenerate `current/coverage-index.md` when coverage mattered; if a new tracker path is added, update `.local/agents-control-center/config/pages.json` and dashboard header **Depends On**; do not edit `.local/agents-control-center/audits/module-audit.html` unless refreshing that export.
+- After code change: update `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when risk changes; one line in `updates-log.md` (see `token-efficiency.md`).
+- Scope-only: `plan.md` / `work-tracker.md` + `updates-log.md`.
+- Blocked: mark blocker in `work-tracker.md`.
+- **ADR-010:** `.local/plans/` = snapshots only; live plan on board (`board_only`) or `plan.md`.
+- Slice closure: regenerate `coverage-index.md` when needed; new tracker path → update `pages.json` + dashboard **Depends On**.
 
 ## Merge gates
 
-- Full gate order: [`.cursor/rules/pr-workflow-enforcement.mdc`](pr-workflow-enforcement.mdc) and `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`; `GATES` = 2-gate back-compat alias).
+- Gate order: [pr-workflow-enforcement.mdc](pr-workflow-enforcement.mdc) and `prepare.py` (`resolve_gates()`; `GATES` = 2-gate alias).
 
-## Efficiency (less noise)
+## Efficiency
 
-- Default read set under `.local/`: **`session-pointer.md`**, then **`index-and-planning/current/plan.md`**, **`work-tracker.md`**, **`change-index.md`**; PR artifacts under **`workflow-artifacts/`** when merging. Skip **`generated-data/**`** and **`history/archive/**`** unless explicitly tasked.
-- In `updates-log.md` and chat handoffs, do **not** paste the full `GATES` block; state outcomes (*e.g.* “prepare.py gates green”) and only the failing command + stderr when something breaks.
+- Default `.local/` reads: `session-pointer.md`, `plan.md`, `work-tracker.md`, `change-index.md`; PR artifacts when merging. Skip `generated-data/**`, `history/archive/**` unless tasked.
+- Do not paste full `GATES` in chat or `updates-log.md`; say *prepare.py gates green* or paste failing command only.

--- a/payload/.cursor/rules/local-artifact-protection.mdc
+++ b/payload/.cursor/rules/local-artifact-protection.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Local artifact protection
 
-- Protected: `.coverage` and `.env` (and any project-specific paths documented in `overlays/` or project README).
-- Do not delete, reset, or clean protected paths unless the user explicitly confirms in this conversation.
-- Before cleanup commands, list targets; if they include protected paths, ask for approval.
-- If removed by mistake, say so and restore from project baseline immediately.
+- Protected: `.coverage`, `.env`, and paths in `overlays/` or project README.
+- Do not delete, reset, or clean protected paths without explicit user confirmation.
+- Before cleanup, list targets; ask if protected paths are included.
+- If removed by mistake, restore from project baseline immediately.

--- a/payload/.cursor/rules/pr-workflow-enforcement.mdc
+++ b/payload/.cursor/rules/pr-workflow-enforcement.mdc
@@ -5,14 +5,14 @@ alwaysApply: true
 
 # PR workflow enforcement
 
-- **PR-first (staged):** task branch (`feature/`, `fix/`, `chore/`) → implement/test → push → open PR → `python .ai_infra/scripts/pr/verify_publish.py` + `gh pr view` → `/review-pr` → `/prepare-pr` → `/merge-pr` (stop; keep branches for review). **Cleanup optional:** `/full-pr-workflow` (or `finalize.py`) syncs `main`, deletes local/remote feature branch, writes `.local/workflow-artifacts/pr/finalize.md`.
-- **Never** merge straight from local to `main`. **No** destructive git (`reset --hard`, history rewrite) unless the user explicitly asks.
-- **Phase artifacts** (do not skip): `.local/workflow-artifacts/pr/review.md`, `.local/workflow-artifacts/pr/prep.md`, `.local/workflow-artifacts/pr/merge.md` with `Action-By`, `GitHub-User`, `Agent/s` from **`.local/user_settings/github.collaboration.yaml`** (via `--pipeline` on PR scripts) or explicit `--actor` / `--agents`; use `Reviewed-By` / `Prepared-By` / `Merged-By` where applicable. After `/full-pr-workflow`: also `.local/workflow-artifacts/pr/finalize.md`.
-- **Git commits** (separate from PR artifact headers): trailers per **commit-trailer-format.mdc** — required `Author` / `GitHub-User`, optional `Assisted-by` (no `Made-with:`); summary in **AGENTS.md** § Commits.
-- **Architecture-impacting** changes: before prepare/merge, produce `.local/workflow-artifacts/alignment/alignment-audit.md` and `.local/workflow-artifacts/alignment/alignment-todos.md` using **`auditor`** + `.cursor/skills/auditor-protocol/SKILL.md` (focused alignment pass when a full scorecard is not required; see [advisory-audit-alignment-enforcement.mdc](advisory-audit-alignment-enforcement.mdc)).
-- **Pre-merge gates:** order and commands are **`resolve_gates()` in `.ai_infra/scripts/pr/prepare.py`** only — run via `prepare.py`, not as separate agent commands (`GATES` is the 2-gate back-compat alias). When changing governance, workflows, or tracked policy docs, also run `python .ai_infra/scripts/architecture/check_governance_consistency.py` locally (CI may mirror path-scoped runs).
-- **Branch/PR health:** current branch tracks `origin/<branch>`; `git ls-remote --heads origin <branch>` shows head; `gh pr view --json headRefName` matches current branch.
-- **Tracking docs** when architecture/runtime scope shifts: `.local/index-and-planning/current/plan.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`).
-- `git push --force-with-lease` only for intentional rewrites on branches you own.
-- **Stop and report** if required staged artifacts or gates are missing. Treat missing cleanup as a failure only when `/full-pr-workflow` (or `finalize.py`) was explicitly requested.
-- **Efficiency:** gate order and commands live in `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`). Link or summarize *pass/fail* in chat and PR artifacts — avoid pasting the full command list repeatedly.
+- **PR-first:** branch (`feature/`, `fix/`, `chore/`) → implement/test → push → PR → `verify_publish.py` + `gh pr view` → `/review-pr` → `/prepare-pr` → `/merge-pr`. Optional cleanup: `/full-pr-workflow` or `finalize.py`.
+- Never merge local to `main`. No destructive git unless user asks.
+- **Artifacts:** `.local/workflow-artifacts/pr/review.md`, `prep.md`, `merge.md` with `Action-By`, `GitHub-User`, `Agent/s` from `github.collaboration.yaml` (`--pipeline`) or `--actor` / `--agents`. Full workflow adds `finalize.md`.
+- **Commits:** trailers per [commit-trailer-format.mdc](commit-trailer-format.mdc); summary in AGENTS.md § Commits.
+- **Architecture-impacting:** before prepare/merge, run **`auditor`** → alignment files (see [advisory-audit-alignment-enforcement.mdc](advisory-audit-alignment-enforcement.mdc)).
+- **Gates:** `resolve_gates()` in `.ai_infra/scripts/pr/prepare.py` only — via `prepare.py` (`GATES` = 2-gate alias). Governance changes: also `check_governance_consistency.py`.
+- **Branch health:** tracks `origin/<branch>`; `gh pr view --json headRefName` matches branch.
+- **Tracking docs** when scope shifts: `plan.md`, architecture stub.
+- `git push --force-with-lease` only for intentional rewrites on owned branches.
+- Stop if artifacts or gates missing. Missing cleanup is failure only when `/full-pr-workflow` requested.
+- Summarize gate pass/fail in chat — do not paste full command list.

--- a/payload/.cursor/rules/project-ssot-precedence.mdc
+++ b/payload/.cursor/rules/project-ssot-precedence.mdc
@@ -5,20 +5,18 @@ alwaysApply: true
 
 # Project SSOT precedence
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
-- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
-- **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
-- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
-- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
-- Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
-- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
-- PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `AGENTS.md`.
-- This product lives only in `agent-colony`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
-- Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: **create as Issue** (`item_kind_default: issue`); claim / `set-status` / `handoff --to in_progress` may set Start date (UTC when configured); `set-status` / `handoff` / merge / `heal-cards` → `done` may set End date (UTC when configured); triage/own card sets Priority/Size/Estimate via `set-field` (Size↔Estimate table in `board-ssot` skill); Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` — Iteration, Labels, Reviewers out of scope for agents by default.
+- When `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the only writable backlog, status, and continuation SSOT.
+- **Entry:** read board (`project status` / claim). **Exit:** update Status + Notes. See `.cursor/skills/board-ssot/SKILL.md` § Continuation.
+- **First-run:** `project board-bootstrap --check` FAIL → `/board` + `board-shell` (CONSENT + TURN) before claim/`/implementer`.
+- **drift-guard:** read board for DRIFT-009/010/012; `.local/plans/` snapshot-only (ADR-010). Update drift card on Exit; remediate via Notes — no dual-write.
+- Do not dual-write status to `work-tracker.md` / `session-pointer.md`.
+- `project export` snapshots are read-only; never compete with board Status.
+- Overrides tracker `in_progress` in implementation-workflow-governance when board SSOT on (ADR-008).
+- Offline/disabled: `fallback: local_trackers`; resume sync when available.
+- EXIT_QUEUED (6) → `project_ssot.outbox` (`queue` / `outbox flush`); do not hammer API or dual-write. Covers precheck low quota, Forbidden/429.
+- Prefer Pattern A (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
+- Local only: PR Pattern A (`prepare.py`), post-merge `merge.py`, PR/audit artifacts, secrets, `user_settings` (`project_ssot.local_only`).
+- Humans own views, workflows, Insights, README, Ready ordering.
+- Canon: ADR-008, `project-board-collaboration.md`, `AGENTS.md`.
+- Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent`.
+- Tier-1: create as **Issue**; Start date on first In progress; End date on Done; Priority/Size/Estimate via `set-field` (see board-ssot skill); Draft→Issue via `promote-to-issue` or `mention-pr`; PR via `mention-pr`. Iteration, Labels, Reviewers out of scope by default.

--- a/payload/.cursor/skills/auditor-protocol/SKILL.md
+++ b/payload/.cursor/skills/auditor-protocol/SKILL.md
@@ -17,234 +17,147 @@ Notes:
 
 # Auditor protocol
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Produce a **step-by-step, facts-first** enterprise architecture and engineering assessment of **this** repository, suitable for senior technical and executive decisions. **No invented architecture.** Every significant claim is tied to repository evidence or labeled **Unknown**.
+Produce a **step-by-step, facts-first** enterprise architecture assessment of **this** repository. **No invented architecture.** Every significant claim is tied to repository evidence or labeled **Unknown**.
 
 ## Evidence contract (mandatory)
 
-Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in the written deliverables.
+Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in written deliverables.
 
-**What counts as evidence (in priority order)**
+**What counts as evidence (priority order)**
 
-1. **Repository paths** — repo-relative file or directory paths you actually opened or searched (e.g. `src/core/foo.py`, `pyproject.toml`, `.github/workflows/`).
-2. **Quoted fragments** — short, faithful quotes from files (configs, docstrings, key symbols) when the claim is non-obvious; add line reference when practical (e.g. `path:42-48` or “see `symbol` in `path`”).
-3. **Command output** — only when run during the audit (e.g. `pytest`, `rg`, `python scripts/...`); record the **exact command** and **outcome** in §2 Audit Method, not vague “tests pass.”
-4. **User context** — label as **`Context:`** (field name); use for business/deployment intent **only**; never treat as **Confirmed** for claims about what the **code** does.
+1. **Repository paths** — repo-relative paths actually opened or searched.
+2. **Quoted fragments** — short faithful quotes when non-obvious; line ref when practical (`path:42-48`).
+3. **Command output** — only when run during the audit; record **exact command** and **outcome** in §2 Audit Method.
+4. **User context** — label **`Context:`**; never treat as **Confirmed** for what the **code** does.
 
 **Per classification**
 
 | Label | Requirement |
 |--------|-------------|
-| **Confirmed** | At least one repo path (or command + output) that directly supports the statement. |
-| **Probable risk** | (a) **Observed:** path + fact; (b) **Inference:** explicitly labeled; (c) **Falsify:** what evidence would confirm or refute. |
-| **Unknown** | State **what was not inspected** or **why** the repo cannot answer (e.g. no deployment manifests in tree, secrets not in repo). |
+| **Confirmed** | At least one repo path (or command + output) directly supports the statement. |
+| **Probable risk** | (a) **Observed:** path + fact; (b) **Inference:** labeled; (c) **Falsify:** what would confirm/refute. |
+| **Unknown** | What was not inspected or why the repo cannot answer. |
 
-**Scorecard (§9)** — For **each** category, the **Evidence** subsection must be a **bulleted list of paths** (and optional line/symbol refs) representing what was actually reviewed for that score. If the list is empty or only generic (“reviewed the codebase”), **cap the score at 3** and set scoring confidence to **Low** unless the gap is explicitly **Unknown**.
+**Scorecard (§9)** — Each category **Evidence** = bulleted paths reviewed. Empty/generic list → **cap score at 3**, confidence **Low** unless explicitly **Unknown**.
 
-**Findings (§7) and actions file** — **Evidence** is mandatory. If you cannot cite a path or command output, rephrase as **Unknown** or omit the finding.
+**Findings (§7) and actions file** — **Evidence** mandatory; else rephrase as **Unknown** or omit.
 
-**§2 Audit Method** — Must list: **sources read** (paths), **searches or scans** (e.g. patterns, tools), **commands run** (if any), and **scope limits** (what was out of scope or time-boxed). Readers must be able to **reproduce** how conclusions were reached.
+**§2 Audit Method** — List: sources read, searches/scans, commands run, scope limits. Readers must reproduce how conclusions were reached.
 
-**Contradictions** — When docs and code disagree, cite **both** sides (paths) and state the conflict before recommending.
+**Contradictions** — When docs and code disagree, cite **both** paths and state the conflict.
 
 ## When to use
 
-- Pre- or post-major refactor, platform review, or diligence-style read of the codebase.
-- When documentation and implementation may diverge (challenge documented architecture with code and config evidence).
-- When you need **module-level** findings, a **weighted scorecard**, and a **prioritized action list** for implementers.
+- Pre/post major refactor, platform review, diligence-style read.
+- Docs vs implementation may diverge.
+- Need module-level findings, weighted scorecard, prioritized actions.
 
 ## Project workflow integration
 
-**Read (do not load all of `.local/` blindly):**
+**Read (targeted, not all of `.local/`):** `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md`, project `docs/architecture/`, `AGENTS.md`, `README.md`, overlay rules, `prepare.py` (`resolve_gates()`).
 
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` — current slice context (if missing, say so).
-- `test-plan.md`, `test-index.md` when assessing test architecture.
-- Project `docs/architecture/`, `AGENTS.md`, `README.md` for stated intent vs implementation.
-- Overlay rules (`overlays/rules/*.mdc`) when installed.
-- `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`; `GATES` = 2-gate alias) for quality-gate reality.
-
-**Write — create directory if needed:**
+**Write:**
 
 | Output | Path |
 |--------|------|
-| Full audit (all sections below) | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md` |
-| Prioritized actions for implementers | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md` |
+| Full audit | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md` |
+| Actions | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md` |
 
-**Report frontmatter (top of `enterprise-architecture-audit.md`):**
+**Frontmatter:**
 
 ```text
 Audit-Type: enterprise-architecture-python
-Audited-By: <agent name or human>
+Audited-By: <agent or human>
 Action-By: <name>
 GitHub-User: <handle>
-Date: <ISO-8601 date>
+Date: <ISO-8601>
 Evidence-Standard: repository + user context only
 ```
 
-**Downstream agents:**
-
-- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items onto **board Ready cards** when `project_ssot.enabled` (Acceptance/Rollback in body); else `work-tracker.md` (one primary `in_progress`). Follow `.cursor/skills/implementer-loop/SKILL.md` + `board-ssot` Continuation contract.
-- **Alignment / maintainer:** if findings are doc-policy-roadmap drift, also record P0/P1 items per `.ai_infra/docs/roadmap/alignment-audit-schema.md` in `.local/workflow-artifacts/alignment/alignment-audit.md` and `alignment-todos.md` (advisory).
-- **Module map depth:** optionally run `.cursor/skills/audit-module-map/SKILL.md` for `module-map` / HTML export; cite those paths as evidence in the enterprise report.
-
-**After the audit:** add a brief entry to `.local/index-and-planning/history/updates-log.md` (artifacts written, no gate laundry lists).
+**Downstream:** **Implementer** → `enterprise-audit-actions.md`; board Ready cards when SSOT on. **Alignment** → `alignment-audit.md` + `alignment-todos.md` per schema. **Module map** → optional `audit-module-map` skill. Brief `updates-log.md` entry after audit.
 
 ### Focused alignment pass (architecture-impacting PRs)
 
-When the **maintainer workflow** requires alignment files for `--arch-impacting` but a **full** `enterprise-architecture-audit.md` is not requested:
+When maintainer workflow requires alignment files but not full enterprise report:
 
-- Stay on **`auditor`** and keep the **Evidence contract** (paths for every Confirmed finding; §2 Audit Method lists what you read/searched).
-- **Write only** (unless the user also wants the full report):
-  - `.local/workflow-artifacts/alignment/alignment-audit.md`
-  - `.local/workflow-artifacts/alignment/alignment-todos.md`
-- Use **`.ai_infra/docs/roadmap/alignment-audit-schema.md`** for finding shape and P0/P1/P2 handling.
-- Scope: compare **touched** roadmap/plan/strategy docs, rules/skills/agents, `src/` + `tests/modules/` relevant to the PR — not a whole-repo scorecard.
-- Include a short **CHK-*** tick table (below) for dimensions that touch the PR; mark N/A for untouched dimensions.
-- **Optional:** note in `alignment-audit.md` that a full enterprise scorecard was deferred.
-- Continuous plan/agent-doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 prose here.
+- Stay on **`auditor`**; keep **Evidence contract**.
+- **Write only:** `alignment-audit.md`, `alignment-todos.md` (schema: `.ai_infra/docs/roadmap/alignment-audit-schema.md`).
+- Scope: **touched** roadmap/plan/rules/skills/agents + relevant `src/` / `tests/modules/` — not whole-repo scorecard.
+- Short **CHK-*** tick table for PR-touching dimensions; N/A elsewhere.
+- Plan/doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 here.
 
----
-
-## Context block (required from user — paste at start of engagement)
+## Context block (paste at start)
 
 ```text
-Context:
-- Business type:
-- Product type:
-- Current users/customers:
-- Expected growth over next 12–24 months:
-- Team size and structure:
-- Deployment platform:
-- Compliance/security requirements:
-- Uptime/SLA expectations:
-- Main business goals:
-- Main roadmap items:
-- Main engineering goals:
-- Main pain points today:
-- Known constraints:
-- Intended future architecture direction:
-- Known incidents or operational failures:
-- Performance concerns already suspected:
-- Areas we especially want challenged:
+Context: Business type · Product · Users/growth · Team · Deployment · Compliance · SLA ·
+Goals · Roadmap · Engineering goals · Pain points · Constraints · Future direction ·
+Incidents · Performance concerns · Areas to challenge
 ```
 
-If the user leaves fields blank, label gaps **Unknown – not provided in context** and lower scoring confidence.
+Blank fields → **Unknown – not provided**; lower scoring confidence.
 
----
+## Operating mode
 
-## Operating mode (non-negotiable)
+Facts-first: inventory → quality → risks → recommendations (never reverse). **Strict / evidence-only / no speculation / step-by-step / Python-specific: ON.**
 
-```text
-Do not jump to recommendations before completing repository inventory and implemented architecture assessment.
-
-Facts-first rule:
-- First describe what exists
-- Then assess quality
-- Then identify risks
-- Then recommend changes
-- Never reverse that order
-
-Strict mode: ON
-Evidence-only mode: ON
-No speculation mode: ON
-Step-by-step mode: ON
-Python-specific analysis mode: ON
-```
-
-**Rules:**
-
-- Do not invent facts. If not verifiable from the repo (and provided context), say: **Unknown – not verifiable from repository evidence**.
+- No invented facts; label **Unknown – not verifiable from repository evidence** when needed.
 - Separate **Confirmed** / **Probable risk** / **Unknown** for material statements.
-- Do not describe architecture as confirmed unless supported by evidence (paths, configs, imports, entrypoints).
-- Be critical and precise. Prefer **insufficient evidence** over assumptions.
-- If evidence conflicts (e.g. docs vs code), call out the conflict.
+- Challenge docs vs code; **documented architecture ≠ real** without verification.
+- No vague likelihood unless explicit **hypothesis** + **evidence gap**.
 
-**Anti-hallucination:** Do not use vague likelihood language (“likely”, “probably intended”) unless framed as an explicit **hypothesis** with the **evidence gap** stated.
+## Mandatory phases (execute in order; show boundaries in report)
 
-**Challenge assumptions:** Actively look for contradictions between folder structure, import graph, runtime entrypoints, and deployment clues. **Documented architecture is not assumed to be real architecture** without verification.
-
-**Review discipline:**
-
-1. Inventory before judgment  
-2. Evidence before interpretation  
-3. Interpretation before recommendation  
-4. Recommendation before roadmap  
-5. Unknowns explicitly called out  
-
----
-
-## Mandatory phases (execute in order; show phase boundaries in the written report)
-
-### Named checklists (CHK-*) — mandatory coverage
-
-Map each checklist into the matching phase. In the written report (or focused alignment), include a **CHK tick table**: id · status (Pass / Gap / N/A / Unknown) · evidence paths. **Do not** invent new skill folders for these dimensions.
+### CHK-* checklists
 
 | Id | Phase | Must cite |
 |----|-------|-----------|
 | `CHK-ARCH` | 2 | Style, dependency direction, cycles |
-| `CHK-GRANULARITY` | 2 / 4 | God modules, blurred boundaries vs `.ai_infra/docs/governance/module-boundaries.md` (kit planes) or consumer `src/` modules |
-| `CHK-PERF` | 3 | Hot paths, N+1/queue clues; **Unknown** if none observable |
-| `CHK-SEC-CODE` | 3 | Secrets handling, injection/trust boundaries in kit scripts / app code in scope |
-| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, hard-stops, MCP `.cursor/mcp.registry.yaml` allowlists, no product auto-fix — **contract compliance**, not LLM jailbreak proof |
-| `CHK-INFRA-KIT` | 1 / 3 | Three planes, install/activate, `integrate validate` clues — **not** consumer cloud infra product |
-| `CHK-DOCS` | 5 | Stated goals vs docs; stale AGENTS / IMPLEMENTATION-STATUS |
+| `CHK-GRANULARITY` | 2 / 4 | God modules vs module-boundaries.md or consumer `src/` |
+| `CHK-PERF` | 3 | Hot paths; **Unknown** if none observable |
+| `CHK-SEC-CODE` | 3 | Secrets, injection/trust boundaries in scope |
+| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, MCP allowlists — contract compliance |
+| `CHK-INFRA-KIT` | 1 / 3 | Three planes, activate, `integrate validate` |
+| `CHK-DOCS` | 5 | Goals vs docs; stale AGENTS / IMPLEMENTATION-STATUS |
 
-### PHASE 1 — Repository inventory (descriptive only)
+Report includes **CHK tick table**: id · Pass/Gap/N/A/Unknown · evidence paths.
 
-Establish facts: Python version(s), dependency tooling, frameworks, entry points, main packages, workers/jobs, APIs/CLI/scripts, data stores, messaging, infra/deployment clues, test layout, docs/ADRs/config.  
-**Output:** inventory table, architecture map sketch (text), confirmed technologies, unknowns.
+### PHASE 1 — Repository inventory
+
+Facts only: Python version, deps, frameworks, entry points, packages, jobs, APIs/CLI, data stores, infra clues, tests, docs/ADRs. **Output:** inventory table, architecture sketch, confirmed tech, unknowns.
 
 ### PHASE 2 — Implemented architecture
 
-Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles. Complete **CHK-ARCH** and start **CHK-GRANULARITY**.  
-**Output:** detected profile, boundary analysis, layering assessment, risks visible from structure.
+Actual style, boundaries, dependency direction, layering, leakage, god modules/cycles. **CHK-ARCH**, start **CHK-GRANULARITY**. **Output:** profile, boundary analysis, structural risks.
 
 ### PHASE 3 — Python engineering and runtime
 
-Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security. Complete **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**.  
-**Output:** evidence-backed findings only; label Confirmed / Probable risk / Unknown.
+Packaging, imports, typing, data access, async/jobs, config/secrets, perf/scaling, reliability, security. **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**. **Output:** evidence-backed findings only.
 
 ### PHASE 4 — Module-by-module audit
 
-For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later). Finish **CHK-GRANULARITY**.  
-Use **Unknown** where needed. **Do not skip** module-level sections for major roots.
+Each **major** module: purpose, surfaces, dependencies, boundary (Clear/Blurred/Violated), coupling, layer, leakage, data ownership, perf/security/test clues, recommendation (Keep/Refactor/Split/Merge/Extract/Defer), effort, priority. Finish **CHK-GRANULARITY**. Do not skip major roots.
 
 ### PHASE 5 — Goal and plan alignment
 
-For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice. Complete **CHK-DOCS**. Continuous plan pulse when plans change is **`drift-guard`** — reference drift artifacts if present; do not re-run DRIFT scripts as a substitute for this phase.
+Per stated goal in docs: alignment (Strong/Partial/Weak), evidence, gaps, action (Preserve/Improve/Simplify/Postpone/Redesign). **CHK-DOCS**. Plan pulse when plans change = **`drift-guard`** — reference drift artifacts; do not substitute DRIFT scripts here.
 
 ### PHASE 6 — Recommended direction
 
-Acceptable for now; what breaks under growth; fix immediately vs intentional deferral; target direction; evolution vs redesign; migration risks; **top 5 highest-ROI** improvements (30–60 days), each repo-specific.
-
----
+What holds now; what breaks at scale; fix now vs defer; target direction; migration risks; **top 5 highest-ROI** improvements (30–60 days), repo-specific.
 
 ## Recommendation standard
 
-Every meaningful recommendation must include: **Problem**, **Evidence**, **Why it matters**, **Recommendation**, **Tradeoffs**, **Implementation approach**, **Effort estimate**, **Priority**, **Affected modules**.  
-Avoid generic bullets (“improve modularity”, “add observability”) without repo ties.
-
-**Migration difficulty** (for each major recommendation): Low / Moderate / High / Very High.
-
-**Optional:** **Top 10 modules by architectural risk** (ranked, with evidence).
-
-**Optional closing section — “Potential dissent from a second architect”:** what a reviewer might dispute, weak evidence, decisions needing human validation.
-
----
+Each recommendation: **Problem**, **Evidence**, **Why it matters**, **Recommendation**, **Tradeoffs**, **Implementation**, **Effort**, **Priority**, **Affected modules**. Migration difficulty: Low / Moderate / High / Very High. No generic bullets without repo ties.
 
 ## Scoring framework
 
-**Scoring rules:**
+Scores need concrete evidence; limited evidence → lower confidence. High scores need **positive** evidence; lack of evidence ≠ quality.
 
-- Do not assign scores from intuition alone.  
-- Every score references concrete evidence.  
-- If evidence is limited, **lower confidence**.  
-- **High scores require positive evidence**, not absence of problems.  
-- **Lack of evidence is not evidence of quality.**  
-- Do not reward absence of visible issues with high scores.
-
-**Categories (1–5):** 1 = materially inadequate for enterprise; 2 = weak/high-risk; 3 = workable/moderate risk; 4 = strong with manageable gaps; 5 = enterprise-strong/low risk.
+**Categories (1–5):** 1 materially inadequate … 5 enterprise-strong.
 
 | Category | Weight |
 |----------|--------|
@@ -263,23 +176,20 @@ Avoid generic bullets (“improve modularity”, “add observability”) withou
 | Documentation and governance | 5% |
 | Strategic alignment | 10% |
 
-For **each** category: Score, Why, Evidence, What is needed to reach the next level.  
-Then: **weighted overall score**, **enterprise readiness level** (Early-stage / Growing / Scaling / Enterprise-capable), **scoring confidence** (High / Medium / Low).
-
----
+Per category: Score, Why, Evidence (paths), path to next level. Then weighted overall, enterprise readiness (Early-stage / Growing / Scaling / Enterprise-capable), confidence (High / Medium / Low).
 
 ## Required report structure
 
-Write `enterprise-architecture-audit.md` with these sections:
+`enterprise-architecture-audit.md`:
 
 1. Executive Summary  
-2. Audit Method (must satisfy the **Evidence contract**: sources, searches, commands, scope limits)  
-2b. **CHK-* tick table** (all seven ids: Pass / Gap / N/A / Unknown + evidence)  
+2. Audit Method (Evidence contract: sources, searches, commands, scope)  
+2b. CHK-* tick table  
 3. Repository Inventory  
 4. Detected Architecture Profile  
 5. Python-Specific Engineering Assessment  
 6. Module-by-Module Deep Dive  
-7. Findings by Severity (Critical / High / Medium / Low — each with Classification, Confidence, Why it matters, Evidence, Recommendation, Tradeoffs, Effort, Priority, Affected areas)  
+7. Findings by Severity (each: Classification, Confidence, Evidence, Recommendation, Effort, Priority)  
 8. Performance & Scalability Risk Table  
 9. Architecture Scorecard (+ weighted overall + readiness + confidence)  
 10. Goal and Plan Alignment  
@@ -288,70 +198,22 @@ Write `enterprise-architecture-audit.md` with these sections:
 13. Top 5 Highest-ROI Changes  
 14. Risks, Unknowns, and Assumptions  
 15. Human Validation Required  
-16. Final Verdict (Acceptable / Acceptable with Risks / Major Redesign Recommended) — rationale, biggest blocker, executive takeaway  
+16. Final Verdict (Acceptable / Acceptable with Risks / Major Redesign Recommended)
 
-**Closing quality bar:**
+Quality bar: concrete at module level; lower confidence instead of inventing certainty.
 
-```text
-Do not summarize vaguely. Be concrete at module level.
-If evidence is incomplete, lower confidence instead of inventing certainty.
-The review should help a senior engineering leader decide:
-- what is fine now
-- what becomes dangerous at scale
-- what to fix first
-- what architecture direction best supports the business plan
-```
+## `enterprise-audit-actions.md`
 
----
+Backlog: **ID** (e.g. `EA-001`), **Title**, **Severity** (P0/P1 mapping), **Classification**, **Evidence** (paths), **Recommendation**, **Effort**, **Migration difficulty**, **Priority**, optional owner, link to audit section.
 
-## `enterprise-audit-actions.md` format
+## Shorter invocation (skill already loaded)
 
-Structured backlog for implementers:
-
-- **ID** (e.g. `EA-001`)  
-- **Title**  
-- **Severity** (map enterprise Critical/High to P0/P1 where appropriate for internal tracking)  
-- **Classification:** Confirmed / Probable risk / Unknown  
-- **Evidence** (paths)  
-- **Recommendation** (one concrete step)  
-- **Effort** / **Migration difficulty** / **Priority**  
-- **Suggested owner role** (optional)  
-- **Link** to section in `enterprise-architecture-audit.md`  
-
----
-
-## Shorter invocation prompt (when full skill context is already loaded)
-
-```text
-Audit this Python repository as a Principal Enterprise Architect.
-
-Work step by step. Facts only. No guessing.
-
-Process:
-1. Inventory the repo
-2. Identify the actual implemented architecture
-3. Assess Python-specific engineering quality
-4. Audit each major module/package
-5. Assess risks, scalability, security, reliability, and operability
-6. Compare current architecture to goals and target direction (from docs + context)
-7. Recommend a practical transition path
-
-Rules:
-- Every major claim must include repository evidence (paths)
-- If not verifiable, say "Unknown – not verifiable from repository evidence"
-- Distinguish Confirmed / Probable risk / Unknown
-- Do not jump to recommendations before inventory and architecture assessment
-- Do not provide generic advice
-- Use the weighted scorecard; high scores require positive evidence
-
-Deliverables: full report + enterprise-audit-actions.md under .local/workflow-artifacts/enterprise-architecture-audit/
-```
+Audit as Principal Enterprise Architect: inventory → implemented architecture → Python quality → modules → risks → goals comparison → transition path. Facts only; weighted scorecard; deliverables under `.local/workflow-artifacts/enterprise-architecture-audit/`.
 
 ## Exit criteria
 
-- Phases 1–6 completed in order in the written report; no early recommendation dump.  
-- **CHK-*** tick table present (full audit) or scoped tick table (focused alignment).  
-- **Evidence contract** satisfied: §2 lists reproducible sources/commands; Confirmed claims and scorecard categories cite paths; no finding in §7 or actions file without **Evidence** paths (or explicit **Unknown**).  
-- Scorecard populated with evidence and confidence; no score without justification.  
-- `enterprise-audit-actions.md` exists with prioritized, repo-tied items (full audit).  
-- Unknowns and human-validation items explicitly listed.
+- Phases 1–6 in order; no early recommendation dump.  
+- CHK-* tick table present (full or focused).  
+- Evidence contract: §2 reproducible; Confirmed/scorecard cite paths; §7/actions have Evidence or **Unknown**.  
+- Scorecard with justification; `enterprise-audit-actions.md` with repo-tied items (full audit).  
+- Unknowns and human-validation items listed.

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -13,313 +13,192 @@ Used By:
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/agent_colony/project_cli.py
- - .ai_infra/install/agent_colony/project_atomics.py
- - .ai_infra/install/agent_colony/gh_project_adapter.py
- - .ai_infra/install/agent_colony/project_recipes.py
- - .ai_infra/install/agent_colony/project_outbox.py
  - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:
- - Pattern A: prefer recipes (claim/handoff/create-from-template); atomics for power use; no dual-write when board_only.
- - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
+ - Pattern A: prefer recipes (claim/handoff/create-from-template); no dual-write when board_only.
 -->
 
 # Board SSOT
 
-## Goal
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
-When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Project as the **only writable SSOT** for backlog, Status, and multi-agent continuation. Prefer CLI over inventing `gh` flags. Local trackers are offline fallback only; read-only exports never compete with board Status.
+When `project_ssot.enabled` and `sync_policy: board_only`, the GitHub Project is the **only writable SSOT** for backlog, Status, and continuation. Prefer CLI over inventing `gh` flags. Local trackers = offline fallback only; read-only exports never compete with board Status.
 
-**Agent:** `.cursor/agents/board.md`  
-**Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
-**ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+**Agent:** `.cursor/agents/board.md` · **Ops:** `.ai_infra/docs/operations/project-board-collaboration.md` · **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
 ## Two-tier plans (ADR-010)
 
 | Tier | Location | Role |
 |------|----------|------|
-| **Live** | Board card body (`board_only`) or `.local/index-and-planning/current/plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
-| **History** | `.local/plans/` (`plan snapshot`, `plan list`, `plan open` for human Build) | Dated snapshots + `index.md` — **never** competing Status or live plan under `board_only` (**DRIFT-012**) |
+| **Live** | Board card body (`board_only`) or `plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
+| **History** | `.local/plans/` (`plan snapshot\|list\|open`) | Snapshots only — **never** competing Status under `board_only` (**DRIFT-012**) |
 
 Agents: `plan list` → read snapshot → execute. Exit: `plan snapshot --slug … --board-item …`. See `.cursor/skills/canvas-artifacts/SKILL.md`.
 
-## First-run (board shell) — before day-to-day cards
+## First-run (board shell)
 
-Day-0 requires the kit **default** shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Priority/Size/Estimate/Start date/End date on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.
+Kit default shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Tier-1 columns on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.
 
-0. **Wire YAML from URLs (if ids missing):** after `gh` auth, human pastes Project URL + repo URL → use `gh project view` / `field-list` → propose `project_ssot` + `default_repo` → human confirms before save. Discovery only — **no** `--ensure-fields` until CONSENT.
-1. Load `.cursor/skills/board-shell/SKILL.md` (coach) and the schema above.
-2. **CONSENT GATE (mandatory):** ask board description (or `use template default`) + `May I proceed to set up the kit default shell?` — only continue on `yes`.
-3. Run `python3 -m agent_colony project doctor` → `project board-bootstrap --check`.
-4. On **exit 5** (view FAIL or Tier-1 column FAIL): TURN PROTOCOL (agent coaches one view at a time; human uses `views-setup.md` as click reference). Optional `--ensure-fields` / `--apply-readme` only after consent. **No** `--apply-shell` CLI today.
-5. Refuse “ready for agents” until `board-bootstrap --check` exits **0** (README non-empty, six views, Tier-1 columns on Status board / Prioritized backlog). Then resume day-to-day Pattern A below.
+1. Wire YAML from Project + repo URLs (human confirms before save). Discovery only — **no** `--ensure-fields` until CONSENT.
+2. Load `.cursor/skills/board-shell/SKILL.md`. **CONSENT GATE:** ask description + `May I proceed to set up the kit default shell?` — continue only on `yes`.
+3. `python3 -m agent_colony project doctor` → `project board-bootstrap --check`.
+4. **Exit 5:** TURN PROTOCOL (human UI via `views-setup.md`). Optional `--ensure-fields` / `--apply-readme` only after consent. **No** `--apply-shell` CLI.
+5. Refuse “ready for agents” until `board-bootstrap --check` exits **0**. Then Pattern A below. **`/auditor`** is not day-0.
 
-**Not first-run:** `/auditor` (architecture-impacting / pre-merge later).
+## Continuation contract
 
-## Continuation contract (all agents — non-negotiable when enabled)
-
-Work is **indexed on the Project**, not in chat alone.
+Work is **indexed on the Project**, not chat alone.
 
 | Phase | Required |
 |-------|----------|
-| **Entry** | Prefer `python3 -m agent_colony project entry` (quota-aware: live \| conserve \| offline_artifacts). Then `get` / `claim` **one** card. Read Acceptance / Rollback / Notes on that card body. Avoid unfiltered `project list` / full `export` every turn — use `export --reuse-if-fresh` when a snapshot is enough. Parallel agents may each Entry, but **one export refresh per parent wave**. |
-| **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit / Forbidden throttle / precheck low quota: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
-| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
+| **Entry** | Prefer `python3 -m agent_colony project entry` (live \| conserve \| offline_artifacts). Then `get` / `claim` **one** card. Read Acceptance / Rollback / Notes. Avoid unfiltered `list` / full `export` every turn — use `export --reuse-if-fresh`. One export refresh per parent wave. |
+| **During** | **One** In progress card for your assignee. Mid-slice progress → card Notes. |
+| **Exit** | Update Status → `in_review` / `done`, or stay `in_progress` with **Notes** naming next agent. Notes via `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **EXIT_QUEUED (6)** / rate-limit / Forbidden / precheck low quota: **do not** retry-loop — op in `.local/generated-data/board-outbox.jsonl`; later `project outbox flush`. |
+| **Never** | Chat-only completion with stale Status. No dual-write tracker `in_progress` under `board_only`. No bare `Agent: implementer` without `@user/` namespace. |
 
-Handoff line (chat + card Notes):
+Handoff line (chat + Notes):
 
 ```text
 item_id=<from project last or create> · @User/implementer · Status=before→after · Priority=p1 · Size=s · Estimate=1 · next=@User/verifier
 Tasks: [P1] …; [P2] …; [P3] …
 ```
 
-Prefer `--last` after create so agents never invent ids.
+Prefer `--last` after create. Multi-collaborator: each `owner.github_user` namespaces agents (`@Alice/implementer` vs `@Bob/implementer`).
 
-Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
+## Tier-1 card fields contract
 
-## Tier-1 card fields contract (all agents — mandatory)
+When you **create** or **own** a card, fill Tier-1 fields. Verifier spot-checks on closure.
 
-When you **create** or **own** a Project card, fill the Tier-1 fields below. Do **not** leave them empty and move on. Verifier spot-checks this on closure.
+### Priority
 
-### Priority scale
+| Label | `set-field --field priority --to` | When |
+|-------|-----------------------------------|------|
+| P0 | `p0` | Blocks merge / release / SSOT |
+| P1 | `p1` | Must do next |
+| P2 | `p2` | Hygiene / polish |
+| P3 (deferred) | `p2` + Notes `deferred` | No `p3` option id in YAML |
 
-| Chat / plan label | Board `set-field --field priority --to` | When |
-|-------------------|----------------------------------------|------|
-| **P0** | `p0` | Blocks merge / release / SSOT integrity |
-| **P1** | `p1` | Must do next |
-| **P2** | `p2` | Planned hygiene / polish |
-| **P3** (deferred) | `p2` + Notes line `deferred` | Optional later — **no** `p3` option id in YAML |
+Priority is independent of Size (P0 can be XS).
 
-Priority is **independent** of Size (a P0 can be XS).
-
-### Size ↔ Estimate rubric (points, not hours)
-
-**Estimate** is relative **points**. Do not invent hours unless the consumer’s Project README defines hours→points.
+### Size ↔ Estimate (points, not hours)
 
 | Size | Typical slice | Estimate band | Default if unsure |
 |------|---------------|---------------|-------------------|
-| **xs** | Trivial (&lt; ~1h), one file / one paragraph | **1** | 1 |
+| **xs** | Trivial, one file | **1** | 1 |
 | **s** | Small, clear boundary | **1–2** | **1** |
-| **m** | Multi-file / multi-step, one PR | **3–5** | **3** |
-| **l** | Large or high risk — prefer split | **5–8** | **5** |
-| **xl** | Too big for one agent turn — **split** before coding | **8+** | refuse / split |
+| **m** | Multi-file, one PR | **3–5** | **3** |
+| **l** | Large / high risk — split | **5–8** | **5** |
+| **xl** | Too big — **split** before coding | **8+** | refuse / split |
 
-**Honesty rules**
-
-1. Prefer smaller cards; if Size would be `l`/`xl`, create multiple Ready cards.
-2. If Size and Estimate disagree with the table, explain in Notes.
-3. Unknown → Size=`s`, Estimate=`1`, and Notes: `Size/Estimate guessed (default s/1)`.
-4. Keep Size and Estimate aligned with this table (e.g. Size=`m` → Estimate in 3–5).
+Honesty: prefer smaller cards; if Size=`l`/`xl`, split. If table mismatch, explain in Notes. Unknown → Size=`s`, Estimate=`1`, Notes: `Size/Estimate guessed (default s/1)`.
 
 ### Timing matrix
 
-| Moment | Status | Priority | Size | Estimate | Start date | End date | Assignee | Linked PR |
-|--------|--------|----------|------|----------|------------|----------|----------|-----------|
-| Create (Ready/Backlog) | ✓ | ✓ required | ✓ | ✓ | — | — | ✓ Issue (owner; `--no-assignee` to skip) | — |
-| First In progress | ✓ | confirm | confirm | confirm | **✓ required** | — | ✓ (Issue) | — |
+| Moment | Status | Priority | Size | Estimate | Start | End | Assignee | Linked PR |
+|--------|--------|----------|------|----------|-------|-----|----------|-----------|
+| Create (Ready/Backlog) | ✓ | ✓ | ✓ | ✓ | — | — | ✓ Issue | — |
+| First In progress | ✓ | confirm | confirm | confirm | **✓** | — | ✓ | — |
 | Open PR | — | — | — | — | — | — | — | ✓ `mention-pr` |
-| Exit In review | ✓ | Notes | Notes | Notes | already set | — | — | if PR |
-| Exit Done | ✓ | Notes | Notes | Notes | already set | **✓ required** | — | if PR |
+| Exit In review | ✓ | Notes | Notes | Notes | set | — | — | if PR |
+| Exit Done | ✓ | Notes | Notes | Notes | set | **✓** | — | if PR |
 
-**Start date** = UTC calendar day work began. Set when Status becomes `in_progress` if empty — via `claim`, `set-status --to in_progress`, or `handoff --to in_progress` (master switch: `conventions.set_start_date_on_claim`). Never set on create while Ready/Backlog.
+**Start date:** UTC day work began. Set on first `in_progress` if empty — `claim`, `set-status --to in_progress`, or `handoff --to in_progress` (`conventions.set_start_date_on_claim`). Never on Ready/Backlog create.
 
-**End date** = UTC calendar day work finished. Set when Status becomes `done` if empty — via `set-status --to done`, `handoff --to done`, merge board sync, or `heal-cards --apply` (master switch: `conventions.set_end_date_on_done`). Never set on create or In progress / In review.
+**End date:** UTC day finished. Set on `done` if empty — `set-status --to done`, `handoff --to done`, merge sync, or `heal-cards --apply` (`conventions.set_end_date_on_done`). Never on create or In progress / In review.
 
-### Mandatory field checklist
+### Field checklist
 
-| Field | When | CLI | Rules |
-|-------|------|-----|-------|
-| **Status** | Always | `claim` / `handoff` / `set-status` | Create defaults `--status ready` (overridable); Exit → `in_review` / `done` |
-| **Priority** | Create / claim / own | `create-from-template --priority p0\|p1\|p2` or `set-field` | Required on template create — no silent default |
-| **Size** | Create / claim / own | `--size` / `set-field --field size --to xs\|s\|m\|l\|xl` | Per Size↔Estimate table; default `s` + Notes if guessed |
-| **Estimate** | Create / claim / own | `--estimate` / `set-field --field estimate --to N` | Points per table; default `1` + Notes if guessed |
-| **Start date** | First In progress | `claim` / `set-status --to in_progress` / `handoff --to in_progress` | Auto when `set_start_date_on_claim` + `fields.start_date.field_id`; if WARN, retry — do not ignore |
-| **End date** | Done | `set-status --to done` / `handoff --to done` / merge / `heal-cards` | Auto when `set_end_date_on_done` + `fields.end_date.field_id`; if WARN, retry — do not ignore |
-| **Assignee** | Create (Issue) / claim re-assert | `create-from-template` auto-assigns `owner.github_user`; `claim` / `set-assignee --login …` | **Create as Issue** (`item_kind_default: issue`). Draft is scratch-only; `--no-assignee` escape hatch |
-| **Linked PR** | When a PR exists | `mention-pr --pr N --last --agent <agent>` | Auto-promotes Draft when `promote_to_issue_on_pr` |
+| Field | When | CLI |
+|-------|------|-----|
+| **Status** | Always | `claim` / `handoff` / `set-status` |
+| **Priority** | Create / own | `create-from-template --priority p0\|p1\|p2` or `set-field` |
+| **Size** | Create / own | `--size` / `set-field --field size --to xs\|s\|m\|l\|xl` |
+| **Estimate** | Create / own | `--estimate` / `set-field --field estimate --to N` |
+| **Start date** | First In progress | `claim` / `set-status` / `handoff` → `in_progress` |
+| **End date** | Done | `set-status` / `handoff` / merge / `heal-cards` → `done` |
+| **Assignee** | Create (Issue) | `create-from-template` (default `owner.github_user`); `claim` / `set-assignee` |
+| **Linked PR** | PR exists | `mention-pr --pr N --last --agent <agent>` |
+
+**Create as Issue** (`item_kind_default: issue`). Draft = scratch only (`--no-assignee` escape hatch). `promote-to-issue --last --agent <name>` when still Draft. `mention-pr` auto-promotes when `promote_to_issue_on_pr: true`.
 
 ```bash
-# Pattern A — Tier-1 at create + Start date on claim
 python3 -m agent_colony project create-from-template \
   --template slice --title "[P1] …" --status ready \
   --priority p1 --size s --estimate 1 --agent implementer
 python3 -m agent_colony project claim --last --agent implementer
-# When opening a shippable PR:
 python3 -m agent_colony project mention-pr --pr N --last --agent implementer
 ```
 
-Plain `project create` (non-template) still needs follow-up `set-field` for Priority/Size/Estimate.
-
-Rules:
-
-1. After create: **Priority + Size + Estimate** before coding; on first In progress confirm **Start date** from CLI output.
-2. Exit Notes and chat: `[P0]…; [P1]…; [P2]…; [P3]…` and `Priority=p? · Size=? · Estimate=?`.
-3. `auditor` / `drift-guard`: recommend Priority/Size/Estimate (per table) when seeding Ready cards.
-4. `verifier`: spot-check Status, Priority, Size, Estimate, **Start date on In progress / In review / Done**, **End date on Done**; Assignee when Issue-backed; Linked PR when a PR opened. Missing Start date on active statuses or missing End date on Done = **incomplete Exit**.
-5. Missing Tier-1 fields = incomplete Exit — fill or document blocker in Notes before handoff.
-
-## When to use
-
-- Any session where `project_ssot.enabled: true`
-- Triage, create, claim, Priority/Size, Status transitions
-- Multi-agent handoffs (implementer → test-runner → verifier, etc.)
-
-## Evidence contract
-
-- Cite CLI output or `gh project` JSON for claims.
-- Label **Unknown** when board unreachable → then `fallback: local_trackers` only.
+Plain `project create` needs follow-up `set-field` for Priority/Size/Estimate. Exit Notes: `[P0]…; [P1]…` and `Priority=p? · Size=? · Estimate=?`. Missing Tier-1 or Start on active statuses / End on Done = **incomplete Exit**.
 
 ## Collaboration
 
-### Human vs agent vs GitHub
+| Surface | Human | Agents |
+|---------|-------|--------|
+| Status / Priority / Size / cards | Yes | Yes (rights below) |
+| Ready prioritization / roadmap | **Owner** | Consume Ready; create agreed work |
+| Views, workflows, Insights, README | **Owner only** | **Never** (browser assist only if human asks) |
+| PR gates, audits, secrets | Local | Local (`local_only`) |
 
-| Surface | Human | Agents | Derived |
-|---------|-------|--------|---------|
-| Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
-| Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
-| Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
-| My items | Assign in UI or `project set-assignee` (human login) | Claim = Status In progress + Notes `@user/agent`; assignee = human only | View filter |
-| PR gates, audits, secrets | Local | Local (`local_only`) | — |
+**Issue vs board Status:** independent by default. Opt-in bridge: `conventions.close_linked_issue_on_cleanup` → `finalize.py` closes linked Issue after merge cleanup. CLI: `project close-linked-issue --pr N` (requires Status=Done first).
 
-### Tier-1 board fields (agents)
+**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` flags missing Status/Tier-1 · `outbox flush` if QUEUED.
 
-| Field / action | When | CLI | Notes |
-|----------------|------|-----|-------|
-| **Start date** | First In progress | `claim` / `set-status --to in_progress` / `handoff --to in_progress` | **Mandatory** when empty — UTC today if `conventions.set_start_date_on_claim: true`; see § Tier-1 card fields contract |
-| **End date** | Done | `set-status` / `handoff` / merge / `heal-cards` → `done` | **Mandatory** when empty — UTC today if `conventions.set_end_date_on_done: true` |
-| **Estimate** | Create / claim / own | `project set-field --field estimate --to N` | **Mandatory** — default `1` if unknown |
-| **Size** | Create / claim / own | `project set-field --field size --to xs\|s\|m\|l\|xl` | **Mandatory** — default `s` if unknown |
-| **Priority** | Create / claim / own | `project set-field --field priority --to p0\|p1\|p2` | **Mandatory** — chat P3 → `p2` + Notes `deferred` |
-| **Assignee** | Create Issue (owner) | `create-from-template` (default) / `claim` / `set-assignee` | **Mandatory on Issue create** — `owner.github_user`; Draft cannot hold Assignees |
-| **Linked PR** | PR open | `project mention-pr --pr N --last` | **Mandatory when a PR exists** for the card |
-| **Promote Draft→Issue** | Only if card is still Draft | `project promote-to-issue --last --agent <name>` | Prefer never needing this — create as Issue |
-| **Out of scope (agents default)** | — | — | Iteration, Labels, Reviewers — human / UI only |
+**Rules:** one In progress per human assignee; Acceptance/Rollback/Notes on card body; no dual-mirror under `board_only` (DRIFT-009); read-only `export` never writes Status; post-merge Done via `merge.py`.
 
-### Issue lifecycle (Draft vs Issue)
+| Agent | Exit (must update board) |
+|-------|--------------------------|
+| implementer | In progress → In review (PR) → Done; fields on own card |
+| test-runner / verifier | Stay on card; → In review or Done with Notes |
+| drift-guard | Drift-pass → Done; cite board Status; hand remediation via Notes/Ready — **no** silent tracker edits |
+| auditor | Audit card → In review/Done; Notes → artifact paths |
 
-| Path | CLI / config | Notes |
-|------|--------------|-------|
-| Default create | `create-from-template` + `item_kind_default: issue` | **Issue** on the Project + linked repo (`default_repo`) — Assignees + Linked PRs work from claim |
-| Scratch only | `item_kind_default: draft` (override) | DraftIssue — no Assignees until `promote-to-issue`; do **not** use for shippable work |
-| Explicit promote | `promote-to-issue --last --agent <name>` | Same `PVTI_`; needed only if card was created as Draft |
-| Auto on PR | `mention-pr` | When `promote_to_issue_on_pr: true` (still useful if a Draft slipped through) |
+Status path: `Ready → In progress → In review → Done`
 
-### Issue state vs board Status (they're independent by default)
+## Procedure (Pattern A)
 
-Board `Status=Done` and the linked GitHub Issue's own `open`/`closed` state are **separate signals** — Status is the continuation SSOT; Issue state is GitHub-native (Issues list, notifications). A card can be `Done` while its Issue stays `open` — this is expected, not a bug, unless you opt in below.
+Never paste placeholder `--id`. After create, use `--last`. `project guide --agent <name>`.
 
-- **Opt-in bridge:** `conventions.close_linked_issue_on_cleanup` (default `false`). When `true`, `full-pr-workflow`'s `finalize.py` best-effort closes the Issue linked to the merged PR's board item, **after** branch cleanup succeeds — never on `set-status`/`claim`/`handoff`, so it can't race ahead of merge/cleanup evidence.
-- **CLI:** `project close-linked-issue --pr N [--dry-run]` — resolves the item via `find-by-pr`; **requires board Status=Done** first (else SKIPPED with remediation); skips when there's no linked Issue, the flag is off, or the Issue is already closed; a `gh` error is `DEFERRED` (non-blocking).
-- **Evidence:** outcome recorded in `finalize.md § Linked Issue Closure` (`PASS` / `SKIPPED` / `DEFERRED` / `DRY-RUN` when `finalize.py --dry-run` is used).
+| Need | Template / action |
+|------|-------------------|
+| slice / feature / chore | `create-from-template --template slice` |
+| bug / fix | `create-from-template --template bug` |
+| research | `--template research` |
+| audit pass | `--template slice` + `[AUDIT] …` then `claim --last` |
+| test-runner / verifier | claim/continue only — **no** create |
 
-### Repair incomplete cards
+**Recipes:**
 
-Empty Status (especially with a CLOSED Issue) breaks Status views. Detection and repair:
-
-```bash
-python3 -m agent_colony project doctor          # WARN counts + heal hint
-python3 -m agent_colony project heal-cards --check
-python3 -m agent_colony project heal-cards --apply [--fill-tier1] [--dry-run]
-python3 -m agent_colony project outbox flush    # if QUEUED
-```
-
-`heal-cards --apply` sets Status→Done only when the linked Issue is CLOSED and Status is empty/non-done. `--fill-tier1` optionally fills missing Priority=`p2` / Size=`s` / Estimate=`1`. `validate-item` flags `missing Status` (and Tier-1 when configured) so empty cards never soft-pass.
-
-### Rules
-
-1. One primary **In progress** per **human assignee** — do not steal others'.
-2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (or `claim`/`handoff` recipes).
-4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
-5. Humans own views, workflows, README, Insights, status updates by default (no view API). If the human **asks** for browser help on views/columns, `/board` may use browser MCP for that turn (see `board-shell`).
-6. Read-only `project export` (if used) never writes Status.
-7. Post-merge Done is Pattern A (`merge.py`), Notes prefixed `@user/merge.py`.
-
-### Per-agent rights (what / when / where)
-
-| Agent | Entry (read board) | Exit (must update board) | Local writes |
-|-------|--------------------|--------------------------|--------------|
-| **board** | status + list | create/move any Status; Priority/Size; hand off to implementer | change-index, updates-log |
-| **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
-| **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
-| **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
-| **integrator** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
-| **auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
-| **drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
-| **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |
-
-### Status path
-
-```text
-Ready → In progress → In review → Done
-```
-
-| Moment | Actor | CLI |
-|--------|-------|-----|
-| Start work | implementer / integrator / test-runner / board | `set-status --to in_progress` |
-| PR open / peer handoff | implementer | `set-status --to in_review` |
-| Part verified closed | implementer / verifier / test-runner | `set-status --to done` |
-| Drift / audit pass closed | drift-guard / auditor | `set-status --to done` (their card) |
-| Queue triage | board or human | create / set-status / set-field |
-
-## Procedure (CLI) — prefer Pattern A recipes
-
-**Never paste docs placeholders as `--id`.** After create, use `--last`. Print recipes: `project guide`.
-
-Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (board brief only — not into a shell). CLI recipes stay in `project guide` and `project-board-collaboration.md`.
-
-### Template routing
-
-| Need | Who | Template / action |
-|------|-----|-------------------|
-| slice / feature / `chore/` | implementer, board, integrator | `create-from-template --template slice` |
-| bug / defect / `fix/` | implementer, board | `create-from-template --template bug` |
-| external / corpus research | researcher, board | `create-from-template --template research` |
-| audit pass | auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
-| consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
-| Project README | **Humans only** | paste `project-readme.md` (board brief) in Project settings UI — or `--apply-readme` |
-
-Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
-
-**Notes format:** `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · text` — auto-stamped by CLI on `claim`, `handoff`, and `append-notes --agent`. Idempotent when timestamp already present. Do not hand-forge times.
-
-**Local continuity:** append UTC-prefixed lines to `history/updates-log.md`; optional row in `history/continuity-index.md` (rolling ≥3 days). Board Notes retain full card lifetime.
-
-1. **Doctor / guide:** `project doctor` · `project guide --agent implementer`
-2. **Status / list:** `project status` · `project list [--status ready|in_progress|in_review]`
-3. **Create:** `project create-from-template --title "[SLICE] short-name" --template slice --status ready --priority p1 --size s --estimate 1 --agent <agent>` (prefer `--acceptance` / `--rollback` at create)
+1. `project doctor` · `project guide --agent implementer`
+2. `project status` · `project list [--status ready|in_progress|in_review]`
+3. **Create:** `create-from-template … --priority p1 --size s --estimate 1 --agent <agent>` (prefer `--acceptance` / `--rollback`)
 4. **Claim:** `project claim --last --agent <this-agent>`
-5. **Fill body (if still TBD):** `project set-section --section acceptance|rollback --text '…' --last --agent <this-agent>` — Notes stay append-only
-6. **Handoff:** `project handoff --last --agent <this-agent> --next <agent> [--to in_review|done]` — **EXIT_VALIDATION (5)** when Acceptance/Rollback are still placeholders (also enforced on `set-status --to in_review|done`)
-7. **Validate:** `project validate-item --last` (same checks; handoff/`set-status` already gate closes)
-8. **Atomics (power use):** `set-status` · `set-field` (priority · size · estimate) · `set-section` · `promote-to-issue` · `mention-pr` · `append-notes --agent` · `get --last` · `export`
-9. **Verify:** `project list` + handoff line; `project last` prints saved id
+5. **Body:** `set-section --section acceptance|rollback --text '…' --last --agent <agent>`
+6. **Handoff:** `handoff --last --agent <this-agent> --next <agent> [--to in_review|done]` — **EXIT_VALIDATION (5)** when Acceptance/Rollback are `(TBD)` (also on `set-status --to in_review|done`)
+7. **Validate:** `validate-item --last`
+8. **Atomics:** `set-status` · `set-field` · `set-section` · `promote-to-issue` · `mention-pr` · `append-notes --agent` · `get --last` · `export`
 
-Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation · `6` queued (outbox; soft-success — flush later).
+Exit codes: `0` ok · `2` usage/config · `3` gh · `4` not found · **`5` validation** · **`6` queued** (outbox; flush later).
 
 Rate-limit: `project outbox status` / `project queue` / `project outbox flush` — see `project_ssot.outbox` in collaboration YAML.
 
 ## Dual-write ban
 
-When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local (`local_only`).
+When `board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local.
+
+## Evidence contract
+
+Cite CLI output or `gh project` JSON. Label **Unknown** when board unreachable → `fallback: local_trackers` only.
 
 ## Exit criteria
 
 - [ ] Entry read board (or explicit offline fallback)
-- [ ] Exit updated Status (or Notes + next agent if still In progress)
-- [ ] If EXIT_QUEUED: confirmed via `outbox status`; no API hammering
-- [ ] Handoff line printed with real item_id
-- [ ] Handoff line printed when another agent continues
-- [ ] No dual-write; no unprompted edits to Project views/workflows/Insights (browser assist only if human asked)
+- [ ] Exit updated Status or Notes + next agent
+- [ ] If EXIT_QUEUED: `outbox status`; no API hammering
+- [ ] Handoff line with real `item_id`
+- [ ] No dual-write; no unprompted Project view/workflow edits
 
 ## Anti-patterns
 
-- Chat-only completion with stale board Status
-- Hardcoding field/option ids
-- Reshuffling Ready/P0 without human or board ask
-- Editing Project views/workflows/Insights unprompted (browser assist only when human asks)
-- Pasting Project settings UI text into a terminal
-- Dual-write board + tracker under `board_only`
-- Multi-step claim without `project claim` / bare Notes without `--agent`
-- Do not push to unrelated repositories
+Chat-only completion · hardcoded field ids · dual-write under `board_only` · multi-step claim without `project claim` · bare Notes without `--agent` · reshuffling Ready without human ask · pasting Project UI into terminal

--- a/payload/.cursor/skills/drift-audit/SKILL.md
+++ b/payload/.cursor/skills/drift-audit/SKILL.md
@@ -18,6 +18,8 @@ Notes:
 
 # Drift audit
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
 Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:

--- a/payload/.cursor/skills/implementer-loop/SKILL.md
+++ b/payload/.cursor/skills/implementer-loop/SKILL.md
@@ -5,6 +5,8 @@ description: Disciplined implementation slices with board SSOT continuation and 
 
 # Implementer loop
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slices.

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -17,6 +17,8 @@ Notes:
 
 # Workflow activate
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 User enabled the **Agent Colony** plugin (`agent-colony`) and opened **their app** (not this kit product repo). Run on first use or when planes are missing.

--- a/rules/advisory-audit-alignment-enforcement.mdc
+++ b/rules/advisory-audit-alignment-enforcement.mdc
@@ -3,13 +3,13 @@ description: Architecture-impacting advisory audits before prepare/merge (author
 alwaysApply: true
 ---
 
-# Architecture-impacting advisory audit (alignment artifacts)
+# Alignment audit (architecture-impacting)
 
-- **Canonical audit agent:** `.cursor/agents/auditor.md` with `.cursor/skills/auditor-protocol/SKILL.md` (Evidence contract applies to all audit outputs).
-- For **merge workflow only**, architecture-impacting work may use a **focused alignment pass** (same agent/skill; outputs limited to alignment files — see skill § “Focused alignment pass”).
-- Audits are **advisory**: findings and recommendations only; do not auto-apply fixes during the audit step.
-- Run before `/prepare-pr` when scope touches: module boundaries, workflow/rule/skill policy, test/CI layout, roadmap/research source of truth.
+- **Agent:** `.cursor/agents/auditor.md` + `.cursor/skills/auditor-protocol/SKILL.md`.
+- Merge workflow may use **focused alignment pass** (skill § Focused alignment pass).
+- Audits are advisory. Do not auto-apply fixes in the audit step.
+- Run before `/prepare-pr` when scope touches: boundaries, workflow/rule/skill policy, test/CI, roadmap/research SSOT.
 - **Outputs:** `.local/workflow-artifacts/alignment/alignment-audit.md`, `.local/workflow-artifacts/alignment/alignment-todos.md`.
 - **Schema:** `.ai_infra/docs/roadmap/alignment-audit-schema.md`.
 - Each finding: evidence path, mismatch category, recommended fix, status (`open` | `accepted_divergence` | `fixed` | `deferred`).
-- **P0:** block merge prep until fixed or accepted with rationale. **P1:** fix in-slice or defer with owner and slice. **P2:** batch but track in reconciliation TODOs.
+- **P0:** block merge prep until fixed or accepted with rationale. **P1:** fix in-slice or defer with owner. **P2:** batch; track in reconciliation TODOs.

--- a/rules/commit-trailer-format.mdc
+++ b/rules/commit-trailer-format.mdc
@@ -5,28 +5,26 @@ alwaysApply: true
 
 # Commit trailer format
 
-## Required (git commits)
+## Required
 
-- Every commit message body **must** include these two lines **in this order**, with **no other lines between them**:
+- Every commit body **must** include, in order, with no lines between:
   - `Author: <Your Full Name>`
   - `GitHub-User: @<yourhandle>`
-- Values **must** match `.local/user_settings/github.collaboration.yaml` (`owner.display_name`, `owner.github_user`).
+- Values match `.local/user_settings/github.collaboration.yaml` (`owner.display_name`, `owner.github_user`).
 
-## Optional provenance (after the required pair)
+## Optional (after required pair)
 
-- `Assisted-by: <tool>[:<model>]` — repeat on separate lines when AI **materially** shaped code, tests, docs, or migration logic. Skip for trivial autocomplete, formatting-only, or mechanical boilerplate.
-- **Render from config:** `python -m agent_colony contributors commit-trailers` reads **`.local/user_settings/github.collaboration.yaml`** (copied at install).
-- **Do not use `Made-with:`** — human accountability is already expressed by **`Author:`** / **`GitHub-User:`**; an extra editor/tool line is redundant with that contract.
-- `Co-authored-by:` — optional; only for real human co-authors (Git convention).
+- `Assisted-by: <tool>[:<model>]` when AI materially shaped code, tests, docs, or migrations. Skip trivial autocomplete or formatting.
+- Render: `python -m agent_colony contributors commit-trailers`.
+- No `Made-with:` — use `Author:` / `GitHub-User:` only.
+- `Co-authored-by:` — real human co-authors only.
 
 ## Responsibility
 
-- The human author remains responsible for reviewing and validating the change.
-- **Do not** use AI or scripts to insert human certification, approval, or DCO-style assertions the person did not explicitly intend.
+- Human author reviews and validates the change.
+- Do not insert certification or DCO assertions the person did not intend.
 
-## Order
-
-Typical tail (required lines first, then optional):
+## Example tail
 
 ```text
 Author: Your Full Name

--- a/rules/file-docstring-header-relations.mdc
+++ b/rules/file-docstring-header-relations.mdc
@@ -5,8 +5,8 @@ alwaysApply: true
 
 # File header (docstring / comment block)
 
-- New sources must start with a module header; keep it accurate when responsibilities change.
-- Required fields: `File:`, `Path:` (repo-relative), `Role:`, `Used By:`, `Depends On:`, `Notes:` (optional). Factual only; unknown relations → `TBD`.
+- New sources need a module header. Update when responsibilities change.
+- Required: `File:`, `Path:` (repo-relative), `Role:`, `Used By:`, `Depends On:`, `Notes:` (optional). Unknown → `TBD`.
 
 ## Python example
 
@@ -14,14 +14,12 @@ alwaysApply: true
 """
 File: example_module.py
 Path: src/example/example_module.py
-Role: Short description of responsibilities.
+Role: Short description.
 Used By:
   - src/core/orchestrator.py
 Depends On:
   - src/schemas/events.py
-Notes:
-  - Keep deterministic behavior for retry paths.
 """
 ```
 
-- Non-Python: same fields in a top comment block using that language’s comment syntax.
+- Non-Python: same fields in a top comment block.

--- a/rules/implementation-workflow-governance.mdc
+++ b/rules/implementation-workflow-governance.mdc
@@ -8,33 +8,33 @@ alwaysApply: true
 ## Lifecycle
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.
-- Before coding: confirm module boundary, acceptance criteria, rollback in `.local/index-and-planning/current/plan.md`; read **`session-pointer.md`** first, then `plan.md`, `work-tracker.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`), `test-plan.md`, `test-index.md`.
-- When `project_ssot.enabled` and `sync_policy: board_only`, **board Entry wins** (`python3 -m agent_colony project status` / claim card); local trackers are offline fallback only.
-- Treat `.local/index-and-planning/current/*`, `history/*`, and `audits/*` as live local execution state; durable workflow doctrine lives in `.ai_infra/docs/operations/*`.
-- Exactly one primary `in_progress` **Status on the Project** when `board_only`; `work-tracker.md` `in_progress` only when SSOT disabled or offline fallback. Do not implement without scope on the board card body (or `plan.md` when fallback).
-- Incremental, reversible slices; KISS. Block release on P0 failures; RCs need CI/CD evidence bundles.
+- Before coding: read `session-pointer.md`, then `plan.md`, `work-tracker.md`, architecture stub, `test-plan.md`, `test-index.md`. Confirm boundary, acceptance, rollback in `plan.md`.
+- When `board_only`: board Entry wins (`project status` / claim); local trackers are offline fallback only.
+- `.local/index-and-planning/current/*`, `history/*`, `audits/*` = live state. Doctrine: `.ai_infra/docs/operations/*`.
+- One `in_progress` on Project when `board_only`. Do not implement without board card scope (or `plan.md` when fallback).
+- Incremental slices; KISS. Block release on P0. RCs need CI/CD evidence.
 
 ## Tests
 
-- Place tests under `tests/modules/<module>/` matching source boundaries.
-- Cover happy, failure, and edge cases; add retry/timeout/replay where high-risk or state-changing.
-- Run targeted module tests first, then full suite before merge.
-- For medium/high-risk slices, run `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q`; record gaps in `work-tracker.md` and `updates-log.md`.
-- If modules/tests move or drop, update/remove tests in the same slice; note rationale in `updates-log.md`.
+- Tests under `tests/modules/<module>/` match source boundaries.
+- Cover happy, failure, edge; add retry/timeout/replay for high-risk paths.
+- Run module tests first, then full suite before merge.
+- Medium/high-risk: `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing -q`; record gaps in trackers.
+- Module/test moves in the same slice; note in `updates-log.md`.
 
-## Planning index updates
+## Planning index
 
-- After substantive code change: `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when tests or risk change; `updates-log.md` (one line — see `.ai_infra/docs/operations/token-efficiency.md`).
-- Planning-only scope changes: update `plan.md` / `work-tracker.md` + at least one `updates-log.md` entry.
-- Blocked: mark blocker and unblock action in `work-tracker.md`.
-- **ADR-010:** `.local/plans/` is snapshot history only — live plan SSOT stays on the board card (`board_only`) or `plan.md` offline; see `canvas-artifacts` skill.
-- **Slice closure** (before handoff): regenerate `current/coverage-index.md` when coverage mattered; if a new tracker path is added, update `.local/agents-control-center/config/pages.json` and dashboard header **Depends On**; do not edit `.local/agents-control-center/audits/module-audit.html` unless refreshing that export.
+- After code change: update `session-pointer.md`, `change-index.md`, `work-tracker.md`; `test-index.md` / `test-plan.md` when risk changes; one line in `updates-log.md` (see `token-efficiency.md`).
+- Scope-only: `plan.md` / `work-tracker.md` + `updates-log.md`.
+- Blocked: mark blocker in `work-tracker.md`.
+- **ADR-010:** `.local/plans/` = snapshots only; live plan on board (`board_only`) or `plan.md`.
+- Slice closure: regenerate `coverage-index.md` when needed; new tracker path → update `pages.json` + dashboard **Depends On**.
 
 ## Merge gates
 
-- Full gate order: [`.cursor/rules/pr-workflow-enforcement.mdc`](pr-workflow-enforcement.mdc) and `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`; `GATES` = 2-gate back-compat alias).
+- Gate order: [pr-workflow-enforcement.mdc](pr-workflow-enforcement.mdc) and `prepare.py` (`resolve_gates()`; `GATES` = 2-gate alias).
 
-## Efficiency (less noise)
+## Efficiency
 
-- Default read set under `.local/`: **`session-pointer.md`**, then **`index-and-planning/current/plan.md`**, **`work-tracker.md`**, **`change-index.md`**; PR artifacts under **`workflow-artifacts/`** when merging. Skip **`generated-data/**`** and **`history/archive/**`** unless explicitly tasked.
-- In `updates-log.md` and chat handoffs, do **not** paste the full `GATES` block; state outcomes (*e.g.* “prepare.py gates green”) and only the failing command + stderr when something breaks.
+- Default `.local/` reads: `session-pointer.md`, `plan.md`, `work-tracker.md`, `change-index.md`; PR artifacts when merging. Skip `generated-data/**`, `history/archive/**` unless tasked.
+- Do not paste full `GATES` in chat or `updates-log.md`; say *prepare.py gates green* or paste failing command only.

--- a/rules/local-artifact-protection.mdc
+++ b/rules/local-artifact-protection.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Local artifact protection
 
-- Protected: `.coverage` and `.env` (and any project-specific paths documented in `overlays/` or project README).
-- Do not delete, reset, or clean protected paths unless the user explicitly confirms in this conversation.
-- Before cleanup commands, list targets; if they include protected paths, ask for approval.
-- If removed by mistake, say so and restore from project baseline immediately.
+- Protected: `.coverage`, `.env`, and paths in `overlays/` or project README.
+- Do not delete, reset, or clean protected paths without explicit user confirmation.
+- Before cleanup, list targets; ask if protected paths are included.
+- If removed by mistake, restore from project baseline immediately.

--- a/rules/pr-workflow-enforcement.mdc
+++ b/rules/pr-workflow-enforcement.mdc
@@ -5,14 +5,14 @@ alwaysApply: true
 
 # PR workflow enforcement
 
-- **PR-first (staged):** task branch (`feature/`, `fix/`, `chore/`) → implement/test → push → open PR → `python .ai_infra/scripts/pr/verify_publish.py` + `gh pr view` → `/review-pr` → `/prepare-pr` → `/merge-pr` (stop; keep branches for review). **Cleanup optional:** `/full-pr-workflow` (or `finalize.py`) syncs `main`, deletes local/remote feature branch, writes `.local/workflow-artifacts/pr/finalize.md`.
-- **Never** merge straight from local to `main`. **No** destructive git (`reset --hard`, history rewrite) unless the user explicitly asks.
-- **Phase artifacts** (do not skip): `.local/workflow-artifacts/pr/review.md`, `.local/workflow-artifacts/pr/prep.md`, `.local/workflow-artifacts/pr/merge.md` with `Action-By`, `GitHub-User`, `Agent/s` from **`.local/user_settings/github.collaboration.yaml`** (via `--pipeline` on PR scripts) or explicit `--actor` / `--agents`; use `Reviewed-By` / `Prepared-By` / `Merged-By` where applicable. After `/full-pr-workflow`: also `.local/workflow-artifacts/pr/finalize.md`.
-- **Git commits** (separate from PR artifact headers): trailers per **commit-trailer-format.mdc** — required `Author` / `GitHub-User`, optional `Assisted-by` (no `Made-with:`); summary in **AGENTS.md** § Commits.
-- **Architecture-impacting** changes: before prepare/merge, produce `.local/workflow-artifacts/alignment/alignment-audit.md` and `.local/workflow-artifacts/alignment/alignment-todos.md` using **`auditor`** + `.cursor/skills/auditor-protocol/SKILL.md` (focused alignment pass when a full scorecard is not required; see [advisory-audit-alignment-enforcement.mdc](advisory-audit-alignment-enforcement.mdc)).
-- **Pre-merge gates:** order and commands are **`resolve_gates()` in `.ai_infra/scripts/pr/prepare.py`** only — run via `prepare.py`, not as separate agent commands (`GATES` is the 2-gate back-compat alias). When changing governance, workflows, or tracked policy docs, also run `python .ai_infra/scripts/architecture/check_governance_consistency.py` locally (CI may mirror path-scoped runs).
-- **Branch/PR health:** current branch tracks `origin/<branch>`; `git ls-remote --heads origin <branch>` shows head; `gh pr view --json headRefName` matches current branch.
-- **Tracking docs** when architecture/runtime scope shifts: `.local/index-and-planning/current/plan.md`, project `docs/architecture/` (local stub: `.local/.../current/architecture.md`).
-- `git push --force-with-lease` only for intentional rewrites on branches you own.
-- **Stop and report** if required staged artifacts or gates are missing. Treat missing cleanup as a failure only when `/full-pr-workflow` (or `finalize.py`) was explicitly requested.
-- **Efficiency:** gate order and commands live in `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`). Link or summarize *pass/fail* in chat and PR artifacts — avoid pasting the full command list repeatedly.
+- **PR-first:** branch (`feature/`, `fix/`, `chore/`) → implement/test → push → PR → `verify_publish.py` + `gh pr view` → `/review-pr` → `/prepare-pr` → `/merge-pr`. Optional cleanup: `/full-pr-workflow` or `finalize.py`.
+- Never merge local to `main`. No destructive git unless user asks.
+- **Artifacts:** `.local/workflow-artifacts/pr/review.md`, `prep.md`, `merge.md` with `Action-By`, `GitHub-User`, `Agent/s` from `github.collaboration.yaml` (`--pipeline`) or `--actor` / `--agents`. Full workflow adds `finalize.md`.
+- **Commits:** trailers per [commit-trailer-format.mdc](commit-trailer-format.mdc); summary in AGENTS.md § Commits.
+- **Architecture-impacting:** before prepare/merge, run **`auditor`** → alignment files (see [advisory-audit-alignment-enforcement.mdc](advisory-audit-alignment-enforcement.mdc)).
+- **Gates:** `resolve_gates()` in `.ai_infra/scripts/pr/prepare.py` only — via `prepare.py` (`GATES` = 2-gate alias). Governance changes: also `check_governance_consistency.py`.
+- **Branch health:** tracks `origin/<branch>`; `gh pr view --json headRefName` matches branch.
+- **Tracking docs** when scope shifts: `plan.md`, architecture stub.
+- `git push --force-with-lease` only for intentional rewrites on owned branches.
+- Stop if artifacts or gates missing. Missing cleanup is failure only when `/full-pr-workflow` requested.
+- Summarize gate pass/fail in chat — do not paste full command list.

--- a/rules/project-ssot-precedence.mdc
+++ b/rules/project-ssot-precedence.mdc
@@ -5,20 +5,18 @@ alwaysApply: true
 
 # Project SSOT precedence
 
-- When `.local/user_settings/github.collaboration.yaml` → `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the **only writable** backlog/status **and continuation** SSOT.
-- **Every agent:** Entry reads the board (`project status` / list / claim); Exit updates Status (and Notes) so the next agent can continue from the Project — not from chat alone. See `.cursor/skills/board-ssot/SKILL.md` § Continuation contract.
-- **First-run (when enabled):** if `project board-bootstrap --check` FAILs the kit default Playground shell (`board-shell.schema.yaml`: six views + Tier-1 columns on primary views) → `/board` + `board-shell` (**CONSENT GATE** then TURN PROTOCOL) before day-to-day claim/`/implementer` (audit is not day-0).
-- **drift-guard:** must read board Status for DRIFT-009 / DRIFT-010 / DRIFT-012; `.local/plans/` is snapshot-only under `board_only` (ADR-010). updates the drift-pass card on Exit; remediations via Notes/Ready handoff — never silent dual-write to trackers.
-- Do **not** dual-write competing slice status to `work-tracker.md` / `session-pointer.md`. Do **not** dual-mirror “for safety.”
-- Read-only `project export` snapshots (if present) never write Status and never compete with board Status.
-- Overrides tracker `in_progress` expectations in `implementation-workflow-governance.mdc` when board SSOT is on — see ADR-008 (`board_only` wins; DRIFT-009).
-- Offline / disabled: `fallback: local_trackers` only — resume board sync when available.
-- Rate-limit: if board writes return EXIT_QUEUED (6), use `project_ssot.outbox` (`queue` / `outbox flush`) — do not hammer GraphQL and do not dual-write Status into trackers. EXIT_QUEUED also covers cached precheck (low remaining) and queueable Forbidden/429 (not missing-scopes).
-- Prefer Pattern A recipes (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
-- PR Pattern A (`prepare.py` `resolve_gates()`), post-merge board close (`merge.py`), PR/audit artifacts, secrets, and user_settings stay local (`project_ssot.local_only`).
-- Humans own Project views, workflows, Insights, README, status updates, Ready prioritization.
-- Canon: `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`, `.ai_infra/docs/operations/project-board-collaboration.md`, `AGENTS.md`.
-- This product lives only in `agent-colony`. Board = only writable SSOT; local = evidence/fallback.
-- Multi-collaborator Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` (CLI stamps UTC; user → their agents) via `append-notes --agent`. Local `history/continuity-index.md` rolls ≥3 days; board Notes keep full card lifetime.
-- Prefer board Pattern A recipes (`claim` / `handoff` / `create-from-template`) over multi-step atomics; never paste Project settings UI into a shell.
-- Tier-1 board fields: **create as Issue** (`item_kind_default: issue`); claim / `set-status` / `handoff --to in_progress` may set Start date (UTC when configured); `set-status` / `handoff` / merge / `heal-cards` → `done` may set End date (UTC when configured); triage/own card sets Priority/Size/Estimate via `set-field` (Size↔Estimate table in `board-ssot` skill); Draft→Issue via `promote-to-issue` (or `mention-pr` auto when `promote_to_issue_on_pr`); PR URL via `mention-pr` — Iteration, Labels, Reviewers out of scope for agents by default.
+- When `project_ssot.enabled: true` and `sync_policy: board_only`, the **GitHub Project** is the only writable backlog, status, and continuation SSOT.
+- **Entry:** read board (`project status` / claim). **Exit:** update Status + Notes. See `.cursor/skills/board-ssot/SKILL.md` § Continuation.
+- **First-run:** `project board-bootstrap --check` FAIL → `/board` + `board-shell` (CONSENT + TURN) before claim/`/implementer`.
+- **drift-guard:** read board for DRIFT-009/010/012; `.local/plans/` snapshot-only (ADR-010). Update drift card on Exit; remediate via Notes — no dual-write.
+- Do not dual-write status to `work-tracker.md` / `session-pointer.md`.
+- `project export` snapshots are read-only; never compete with board Status.
+- Overrides tracker `in_progress` in implementation-workflow-governance when board SSOT on (ADR-008).
+- Offline/disabled: `fallback: local_trackers`; resume sync when available.
+- EXIT_QUEUED (6) → `project_ssot.outbox` (`queue` / `outbox flush`); do not hammer API or dual-write. Covers precheck low quota, Forbidden/429.
+- Prefer Pattern A (`claim --last`, `handoff --last`, `guide`) over raw multi-step claim.
+- Local only: PR Pattern A (`prepare.py`), post-merge `merge.py`, PR/audit artifacts, secrets, `user_settings` (`project_ssot.local_only`).
+- Humans own views, workflows, Insights, README, Ready ordering.
+- Canon: ADR-008, `project-board-collaboration.md`, `AGENTS.md`.
+- Notes: `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent`.
+- Tier-1: create as **Issue**; Start date on first In progress; End date on Done; Priority/Size/Estimate via `set-field` (see board-ssot skill); Draft→Issue via `promote-to-issue` or `mention-pr`; PR via `mention-pr`. Iteration, Labels, Reviewers out of scope by default.

--- a/skills/auditor-protocol/SKILL.md
+++ b/skills/auditor-protocol/SKILL.md
@@ -17,234 +17,147 @@ Notes:
 
 # Auditor protocol
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Produce a **step-by-step, facts-first** enterprise architecture and engineering assessment of **this** repository, suitable for senior technical and executive decisions. **No invented architecture.** Every significant claim is tied to repository evidence or labeled **Unknown**.
+Produce a **step-by-step, facts-first** enterprise architecture assessment of **this** repository. **No invented architecture.** Every significant claim is tied to repository evidence or labeled **Unknown**.
 
 ## Evidence contract (mandatory)
 
-Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in the written deliverables.
+Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in written deliverables.
 
-**What counts as evidence (in priority order)**
+**What counts as evidence (priority order)**
 
-1. **Repository paths** — repo-relative file or directory paths you actually opened or searched (e.g. `src/core/foo.py`, `pyproject.toml`, `.github/workflows/`).
-2. **Quoted fragments** — short, faithful quotes from files (configs, docstrings, key symbols) when the claim is non-obvious; add line reference when practical (e.g. `path:42-48` or “see `symbol` in `path`”).
-3. **Command output** — only when run during the audit (e.g. `pytest`, `rg`, `python scripts/...`); record the **exact command** and **outcome** in §2 Audit Method, not vague “tests pass.”
-4. **User context** — label as **`Context:`** (field name); use for business/deployment intent **only**; never treat as **Confirmed** for claims about what the **code** does.
+1. **Repository paths** — repo-relative paths actually opened or searched.
+2. **Quoted fragments** — short faithful quotes when non-obvious; line ref when practical (`path:42-48`).
+3. **Command output** — only when run during the audit; record **exact command** and **outcome** in §2 Audit Method.
+4. **User context** — label **`Context:`**; never treat as **Confirmed** for what the **code** does.
 
 **Per classification**
 
 | Label | Requirement |
 |--------|-------------|
-| **Confirmed** | At least one repo path (or command + output) that directly supports the statement. |
-| **Probable risk** | (a) **Observed:** path + fact; (b) **Inference:** explicitly labeled; (c) **Falsify:** what evidence would confirm or refute. |
-| **Unknown** | State **what was not inspected** or **why** the repo cannot answer (e.g. no deployment manifests in tree, secrets not in repo). |
+| **Confirmed** | At least one repo path (or command + output) directly supports the statement. |
+| **Probable risk** | (a) **Observed:** path + fact; (b) **Inference:** labeled; (c) **Falsify:** what would confirm/refute. |
+| **Unknown** | What was not inspected or why the repo cannot answer. |
 
-**Scorecard (§9)** — For **each** category, the **Evidence** subsection must be a **bulleted list of paths** (and optional line/symbol refs) representing what was actually reviewed for that score. If the list is empty or only generic (“reviewed the codebase”), **cap the score at 3** and set scoring confidence to **Low** unless the gap is explicitly **Unknown**.
+**Scorecard (§9)** — Each category **Evidence** = bulleted paths reviewed. Empty/generic list → **cap score at 3**, confidence **Low** unless explicitly **Unknown**.
 
-**Findings (§7) and actions file** — **Evidence** is mandatory. If you cannot cite a path or command output, rephrase as **Unknown** or omit the finding.
+**Findings (§7) and actions file** — **Evidence** mandatory; else rephrase as **Unknown** or omit.
 
-**§2 Audit Method** — Must list: **sources read** (paths), **searches or scans** (e.g. patterns, tools), **commands run** (if any), and **scope limits** (what was out of scope or time-boxed). Readers must be able to **reproduce** how conclusions were reached.
+**§2 Audit Method** — List: sources read, searches/scans, commands run, scope limits. Readers must reproduce how conclusions were reached.
 
-**Contradictions** — When docs and code disagree, cite **both** sides (paths) and state the conflict before recommending.
+**Contradictions** — When docs and code disagree, cite **both** paths and state the conflict.
 
 ## When to use
 
-- Pre- or post-major refactor, platform review, or diligence-style read of the codebase.
-- When documentation and implementation may diverge (challenge documented architecture with code and config evidence).
-- When you need **module-level** findings, a **weighted scorecard**, and a **prioritized action list** for implementers.
+- Pre/post major refactor, platform review, diligence-style read.
+- Docs vs implementation may diverge.
+- Need module-level findings, weighted scorecard, prioritized actions.
 
 ## Project workflow integration
 
-**Read (do not load all of `.local/` blindly):**
+**Read (targeted, not all of `.local/`):** `plan.md`, `work-tracker.md`, `test-plan.md`, `test-index.md`, project `docs/architecture/`, `AGENTS.md`, `README.md`, overlay rules, `prepare.py` (`resolve_gates()`).
 
-- `.local/index-and-planning/current/plan.md`, `work-tracker.md` — current slice context (if missing, say so).
-- `test-plan.md`, `test-index.md` when assessing test architecture.
-- Project `docs/architecture/`, `AGENTS.md`, `README.md` for stated intent vs implementation.
-- Overlay rules (`overlays/rules/*.mdc`) when installed.
-- `.ai_infra/scripts/pr/prepare.py` (`resolve_gates()`; `GATES` = 2-gate alias) for quality-gate reality.
-
-**Write — create directory if needed:**
+**Write:**
 
 | Output | Path |
 |--------|------|
-| Full audit (all sections below) | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md` |
-| Prioritized actions for implementers | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md` |
+| Full audit | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-architecture-audit.md` |
+| Actions | `.local/workflow-artifacts/enterprise-architecture-audit/enterprise-audit-actions.md` |
 
-**Report frontmatter (top of `enterprise-architecture-audit.md`):**
+**Frontmatter:**
 
 ```text
 Audit-Type: enterprise-architecture-python
-Audited-By: <agent name or human>
+Audited-By: <agent or human>
 Action-By: <name>
 GitHub-User: <handle>
-Date: <ISO-8601 date>
+Date: <ISO-8601>
 Evidence-Standard: repository + user context only
 ```
 
-**Downstream agents:**
-
-- **Implementer:** consume `enterprise-audit-actions.md`; move agreed items onto **board Ready cards** when `project_ssot.enabled` (Acceptance/Rollback in body); else `work-tracker.md` (one primary `in_progress`). Follow `.cursor/skills/implementer-loop/SKILL.md` + `board-ssot` Continuation contract.
-- **Alignment / maintainer:** if findings are doc-policy-roadmap drift, also record P0/P1 items per `.ai_infra/docs/roadmap/alignment-audit-schema.md` in `.local/workflow-artifacts/alignment/alignment-audit.md` and `alignment-todos.md` (advisory).
-- **Module map depth:** optionally run `.cursor/skills/audit-module-map/SKILL.md` for `module-map` / HTML export; cite those paths as evidence in the enterprise report.
-
-**After the audit:** add a brief entry to `.local/index-and-planning/history/updates-log.md` (artifacts written, no gate laundry lists).
+**Downstream:** **Implementer** → `enterprise-audit-actions.md`; board Ready cards when SSOT on. **Alignment** → `alignment-audit.md` + `alignment-todos.md` per schema. **Module map** → optional `audit-module-map` skill. Brief `updates-log.md` entry after audit.
 
 ### Focused alignment pass (architecture-impacting PRs)
 
-When the **maintainer workflow** requires alignment files for `--arch-impacting` but a **full** `enterprise-architecture-audit.md` is not requested:
+When maintainer workflow requires alignment files but not full enterprise report:
 
-- Stay on **`auditor`** and keep the **Evidence contract** (paths for every Confirmed finding; §2 Audit Method lists what you read/searched).
-- **Write only** (unless the user also wants the full report):
-  - `.local/workflow-artifacts/alignment/alignment-audit.md`
-  - `.local/workflow-artifacts/alignment/alignment-todos.md`
-- Use **`.ai_infra/docs/roadmap/alignment-audit-schema.md`** for finding shape and P0/P1/P2 handling.
-- Scope: compare **touched** roadmap/plan/strategy docs, rules/skills/agents, `src/` + `tests/modules/` relevant to the PR — not a whole-repo scorecard.
-- Include a short **CHK-*** tick table (below) for dimensions that touch the PR; mark N/A for untouched dimensions.
-- **Optional:** note in `alignment-audit.md` that a full enterprise scorecard was deferred.
-- Continuous plan/agent-doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 prose here.
+- Stay on **`auditor`**; keep **Evidence contract**.
+- **Write only:** `alignment-audit.md`, `alignment-todos.md` (schema: `.ai_infra/docs/roadmap/alignment-audit-schema.md`).
+- Scope: **touched** roadmap/plan/rules/skills/agents + relevant `src/` / `tests/modules/` — not whole-repo scorecard.
+- Short **CHK-*** tick table for PR-touching dimensions; N/A elsewhere.
+- Plan/doctrine pulse remains **`drift-guard`** — do not duplicate DRIFT-011 here.
 
----
-
-## Context block (required from user — paste at start of engagement)
+## Context block (paste at start)
 
 ```text
-Context:
-- Business type:
-- Product type:
-- Current users/customers:
-- Expected growth over next 12–24 months:
-- Team size and structure:
-- Deployment platform:
-- Compliance/security requirements:
-- Uptime/SLA expectations:
-- Main business goals:
-- Main roadmap items:
-- Main engineering goals:
-- Main pain points today:
-- Known constraints:
-- Intended future architecture direction:
-- Known incidents or operational failures:
-- Performance concerns already suspected:
-- Areas we especially want challenged:
+Context: Business type · Product · Users/growth · Team · Deployment · Compliance · SLA ·
+Goals · Roadmap · Engineering goals · Pain points · Constraints · Future direction ·
+Incidents · Performance concerns · Areas to challenge
 ```
 
-If the user leaves fields blank, label gaps **Unknown – not provided in context** and lower scoring confidence.
+Blank fields → **Unknown – not provided**; lower scoring confidence.
 
----
+## Operating mode
 
-## Operating mode (non-negotiable)
+Facts-first: inventory → quality → risks → recommendations (never reverse). **Strict / evidence-only / no speculation / step-by-step / Python-specific: ON.**
 
-```text
-Do not jump to recommendations before completing repository inventory and implemented architecture assessment.
-
-Facts-first rule:
-- First describe what exists
-- Then assess quality
-- Then identify risks
-- Then recommend changes
-- Never reverse that order
-
-Strict mode: ON
-Evidence-only mode: ON
-No speculation mode: ON
-Step-by-step mode: ON
-Python-specific analysis mode: ON
-```
-
-**Rules:**
-
-- Do not invent facts. If not verifiable from the repo (and provided context), say: **Unknown – not verifiable from repository evidence**.
+- No invented facts; label **Unknown – not verifiable from repository evidence** when needed.
 - Separate **Confirmed** / **Probable risk** / **Unknown** for material statements.
-- Do not describe architecture as confirmed unless supported by evidence (paths, configs, imports, entrypoints).
-- Be critical and precise. Prefer **insufficient evidence** over assumptions.
-- If evidence conflicts (e.g. docs vs code), call out the conflict.
+- Challenge docs vs code; **documented architecture ≠ real** without verification.
+- No vague likelihood unless explicit **hypothesis** + **evidence gap**.
 
-**Anti-hallucination:** Do not use vague likelihood language (“likely”, “probably intended”) unless framed as an explicit **hypothesis** with the **evidence gap** stated.
+## Mandatory phases (execute in order; show boundaries in report)
 
-**Challenge assumptions:** Actively look for contradictions between folder structure, import graph, runtime entrypoints, and deployment clues. **Documented architecture is not assumed to be real architecture** without verification.
-
-**Review discipline:**
-
-1. Inventory before judgment  
-2. Evidence before interpretation  
-3. Interpretation before recommendation  
-4. Recommendation before roadmap  
-5. Unknowns explicitly called out  
-
----
-
-## Mandatory phases (execute in order; show phase boundaries in the written report)
-
-### Named checklists (CHK-*) — mandatory coverage
-
-Map each checklist into the matching phase. In the written report (or focused alignment), include a **CHK tick table**: id · status (Pass / Gap / N/A / Unknown) · evidence paths. **Do not** invent new skill folders for these dimensions.
+### CHK-* checklists
 
 | Id | Phase | Must cite |
 |----|-------|-----------|
 | `CHK-ARCH` | 2 | Style, dependency direction, cycles |
-| `CHK-GRANULARITY` | 2 / 4 | God modules, blurred boundaries vs `.ai_infra/docs/governance/module-boundaries.md` (kit planes) or consumer `src/` modules |
-| `CHK-PERF` | 3 | Hot paths, N+1/queue clues; **Unknown** if none observable |
-| `CHK-SEC-CODE` | 3 | Secrets handling, injection/trust boundaries in kit scripts / app code in scope |
-| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, hard-stops, MCP `.cursor/mcp.registry.yaml` allowlists, no product auto-fix — **contract compliance**, not LLM jailbreak proof |
-| `CHK-INFRA-KIT` | 1 / 3 | Three planes, install/activate, `integrate validate` clues — **not** consumer cloud infra product |
-| `CHK-DOCS` | 5 | Stated goals vs docs; stale AGENTS / IMPLEMENTATION-STATUS |
+| `CHK-GRANULARITY` | 2 / 4 | God modules vs module-boundaries.md or consumer `src/` |
+| `CHK-PERF` | 3 | Hot paths; **Unknown** if none observable |
+| `CHK-SEC-CODE` | 3 | Secrets, injection/trust boundaries in scope |
+| `CHK-SEC-AGENT` | 1 / 3 | Agent write-scope, MCP allowlists — contract compliance |
+| `CHK-INFRA-KIT` | 1 / 3 | Three planes, activate, `integrate validate` |
+| `CHK-DOCS` | 5 | Goals vs docs; stale AGENTS / IMPLEMENTATION-STATUS |
 
-### PHASE 1 — Repository inventory (descriptive only)
+Report includes **CHK tick table**: id · Pass/Gap/N/A/Unknown · evidence paths.
 
-Establish facts: Python version(s), dependency tooling, frameworks, entry points, main packages, workers/jobs, APIs/CLI/scripts, data stores, messaging, infra/deployment clues, test layout, docs/ADRs/config.  
-**Output:** inventory table, architecture map sketch (text), confirmed technologies, unknowns.
+### PHASE 1 — Repository inventory
+
+Facts only: Python version, deps, frameworks, entry points, packages, jobs, APIs/CLI, data stores, infra clues, tests, docs/ADRs. **Output:** inventory table, architecture sketch, confirmed tech, unknowns.
 
 ### PHASE 2 — Implemented architecture
 
-Infer **actual** style (monolith, layered monolith, modular monolith, services, event-driven, hybrid, etc.), boundaries, dependency direction, layering, shared core, framework leakage, god modules/cycles. Complete **CHK-ARCH** and start **CHK-GRANULARITY**.  
-**Output:** detected profile, boundary analysis, layering assessment, risks visible from structure.
+Actual style, boundaries, dependency direction, layering, leakage, god modules/cycles. **CHK-ARCH**, start **CHK-GRANULARITY**. **Output:** profile, boundary analysis, structural risks.
 
 ### PHASE 3 — Python engineering and runtime
 
-Assess: packaging/layout, import discipline, typing and contracts, data access/ORM patterns, async/concurrency/jobs, config/secrets, performance/scaling clues, reliability/operability, security. Complete **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**.  
-**Output:** evidence-backed findings only; label Confirmed / Probable risk / Unknown.
+Packaging, imports, typing, data access, async/jobs, config/secrets, perf/scaling, reliability, security. **CHK-PERF**, **CHK-SEC-CODE**, **CHK-SEC-AGENT**, **CHK-INFRA-KIT**. **Output:** evidence-backed findings only.
 
 ### PHASE 4 — Module-by-module audit
 
-For each **major** module/package under `src/` (and analogous roots): name, purpose, evidence of responsibility, public surfaces, dependencies, boundary quality (Clear / Blurred / Violated), coupling/cohesion, layer placement, framework leakage, data ownership clues, perf/security/ops concerns, test clues, recommendation (Keep / Refactor / Split / Merge / Extract / Defer), why, effort, priority (Now / Next / Later). Finish **CHK-GRANULARITY**.  
-Use **Unknown** where needed. **Do not skip** module-level sections for major roots.
+Each **major** module: purpose, surfaces, dependencies, boundary (Clear/Blurred/Violated), coupling, layer, leakage, data ownership, perf/security/test clues, recommendation (Keep/Refactor/Split/Merge/Extract/Defer), effort, priority. Finish **CHK-GRANULARITY**. Do not skip major roots.
 
 ### PHASE 5 — Goal and plan alignment
 
-For each stated goal/roadmap/architecture intent found in repo docs: alignment (Strong / Partial / Weak), evidence, gaps, risks, recommended action (Preserve / Improve / Simplify / Postpone / Redesign). Tie to evidence, not generic advice. Complete **CHK-DOCS**. Continuous plan pulse when plans change is **`drift-guard`** — reference drift artifacts if present; do not re-run DRIFT scripts as a substitute for this phase.
+Per stated goal in docs: alignment (Strong/Partial/Weak), evidence, gaps, action (Preserve/Improve/Simplify/Postpone/Redesign). **CHK-DOCS**. Plan pulse when plans change = **`drift-guard`** — reference drift artifacts; do not substitute DRIFT scripts here.
 
 ### PHASE 6 — Recommended direction
 
-Acceptable for now; what breaks under growth; fix immediately vs intentional deferral; target direction; evolution vs redesign; migration risks; **top 5 highest-ROI** improvements (30–60 days), each repo-specific.
-
----
+What holds now; what breaks at scale; fix now vs defer; target direction; migration risks; **top 5 highest-ROI** improvements (30–60 days), repo-specific.
 
 ## Recommendation standard
 
-Every meaningful recommendation must include: **Problem**, **Evidence**, **Why it matters**, **Recommendation**, **Tradeoffs**, **Implementation approach**, **Effort estimate**, **Priority**, **Affected modules**.  
-Avoid generic bullets (“improve modularity”, “add observability”) without repo ties.
-
-**Migration difficulty** (for each major recommendation): Low / Moderate / High / Very High.
-
-**Optional:** **Top 10 modules by architectural risk** (ranked, with evidence).
-
-**Optional closing section — “Potential dissent from a second architect”:** what a reviewer might dispute, weak evidence, decisions needing human validation.
-
----
+Each recommendation: **Problem**, **Evidence**, **Why it matters**, **Recommendation**, **Tradeoffs**, **Implementation**, **Effort**, **Priority**, **Affected modules**. Migration difficulty: Low / Moderate / High / Very High. No generic bullets without repo ties.
 
 ## Scoring framework
 
-**Scoring rules:**
+Scores need concrete evidence; limited evidence → lower confidence. High scores need **positive** evidence; lack of evidence ≠ quality.
 
-- Do not assign scores from intuition alone.  
-- Every score references concrete evidence.  
-- If evidence is limited, **lower confidence**.  
-- **High scores require positive evidence**, not absence of problems.  
-- **Lack of evidence is not evidence of quality.**  
-- Do not reward absence of visible issues with high scores.
-
-**Categories (1–5):** 1 = materially inadequate for enterprise; 2 = weak/high-risk; 3 = workable/moderate risk; 4 = strong with manageable gaps; 5 = enterprise-strong/low risk.
+**Categories (1–5):** 1 materially inadequate … 5 enterprise-strong.
 
 | Category | Weight |
 |----------|--------|
@@ -263,23 +176,20 @@ Avoid generic bullets (“improve modularity”, “add observability”) withou
 | Documentation and governance | 5% |
 | Strategic alignment | 10% |
 
-For **each** category: Score, Why, Evidence, What is needed to reach the next level.  
-Then: **weighted overall score**, **enterprise readiness level** (Early-stage / Growing / Scaling / Enterprise-capable), **scoring confidence** (High / Medium / Low).
-
----
+Per category: Score, Why, Evidence (paths), path to next level. Then weighted overall, enterprise readiness (Early-stage / Growing / Scaling / Enterprise-capable), confidence (High / Medium / Low).
 
 ## Required report structure
 
-Write `enterprise-architecture-audit.md` with these sections:
+`enterprise-architecture-audit.md`:
 
 1. Executive Summary  
-2. Audit Method (must satisfy the **Evidence contract**: sources, searches, commands, scope limits)  
-2b. **CHK-* tick table** (all seven ids: Pass / Gap / N/A / Unknown + evidence)  
+2. Audit Method (Evidence contract: sources, searches, commands, scope)  
+2b. CHK-* tick table  
 3. Repository Inventory  
 4. Detected Architecture Profile  
 5. Python-Specific Engineering Assessment  
 6. Module-by-Module Deep Dive  
-7. Findings by Severity (Critical / High / Medium / Low — each with Classification, Confidence, Why it matters, Evidence, Recommendation, Tradeoffs, Effort, Priority, Affected areas)  
+7. Findings by Severity (each: Classification, Confidence, Evidence, Recommendation, Effort, Priority)  
 8. Performance & Scalability Risk Table  
 9. Architecture Scorecard (+ weighted overall + readiness + confidence)  
 10. Goal and Plan Alignment  
@@ -288,70 +198,22 @@ Write `enterprise-architecture-audit.md` with these sections:
 13. Top 5 Highest-ROI Changes  
 14. Risks, Unknowns, and Assumptions  
 15. Human Validation Required  
-16. Final Verdict (Acceptable / Acceptable with Risks / Major Redesign Recommended) — rationale, biggest blocker, executive takeaway  
+16. Final Verdict (Acceptable / Acceptable with Risks / Major Redesign Recommended)
 
-**Closing quality bar:**
+Quality bar: concrete at module level; lower confidence instead of inventing certainty.
 
-```text
-Do not summarize vaguely. Be concrete at module level.
-If evidence is incomplete, lower confidence instead of inventing certainty.
-The review should help a senior engineering leader decide:
-- what is fine now
-- what becomes dangerous at scale
-- what to fix first
-- what architecture direction best supports the business plan
-```
+## `enterprise-audit-actions.md`
 
----
+Backlog: **ID** (e.g. `EA-001`), **Title**, **Severity** (P0/P1 mapping), **Classification**, **Evidence** (paths), **Recommendation**, **Effort**, **Migration difficulty**, **Priority**, optional owner, link to audit section.
 
-## `enterprise-audit-actions.md` format
+## Shorter invocation (skill already loaded)
 
-Structured backlog for implementers:
-
-- **ID** (e.g. `EA-001`)  
-- **Title**  
-- **Severity** (map enterprise Critical/High to P0/P1 where appropriate for internal tracking)  
-- **Classification:** Confirmed / Probable risk / Unknown  
-- **Evidence** (paths)  
-- **Recommendation** (one concrete step)  
-- **Effort** / **Migration difficulty** / **Priority**  
-- **Suggested owner role** (optional)  
-- **Link** to section in `enterprise-architecture-audit.md`  
-
----
-
-## Shorter invocation prompt (when full skill context is already loaded)
-
-```text
-Audit this Python repository as a Principal Enterprise Architect.
-
-Work step by step. Facts only. No guessing.
-
-Process:
-1. Inventory the repo
-2. Identify the actual implemented architecture
-3. Assess Python-specific engineering quality
-4. Audit each major module/package
-5. Assess risks, scalability, security, reliability, and operability
-6. Compare current architecture to goals and target direction (from docs + context)
-7. Recommend a practical transition path
-
-Rules:
-- Every major claim must include repository evidence (paths)
-- If not verifiable, say "Unknown – not verifiable from repository evidence"
-- Distinguish Confirmed / Probable risk / Unknown
-- Do not jump to recommendations before inventory and architecture assessment
-- Do not provide generic advice
-- Use the weighted scorecard; high scores require positive evidence
-
-Deliverables: full report + enterprise-audit-actions.md under .local/workflow-artifacts/enterprise-architecture-audit/
-```
+Audit as Principal Enterprise Architect: inventory → implemented architecture → Python quality → modules → risks → goals comparison → transition path. Facts only; weighted scorecard; deliverables under `.local/workflow-artifacts/enterprise-architecture-audit/`.
 
 ## Exit criteria
 
-- Phases 1–6 completed in order in the written report; no early recommendation dump.  
-- **CHK-*** tick table present (full audit) or scoped tick table (focused alignment).  
-- **Evidence contract** satisfied: §2 lists reproducible sources/commands; Confirmed claims and scorecard categories cite paths; no finding in §7 or actions file without **Evidence** paths (or explicit **Unknown**).  
-- Scorecard populated with evidence and confidence; no score without justification.  
-- `enterprise-audit-actions.md` exists with prioritized, repo-tied items (full audit).  
-- Unknowns and human-validation items explicitly listed.
+- Phases 1–6 in order; no early recommendation dump.  
+- CHK-* tick table present (full or focused).  
+- Evidence contract: §2 reproducible; Confirmed/scorecard cite paths; §7/actions have Evidence or **Unknown**.  
+- Scorecard with justification; `enterprise-audit-actions.md` with repo-tied items (full audit).  
+- Unknowns and human-validation items listed.

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -13,313 +13,192 @@ Used By:
 Depends On:
  - .local/user_settings/github.collaboration.yaml (project_ssot)
  - .ai_infra/install/agent_colony/project_cli.py
- - .ai_infra/install/agent_colony/project_atomics.py
- - .ai_infra/install/agent_colony/gh_project_adapter.py
- - .ai_infra/install/agent_colony/project_recipes.py
- - .ai_infra/install/agent_colony/project_outbox.py
  - .ai_infra/docs/operations/project-board-collaboration.md
  - ADR-008-project-board-ssot.md
 Notes:
- - Pattern A: prefer recipes (claim/handoff/create-from-template); atomics for power use; no dual-write when board_only.
- - Continuation is board-anchored: every agent Entry reads the Project; Exit updates Status.
+ - Pattern A: prefer recipes (claim/handoff/create-from-template); no dual-write when board_only.
 -->
 
 # Board SSOT
 
-## Goal
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
-When `project_ssot.enabled` and `sync_policy: board_only`, use the GitHub Project as the **only writable SSOT** for backlog, Status, and multi-agent continuation. Prefer CLI over inventing `gh` flags. Local trackers are offline fallback only; read-only exports never compete with board Status.
+When `project_ssot.enabled` and `sync_policy: board_only`, the GitHub Project is the **only writable SSOT** for backlog, Status, and continuation. Prefer CLI over inventing `gh` flags. Local trackers = offline fallback only; read-only exports never compete with board Status.
 
-**Agent:** `.cursor/agents/board.md`  
-**Ops mirror:** `.ai_infra/docs/operations/project-board-collaboration.md`  
-**ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
+**Agent:** `.cursor/agents/board.md` · **Ops:** `.ai_infra/docs/operations/project-board-collaboration.md` · **ADR:** `.ai_infra/docs/decisions/ADR-008-project-board-ssot.md`
 
 ## Two-tier plans (ADR-010)
 
 | Tier | Location | Role |
 |------|----------|------|
-| **Live** | Board card body (`board_only`) or `.local/index-and-planning/current/plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
-| **History** | `.local/plans/` (`plan snapshot`, `plan list`, `plan open` for human Build) | Dated snapshots + `index.md` — **never** competing Status or live plan under `board_only` (**DRIFT-012**) |
+| **Live** | Board card body (`board_only`) or `plan.md` (offline) | Acceptance, scope, rollback — only writable plan SSOT |
+| **History** | `.local/plans/` (`plan snapshot\|list\|open`) | Snapshots only — **never** competing Status under `board_only` (**DRIFT-012**) |
 
 Agents: `plan list` → read snapshot → execute. Exit: `plan snapshot --slug … --board-item …`. See `.cursor/skills/canvas-artifacts/SKILL.md`.
 
-## First-run (board shell) — before day-to-day cards
+## First-run (board shell)
 
-Day-0 requires the kit **default** shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Priority/Size/Estimate/Start date/End date on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.
+Kit default shell: `.ai_infra/templates/project-board/board-shell.schema.yaml` (six Playground views; Tier-1 columns on Status board + Prioritized backlog). Overlay: `.local/user_settings/board-shell.schema.yaml` when present.
 
-0. **Wire YAML from URLs (if ids missing):** after `gh` auth, human pastes Project URL + repo URL → use `gh project view` / `field-list` → propose `project_ssot` + `default_repo` → human confirms before save. Discovery only — **no** `--ensure-fields` until CONSENT.
-1. Load `.cursor/skills/board-shell/SKILL.md` (coach) and the schema above.
-2. **CONSENT GATE (mandatory):** ask board description (or `use template default`) + `May I proceed to set up the kit default shell?` — only continue on `yes`.
-3. Run `python3 -m agent_colony project doctor` → `project board-bootstrap --check`.
-4. On **exit 5** (view FAIL or Tier-1 column FAIL): TURN PROTOCOL (agent coaches one view at a time; human uses `views-setup.md` as click reference). Optional `--ensure-fields` / `--apply-readme` only after consent. **No** `--apply-shell` CLI today.
-5. Refuse “ready for agents” until `board-bootstrap --check` exits **0** (README non-empty, six views, Tier-1 columns on Status board / Prioritized backlog). Then resume day-to-day Pattern A below.
+1. Wire YAML from Project + repo URLs (human confirms before save). Discovery only — **no** `--ensure-fields` until CONSENT.
+2. Load `.cursor/skills/board-shell/SKILL.md`. **CONSENT GATE:** ask description + `May I proceed to set up the kit default shell?` — continue only on `yes`.
+3. `python3 -m agent_colony project doctor` → `project board-bootstrap --check`.
+4. **Exit 5:** TURN PROTOCOL (human UI via `views-setup.md`). Optional `--ensure-fields` / `--apply-readme` only after consent. **No** `--apply-shell` CLI.
+5. Refuse “ready for agents” until `board-bootstrap --check` exits **0**. Then Pattern A below. **`/auditor`** is not day-0.
 
-**Not first-run:** `/auditor` (architecture-impacting / pre-merge later).
+## Continuation contract
 
-## Continuation contract (all agents — non-negotiable when enabled)
-
-Work is **indexed on the Project**, not in chat alone.
+Work is **indexed on the Project**, not chat alone.
 
 | Phase | Required |
 |-------|----------|
-| **Entry** | Prefer `python3 -m agent_colony project entry` (quota-aware: live \| conserve \| offline_artifacts). Then `get` / `claim` **one** card. Read Acceptance / Rollback / Notes on that card body. Avoid unfiltered `project list` / full `export` every turn — use `export --reuse-if-fresh` when a snapshot is enough. Parallel agents may each Entry, but **one export refresh per parent wave**. |
-| **During** | Keep **one** In progress card for your assignee. Put progress notes on the card body when handing off mid-slice. |
-| **Exit** | **Always** update Status for the card you worked: → `in_review` (PR/handoff) or → `done` (your part closed) or leave `in_progress` with **Notes** naming the next agent. Notes **must** use `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **If EXIT_QUEUED (6)** / rate-limit / Forbidden throttle / precheck low quota: do **not** retry in a loop — op is in `.local/generated-data/board-outbox.jsonl`; continue local evidence; later `project outbox flush`. |
-| **Never** | Finish in chat only while leaving the card Stuck in Ready/Backlog. Never dual-write tracker `in_progress` under `board_only`. Never write bare `Agent: implementer` without `@user/` namespace. |
+| **Entry** | Prefer `python3 -m agent_colony project entry` (live \| conserve \| offline_artifacts). Then `get` / `claim` **one** card. Read Acceptance / Rollback / Notes. Avoid unfiltered `list` / full `export` every turn — use `export --reuse-if-fresh`. One export refresh per parent wave. |
+| **During** | **One** In progress card for your assignee. Mid-slice progress → card Notes. |
+| **Exit** | Update Status → `in_review` / `done`, or stay `in_progress` with **Notes** naming next agent. Notes via `append-notes --agent <this-agent>` → `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · …` (CLI stamps UTC). Print handoff line. **EXIT_QUEUED (6)** / rate-limit / Forbidden / precheck low quota: **do not** retry-loop — op in `.local/generated-data/board-outbox.jsonl`; later `project outbox flush`. |
+| **Never** | Chat-only completion with stale Status. No dual-write tracker `in_progress` under `board_only`. No bare `Agent: implementer` without `@user/` namespace. |
 
-Handoff line (chat + card Notes):
+Handoff line (chat + Notes):
 
 ```text
 item_id=<from project last or create> · @User/implementer · Status=before→after · Priority=p1 · Size=s · Estimate=1 · next=@User/verifier
 Tasks: [P1] …; [P2] …; [P3] …
 ```
 
-Prefer `--last` after create so agents never invent ids.
+Prefer `--last` after create. Multi-collaborator: each `owner.github_user` namespaces agents (`@Alice/implementer` vs `@Bob/implementer`).
 
-Multi-collaborator: each human’s `owner.github_user` namespaces their agents (`@Alice/implementer` vs `@Bob/implementer`) on the same board.
+## Tier-1 card fields contract
 
-## Tier-1 card fields contract (all agents — mandatory)
+When you **create** or **own** a card, fill Tier-1 fields. Verifier spot-checks on closure.
 
-When you **create** or **own** a Project card, fill the Tier-1 fields below. Do **not** leave them empty and move on. Verifier spot-checks this on closure.
+### Priority
 
-### Priority scale
+| Label | `set-field --field priority --to` | When |
+|-------|-----------------------------------|------|
+| P0 | `p0` | Blocks merge / release / SSOT |
+| P1 | `p1` | Must do next |
+| P2 | `p2` | Hygiene / polish |
+| P3 (deferred) | `p2` + Notes `deferred` | No `p3` option id in YAML |
 
-| Chat / plan label | Board `set-field --field priority --to` | When |
-|-------------------|----------------------------------------|------|
-| **P0** | `p0` | Blocks merge / release / SSOT integrity |
-| **P1** | `p1` | Must do next |
-| **P2** | `p2` | Planned hygiene / polish |
-| **P3** (deferred) | `p2` + Notes line `deferred` | Optional later — **no** `p3` option id in YAML |
+Priority is independent of Size (P0 can be XS).
 
-Priority is **independent** of Size (a P0 can be XS).
-
-### Size ↔ Estimate rubric (points, not hours)
-
-**Estimate** is relative **points**. Do not invent hours unless the consumer’s Project README defines hours→points.
+### Size ↔ Estimate (points, not hours)
 
 | Size | Typical slice | Estimate band | Default if unsure |
 |------|---------------|---------------|-------------------|
-| **xs** | Trivial (&lt; ~1h), one file / one paragraph | **1** | 1 |
+| **xs** | Trivial, one file | **1** | 1 |
 | **s** | Small, clear boundary | **1–2** | **1** |
-| **m** | Multi-file / multi-step, one PR | **3–5** | **3** |
-| **l** | Large or high risk — prefer split | **5–8** | **5** |
-| **xl** | Too big for one agent turn — **split** before coding | **8+** | refuse / split |
+| **m** | Multi-file, one PR | **3–5** | **3** |
+| **l** | Large / high risk — split | **5–8** | **5** |
+| **xl** | Too big — **split** before coding | **8+** | refuse / split |
 
-**Honesty rules**
-
-1. Prefer smaller cards; if Size would be `l`/`xl`, create multiple Ready cards.
-2. If Size and Estimate disagree with the table, explain in Notes.
-3. Unknown → Size=`s`, Estimate=`1`, and Notes: `Size/Estimate guessed (default s/1)`.
-4. Keep Size and Estimate aligned with this table (e.g. Size=`m` → Estimate in 3–5).
+Honesty: prefer smaller cards; if Size=`l`/`xl`, split. If table mismatch, explain in Notes. Unknown → Size=`s`, Estimate=`1`, Notes: `Size/Estimate guessed (default s/1)`.
 
 ### Timing matrix
 
-| Moment | Status | Priority | Size | Estimate | Start date | End date | Assignee | Linked PR |
-|--------|--------|----------|------|----------|------------|----------|----------|-----------|
-| Create (Ready/Backlog) | ✓ | ✓ required | ✓ | ✓ | — | — | ✓ Issue (owner; `--no-assignee` to skip) | — |
-| First In progress | ✓ | confirm | confirm | confirm | **✓ required** | — | ✓ (Issue) | — |
+| Moment | Status | Priority | Size | Estimate | Start | End | Assignee | Linked PR |
+|--------|--------|----------|------|----------|-------|-----|----------|-----------|
+| Create (Ready/Backlog) | ✓ | ✓ | ✓ | ✓ | — | — | ✓ Issue | — |
+| First In progress | ✓ | confirm | confirm | confirm | **✓** | — | ✓ | — |
 | Open PR | — | — | — | — | — | — | — | ✓ `mention-pr` |
-| Exit In review | ✓ | Notes | Notes | Notes | already set | — | — | if PR |
-| Exit Done | ✓ | Notes | Notes | Notes | already set | **✓ required** | — | if PR |
+| Exit In review | ✓ | Notes | Notes | Notes | set | — | — | if PR |
+| Exit Done | ✓ | Notes | Notes | Notes | set | **✓** | — | if PR |
 
-**Start date** = UTC calendar day work began. Set when Status becomes `in_progress` if empty — via `claim`, `set-status --to in_progress`, or `handoff --to in_progress` (master switch: `conventions.set_start_date_on_claim`). Never set on create while Ready/Backlog.
+**Start date:** UTC day work began. Set on first `in_progress` if empty — `claim`, `set-status --to in_progress`, or `handoff --to in_progress` (`conventions.set_start_date_on_claim`). Never on Ready/Backlog create.
 
-**End date** = UTC calendar day work finished. Set when Status becomes `done` if empty — via `set-status --to done`, `handoff --to done`, merge board sync, or `heal-cards --apply` (master switch: `conventions.set_end_date_on_done`). Never set on create or In progress / In review.
+**End date:** UTC day finished. Set on `done` if empty — `set-status --to done`, `handoff --to done`, merge sync, or `heal-cards --apply` (`conventions.set_end_date_on_done`). Never on create or In progress / In review.
 
-### Mandatory field checklist
+### Field checklist
 
-| Field | When | CLI | Rules |
-|-------|------|-----|-------|
-| **Status** | Always | `claim` / `handoff` / `set-status` | Create defaults `--status ready` (overridable); Exit → `in_review` / `done` |
-| **Priority** | Create / claim / own | `create-from-template --priority p0\|p1\|p2` or `set-field` | Required on template create — no silent default |
-| **Size** | Create / claim / own | `--size` / `set-field --field size --to xs\|s\|m\|l\|xl` | Per Size↔Estimate table; default `s` + Notes if guessed |
-| **Estimate** | Create / claim / own | `--estimate` / `set-field --field estimate --to N` | Points per table; default `1` + Notes if guessed |
-| **Start date** | First In progress | `claim` / `set-status --to in_progress` / `handoff --to in_progress` | Auto when `set_start_date_on_claim` + `fields.start_date.field_id`; if WARN, retry — do not ignore |
-| **End date** | Done | `set-status --to done` / `handoff --to done` / merge / `heal-cards` | Auto when `set_end_date_on_done` + `fields.end_date.field_id`; if WARN, retry — do not ignore |
-| **Assignee** | Create (Issue) / claim re-assert | `create-from-template` auto-assigns `owner.github_user`; `claim` / `set-assignee --login …` | **Create as Issue** (`item_kind_default: issue`). Draft is scratch-only; `--no-assignee` escape hatch |
-| **Linked PR** | When a PR exists | `mention-pr --pr N --last --agent <agent>` | Auto-promotes Draft when `promote_to_issue_on_pr` |
+| Field | When | CLI |
+|-------|------|-----|
+| **Status** | Always | `claim` / `handoff` / `set-status` |
+| **Priority** | Create / own | `create-from-template --priority p0\|p1\|p2` or `set-field` |
+| **Size** | Create / own | `--size` / `set-field --field size --to xs\|s\|m\|l\|xl` |
+| **Estimate** | Create / own | `--estimate` / `set-field --field estimate --to N` |
+| **Start date** | First In progress | `claim` / `set-status` / `handoff` → `in_progress` |
+| **End date** | Done | `set-status` / `handoff` / merge / `heal-cards` → `done` |
+| **Assignee** | Create (Issue) | `create-from-template` (default `owner.github_user`); `claim` / `set-assignee` |
+| **Linked PR** | PR exists | `mention-pr --pr N --last --agent <agent>` |
+
+**Create as Issue** (`item_kind_default: issue`). Draft = scratch only (`--no-assignee` escape hatch). `promote-to-issue --last --agent <name>` when still Draft. `mention-pr` auto-promotes when `promote_to_issue_on_pr: true`.
 
 ```bash
-# Pattern A — Tier-1 at create + Start date on claim
 python3 -m agent_colony project create-from-template \
   --template slice --title "[P1] …" --status ready \
   --priority p1 --size s --estimate 1 --agent implementer
 python3 -m agent_colony project claim --last --agent implementer
-# When opening a shippable PR:
 python3 -m agent_colony project mention-pr --pr N --last --agent implementer
 ```
 
-Plain `project create` (non-template) still needs follow-up `set-field` for Priority/Size/Estimate.
-
-Rules:
-
-1. After create: **Priority + Size + Estimate** before coding; on first In progress confirm **Start date** from CLI output.
-2. Exit Notes and chat: `[P0]…; [P1]…; [P2]…; [P3]…` and `Priority=p? · Size=? · Estimate=?`.
-3. `auditor` / `drift-guard`: recommend Priority/Size/Estimate (per table) when seeding Ready cards.
-4. `verifier`: spot-check Status, Priority, Size, Estimate, **Start date on In progress / In review / Done**, **End date on Done**; Assignee when Issue-backed; Linked PR when a PR opened. Missing Start date on active statuses or missing End date on Done = **incomplete Exit**.
-5. Missing Tier-1 fields = incomplete Exit — fill or document blocker in Notes before handoff.
-
-## When to use
-
-- Any session where `project_ssot.enabled: true`
-- Triage, create, claim, Priority/Size, Status transitions
-- Multi-agent handoffs (implementer → test-runner → verifier, etc.)
-
-## Evidence contract
-
-- Cite CLI output or `gh project` JSON for claims.
-- Label **Unknown** when board unreachable → then `fallback: local_trackers` only.
+Plain `project create` needs follow-up `set-field` for Priority/Size/Estimate. Exit Notes: `[P0]…; [P1]…` and `Priority=p? · Size=? · Estimate=?`. Missing Tier-1 or Start on active statuses / End on Done = **incomplete Exit**.
 
 ## Collaboration
 
-### Human vs agent vs GitHub
+| Surface | Human | Agents |
+|---------|-------|--------|
+| Status / Priority / Size / cards | Yes | Yes (rights below) |
+| Ready prioritization / roadmap | **Owner** | Consume Ready; create agreed work |
+| Views, workflows, Insights, README | **Owner only** | **Never** (browser assist only if human asks) |
+| PR gates, audits, secrets | Local | Local (`local_only`) |
 
-| Surface | Human | Agents | Derived |
-|---------|-------|--------|---------|
-| Status / Priority / Size / create cards | Yes | Yes (rights table) | — |
-| Ready prioritization / roadmap shape | **Owner** | Consume Ready; create cards for agreed work | — |
-| Views, workflows, Insights, Project README, status updates | **Owner only** | **Never** | Insights auto |
-| My items | Assign in UI or `project set-assignee` (human login) | Claim = Status In progress + Notes `@user/agent`; assignee = human only | View filter |
-| PR gates, audits, secrets | Local | Local (`local_only`) | — |
+**Issue vs board Status:** independent by default. Opt-in bridge: `conventions.close_linked_issue_on_cleanup` → `finalize.py` closes linked Issue after merge cleanup. CLI: `project close-linked-issue --pr N` (requires Status=Done first).
 
-### Tier-1 board fields (agents)
+**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` flags missing Status/Tier-1 · `outbox flush` if QUEUED.
 
-| Field / action | When | CLI | Notes |
-|----------------|------|-----|-------|
-| **Start date** | First In progress | `claim` / `set-status --to in_progress` / `handoff --to in_progress` | **Mandatory** when empty — UTC today if `conventions.set_start_date_on_claim: true`; see § Tier-1 card fields contract |
-| **End date** | Done | `set-status` / `handoff` / merge / `heal-cards` → `done` | **Mandatory** when empty — UTC today if `conventions.set_end_date_on_done: true` |
-| **Estimate** | Create / claim / own | `project set-field --field estimate --to N` | **Mandatory** — default `1` if unknown |
-| **Size** | Create / claim / own | `project set-field --field size --to xs\|s\|m\|l\|xl` | **Mandatory** — default `s` if unknown |
-| **Priority** | Create / claim / own | `project set-field --field priority --to p0\|p1\|p2` | **Mandatory** — chat P3 → `p2` + Notes `deferred` |
-| **Assignee** | Create Issue (owner) | `create-from-template` (default) / `claim` / `set-assignee` | **Mandatory on Issue create** — `owner.github_user`; Draft cannot hold Assignees |
-| **Linked PR** | PR open | `project mention-pr --pr N --last` | **Mandatory when a PR exists** for the card |
-| **Promote Draft→Issue** | Only if card is still Draft | `project promote-to-issue --last --agent <name>` | Prefer never needing this — create as Issue |
-| **Out of scope (agents default)** | — | — | Iteration, Labels, Reviewers — human / UI only |
+**Rules:** one In progress per human assignee; Acceptance/Rollback/Notes on card body; no dual-mirror under `board_only` (DRIFT-009); read-only `export` never writes Status; post-merge Done via `merge.py`.
 
-### Issue lifecycle (Draft vs Issue)
+| Agent | Exit (must update board) |
+|-------|--------------------------|
+| implementer | In progress → In review (PR) → Done; fields on own card |
+| test-runner / verifier | Stay on card; → In review or Done with Notes |
+| drift-guard | Drift-pass → Done; cite board Status; hand remediation via Notes/Ready — **no** silent tracker edits |
+| auditor | Audit card → In review/Done; Notes → artifact paths |
 
-| Path | CLI / config | Notes |
-|------|--------------|-------|
-| Default create | `create-from-template` + `item_kind_default: issue` | **Issue** on the Project + linked repo (`default_repo`) — Assignees + Linked PRs work from claim |
-| Scratch only | `item_kind_default: draft` (override) | DraftIssue — no Assignees until `promote-to-issue`; do **not** use for shippable work |
-| Explicit promote | `promote-to-issue --last --agent <name>` | Same `PVTI_`; needed only if card was created as Draft |
-| Auto on PR | `mention-pr` | When `promote_to_issue_on_pr: true` (still useful if a Draft slipped through) |
+Status path: `Ready → In progress → In review → Done`
 
-### Issue state vs board Status (they're independent by default)
+## Procedure (Pattern A)
 
-Board `Status=Done` and the linked GitHub Issue's own `open`/`closed` state are **separate signals** — Status is the continuation SSOT; Issue state is GitHub-native (Issues list, notifications). A card can be `Done` while its Issue stays `open` — this is expected, not a bug, unless you opt in below.
+Never paste placeholder `--id`. After create, use `--last`. `project guide --agent <name>`.
 
-- **Opt-in bridge:** `conventions.close_linked_issue_on_cleanup` (default `false`). When `true`, `full-pr-workflow`'s `finalize.py` best-effort closes the Issue linked to the merged PR's board item, **after** branch cleanup succeeds — never on `set-status`/`claim`/`handoff`, so it can't race ahead of merge/cleanup evidence.
-- **CLI:** `project close-linked-issue --pr N [--dry-run]` — resolves the item via `find-by-pr`; **requires board Status=Done** first (else SKIPPED with remediation); skips when there's no linked Issue, the flag is off, or the Issue is already closed; a `gh` error is `DEFERRED` (non-blocking).
-- **Evidence:** outcome recorded in `finalize.md § Linked Issue Closure` (`PASS` / `SKIPPED` / `DEFERRED` / `DRY-RUN` when `finalize.py --dry-run` is used).
+| Need | Template / action |
+|------|-------------------|
+| slice / feature / chore | `create-from-template --template slice` |
+| bug / fix | `create-from-template --template bug` |
+| research | `--template research` |
+| audit pass | `--template slice` + `[AUDIT] …` then `claim --last` |
+| test-runner / verifier | claim/continue only — **no** create |
 
-### Repair incomplete cards
+**Recipes:**
 
-Empty Status (especially with a CLOSED Issue) breaks Status views. Detection and repair:
-
-```bash
-python3 -m agent_colony project doctor          # WARN counts + heal hint
-python3 -m agent_colony project heal-cards --check
-python3 -m agent_colony project heal-cards --apply [--fill-tier1] [--dry-run]
-python3 -m agent_colony project outbox flush    # if QUEUED
-```
-
-`heal-cards --apply` sets Status→Done only when the linked Issue is CLOSED and Status is empty/non-done. `--fill-tier1` optionally fills missing Priority=`p2` / Size=`s` / Estimate=`1`. `validate-item` flags `missing Status` (and Tier-1 when configured) so empty cards never soft-pass.
-
-### Rules
-
-1. One primary **In progress** per **human assignee** — do not steal others'.
-2. Pull from **Ready** or continue your In progress.
-3. Acceptance / Rollback / Notes on **card body** = continuation index. Attribution = `@owner.github_user/<agent> · <ISO-8601-UTC> · …` via `append-notes --agent` (or `claim`/`handoff` recipes).
-4. Under `board_only`: no competing tracker `in_progress` (DRIFT-009); no dual-mirror “for safety.”
-5. Humans own views, workflows, README, Insights, status updates by default (no view API). If the human **asks** for browser help on views/columns, `/board` may use browser MCP for that turn (see `board-shell`).
-6. Read-only `project export` (if used) never writes Status.
-7. Post-merge Done is Pattern A (`merge.py`), Notes prefixed `@user/merge.py`.
-
-### Per-agent rights (what / when / where)
-
-| Agent | Entry (read board) | Exit (must update board) | Local writes |
-|-------|--------------------|--------------------------|--------------|
-| **board** | status + list | create/move any Status; Priority/Size; hand off to implementer | change-index, updates-log |
-| **implementer** | status + Ready/claim | In progress → In review (PR) → Done; fields on own card; may create slice cards | code; change-index; PR |
-| **test-runner** | status + slice card | Stay on card; → In review when tests gate PR; Done when test-only slice closes | test-index / test-plan |
-| **verifier** | status + related card | Confirm → Done or leave In review with Notes (failures) | evidence / PR artifacts |
-| **integrator** | status + Ready/claim | claim → Done on integration card; may create cards | integrate / payload |
-| **auditor** | status + audit card | Audit card → In review/Done; Notes point to artifact paths | `.local/workflow-artifacts/…` |
-| **drift-guard** | **Must** status + list In progress (dual-write check) | Drift-pass card → Done (or In review if P0/P1 need human); cite board Status in drift-audit; hand remediation to board/implementer via Ready card or Notes — **do not** silent-edit trackers | drift-audit / drift-todos |
-| **researcher** | status + research card if any | If a research card exists → Done + Notes with corpus paths; else read-only | `_research_results/` |
-
-### Status path
-
-```text
-Ready → In progress → In review → Done
-```
-
-| Moment | Actor | CLI |
-|--------|-------|-----|
-| Start work | implementer / integrator / test-runner / board | `set-status --to in_progress` |
-| PR open / peer handoff | implementer | `set-status --to in_review` |
-| Part verified closed | implementer / verifier / test-runner | `set-status --to done` |
-| Drift / audit pass closed | drift-guard / auditor | `set-status --to done` (their card) |
-| Queue triage | board or human | create / set-status / set-field |
-
-## Procedure (CLI) — prefer Pattern A recipes
-
-**Never paste docs placeholders as `--id`.** After create, use `--last`. Print recipes: `project guide`.
-
-Human Project README: paste `.ai_infra/templates/project-board/project-readme.md` in the Project settings UI (board brief only — not into a shell). CLI recipes stay in `project guide` and `project-board-collaboration.md`.
-
-### Template routing
-
-| Need | Who | Template / action |
-|------|-----|-------------------|
-| slice / feature / `chore/` | implementer, board, integrator | `create-from-template --template slice` |
-| bug / defect / `fix/` | implementer, board | `create-from-template --template bug` |
-| external / corpus research | researcher, board | `create-from-template --template research` |
-| audit pass | auditor | `--template slice` + title `[AUDIT] …` then `claim --last` |
-| consume existing card | test-runner, verifier | **No** `create-from-template` — claim/continue only |
-| Project README | **Humans only** | paste `project-readme.md` (board brief) in Project settings UI — or `--apply-readme` |
-
-Index: `.ai_infra/templates/project-board/README.md`. After create, always `claim --last` / `handoff --last` (never invent ids).
-
-**Notes format:** `@owner.github_user/<agent> · YYYY-MM-DDTHH:MM:SSZ · text` — auto-stamped by CLI on `claim`, `handoff`, and `append-notes --agent`. Idempotent when timestamp already present. Do not hand-forge times.
-
-**Local continuity:** append UTC-prefixed lines to `history/updates-log.md`; optional row in `history/continuity-index.md` (rolling ≥3 days). Board Notes retain full card lifetime.
-
-1. **Doctor / guide:** `project doctor` · `project guide --agent implementer`
-2. **Status / list:** `project status` · `project list [--status ready|in_progress|in_review]`
-3. **Create:** `project create-from-template --title "[SLICE] short-name" --template slice --status ready --priority p1 --size s --estimate 1 --agent <agent>` (prefer `--acceptance` / `--rollback` at create)
+1. `project doctor` · `project guide --agent implementer`
+2. `project status` · `project list [--status ready|in_progress|in_review]`
+3. **Create:** `create-from-template … --priority p1 --size s --estimate 1 --agent <agent>` (prefer `--acceptance` / `--rollback`)
 4. **Claim:** `project claim --last --agent <this-agent>`
-5. **Fill body (if still TBD):** `project set-section --section acceptance|rollback --text '…' --last --agent <this-agent>` — Notes stay append-only
-6. **Handoff:** `project handoff --last --agent <this-agent> --next <agent> [--to in_review|done]` — **EXIT_VALIDATION (5)** when Acceptance/Rollback are still placeholders (also enforced on `set-status --to in_review|done`)
-7. **Validate:** `project validate-item --last` (same checks; handoff/`set-status` already gate closes)
-8. **Atomics (power use):** `set-status` · `set-field` (priority · size · estimate) · `set-section` · `promote-to-issue` · `mention-pr` · `append-notes --agent` · `get --last` · `export`
-9. **Verify:** `project list` + handoff line; `project last` prints saved id
+5. **Body:** `set-section --section acceptance|rollback --text '…' --last --agent <agent>`
+6. **Handoff:** `handoff --last --agent <this-agent> --next <agent> [--to in_review|done]` — **EXIT_VALIDATION (5)** when Acceptance/Rollback are `(TBD)` (also on `set-status --to in_review|done`)
+7. **Validate:** `validate-item --last`
+8. **Atomics:** `set-status` · `set-field` · `set-section` · `promote-to-issue` · `mention-pr` · `append-notes --agent` · `get --last` · `export`
 
-Exit codes: `0` ok · `2` usage/config (includes placeholder `--id`) · `3` gh · `4` not found · `5` validation · `6` queued (outbox; soft-success — flush later).
+Exit codes: `0` ok · `2` usage/config · `3` gh · `4` not found · **`5` validation** · **`6` queued** (outbox; flush later).
 
 Rate-limit: `project outbox status` / `project queue` / `project outbox flush` — see `project_ssot.outbox` in collaboration YAML.
 
 ## Dual-write ban
 
-When `sync_policy: board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local (`local_only`).
+When `board_only`, do **not** mark the same slice `in_progress` in `work-tracker.md`. PR/audit artifacts stay local.
+
+## Evidence contract
+
+Cite CLI output or `gh project` JSON. Label **Unknown** when board unreachable → `fallback: local_trackers` only.
 
 ## Exit criteria
 
 - [ ] Entry read board (or explicit offline fallback)
-- [ ] Exit updated Status (or Notes + next agent if still In progress)
-- [ ] If EXIT_QUEUED: confirmed via `outbox status`; no API hammering
-- [ ] Handoff line printed with real item_id
-- [ ] Handoff line printed when another agent continues
-- [ ] No dual-write; no unprompted edits to Project views/workflows/Insights (browser assist only if human asked)
+- [ ] Exit updated Status or Notes + next agent
+- [ ] If EXIT_QUEUED: `outbox status`; no API hammering
+- [ ] Handoff line with real `item_id`
+- [ ] No dual-write; no unprompted Project view/workflow edits
 
 ## Anti-patterns
 
-- Chat-only completion with stale board Status
-- Hardcoding field/option ids
-- Reshuffling Ready/P0 without human or board ask
-- Editing Project views/workflows/Insights unprompted (browser assist only when human asks)
-- Pasting Project settings UI text into a terminal
-- Dual-write board + tracker under `board_only`
-- Multi-step claim without `project claim` / bare Notes without `--agent`
-- Do not push to unrelated repositories
+Chat-only completion · hardcoded field ids · dual-write under `board_only` · multi-step claim without `project claim` · bare Notes without `--agent` · reshuffling Ready without human ask · pasting Project UI into terminal

--- a/skills/drift-audit/SKILL.md
+++ b/skills/drift-audit/SKILL.md
@@ -18,6 +18,8 @@ Notes:
 
 # Drift audit
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
 Detect **operational workflow drift** and a **falsifiable goal/doctrine pulse**:

--- a/skills/implementer-loop/SKILL.md
+++ b/skills/implementer-loop/SKILL.md
@@ -5,6 +5,8 @@ description: Disciplined implementation slices with board SSOT continuation and 
 
 # Implementer loop
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slices.

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -17,6 +17,8 @@ Notes:
 
 # Workflow activate
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 User enabled the **Agent Colony** plugin (`agent-colony`) and opened **their app** (not this kit product repo). Run on first use or when planes are missing.

--- a/tests/modules/install/test_doc_cli_digest.py
+++ b/tests/modules/install/test_doc_cli_digest.py
@@ -1,0 +1,78 @@
+"""
+File: test_doc_cli_digest.py
+Path: tests/modules/install/test_doc_cli_digest.py
+Role: Tests for doc roster-digest and doc summarize CLI.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/install/agent_colony/doc_cli.py
+Notes:
+ - No live network; uses tmp_path agent stubs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PKG_DIR = REPO_ROOT / ".ai_infra" / "install" / "agent_colony"
+if str(_PKG_DIR) not in sys.path:
+    sys.path.insert(0, str(_PKG_DIR))
+
+import doc_cli  # noqa: E402
+
+
+def test_roster_digest_text(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    agents = tmp_path / ".cursor" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "implementer.md").write_text(
+        "---\nname: implementer\ndescription: Does slices.\n---\n# Implementer\n",
+        encoding="utf-8",
+    )
+    (agents / "board.md").write_text(
+        "---\nname: board\ndescription: Owns board SSOT.\n---\n# Board\n",
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(directory=tmp_path, json=False)
+    assert doc_cli.cmd_doc_roster_digest(args) == 0
+    out = capsys.readouterr().out
+    assert "agents=2" in out
+    assert "implementer" in out
+    assert "board" in out
+
+
+def test_roster_digest_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    agents = tmp_path / ".cursor" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "verifier.md").write_text(
+        "---\ndescription: Checks claims.\n---\n",
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(directory=tmp_path, json=True)
+    assert doc_cli.cmd_doc_roster_digest(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 1
+    assert payload["agents"][0]["id"] == "verifier"
+
+
+def test_summarize_skips_html_comments(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    doc = tmp_path / "notes.md"
+    doc.write_text(
+        "<!--\nhidden\n-->\n\n# Title\n\nBody line\n\n",
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, path="notes.md", lines=10, json=False
+    )
+    assert doc_cli.cmd_doc_summarize(args) == 0
+    out = capsys.readouterr().out
+    assert "# Title" in out
+    assert "Body line" in out
+    assert "hidden" not in out

--- a/tests/modules/install/test_project_entry_efficiency.py
+++ b/tests/modules/install/test_project_entry_efficiency.py
@@ -492,3 +492,74 @@ def test_cmd_entry_conserve_items_not_list(
     out = capsys.readouterr().out
     assert "mode=conserve" in out
     assert "(no items)" in out
+
+
+def test_cmd_entry_digest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot_with_efficiency()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli._outbox,
+        "graphql_rate_limit",
+        lambda: {"remaining": 4000, "limit": 5000},
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot_arg, *, limit=50: (
+            [
+                {
+                    "id": "PVTI_d1",
+                    "title": "Digest work",
+                    "status": "In Progress",
+                    "priority": "P1",
+                }
+            ],
+            None,
+        ),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        also_ready=False,
+        force_live=False,
+        limit=None,
+        digest=True,
+        json=False,
+    )
+    assert project_cli.cmd_entry(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "enabled:" not in out
+    assert "mode=live" in out
+    assert "items=1" in out
+    assert "PVTI_d1" in out
+
+
+def test_cmd_entry_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ssot = _ssot_with_efficiency()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli._outbox,
+        "graphql_rate_limit",
+        lambda: {"remaining": 4000, "limit": 5000},
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot_arg, *, limit=50: ([], None),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        also_ready=False,
+        force_live=False,
+        limit=None,
+        digest=False,
+        json=True,
+    )
+    assert project_cli.cmd_entry(args) == project_cli.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "live"
+    assert payload["item_count"] == 0
+    assert payload["next"] == "claim|get"

--- a/tests/modules/scripts/test_prepare_summary.py
+++ b/tests/modules/scripts/test_prepare_summary.py
@@ -1,0 +1,64 @@
+"""
+File: test_prepare_summary.py
+Path: tests/modules/scripts/test_prepare_summary.py
+Role: Tests prepare.py --summary output path with --skip-gates.
+Used By:
+ - pytest
+Depends On:
+ - .ai_infra/scripts/pr/prepare.py
+Notes:
+ - Uses --skip-gates to avoid running full gate suite.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PREPARE_PATH = REPO_ROOT / ".ai_infra" / "scripts" / "pr" / "prepare.py"
+
+
+def _load_prepare():
+    spec = importlib.util.spec_from_file_location("prepare_mod", PREPARE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["prepare_mod"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_prepare_summary_skip_gates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    prepare = _load_prepare()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".local" / "workflow-artifacts" / "pr").mkdir(parents=True)
+    monkeypatch.setattr(prepare, "ensure_workflow_artifacts_dir", lambda: None)
+    monkeypatch.setattr(
+        prepare,
+        "PREP_MD",
+        tmp_path / ".local" / "workflow-artifacts" / "pr" / "prep.md",
+    )
+    monkeypatch.setattr(
+        prepare,
+        "resolve_pr_attribution",
+        lambda **kwargs: ("Test User", "implementer", "@test"),
+    )
+    monkeypatch.setattr(prepare, "_current_branch", lambda: "feature/x")
+    monkeypatch.setattr(prepare, "_head_sha", lambda: "abc123")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prepare.py", "--pr", "1", "--skip-gates", "--summary", "--actor", "Test User"],
+    )
+    assert prepare.main() == 0
+    out = capsys.readouterr().out
+    assert "prepare: PASS" in out
+    assert "externally verified" in out
+    assert prepare.PREP_MD.is_file()


### PR DESCRIPTION
## Summary
- Add **Use ASD-STE100** free prose guide (`asd-ste100-prose.md`) and link from token-efficiency / abbreviations / ops index
- Thin 8 agent cards (dedupe Tier-1/MCP boilerplate; ≥30% size cut vs ~59 KB baseline), high-traffic skills, 7 alwaysApply rules (≥20%), and AGENTS.md (≤120 lines)
- CLI digests: `project entry --digest|--json`, `doc roster-digest`, `doc summarize`, `prepare.py --summary` + tests (1510 collected)

## Test plan
- [x] `make doc-validate` green
- [x] `check_governance_consistency` + `integrate validate` green
- [x] `sync_plugin_bundle.py --check` green
- [x] Targeted digest tests + board bootstrap agent stub test
- [ ] CI `quality` required check green