### PR TITLE
Use ASD-STE100 — remaining skills (.cursor/.agents) [Slice 7]

### DIFF
--- a/.agents/skills/audit-alignment/SKILL.md
+++ b/.agents/skills/audit-alignment/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Audit alignment (deprecated stub — retire pending)
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Do not use this file as the primary workflow.** The canonical audit agent is **`auditor`**.
 
 - **Agent:** `.cursor/agents/auditor.md`

--- a/.agents/skills/full-pr-workflow/SKILL.md
+++ b/.agents/skills/full-pr-workflow/SKILL.md
@@ -6,7 +6,9 @@ disable-model-invocation: true
 
 # Full PR workflow (maintainer)
 
-**Goal:** Merge a PR and then clean up the repo (sync `main`, delete local + remote feature branches) with a dedicated **finalize** phase.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+**Goal:** Merge a PR and clean up the repo (sync `main`, delete branches) via **finalize**.
 
 ## Order
 

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Merge PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Merge only when artifacts + gates are satisfied.
 
 ## Steps

--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -6,9 +6,11 @@ disable-model-invocation: true
 
 # PR workflow (maintainer)
 
-**Implementer work:** when `project_ssot.enabled` + `board_only`, slice status lives on the **GitHub Project** (Entry/Exit continuation). Local `.local/index-and-planning/current/*` is offline fallback only — see ADR-008 and `project-ssot-precedence.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
-This skill is the **merge path** only: **review → prepare → merge** (slash skills: `review-pr`, `prepare-pr`, `merge-pr`).
+**Implementer work:** board SSOT when `project_ssot.enabled` + `board_only`; local trackers are offline fallback (ADR-008). Slice closure: `workflow-complete.md` §F.
+
+**Merge path only:** review → prepare → merge (`review-pr`, `prepare-pr`, `merge-pr`).
 
 ## Order
 

--- a/.agents/skills/prepare-pr/SKILL.md
+++ b/.agents/skills/prepare-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Prepare PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Green gates + documented evidence in `prep.md`.
 
 ## Steps

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Review PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Decide if the PR is ready for `/prepare-pr`.
 
 ## Steps

--- a/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -55,7 +55,8 @@ Research goal: clearer prose → fewer tokens → measure before/after byte and 
 | Surface | Rule |
 |---------|------|
 | Agent cards | Keep Anchors short. Point here + `token-efficiency.md`. |
-| Skills | Procedure lives in the skill. Cards link to sections. |
+| Skills (`.cursor/skills/`) | Procedure lives in the skill. Cards link to sections. |
+| Maintainer slash skills (`.agents/skills/`) | One command per step; link `pr-workflow` for detail. |
 | Board Notes | Attributed one-liners. No gate dumps. |
 | Chat handoff | One line: Status · next · Tasks `[P…]` |
 

--- a/.ai_infra/docs/operations/token-efficiency.md
+++ b/.ai_infra/docs/operations/token-efficiency.md
@@ -25,9 +25,18 @@ Load the section you need. Do not load whole skills by default.
 | Skill | Read when | Prefer |
 |-------|-----------|--------|
 | `board-ssot` | Mutating Status / Tier-1 | § Continuation · § Tier-1 |
+| `board-shell` | First-run shell / bootstrap FAIL | § CONSENT GATE · § TURN PROTOCOL |
 | `implementer-loop` | Implement slice | Full skill (short) |
+| `integrator-protocol` | New agent/skill/MCP | Evidence contract + current phase |
 | `drift-audit` | drift-guard pass | Steps 1–3 |
 | `auditor-protocol` | Audit task | Evidence contract + current phase |
+| `audit-orchestration` | Full audit closure | Phase 0 preflight + delegation rules |
+| `audit-module-map` | Deep module topology | Constraints + output contract |
+| `mcp-connect` | External MCP setup | Intents table + Pattern A CLI |
+| `research-corpus` | Research pack work | Intake + anti-loop |
+| `canvas-artifacts` | Canvas/plan snapshots | Tiers table + CLI |
+| `test-coverage` | Tests / coverage slice | Procedure steps 1–7 |
+| `update-agent-colony` | Consumer kit upgrade | Commands + version gate |
 | `workflow-activate` | Consumer install | “When user just installed” |
 
 ## Read set (default)

--- a/.cursor/skills/audit-module-map/SKILL.md
+++ b/.cursor/skills/audit-module-map/SKILL.md
@@ -3,73 +3,52 @@ name: audit-module-map
 description: Builds a deep per-module workflow map with importance, goals, and visual architecture output.
 ---
 
-# Audit Module Map (Advisory-Only)
+# Audit module map (advisory-only)
+
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
 ## Relationship to audits
 
-This is a **depth tool** for **`auditor`**, not a separate audit authority. Run it when the enterprise architecture audit (or a focused alignment pass) needs HTML/topology evidence; fold outputs into the parent audit’s citations.
+Depth tool for **`auditor`**, not a separate audit authority. Run when enterprise audit (or focused alignment pass) needs HTML/topology evidence. Fold outputs into parent audit citations.
 
-## Goal
+## When
 
-Produce a module-by-module audit that explains workflow, behavior, importance, and intended goal, with a visual architecture map and detailed results.
+- **`auditor`** requests deep module topology or `module-audit.html` export
+- Team needs current module map before architecture reconciliation
+- Documentation drift suspected across module boundaries
 
-## When to Use
+## Required sources
 
-- **`auditor`** requests deep module topology or `module-audit.html` export.
-- Team needs a current module map before architecture reconciliation.
-- Documentation drift is suspected across module boundaries and ownership.
+- `README.md`, `AGENTS.md`
+- Project strategy/plan docs (when consumer defines them)
+- `tests/modules/*`
+- `.cursor/rules/*`, `.cursor/skills/*`
+- `.agents/skills/*` (maintainer context)
 
-## Required Sources
+## Constraints
 
-- `README.md` and `AGENTS.md`
-- Project strategy/plan docs (when the consumer repo defines them)
-- `tests/modules/*` (or project test tree)
-- `.cursor/rules/*` and `.cursor/skills/*`
-- `.agents/skills/*` (maintainer workflow context)
+1. Advisory-only: do not auto-remediate during this audit.
+2. Evidence-backed statements only; concrete file paths per claim.
+3. Distinguish canonical docs from archival/historical docs.
+4. Uncertain ownership → `TBD` + follow-up callout.
 
-## Mandatory Constraints
+## Steps
 
-1. Advisory-only: do not auto-remediate findings during this audit.
-2. Use evidence-backed statements only; include concrete file paths for each claim.
-3. Distinguish canonical current-state docs from archival/historical docs.
-4. Mark uncertain ownership as `TBD` and call out required follow-up.
-
-## Execution Steps
-
-1. Inventory module roots under `src/` and map corresponding test ownership under `tests/modules/`.
-2. For each module, document:
-   - goal
-   - workflow/how it works (entrypoints, key contracts, control flow)
-   - importance (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`) with rationale
-   - key dependencies and key dependents
-3. Build an architecture-layer graphic showing module placement and directional data/control flow.
-4. Identify drift/gaps in:
-   - module-to-test mapping
-   - module documentation coverage
-   - rules/skill guidance needed for repeatable audits
+1. Inventory module roots under `src/`; map test ownership under `tests/modules/`.
+2. Per module document: goal, workflow (entrypoints, contracts, control flow), importance (`CRITICAL`|`HIGH`|`MEDIUM`|`LOW`) + rationale, dependencies, dependents.
+3. Build architecture-layer graphic (placement + data/control flow).
+4. Identify drift/gaps: module-to-test mapping, doc coverage, rules/skill guidance.
 5. Emit:
-   - `.local/module-map.md` (detailed module catalog)
-   - `.local/agents-control-center/audits/module-audit.html` (visual report with architecture graphic and per-module cards)
-   - Optional reconciliation findings appended into `.local/workflow-artifacts/alignment/alignment-audit.md` and `.local/workflow-artifacts/alignment/alignment-todos.md`
+   - `.local/module-map.md`
+   - `.local/agents-control-center/audits/module-audit.html`
+   - Optional: append to `alignment-audit.md` + `alignment-todos.md`
 
-## Output Contract
+## Output contract (per module)
 
-For each module entry, include:
+`module_name` · `source_paths` · `test_paths` · `importance` · `goal` · `workflow` · `key_contracts` · `dependencies` · `dependents` · `evidence` · `gaps_or_risks`
 
-- `module_name`
-- `source_paths`
-- `test_paths`
-- `importance`
-- `goal`
-- `workflow`
-- `key_contracts`
-- `dependencies`
-- `dependents`
-- `evidence`
-- `gaps_or_risks`
+## Exit criteria
 
-## Exit Criteria
-
-- Every production module has an explicit ownership/mapping entry (or `TBD` with rationale).
-- The architecture graphic and module deep-dive results are generated and readable.
-- Any accuracy-improving updates needed for rules/skills/agents are explicitly listed with evidence.
+- Every production module has ownership entry (or `TBD` + rationale).
+- Architecture graphic and module deep-dive are readable.
+- Rules/skills/agent updates listed with evidence when needed.

--- a/.cursor/skills/audit-orchestration/SKILL.md
+++ b/.cursor/skills/audit-orchestration/SKILL.md
@@ -20,16 +20,18 @@ Notes:
 
 # Audit orchestration
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Run a **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts and apply approved fixes — without one agent re-running every shell command.
+Run **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts — without one agent re-running every shell command.
 
 ## Cadence
 
 | Trigger | Auditor depth | Drift |
 |---------|---------------|-------|
-| **Architecture-impacting PR** | Focused alignment + scoped CHK-* tick table | `drift validate` via prepare; optional drift-guard artifacts |
-| **Quarterly / kit release readiness** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
+| **Architecture-impacting PR** | Focused alignment + scoped CHK-* | `drift validate` via prepare; optional drift-guard |
+| **Quarterly / kit release** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
 | **Ad-hoc full audit** | Same as quarterly | Same |
 
 Do **not** run full CHK-* scorecard on every PR.
@@ -46,36 +48,34 @@ Run **once**; capture JSON for downstream agents:
 
 ```bash
 make verify-all
-# or with artifacts for agents:
+# or with artifacts:
 python -m agent_colony verify all --write-preflight
 python -m agent_colony doc validate --write-preflight
 python -m agent_colony drift validate --directory .
 ```
 
-**MCP (preferred in Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
+**MCP (Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
 
-**Read:** `.local/workflow-artifacts/audit/preflight.json` and `doc-facts-preflight.json` if present.
+**Read:** `.local/workflow-artifacts/audit/preflight.json`, `doc-facts-preflight.json` if present.
 
-**Stop on P0** from doc validate or drift; hand to **implementer** only for mechanical fixes the user approved.
+**Stop on P0** from doc validate or drift; hand to **implementer** only for approved mechanical fixes.
 
 ## Phase 1 — Parallel discovery (Task delegation)
 
-Launch concurrently:
-
 | Subagent | Mode | Deliverable |
 |----------|------|-------------|
-| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + **CHK-* tick table**. PR-scoped: alignment artifacts only |
-| `audit-module-map` skill (optional) | artifact-write (`.local/` only) | `.local/module-map.md` summary for audit §3 |
+| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + CHK-* table. PR-scoped: alignment only |
+| `audit-module-map` (optional) | artifact-write | `.local/module-map.md` summary for audit §3 |
 
-Parent **does not** duplicate inventory searches — consumes subagent outputs + preflight JSON.
+Parent consumes subagent outputs + preflight JSON — no duplicate inventory searches.
 
 ## Phase 2 — Mechanical remediation (user-approved only)
 
-When `enterprise-audit-actions.md` or doc validate lists **DOC-*** / doc-sync items:
+When `enterprise-audit-actions.md` or doc validate lists **DOC-*** items:
 
 | Subagent | Scope |
 |----------|-------|
-| `implementer` | Tracked doc/template fixes only; no scope creep |
+| `implementer` | Tracked doc/template fixes only |
 
 After edits:
 
@@ -89,22 +89,22 @@ make doc-validate
 
 | Subagent | When |
 |----------|------|
-| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift findings |
+| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift |
 | `verifier` | Spot-check top audit claims vs preflight + repo paths |
 
 ## Phase 4 — Maintainer PR
 
-Human or maintainer agent: `review-pr` → `prepare-pr` → `merge-pr` on a `feature/` or `chore/` branch.
+Human or maintainer: `review-pr` → `prepare-pr` → `merge-pr` on `feature/` or `chore/` branch.
 
 ## Delegation rules
 
-1. **Scripts before agents** — never let an agent re-run five gates if preflight JSON is fresh (<1 session).
-2. **One primary `in_progress`** during implementer slice: when `project_ssot.enabled` + `sync_policy: board_only`, Status lives on the **Project board** (`project status` → claim with `set-status --to in_progress`); do **not** dual-write tracker `in_progress`. When SSOT is disabled or offline fallback is active, one primary `in_progress` in `work-tracker.md`.
-3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`. Under `board_only`, do not auto-edit board card body or local `plan.md` / `work-tracker.md`; offline fallback: do not auto-edit `plan.md` / `work-tracker.md`.
+1. **Scripts before agents** — do not re-run five gates if preflight JSON is fresh (<1 session).
+2. **One primary `in_progress`:** board SSOT when enabled; else `work-tracker.md`. No dual-write under `board_only`.
+3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`.
 4. **Canvases** — optional IDE artifacts; not merge gates.
-5. **Token efficiency** — cite preflight pass/fail in chat; paste failing command output only.
-6. **Ownership** — continuous plan/agent-doctrine coherence = `drift-guard`; deep CHK-* = `auditor`. No new trash agents.
+5. **Token efficiency** — cite preflight pass/fail; paste failing stderr only.
+6. **Ownership** — plan/agent-doctrine = `drift-guard`; deep CHK-* = `auditor`.
 
 ## Handoff format
 
-Preflight exit • audit artifact paths • CHK-* gaps • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR
+Preflight exit · audit artifact paths · CHK-* gaps · P0/P1 counts · branch name · next: implementer | drift-guard | verifier | maintainer PR

--- a/.cursor/skills/board-shell/SKILL.md
+++ b/.cursor/skills/board-shell/SKILL.md
@@ -20,28 +20,32 @@ Notes:
 
 # Board shell
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-- Fresh consumer after `/workflow-activate` + identity in `github.collaboration.yaml` (board ids may still be empty)
-- Human pastes **Project URL + repo URL** after `gh` auth — help wire `project_ssot` / `default_repo` before shell check
-- User asks to apply the **kit default** board shell (Playground parity: six views + Tier-1 columns)
-- `board-bootstrap --check` FAILs missing default views or **FAILs** Tier-1 columns on Status board / Prioritized backlog / empty README
+- Fresh consumer after `/workflow-activate` + identity in `github.collaboration.yaml`
+- Human pastes **Project URL + repo URL** after `gh` auth
+- User asks for kit default shell (six views + Tier-1 columns)
+- `board-bootstrap --check` FAILs views, Tier-1 columns, or empty README
 
 ## Non-negotiable
 
 | Do | Do not |
 |----|--------|
-| **CONSENT GATE** before any shell apply (below) | Create/mutate shell without description + explicit proceed |
-| After `gh` auth, accept Project + repo URLs and propose YAML via `gh project view` / `field-list` | Write YAML without human confirm |
-| Coach humans through TURN PROTOCOL (`views-setup.md` = click reference only) | Dump “follow views-setup.md” and stop; undocumented GraphQL view mutations |
-| Run `board-bootstrap --check` until exit 0 (views + Tier-1 columns) | Mutate Insights / workflows / status updates without approval |
-| Optional `--ensure-fields` / `--apply-readme` **only after** CONSENT GATE (no view-apply CLI; **`--apply-shell` is not shipped**) | Invent field option ids into YAML without discovery |
-| Smoke `create-from-template` | Claim “ready” while `--check` exit 5 or Prioritized backlog lacks **Priority** |
-| Default: coach TURN PROTOCOL (human clicks); **if user asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn | Open browser MCP unprompted; multi-view instruction dumps; undocumented GraphQL view mutations |
+| **CONSENT GATE** before shell apply | Mutate shell without description + explicit proceed |
+| Accept Project + repo URLs; propose YAML via `gh project view` / `field-list` | Write YAML without human confirm |
+| Coach **TURN PROTOCOL** — one turn at a time | Dump “follow views-setup.md” and stop |
+| Run `board-bootstrap --check` until exit 0 | Undocumented GraphQL view mutations |
+| `--ensure-fields` / `--apply-readme` only after CONSENT | Invent field option ids without discovery |
+| Smoke `create-from-template` | Claim ready while `--check` exit 5 |
+| Browser MCP only when user asks | Open browser unprompted |
 
-## CONSENT GATE (mandatory — every first-run shell) 
+Click reference: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md) § Browser assist map.
 
-**Before** TURN PROTOCOL, `--ensure-fields`, `--apply-readme`, or any future `--apply-shell`, stop and ask the human **both** questions in one message. Do **not** proceed until answered.
+## CONSENT GATE (mandatory — every first-run shell)
+
+**Before** TURN PROTOCOL, `--ensure-fields`, `--apply-readme`, or any future `--apply-shell`, stop and ask **both** questions in one message. Do **not** proceed until answered.
 
 ### Q1 — Board description (README blurb)
 
@@ -52,9 +56,9 @@ What short description should appear on this Project board?
 (Reply with 1–3 sentences for the Project README, or say "use template default".)
 ```
 
-- If they give text → keep it for README placeholders / `--apply-readme` body merge.
-- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (board brief; title/repo filled from YAML).
-- If README already non-empty and they say keep it → record that; skip overwrite unless they ask.
+- Custom text → keep for `--apply-readme` body merge.
+- `use template default` → `.ai_infra/templates/project-board/project-readme.md`.
+- README already non-empty + keep → record; skip overwrite unless asked.
 
 ### Q2 — Proceed to create / coach the default shell?
 
@@ -65,9 +69,9 @@ May I proceed to set up the kit default Playground board shell on this Project
 (six views + Tier-1 columns + README)? Reply "yes" or "no".
 ```
 
-- **`yes`** → continue Entry check + TURN PROTOCOL (and/or approved CLI flags).
-- **`no`** → stop. Do not coach views, do not `--apply-readme` / `--ensure-fields`. Offer day-to-day triage only if shell already green.
-- Ambiguous reply → ask again. Never assume yes.
+- **`yes`** → Entry check + TURN PROTOCOL (and/or approved CLI flags).
+- **`no`** → stop. Offer day-to-day triage only if shell already green.
+- Ambiguous → ask again. Never assume yes.
 
 Print after answers:
 
@@ -79,120 +83,63 @@ Only `proceed=yes` unlocks the rest of this skill.
 
 ## Entry
 
-0. Run **CONSENT GATE** (Q1 + Q2). If `proceed=no` → Exit with consent line only.
-1. If board ids missing and human provided URLs: propose collaboration YAML, confirm, save. After wire, print:
+0. Run **CONSENT GATE**. If `proceed=no` → Exit with consent line only.
+1. If board ids missing and human provided URLs: propose collaboration YAML, confirm, save. Print:
 
 ```text
 board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
 ```
 
-**Automation boundary:** API automates YAML, field defs, README; **UI required** for six views + Tier-1 column visibility (GitHub has no public view mutation API).
+**Automation boundary:** API automates YAML, field defs, README. **UI required** for six views + Tier-1 column visibility (no public view mutation API).
 
 2. `python3 -m agent_colony project status`
 3. `python3 -m agent_colony project doctor`
-4. Load desired state:
-   - Overlay if present: `.local/user_settings/board-shell.schema.yaml`
-   - Else: `.ai_infra/templates/project-board/board-shell.schema.yaml`
+4. Load schema: overlay `.local/user_settings/board-shell.schema.yaml` or template `.ai_infra/templates/project-board/board-shell.schema.yaml`
 5. `python3 -m agent_colony project board-bootstrap --check`
 
-## Loop (refuse ready until default shell passes)
+## Loop
 
 ```text
 CONSENT GATE → doctor → board-bootstrap --check → (gaps?) → TURN PROTOCOL → re-check → smoke → ready
 ```
 
-**Read FAIL lines literally:** `FAIL — missing minimum view 'Status board'` (etc.) / `WARN — rename default view 'View 1'` → human UI until official apply CLI ships. Empty README / `--apply-readme` is a **separate** fix after consent — never tell the user a view-missing FAIL is “only README”.
+Read FAIL lines literally. Empty README is a **separate** fix after consent — never call a view-missing FAIL “only README”.
 
-### WARN vs FAIL (schema check)
+### WARN vs FAIL
 
 | Outcome | Typical cause | Coach action |
 |---------|---------------|--------------|
-| **FAIL** (exit non-zero) | Missing a **default** Playground view; empty README | Enter **TURN PROTOCOL** below — do not stop after one sentence |
-| **WARN** (exit 0) | Missing Tier-1 **columns** on primary views | Now **FAIL (exit 5)** — coach Turn H until green |
-| **WARN** (exit 0) | Leftover `View N`; layout mismatch | Coach rename/columns until cleared |
-| **PASS** | Six views + README + `board-bootstrap --check` exit 0 | Smoke card → day-to-day Pattern A |
+| **FAIL** (exit non-zero) | Missing default Playground view; empty README | **TURN PROTOCOL** — one turn, re-check |
+| **WARN** (exit 0) | Missing Tier-1 columns on primary views | Now **FAIL (exit 5)** — coach until green |
+| **WARN** (exit 0) | Leftover `View N`; layout mismatch | Rename/columns until cleared |
+| **PASS** | Six views + README + `--check` exit 0 | Smoke card → Pattern A |
 
-### TURN PROTOCOL (mandatory when views FAIL) — do not skip
+### TURN PROTOCOL (mandatory when views FAIL)
 
-You **must** run this conversation loop. **Forbidden:** “follow views-setup.md”, “rename View 1”, or “add columns” as a single dump then waiting forever. **Required:** one concrete UI turn, wait for human “done”, then next turn.
+**Required:** one concrete UI turn → wait for human `done` → re-check → next turn.
 
-**Default:** human performs clicks in GitHub UI; you coach one turn at a time.
+**Forbidden:** single dump of views-setup.md then wait forever.
 
-**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers. Follow **Browser assist map** below (same targets as `views-setup.md`).
+**Default:** human clicks in GitHub UI; you coach one turn.
 
-**Open:** Project URL from `project status` (e.g. `https://github.com/users/…/projects/N`).
+**Opt-in browser assist:** When user explicitly asks (e.g. “use cursor-ide-browser”), you may use browser MCP for **that turn only**. Stop on login/2FA/permission blockers. Targets: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md) § Browser assist map.
 
-### Browser assist map (universal click targets — opt-in only)
+**Open:** Project URL from `project status`.
 
-Use this when driving **cursor-ide-browser** (or when coaching clicks). Prefer **minimal 2-view** path unless the user asked for six-view Playground. After each turn: `board-bootstrap --check`.
+| Turn | Goal | Done when |
+|------|------|-----------|
+| A | Rename **View 1** → **Status board**; Board layout; Group by **Status**; Tier-1 columns | Human replies `done`; fewer FAILs |
+| B | **+ New view** → Table → **Prioritized backlog** + Tier-1 columns | `done`; re-check |
+| C | **+ New view** → Roadmap → **Roadmap** | `done`; re-check |
+| D | **+ New view** → Table → **Bugs**; filter title `[BUG]` | `done`; re-check |
+| E | **+ New view** → Table → **In review**; filter Status = In review | `done`; re-check |
+| F | **+ New view** → Table → **My items**; filter Assignees = `@me` | `done`; re-check |
+| G | README via `--apply-readme` or paste `project-readme.md` | README non-empty; re-check |
+| H | Clear Tier-1 column FAILs on Status board / Prioritized backlog | `--check` exits **0** |
 
-| Goal | Where to go (GitHub Project UI) | Done when |
-|------|----------------------------------|-----------|
-| Open project | Navigate to Project URL from `project status` | Project header + view tabs visible |
-| Select a view | Click the **view tab** by exact name (`Status board`, `Prioritized backlog`, …) | That view is active |
-| Rename view | Active tab → **⋯** (or right-click / View menu) → **Rename** → type kit name → confirm | Tab label matches schema |
-| New view | **+ New view** (or **New view**) → pick layout → name it | New tab exists with correct name |
-| Layout | View menu / **⋯** → **Layout** → **Board** / **Table** / **Roadmap** | Layout matches turn |
-| Group by (required) | View menu / toolbar **Group by** → **Status** (Status board) | Board columns are Status groups |
-| Show Tier-1 columns | Active view → **+** / field picker / **Fields** / **View settings → Fields** → enable **Priority**, **Size**, **Estimate**, **Start date**, **End date** | `--check` no longer FAILs those columns on that view |
-| Clear Slice by (if set by mistake) | View menu → **Slice by** → **No slicing** (or clear) | No slice chips; groups only if Group by set |
-| Save view | If UI shows unsaved / **Save** on the view | Changes persist after reload |
-| README | Prefer CLI `--apply-readme` after consent; else Project **⋯** / Settings → **README** | README non-empty; `--check` OK |
+**Fast minimal path:** Turn A → Turn B → Turn G → Turn H if needed → exit **0**.
 
-**Fast minimal path (browser):** Turn A (Status board rename/layout/Group by Status + Tier-1 fields) → Turn B (Prioritized backlog Table + Tier-1 fields) → Turn G (README) → Turn H only if `--check` still FAILs columns → exit when `--check` **0**.
-
-**Optional polish (not a bootstrap gate):** on **Prioritized backlog** → **Group by** → **Priority** (P0/P1/P2 sections). Empty boards may hide empty group headers until cards have Priority set. Do **not** block “ready for agents” on this.
-
-**Browser stop conditions:** login / 2FA / permission / CAPTCHA / “can’t find control after 2 tries” → hand back to human with the same turn table row; do not invent GraphQL view mutations.
-
-**Turn A — kill `View 1` → Status board**
-
-1. Tell human: open the Project → click the view tab named **View 1** (or similar).
-2. Rename it to **Status board**.
-3. Layout = **Board**; Group by = **Status**.
-4. Show fields/columns: Title, Assignees, Status, **Priority**, **Size**, **Estimate**, **Start date**, **End date**, Linked pull requests.
-5. Ask: reply `done` when Status board exists. Then re-run `--check` (expect fewer FAILs).
-
-**Turn B — Prioritized backlog (new Table view)**
-
-1. **+ New view** → Table → name **Prioritized backlog**.
-2. Show same Tier-1 columns as Status board (**Priority** required).
-3. Wait for `done` → re-check.
-
-**Turn C — Roadmap**
-
-1. **+ New view** → Roadmap layout → name **Roadmap**.
-2. Wait for `done` → re-check.
-
-**Turn D — Bugs**
-
-1. **+ New view** → Table → name **Bugs** (emoji optional).
-2. Filter: title contains `[BUG]`.
-3. Wait for `done` → re-check.
-
-**Turn E — In review**
-
-1. **+ New view** → Table → name **In review**.
-2. Filter: Status = **In review**.
-3. Wait for `done` → re-check.
-
-**Turn F — My items**
-
-1. **+ New view** → Table → name **My items**.
-2. Filter: Assignees = `@me`.
-3. Wait for `done` → re-check.
-
-**Turn G — README**
-
-```bash
-python3 -m agent_colony project board-bootstrap --check --apply-readme
-```
-
-Or paste contents of `project-readme.md` into Project README settings. Re-check.
-
-**Turn H — clear Tier-1 column FAILs**
-
-If `--check` still FAILs missing Priority/Size/Estimate/Start date/End date on Status board or Prioritized backlog: open that view → **+** field picker → show the missing columns. Re-check until `board-bootstrap --check` exits **0** (no view FAIL and no Tier-1 column FAILs). Leftover `View N` WARNs are cosmetic and can be cleared separately.
+**Optional polish:** Group by Priority on Prioritized backlog — not a bootstrap gate.
 
 Between every turn print:
 
@@ -200,7 +147,7 @@ Between every turn print:
 board-shell turn: A|B|C|D|E|F|G|H · waiting=human · next=<view or column>
 ```
 
-Use checklist: `.ai_infra/templates/project-board/views-checklist.md`. Canon clicks: `.ai_infra/templates/project-board/views-setup.md`.
+Checklist: `.ai_infra/templates/project-board/views-checklist.md`. Canon clicks: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md).
 
 ### Optional automation (official API only)
 
@@ -209,51 +156,37 @@ python3 -m agent_colony project board-bootstrap --check --ensure-fields
 python3 -m agent_colony project board-bootstrap --check --apply-readme
 ```
 
-- `--ensure-fields`: create missing **field definitions** by name; print suggested YAML field ids (human confirms before editing collaboration.yaml). Does **not** create views.
-- `--apply-readme`: push templated README via `updateProjectV2` (opt-in; user approval).
+- `--ensure-fields`: create missing field definitions; print suggested YAML ids. Does **not** create views.
+- `--apply-readme`: push templated README via `updateProjectV2` (opt-in).
 
 Respect GraphQL quota / outbox — never retry-loop.
 
-### Smoke card (prove Tier-1)
+### Smoke card
 
 ```bash
 python3 -m agent_colony project create-from-template \
   --title "[LIVE-SMOKE] board shell onboard" --template slice \
   --status ready --priority p2 --size xs --estimate 0.5 --agent board
 python3 -m agent_colony project validate-item --last
-# cleanup: delete smoke item or set Done with Notes "smoke cleanup"
 ```
 
 ## Customization
 
-### Minimal 2-view overlay
+**Minimal 2-view:** copy `board-shell.schema.minimal.yaml` exemplar → `.local/user_settings/board-shell.schema.yaml`. Coach Turns A + B only. Re-check after each turn.
 
-When the user asks for a **simple board** (Status board + Prioritized backlog only):
-
-1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
-2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
-3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F. Optional: **Group by Priority** on Prioritized backlog (polish; not a `--check` gate).
-4. Re-run `board-bootstrap --check` after each turn until exit **0**.
-
-### Playground default (six views)
-
-- Edit overlay `.local/user_settings/board-shell.schema.yaml` only if your team intentionally drops a Playground view (expect FAIL→WARN tradeoffs).
-- **Safe:** Insights, Iteration columns, filters. (End date is Tier-1 — keep visible on Status board / Prioritized backlog.)
-- **Unsafe:** remove Status / Priority / Size / Estimate / Start date / End date fields, or hide **Priority** on Prioritized backlog.
+**Playground default (six views):** edit overlay only if team intentionally drops a view. **Unsafe:** remove Tier-1 fields or hide Priority on Prioritized backlog.
 
 ## Exit
-
-Print:
 
 ```text
 board-shell: minimum=pass|fail · recommended=N missing · schema=<path> · next=day-to-day Pattern A
 ```
 
-Only say **ready for agents** when `board-bootstrap --check` exits **0** (no view FAIL, no Tier-1 column FAIL on Status board / Prioritized backlog, README non-empty).
+Say **ready for agents** only when `board-bootstrap --check` exits **0**.
 
 ## Canon
 
 - Schema: `.ai_infra/templates/project-board/board-shell.schema.yaml`
-- Click map: `.ai_infra/templates/project-board/views-setup.md` § Browser assist map
-- Day-to-day cards: `.cursor/skills/board-ssot/SKILL.md`
-- ADR-008: no view API; coach + check by default; browser MCP only when user asks
+- Clicks: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md)
+- Day-to-day: `.cursor/skills/board-ssot/SKILL.md`
+- ADR-008: coach + check by default; browser MCP only when user asks

--- a/.cursor/skills/canvas-artifacts/SKILL.md
+++ b/.cursor/skills/canvas-artifacts/SKILL.md
@@ -5,6 +5,8 @@ description: Three-tier canvas and plan snapshot workflow via agent_colony canva
 
 # Canvas and plan artifacts (Pattern A)
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 - Editing kit canvases in `canvases/` and needing IDE preview
@@ -32,15 +34,15 @@ python3 -m agent_colony canvas save --slug billing-review --agent implementer
 ```
 
 - Use `export default function NameCanvas()` in `.canvas.tsx` files.
-- `sync --all` requires `--force` (avoid silent overwrite).
+- `sync --all` requires `--force`.
 
 ## Plan CLI
 
 ```bash
 python3 -m agent_colony plan snapshot --slug slice-170 --agent implementer --board-item PVTI_xxx
 python3 -m agent_colony plan list
-python3 -m agent_colony plan open --slug slice-170          # human Build bridge
-python3 -m agent_colony plan open --slug slice-170 --force  # overwrite Cursor twin
+python3 -m agent_colony plan open --slug slice-170
+python3 -m agent_colony plan open --slug slice-170 --force
 python3 -m agent_colony plan snapshot --slug my-plan --from cursor-plan:my-plan.plan.md
 ```
 
@@ -49,21 +51,21 @@ Never treat `.local/plans/` as active backlog under `board_only`.
 ## Agent rituals
 
 1. **Product canvas:** edit repo → `canvas sync --name …` → Open Canvas in IDE.
-2. **Ephemeral canvas:** write via Cursor canvas skill to managed path → `canvas save --slug …`.
+2. **Ephemeral canvas:** write via Cursor canvas skill → `canvas save --slug …`.
 3. **Plan mode exit:** `plan snapshot --slug …` with board item id when known.
 
-### Consumer plans (agent build — Path A)
+### Consumer plans (Path A)
 
-Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
+Agents **never depend on** the IDE Build button:
 
-1. `plan list` — discover slugs under `.local/plans/`
-2. Read `.local/plans/<latest>-<slug>.plan.md` (+ sibling `.meta.yaml`)
-3. Execute todos / acceptance as implementer (no Build required)
-4. **Human-only:** `plan open --slug …` → Plans UI → Build (copies latest snapshot to `~/.cursor/plans/<slug>.plan.md`)
-5. After plan-mode work in Cursor: `plan snapshot --from cursor-plan:…` to re-anchor history in `.local/plans/`
+1. `plan list` — discover slugs
+2. Read `.local/plans/<latest>-<slug>.plan.md` (+ `.meta.yaml`)
+3. Execute todos as implementer
+4. **Human-only:** `plan open --slug …` → Plans UI → Build
+5. After plan-mode work: `plan snapshot --from cursor-plan:…`
 
-`plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
+`plan snapshot` preserves YAML frontmatter (`name` / `overview` / `todos`) for Build.
 
-**Indexing:** only `*.plan.md` (+ sibling `*.meta.yaml`) appear in `plan list` / `index.md`. Plain `.md` files dropped under `.local/plans/` are orphans — remove or re-snapshot via `plan snapshot --from <path>`.
+**Indexing:** only `*.plan.md` (+ `*.meta.yaml`) in `plan list`. Orphans → re-snapshot or remove.
 
 Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/.cursor/skills/integrator-protocol/SKILL.md
+++ b/.cursor/skills/integrator-protocol/SKILL.md
@@ -5,177 +5,105 @@ description: Procedural integration of new agents, skills, MCP servers, and kit 
 
 # Integrator protocol
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Integrate **new agents, skills, MCP servers, scripts, or docs** into the kit so the user gets the same **unpack + personal settings** experience: full consumer infrastructure from the plugin, human completes `.local/user_settings/`, everything else stays **procedural, deterministic, and enterprise-grade**.
+Integrate **new agents, skills, MCP servers, scripts, or docs** for unpack + personal settings. Keep work procedural and deterministic.
 
-**Canonical ops mirror:** `.ai_infra/docs/operations/mas-infrastructure-integration.md`
-
-## When to use
-
-- User adds a **new Cursor agent** or **skill**
-- User connects an **external MCP server** for multiple agents
-- User expands **manifest / install contract / plugin payload**
-- User asks to merge a **standalone agent** into the MAS pipeline (or keep independent but governed)
-
-**Agent card:** `.cursor/agents/integrator.md`
+**Canonical ops:** [mas-infrastructure-integration.md](../../.ai_infra/docs/operations/mas-infrastructure-integration.md) · **Agent:** `.cursor/agents/integrator.md`
 
 ## Evidence contract
 
-- Every integration claim cites a **repo path** or **command output**.
-- If not inspected: label **Unknown** — do not invent file layout or gate behavior.
-- No narrative without a checklist row or script result backing it.
+- Every claim cites **repo path** or **command output**.
+- Not inspected → **Unknown**. No invented layout or gate behavior.
 
----
+## Phase 0 — Intake
 
-## Phase 0 — Intake (classify)
+| Type | Examples | Outputs |
+|------|----------|---------|
+| **Agent** | `my-domain-agent.md` | `.cursor/agents/`, registry |
+| **Skill** | `.cursor/skills/` or `.agents/skills/` | SKILL.md, plugin sync |
+| **MCP** | GitHub, browser, DB | `mcp.user.json`, registry |
+| **Infrastructure** | script, gate | `.ai_infra/`, manifest, tests |
+| **Doc-only** | runbook | `.ai_infra/docs/` |
 
-| Type | Examples | Primary outputs |
-|------|----------|-----------------|
-| **Agent** | `my-domain-agent.md` | `.cursor/agents/`, registry, optional pipeline |
-| **Skill** | `.cursor/skills/foo/` or `.agents/skills/` | SKILL.md, cross-links, plugin sync |
-| **MCP external** | GitHub, browser, DB | `mcp.user.json`, registry, `mcp.agents.yaml` worksheet |
-| **Infrastructure** | new script, gate, template dir | `.ai_infra/`, manifest, tests |
-| **Doc-only** | runbook, charter | `.ai_infra/docs/` |
+Ask: MAS-integrated vs independent (ADR-006)? Architecture/manifest touch → plan `auditor`. Consumer-visible → `manifest.yaml` + `install-contract.json`. Research pack → read `AGENT_BRIEF.md`.
 
-Ask (or infer from request):
+## Phase 1 — Read base workflow
 
-1. **MAS-integrated** or **independent contract**? (see ADR-006: `.ai_infra/docs/decisions/ADR-006-agent-integration-model.md`)
-2. Touches **architecture / manifest / workflows**? → plan `auditor` before merge prep.
-3. **Consumer-visible** (copied on install)? → update `manifest.yaml` + `install-contract.json`.
-4. Research pack cited? → read `_research_results/sources/<slug>/AGENT_BRIEF.md` before classifying.
+`workflow-architecture.md` · `agent-workflow-procedures.md` · `local-workspace-layout.md` · `github.collaboration.yaml` · similar agent/skill as template.
 
----
+## Phase 2 — Templates
 
-## Phase 1 — Read base workflow (do not skip)
-
-Minimum read set:
-
-1. `.ai_infra/docs/architecture/workflow-architecture.md` — three planes
-2. `.ai_infra/docs/operations/agent-workflow-procedures.md` — Pattern A
-3. `.ai_infra/docs/operations/local-workspace-layout.md` — `.local/` contract
-4. `.local/user_settings/github.collaboration.yaml` — pipelines + attribution
-5. Target area already in repo (similar agent/skill as template)
-
----
-
-## Phase 2 — Apply templates
-
-Copy and edit from **`.ai_infra/templates/agent-integration/`**:
+From `.ai_infra/templates/agent-integration/`:
 
 | Template | Use |
 |----------|-----|
-| `AGENT.template.md` | New `.cursor/agents/<id>.md` |
-| `SKILL.template.md` | New skill under `.cursor/skills/<name>/` |
-| `INTEGRATION-CHECKLIST.md` | Track slice; when `project_ssot.enabled` + `board_only`, attach to the **board card** body/Notes; else attach to `work-tracker.md` |
+| `AGENT.template.md` | `.cursor/agents/<id>.md` |
+| `SKILL.template.md` | `.cursor/skills/<name>/` |
+| `INTEGRATION-CHECKLIST.md` | Board card or `work-tracker.md` |
 
-**Agent file rules:**
+**Agent:** frontmatter; **Anchor**; **Read first**; **MCP integration**. Board SSOT when enabled; else `session-pointer.md`. Independent agents: omit pipelines unless PR phase owner.
 
-- YAML frontmatter: `name`, `model`, `description`
-- **Anchor** block (Entry/Exit) — same discipline as `implementer.md`
-- **Read first** — bounded file set; no whole-repo loads
-- **MCP integration** section — required (governance scanner)
-- Procedural exits: when `project_ssot.enabled` + `board_only`, **Entry/Exit** on Project (`project status` → `set-status` / Notes); update `change-index.md`. `session-pointer.md` is offline fallback / session pointer only — not Status SSOT. When SSOT disabled/offline: update `session-pointer.md`, `change-index.md`
+## Phase 3 — Wire surfaces
 
-**Independent agent:** still includes Anchor + universal rules; omit from `github.collaboration.yaml` pipelines unless it participates in PR phases.
-
----
-
-## Phase 3 — Wire integration surfaces
-
-### A. MAS-integrated agent (multi-agent system)
+### MAS-integrated
 
 | Step | Action |
 |------|--------|
-| 1 | Add `.cursor/agents/<id>.md` from template |
-| 2 | Add skill if procedural steps are non-trivial |
-| 3 | Update `.cursor/mcp.registry.yaml` (+ example): list agent under `agent-colony-mcp` or external server |
-| 4 | Update `.local/user_settings/mcp.agents.yaml` worksheet + exemplar under `templates/user-settings/` |
-| 5 | Add to `github.collaboration.yaml` pipeline if it runs in PR/slice flow (or rely on `--agents-from-session` via `change-index`) |
-| 6 | If consumer-installed: add paths to `manifest.yaml` / `install-contract.json` when new dirs ship |
-| 7 | If marketplace: `make sync-plugin` + `make check-plugin` |
-| 8 | Add tests under `tests/modules/` if new scripts |
+| 1–2 | Agent + skill if non-trivial |
+| 3–4 | `mcp.registry.yaml` + `mcp.agents.yaml` worksheet |
+| 5 | `github.collaboration.yaml` pipeline if PR/slice |
+| 6–7 | `manifest.yaml` / `install-contract.json`; `make sync-plugin` + `check-plugin` |
+| 8 | `tests/modules/` if new scripts |
 
-### B. Independent agent (governed, not in MAS pipeline)
+### Independent
 
-| Step | Action |
-|------|--------|
-| 1 | Agent + skill with explicit **boundaries** (what it must not do) |
-| 2 | Registry: optional MCP servers scoped to that agent id only |
-| 3 | **Do not** add to core PR pipelines unless it owns a maintainer phase |
-| 4 | Document handoff to `implementer` / `integrator` when work crosses into kit infrastructure |
+Agent + skill with **boundaries**; optional scoped MCP; no core PR pipeline unless maintainer phase; document handoff when crossing kit infra.
 
-### C. External MCP server
+### External MCP
 
-Follow `.ai_infra/docs/operations/connect-external-mcp.md` plus:
+[connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md): `mcp.agents.yaml` row → `mcp.user.json` fragment → `mcp.registry.yaml` → `mcp validate`.
 
-1. Row in `.local/user_settings/mcp.agents.yaml`
-2. Fragment in `.cursor/mcp.user.json` (gitignored)
-3. Keys in `.cursor/mcp.registry.yaml` — `agents: [...]` per server
-4. `python -m agent_colony mcp validate`
+### Canvases / plans (ADR-010)
 
-### D. Canvases / plans (ADR-010)
+`.cursor/skills/canvas-artifacts/SKILL.md`. `.local/plans/` = snapshots only.
 
-When touching `canvases/`, `.local/canvases/`, or `.local/plans/`:
+### Maintainer script
 
-1. Read `.cursor/skills/canvas-artifacts/SKILL.md` and [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md).
-2. Repo `canvases/` = git SSOT → `canvas sync` → optional `canvas save` to `.local/canvases/`.
-3. `.local/plans/` = snapshot history only; live plan stays on board card / `plan.md` — wire `plan snapshot|list|open` in docs/agent cards as needed.
-4. After canvas edits: `python3 -m agent_colony canvas sync --name <stem>` (+ `canvas doctor` smoke).
+`.ai_infra/scripts/` only; never duplicate `GATES` outside `prepare.py`; file header on new Python; thin MCP wrapper in `agent_colony_mcp/server.py`.
 
-### E. New maintainer script
-
-- Lives under `.ai_infra/scripts/` — never duplicate `GATES` outside `prepare.py`
-- File header per `file-docstring-header-relations.mdc`
-- Wire MCP tool in `agent_colony_mcp/server.py` only as thin wrapper (Pattern A)
-
----
-
-## Phase 4 — Verify (commands, not prose)
-
-Run applicable subset:
+## Phase 4 — Verify
 
 ```bash
 python -m agent_colony contributors validate
 python -m agent_colony integrate validate
-python .ai_infra/scripts/architecture/check_governance_consistency.py   # if .cursor/ or workflows changed
+python .ai_infra/scripts/architecture/check_governance_consistency.py   # if .cursor/ changed
 pytest -q tests/modules/<relevant>/
-make gates                    # kit dev
-make check-plugin             # if agents/rules/skills/payload touched
-make install-dry-run          # if manifest / scaffold changed
-python -m agent_colony health --directory .
+make gates && make check-plugin    # if payload touched
+make install-dry-run               # if manifest changed
 ```
 
-Record PASS/FAIL in `change-index.md` and `updates-log.md`.
-
----
+Say *prepare gates green* or paste failing stderr. Record in `change-index.md` + `updates-log.md`.
 
 ## Phase 5 — Handoff
 
-| Outcome | Next agent |
-|---------|------------|
-| Needs product code / tests | `implementer` + `test-runner` |
-| Architecture-impacting | `auditor` → alignment artifacts |
-| Ready for PR | maintainer `review-pr` with `--pipeline` + `--agents-from-session` |
+| Outcome | Next |
+|---------|------|
+| Product code / tests | `implementer` + `test-runner` |
+| Architecture-impacting | `auditor` |
+| Ready for PR | `review-pr` with `--pipeline` + `--agents-from-session` |
 
----
+## Anti-patterns
 
-## Anti-patterns (reject)
-
-- Duplicating `prepare.py` GATES in skills or agent prose
-- New agents without Anchor / MCP integration section
-- Skipping `change-index.md` Agent column (breaks PR `--agents-from-session`)
-- `Made-with:` or fake human sign-off in commits
-- Loading entire `.local/` or megadocs when a checklist suffices
-- Independent agents that bypass governance scripts
-
----
+Duplicate GATES in prose · agents without Anchor/MCP · skip `change-index.md` Agent column · `Made-with:` · load entire `.local/` · independent agents bypass governance.
 
 ## Exit criteria
 
-- [ ] Integration type documented (MAS vs independent)
-- [ ] Templates filled; file headers present on new Python
-- [ ] Registry / user_settings exemplars updated if MCP or pipelines affected
-- [ ] Manifest + install-contract if consumer tree changed
-- [ ] Verification commands run; failures fixed or logged as blockers
-- [ ] Board Status/Notes updated when `project_ssot.enabled` + `board_only`; else `session-pointer.md` updated. `change-index.md` always updated
+- [ ] Type documented (MAS vs independent)
+- [ ] Templates + file headers on new Python
+- [ ] Registry/exemplars if MCP/pipelines touched
+- [ ] Manifest if consumer tree changed
+- [ ] Verify commands run; blockers logged
+- [ ] Board Notes when `board_only`; `change-index.md` always

--- a/.cursor/skills/mcp-connect/SKILL.md
+++ b/.cursor/skills/mcp-connect/SKILL.md
@@ -5,6 +5,8 @@ description: Connect external MCP servers to Agent Colony agents via mcp.user.js
 
 # MCP connect
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom APIs) alongside built-in `agent-colony-mcp`.
@@ -13,22 +15,20 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 
 ### 1. Enable DeepWiki (default zero-auth)
 
-Consumer activate already seeds DeepWiki when `mcp.user.json` / registry keys are missing. On an existing workspace:
-
 ```bash
 python3 -m agent_colony mcp seed --deepwiki
 python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp smoke --server deepwiki
 ```
 
-Optional: `--force-registry-agents` to reset `deepwiki.agents` to the seven Pattern A agents.
+Optional: `--force-registry-agents` to reset `deepwiki.agents` to seven Pattern A agents.
 
 ### 2. Link custom (auth or private)
 
 ```bash
 python3 -m agent_colony mcp link --name my-api --file .cursor/mcp.d/my-api.json
 # edit .cursor/mcp.registry.yaml — map agents
-python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN   # if needed
+python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN
 python3 -m agent_colony mcp validate
 ```
 
@@ -38,41 +38,34 @@ python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp doctor
 python3 -m agent_colony mcp smoke --server agent-colony-mcp
 python3 -m agent_colony mcp smoke --server deepwiki
-# DeepWiki live call (repoName; repo must be indexed on deepwiki.com):
 python3 -m agent_colony mcp call --server deepwiki --tool ask_question \
   --args-json '{"repoName":"karpathy/nanochat","question":"What is nanochat in one sentence?"}'
 ```
 
-### Agent contract — DeepWiki
+### DeepWiki agent contract
 
 | Do | Do not |
 |----|--------|
-| `list-tools --server deepwiki` before inventing args | Guess `repo` — the tool wants **`repoName`** |
-| Pass `owner/repo` as `repoName` (same slug as GitHub) | Pass a deepwiki.com URL as the MCP arg |
-| Prefer indexed smoke targets (e.g. `karpathy/nanochat`) | Treat “Repository not found” as a kit bug — index on deepwiki.com first |
-| Use GitHub URL / `github:` for `research init\|fetch` | Use DeepWiki MCP as a substitute for cloning the corpus |
+| `list-tools --server deepwiki` before inventing args | Guess `repo` — tool wants **`repoName`** |
+| Pass `owner/repo` as `repoName` | Pass deepwiki.com URL as MCP arg |
+| Prefer indexed smoke targets (e.g. `karpathy/nanochat`) | Treat “Repository not found” as kit bug |
+| Use GitHub URL / `github:` for `research init\|fetch` | Use DeepWiki as substitute for cloning corpus |
 
-## Steps (<5 min) — first-time worksheets
+## First-time setup (<5 min)
 
-1. Copy `.cursor/mcp.registry.yaml.example` → `.cursor/mcp.registry.yaml` (if live missing and you did not activate)
-2. Copy `.cursor/mcp.user.example.json` → `.cursor/mcp.user.json` (gitignored) — or prefer `mcp seed --deepwiki`
-3. Or link a fragment:
-
-```bash
-python3 -m agent_colony mcp link --name my-api --file .cursor/mcp.d/my-api.json
-```
-
-4. Map the server to agents in `mcp.registry.yaml`
-5. Merge and validate:
+1. Copy `.cursor/mcp.registry.yaml.example` → `.cursor/mcp.registry.yaml` (if missing)
+2. Copy `.cursor/mcp.user.example.json` → `.cursor/mcp.user.json` — or `mcp seed --deepwiki`
+3. Map server to agents in `mcp.registry.yaml`
+4. Validate:
 
 ```bash
 python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp doctor
 ```
 
-6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
+5. Optional: enable MCP in Cursor settings (`CallMcpTool` convenience).
 
-**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+**Pattern A (canonical):** agents call MCP via CLI:
 
 ```bash
 python3 -m agent_colony mcp list-tools --server agent-colony-mcp
@@ -81,17 +74,17 @@ python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN
 python3 -m agent_colony mcp smoke --server agent-colony-mcp
 ```
 
-Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
+Walkthrough: [connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md) § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `python3 -m agent_colony mcp validate` exits 0
-- `python3 -m agent_colony mcp doctor` shows configured vs host-loaded
+- `mcp validate` exits 0
+- `mcp doctor` shows configured vs host-loaded
 - `mcp list-tools` / `mcp call` work for allowlisted servers
-- Target agent markdown includes the server under **MCP integration**
+- Target agent markdown includes server under **MCP integration**
 
 ## Reference
 
-- `.ai_infra/docs/operations/connect-external-mcp.md`
-- `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
-- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`
+- [connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md)
+- [ADR-004](../../.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md)
+- [ADR-009](../../.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md)

--- a/.cursor/skills/research-corpus/SKILL.md
+++ b/.cursor/skills/research-corpus/SKILL.md
@@ -5,124 +5,95 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 # Research corpus
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-- External research: user chat, another agent’s handoff/Notes, or a board research card names a source.
-- Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` when present under `_research_results/`.
+- External research: user chat, peer handoff/Notes, or board research card names a source
+- Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` under `_research_results/`
 
-**Not for:** product code changes, PR merge, `.local/` implementation — use `implementer` / `.agents/skills/pr-workflow/SKILL.md`.
+**Not for:** product code, PR merge, `.local/` implementation — use `implementer` / `pr-workflow`.
 
-## Agent
-
-**`.cursor/agents/researcher.md`**. Hub: `.agents/skills/RESEARCH_WORKFLOW.md`.
+**Agent:** `.cursor/agents/researcher.md` · Hub: `.agents/skills/RESEARCH_WORKFLOW.md`
 
 ## Read first
 
-1. This skill (intake → rounds)
+1. This skill
 2. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
-3. Incoming chat / board card / peer handoff (see Intake)
+3. Incoming chat / board card / peer handoff
 4. Pack `BRIEF.md` when continuing a slug
 
-## Intake (adapt — do not require a formal paste)
+## Intake
 
-Build a Brief from **any** of:
-
-1. **User chat** — including terse forms like `/researcher https://github.com/owner/repo`
-2. **Peer agents** — board Notes, handoff line, cited `AGENT_BRIEF.md` / pack path, implementer/integrator ask
-3. **Board card** — `create-from-template --template research --priority p2` body Brief table
-4. **Existing** `sources/<slug>/BRIEF.md`
+Build a Brief from user chat, peer Notes/handoff, board card, or existing `BRIEF.md`.
 
 ### Normalize source
 
 | Input | Normalized |
 |-------|------------|
-| `https://github.com/owner/repo` | OK for CLI; also record `github:owner/repo` |
-| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` (CLI accepts HTTPS tree URLs) |
+| `https://github.com/owner/repo` | OK; also `github:owner/repo` |
+| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` |
 | `github:owner/repo[@ref]` | Canonical |
 | Local path | `path:…` or bare path |
 
-**DeepWiki is not a research source locator.** Packs clone from GitHub/`path:`. Optional wiki Q&A uses MCP `deepwiki` with **`repoName":"owner/repo"`** (must be indexed on [deepwiki.com](https://deepwiki.com)) — see `researcher` MCP section and `/mcp-connect`. Do not pass a deepwiki.com URL to `research init --source`.
+**DeepWiki is not a research source locator.** Packs clone from GitHub/`path:`. Optional wiki Q&A: MCP `deepwiki` with `repoName":"owner/repo"` — see `mcp-connect`. Do not pass deepwiki.com URL to `research init --source`.
 
 ### Defaults (terse chat)
 
-If only a link/path is given:
+If only a link/path:
 
-- **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
+- **question:** Map architecture, entrypoints, patterns for MAS kit; produce `AGENT_BRIEF`.
 - **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
-- **slug:** repo (or directory) name, lowercase with hyphens
-- **consumers:** implementer, integrator (plus the requesting agent if known)
+- **slug:** repo name, lowercase hyphens
+- **consumers:** implementer, integrator (+ requester if known)
 - **rounds_max:** 6
 
-Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
+Refuse only when no source and no `mode: self`. Missing question → use default; state in Notes.
 
 ### GitHub access
 
-| Visibility | Requirement |
-|------------|-------------|
-| Public | Network + `gh` or `git` clone |
-| Private | Same, plus consumer auth (`gh auth login` / git credentials that can clone the URL) |
+Public: network + `gh` or `git`. Private: + consumer auth. Clone failure → report once; stop.
 
-Clone failures: report once and stop — no retry loop.
-
-### Brief contract (persisted)
-
-Write via `research init` into `BRIEF.md`:
-
-```text
-source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
-question: <what MAS / requesting agent needs>
-lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
-rounds_max: 6
-consumers: [implementer, integrator, …]
-slug: <derived or explicit>
-```
-
-## Procedural setup
+### Brief contract
 
 ```bash
 python3 -m agent_colony research init --slug <slug> --source '…' --question '…'
 python3 -m agent_colony research fetch --slug <slug> --source '…'
 ```
 
-`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch prefers `gh repo clone` (private-friendly), else `git clone --depth 1` into `_research_results/cache/<slug>/`. Re-fetch requires `--force`.
+`--source`: HTTPS GitHub, `github:…`, `path:…`, or local path. Re-fetch needs `--force`.
 
 ## Anti-loop (hard stop)
 
 | Rule | Behavior |
 |------|----------|
-| Cap | Deepen ≤ `rounds_max` (default 6); never round 7+ |
-| Idempotent init/fetch | Existing pack / `SOURCE.md` → refuse unless `--force` |
-| Closed pack | `INDEX.status=complete` + validate PASS → **exit**; do not deepen again unless user reopens |
-| Failures | One clone attempt; surface error; stop |
-| Gaps | Remaining questions → document gaps; set `blocked` or complete with gaps — do not spin |
+| Cap | ≤ `rounds_max` (default 6) |
+| Idempotent | Existing pack → refuse unless `--force` |
+| Closed pack | `INDEX.status=complete` + validate PASS → **exit** |
+| Failures | One clone attempt; stop |
+| Gaps | Document; set `blocked` or complete with gaps |
 
-## Multi-round loop (active)
+## Multi-round loop
 
-Work only under `_research_results/sources/<slug>/`. Read foreign trees read-only.
+Work under `_research_results/sources/<slug>/` only. Foreign trees read-only.
 
-1. **Scout** — confirm `SOURCE.md` pin (SHA/path); note languages/size.
-2. **Map** — write `MAP.md` (entrypoints, layout, docs).
-3. **Extract** — for each lens in Brief, fill `findings/<lens>.md` with path + line evidence.
-4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`). **Stop deepening when N == rounds_max.**
-5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
-6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed` ≤ `rounds_max`).
-7. **Validate** — `python3 -m agent_colony research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known). **Then stop.**
+1. **Scout** — confirm `SOURCE.md` pin
+2. **Map** — `MAP.md`
+3. **Extract** — `findings/<lens>.md` with path + line evidence
+4. **Deepen** — `rounds/round-N.md` (N ≤ `rounds_max`)
+5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`
+6. **Pack** — `AGENT_BRIEF.md` + `INDEX.json`
+7. **Validate** — `research validate --slug <slug>`
+8. **Exit** — board Done + Notes; handoff to consumer; **stop**
 
-## Mode: self (optional)
+## Mode: self
 
-If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only.
+One backlog ID per session when `DEPTH_BACKLOG.md` exists and user asks.
 
-## Lenses (default)
-
-`architecture` · `cli` · `agents` · `skills` · `tests` · `decisions` · `patterns`
-
-## Output format
+## Output
 
 ```text
 slug · mode · rounds · curated_count · AGENT_BRIEF path · validate PASS/FAIL · next consumer
 ```
 
-## Status
-
-**Agent shipped/proven** (2026-07-19): live external pack (`flexiai-toolsmith`, 18 curated, validate PASS) + verifier Claim A (efficiency) / Claim B (correctness) VERIFIED. Corpus remains **opt-in** after first `research init` — not an incomplete agent. Canvas: `canvases/agent-researcher.canvas.tsx`.
+Canvas: `canvases/agent-researcher.canvas.tsx`.

--- a/.cursor/skills/test-coverage/SKILL.md
+++ b/.cursor/skills/test-coverage/SKILL.md
@@ -5,6 +5,8 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 
 # Test coverage
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 `src/**` or `scripts/**` behavior change; coverage or regression requests; medium/high risk before merge.
@@ -13,16 +15,16 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 
 1. Target modules/symbols; matrix: valid / boundary / invalid, lifecycle, failure/recovery.
 2. Tests under `tests/modules/<module>/`.
-3. Update `.local/index-and-planning/current/test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
-4. Run: `pytest` scoped to module → broader as needed. Before merge path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (see `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
-5. For coverage evidence, install `dev` extras (`pip install -e ".[dev]"`) then run `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing --cov-report=json -q` (writes **`coverage.json` only** — do not invent alternate names). Prefer `grep`/`python` over `rg` when filtering shell output — `rg` is often absent from the user PATH. Record gaps in board card Notes when `project_ssot.enabled` + `board_only`, else `work-tracker.md`; always one line in `updates-log.md` per `implementation-workflow-governance.mdc`. **Scope:** this metric tracks the installable kit import surface (`.ai_infra/**` modules imported during tests + `agent_colony/**`); subprocess-only scanners (`check_governance_consistency.py`, `check_debrand.py`, etc.) are validated via their own module tests but excluded from `--cov` by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
-6. **After scoped coverage reaches 100%** (or any coverage-closure slice): mandatory doc reality sync — update `IMPLEMENTATION-STATUS.md` **Tests:** + coverage scope numbers, regenerate `.local/index-and-planning/current/coverage-index.md` via `make coverage-index`, run `make doc-validate`, sync related README/AGENTS/repository-map claims, then `make sync-plugin` when skills/docs payload copies change.
-7. Report: modules • edges added • gaps • tracker edits.
+3. Update `test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
+4. Run scoped `pytest` → broader as needed. Before merge: **`check_testing_artifacts.py`** (via `prepare.py` `resolve_gates()`).
+5. Coverage evidence: `pip install -e ".[dev]"` then `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing --cov-report=json -q` (writes **`coverage.json`** only). Record gaps in board Notes when `board_only`, else `work-tracker.md`; one line in `updates-log.md`. Scope: kit import surface; subprocess scanners excluded by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
+6. **After 100% scoped coverage:** sync `IMPLEMENTATION-STATUS.md`, regenerate `coverage-index.md` via `make coverage-index`, `make doc-validate`, sync README/AGENTS claims, `make sync-plugin` when payload copies change.
+7. Report: modules · edges added · gaps · tracker edits.
 
 ## Themes (when relevant)
 
-Validation boundaries • error/reason codes • retry/replay on risky flows • async cleanup • policy negative paths.
+Validation boundaries · error/reason codes · retry/replay · async cleanup · policy negative paths.
 
 ## Output
 
-`Coverage summary` → `Tests added/updated` → `Edge cases` → `Gaps` → `Index/plan updates` (paths in backticks).
+`Coverage summary` → `Tests added/updated` → `Edge cases` → `Gaps` → `Index/plan updates`.

--- a/.cursor/skills/update-agent-colony/SKILL.md
+++ b/.cursor/skills/update-agent-colony/SKILL.md
@@ -19,53 +19,45 @@ Notes:
 
 # Update Agent Colony
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-User already ran **`/workflow-activate`** in **their app**, then updated the **Agent Colony** plugin (or kit tag) and needs kit-managed files refreshed.
+User ran **`/workflow-activate`** in **their app**, then updated the Agent Colony plugin and needs kit-managed files refreshed.
 
 **Not for first install** — use [workflow-activate](workflow-activate/SKILL.md) when `.ai_infra/` is missing.
 
 ## Guide the user
 
-1. Confirm the open folder is **their activated app**, not the kit product repo.
-2. Prefer Agent chat **`/update-agent-colony`**, or the Pattern A command below.
-3. Explain version gate briefly:
+1. Confirm folder is **their activated app**, not kit-dev repo.
+2. Prefer **`/update-agent-colony`** or Pattern A command below.
+3. Version gate:
    - **same / newer installed** → light heal (dashboards, `.gitignore`, `STARTER-001`, missing `.venv`)
    - **source newer** or **`--force`** → full overwrite of kit-managed agents/rules/skills/scripts
 4. After upgrade: `health` + `mcp validate`.
 
-## One command
+## Commands
 
 ```bash
 source .venv/bin/activate
 python3 -m agent_colony update --directory .
+python3 -m agent_colony update --directory . --check      # no writes
+python3 -m agent_colony update --directory . --force      # full refresh
 ```
 
-**Check only (no writes):**
-
-```bash
-python3 -m agent_colony update --directory . --check
-```
-
-**Force full refresh** (even when versions match):
-
-```bash
-python3 -m agent_colony update --directory . --force
-```
-
-**Source resolution** matches activate: `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
+**Source resolution:** `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
 
 ## What update does
 
 | Condition | Action |
 |-----------|--------|
-| No `.ai_infra/` or missing `.kit-version` | Fail — tell user to run `/workflow-activate` |
-| `installed == available` (and not `--force`) | Light heal only |
-| `available > installed` or `--force` | Full scaffold refresh (same as `activate --force`) |
+| No `.ai_infra/` or missing `.kit-version` | Fail — run `/workflow-activate` |
+| `installed == available` (not `--force`) | Light heal only |
+| `available > installed` or `--force` | Full scaffold refresh |
 
-**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, existing trackers.
+**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, trackers.
 
-**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI copy, `.kit-version`, kit-managed dashboards.
+**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI, `.kit-version`, dashboards.
 
 ## Post-update
 
@@ -78,6 +70,6 @@ Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.
 
 ## Anti-patterns
 
-- Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
-- Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
-- Do **not** run `update --force` inside the **kit-dev product repo** (`agent-colony`) — scaffold treats it as a consumer install and fails (`forbidden in slim install: full kit tests tree`). Kit-dev workflow: edit sources → `make sync-plugin` → commit. Use `update` only in **activated consumer apps**.
+- Re-run plain `/workflow-activate` expecting agents/skills refresh — heals only when planes ready.
+- Overwrite consumer `user_settings` or invent second Status writer under `board_only`.
+- Run `update --force` in **kit-dev repo** — fails (`forbidden in slim install`). Kit-dev: edit sources → `make sync-plugin` → commit.

--- a/payload/.agents/skills/audit-alignment/SKILL.md
+++ b/payload/.agents/skills/audit-alignment/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Audit alignment (deprecated stub — retire pending)
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Do not use this file as the primary workflow.** The canonical audit agent is **`auditor`**.
 
 - **Agent:** `.cursor/agents/auditor.md`

--- a/payload/.agents/skills/full-pr-workflow/SKILL.md
+++ b/payload/.agents/skills/full-pr-workflow/SKILL.md
@@ -6,7 +6,9 @@ disable-model-invocation: true
 
 # Full PR workflow (maintainer)
 
-**Goal:** Merge a PR and then clean up the repo (sync `main`, delete local + remote feature branches) with a dedicated **finalize** phase.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+**Goal:** Merge a PR and clean up the repo (sync `main`, delete branches) via **finalize**.
 
 ## Order
 

--- a/payload/.agents/skills/merge-pr/SKILL.md
+++ b/payload/.agents/skills/merge-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Merge PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Merge only when artifacts + gates are satisfied.
 
 ## Steps

--- a/payload/.agents/skills/pr-workflow/SKILL.md
+++ b/payload/.agents/skills/pr-workflow/SKILL.md
@@ -6,9 +6,11 @@ disable-model-invocation: true
 
 # PR workflow (maintainer)
 
-**Implementer work:** when `project_ssot.enabled` + `board_only`, slice status lives on the **GitHub Project** (Entry/Exit continuation). Local `.local/index-and-planning/current/*` is offline fallback only — see ADR-008 and `project-ssot-precedence.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
-This skill is the **merge path** only: **review → prepare → merge** (slash skills: `review-pr`, `prepare-pr`, `merge-pr`).
+**Implementer work:** board SSOT when `project_ssot.enabled` + `board_only`; local trackers are offline fallback (ADR-008). Slice closure: `workflow-complete.md` §F.
+
+**Merge path only:** review → prepare → merge (`review-pr`, `prepare-pr`, `merge-pr`).
 
 ## Order
 

--- a/payload/.agents/skills/prepare-pr/SKILL.md
+++ b/payload/.agents/skills/prepare-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Prepare PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Green gates + documented evidence in `prep.md`.
 
 ## Steps

--- a/payload/.agents/skills/review-pr/SKILL.md
+++ b/payload/.agents/skills/review-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Review PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Decide if the PR is ready for `/prepare-pr`.
 
 ## Steps

--- a/payload/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/payload/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -55,7 +55,8 @@ Research goal: clearer prose → fewer tokens → measure before/after byte and 
 | Surface | Rule |
 |---------|------|
 | Agent cards | Keep Anchors short. Point here + `token-efficiency.md`. |
-| Skills | Procedure lives in the skill. Cards link to sections. |
+| Skills (`.cursor/skills/`) | Procedure lives in the skill. Cards link to sections. |
+| Maintainer slash skills (`.agents/skills/`) | One command per step; link `pr-workflow` for detail. |
 | Board Notes | Attributed one-liners. No gate dumps. |
 | Chat handoff | One line: Status · next · Tasks `[P…]` |
 

--- a/payload/.ai_infra/docs/operations/token-efficiency.md
+++ b/payload/.ai_infra/docs/operations/token-efficiency.md
@@ -25,9 +25,18 @@ Load the section you need. Do not load whole skills by default.
 | Skill | Read when | Prefer |
 |-------|-----------|--------|
 | `board-ssot` | Mutating Status / Tier-1 | § Continuation · § Tier-1 |
+| `board-shell` | First-run shell / bootstrap FAIL | § CONSENT GATE · § TURN PROTOCOL |
 | `implementer-loop` | Implement slice | Full skill (short) |
+| `integrator-protocol` | New agent/skill/MCP | Evidence contract + current phase |
 | `drift-audit` | drift-guard pass | Steps 1–3 |
 | `auditor-protocol` | Audit task | Evidence contract + current phase |
+| `audit-orchestration` | Full audit closure | Phase 0 preflight + delegation rules |
+| `audit-module-map` | Deep module topology | Constraints + output contract |
+| `mcp-connect` | External MCP setup | Intents table + Pattern A CLI |
+| `research-corpus` | Research pack work | Intake + anti-loop |
+| `canvas-artifacts` | Canvas/plan snapshots | Tiers table + CLI |
+| `test-coverage` | Tests / coverage slice | Procedure steps 1–7 |
+| `update-agent-colony` | Consumer kit upgrade | Commands + version gate |
 | `workflow-activate` | Consumer install | “When user just installed” |
 
 ## Read set (default)

--- a/payload/.cursor/skills/audit-module-map/SKILL.md
+++ b/payload/.cursor/skills/audit-module-map/SKILL.md
@@ -3,73 +3,52 @@ name: audit-module-map
 description: Builds a deep per-module workflow map with importance, goals, and visual architecture output.
 ---
 
-# Audit Module Map (Advisory-Only)
+# Audit module map (advisory-only)
+
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
 ## Relationship to audits
 
-This is a **depth tool** for **`auditor`**, not a separate audit authority. Run it when the enterprise architecture audit (or a focused alignment pass) needs HTML/topology evidence; fold outputs into the parent audit’s citations.
+Depth tool for **`auditor`**, not a separate audit authority. Run when enterprise audit (or focused alignment pass) needs HTML/topology evidence. Fold outputs into parent audit citations.
 
-## Goal
+## When
 
-Produce a module-by-module audit that explains workflow, behavior, importance, and intended goal, with a visual architecture map and detailed results.
+- **`auditor`** requests deep module topology or `module-audit.html` export
+- Team needs current module map before architecture reconciliation
+- Documentation drift suspected across module boundaries
 
-## When to Use
+## Required sources
 
-- **`auditor`** requests deep module topology or `module-audit.html` export.
-- Team needs a current module map before architecture reconciliation.
-- Documentation drift is suspected across module boundaries and ownership.
+- `README.md`, `AGENTS.md`
+- Project strategy/plan docs (when consumer defines them)
+- `tests/modules/*`
+- `.cursor/rules/*`, `.cursor/skills/*`
+- `.agents/skills/*` (maintainer context)
 
-## Required Sources
+## Constraints
 
-- `README.md` and `AGENTS.md`
-- Project strategy/plan docs (when the consumer repo defines them)
-- `tests/modules/*` (or project test tree)
-- `.cursor/rules/*` and `.cursor/skills/*`
-- `.agents/skills/*` (maintainer workflow context)
+1. Advisory-only: do not auto-remediate during this audit.
+2. Evidence-backed statements only; concrete file paths per claim.
+3. Distinguish canonical docs from archival/historical docs.
+4. Uncertain ownership → `TBD` + follow-up callout.
 
-## Mandatory Constraints
+## Steps
 
-1. Advisory-only: do not auto-remediate findings during this audit.
-2. Use evidence-backed statements only; include concrete file paths for each claim.
-3. Distinguish canonical current-state docs from archival/historical docs.
-4. Mark uncertain ownership as `TBD` and call out required follow-up.
-
-## Execution Steps
-
-1. Inventory module roots under `src/` and map corresponding test ownership under `tests/modules/`.
-2. For each module, document:
-   - goal
-   - workflow/how it works (entrypoints, key contracts, control flow)
-   - importance (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`) with rationale
-   - key dependencies and key dependents
-3. Build an architecture-layer graphic showing module placement and directional data/control flow.
-4. Identify drift/gaps in:
-   - module-to-test mapping
-   - module documentation coverage
-   - rules/skill guidance needed for repeatable audits
+1. Inventory module roots under `src/`; map test ownership under `tests/modules/`.
+2. Per module document: goal, workflow (entrypoints, contracts, control flow), importance (`CRITICAL`|`HIGH`|`MEDIUM`|`LOW`) + rationale, dependencies, dependents.
+3. Build architecture-layer graphic (placement + data/control flow).
+4. Identify drift/gaps: module-to-test mapping, doc coverage, rules/skill guidance.
 5. Emit:
-   - `.local/module-map.md` (detailed module catalog)
-   - `.local/agents-control-center/audits/module-audit.html` (visual report with architecture graphic and per-module cards)
-   - Optional reconciliation findings appended into `.local/workflow-artifacts/alignment/alignment-audit.md` and `.local/workflow-artifacts/alignment/alignment-todos.md`
+   - `.local/module-map.md`
+   - `.local/agents-control-center/audits/module-audit.html`
+   - Optional: append to `alignment-audit.md` + `alignment-todos.md`
 
-## Output Contract
+## Output contract (per module)
 
-For each module entry, include:
+`module_name` · `source_paths` · `test_paths` · `importance` · `goal` · `workflow` · `key_contracts` · `dependencies` · `dependents` · `evidence` · `gaps_or_risks`
 
-- `module_name`
-- `source_paths`
-- `test_paths`
-- `importance`
-- `goal`
-- `workflow`
-- `key_contracts`
-- `dependencies`
-- `dependents`
-- `evidence`
-- `gaps_or_risks`
+## Exit criteria
 
-## Exit Criteria
-
-- Every production module has an explicit ownership/mapping entry (or `TBD` with rationale).
-- The architecture graphic and module deep-dive results are generated and readable.
-- Any accuracy-improving updates needed for rules/skills/agents are explicitly listed with evidence.
+- Every production module has ownership entry (or `TBD` + rationale).
+- Architecture graphic and module deep-dive are readable.
+- Rules/skills/agent updates listed with evidence when needed.

--- a/payload/.cursor/skills/audit-orchestration/SKILL.md
+++ b/payload/.cursor/skills/audit-orchestration/SKILL.md
@@ -20,16 +20,18 @@ Notes:
 
 # Audit orchestration
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Run a **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts and apply approved fixes — without one agent re-running every shell command.
+Run **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts — without one agent re-running every shell command.
 
 ## Cadence
 
 | Trigger | Auditor depth | Drift |
 |---------|---------------|-------|
-| **Architecture-impacting PR** | Focused alignment + scoped CHK-* tick table | `drift validate` via prepare; optional drift-guard artifacts |
-| **Quarterly / kit release readiness** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
+| **Architecture-impacting PR** | Focused alignment + scoped CHK-* | `drift validate` via prepare; optional drift-guard |
+| **Quarterly / kit release** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
 | **Ad-hoc full audit** | Same as quarterly | Same |
 
 Do **not** run full CHK-* scorecard on every PR.
@@ -46,36 +48,34 @@ Run **once**; capture JSON for downstream agents:
 
 ```bash
 make verify-all
-# or with artifacts for agents:
+# or with artifacts:
 python -m agent_colony verify all --write-preflight
 python -m agent_colony doc validate --write-preflight
 python -m agent_colony drift validate --directory .
 ```
 
-**MCP (preferred in Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
+**MCP (Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
 
-**Read:** `.local/workflow-artifacts/audit/preflight.json` and `doc-facts-preflight.json` if present.
+**Read:** `.local/workflow-artifacts/audit/preflight.json`, `doc-facts-preflight.json` if present.
 
-**Stop on P0** from doc validate or drift; hand to **implementer** only for mechanical fixes the user approved.
+**Stop on P0** from doc validate or drift; hand to **implementer** only for approved mechanical fixes.
 
 ## Phase 1 — Parallel discovery (Task delegation)
 
-Launch concurrently:
-
 | Subagent | Mode | Deliverable |
 |----------|------|-------------|
-| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + **CHK-* tick table**. PR-scoped: alignment artifacts only |
-| `audit-module-map` skill (optional) | artifact-write (`.local/` only) | `.local/module-map.md` summary for audit §3 |
+| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + CHK-* table. PR-scoped: alignment only |
+| `audit-module-map` (optional) | artifact-write | `.local/module-map.md` summary for audit §3 |
 
-Parent **does not** duplicate inventory searches — consumes subagent outputs + preflight JSON.
+Parent consumes subagent outputs + preflight JSON — no duplicate inventory searches.
 
 ## Phase 2 — Mechanical remediation (user-approved only)
 
-When `enterprise-audit-actions.md` or doc validate lists **DOC-*** / doc-sync items:
+When `enterprise-audit-actions.md` or doc validate lists **DOC-*** items:
 
 | Subagent | Scope |
 |----------|-------|
-| `implementer` | Tracked doc/template fixes only; no scope creep |
+| `implementer` | Tracked doc/template fixes only |
 
 After edits:
 
@@ -89,22 +89,22 @@ make doc-validate
 
 | Subagent | When |
 |----------|------|
-| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift findings |
+| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift |
 | `verifier` | Spot-check top audit claims vs preflight + repo paths |
 
 ## Phase 4 — Maintainer PR
 
-Human or maintainer agent: `review-pr` → `prepare-pr` → `merge-pr` on a `feature/` or `chore/` branch.
+Human or maintainer: `review-pr` → `prepare-pr` → `merge-pr` on `feature/` or `chore/` branch.
 
 ## Delegation rules
 
-1. **Scripts before agents** — never let an agent re-run five gates if preflight JSON is fresh (<1 session).
-2. **One primary `in_progress`** during implementer slice: when `project_ssot.enabled` + `sync_policy: board_only`, Status lives on the **Project board** (`project status` → claim with `set-status --to in_progress`); do **not** dual-write tracker `in_progress`. When SSOT is disabled or offline fallback is active, one primary `in_progress` in `work-tracker.md`.
-3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`. Under `board_only`, do not auto-edit board card body or local `plan.md` / `work-tracker.md`; offline fallback: do not auto-edit `plan.md` / `work-tracker.md`.
+1. **Scripts before agents** — do not re-run five gates if preflight JSON is fresh (<1 session).
+2. **One primary `in_progress`:** board SSOT when enabled; else `work-tracker.md`. No dual-write under `board_only`.
+3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`.
 4. **Canvases** — optional IDE artifacts; not merge gates.
-5. **Token efficiency** — cite preflight pass/fail in chat; paste failing command output only.
-6. **Ownership** — continuous plan/agent-doctrine coherence = `drift-guard`; deep CHK-* = `auditor`. No new trash agents.
+5. **Token efficiency** — cite preflight pass/fail; paste failing stderr only.
+6. **Ownership** — plan/agent-doctrine = `drift-guard`; deep CHK-* = `auditor`.
 
 ## Handoff format
 
-Preflight exit • audit artifact paths • CHK-* gaps • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR
+Preflight exit · audit artifact paths · CHK-* gaps · P0/P1 counts · branch name · next: implementer | drift-guard | verifier | maintainer PR

--- a/payload/.cursor/skills/board-shell/SKILL.md
+++ b/payload/.cursor/skills/board-shell/SKILL.md
@@ -20,28 +20,32 @@ Notes:
 
 # Board shell
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-- Fresh consumer after `/workflow-activate` + identity in `github.collaboration.yaml` (board ids may still be empty)
-- Human pastes **Project URL + repo URL** after `gh` auth — help wire `project_ssot` / `default_repo` before shell check
-- User asks to apply the **kit default** board shell (Playground parity: six views + Tier-1 columns)
-- `board-bootstrap --check` FAILs missing default views or **FAILs** Tier-1 columns on Status board / Prioritized backlog / empty README
+- Fresh consumer after `/workflow-activate` + identity in `github.collaboration.yaml`
+- Human pastes **Project URL + repo URL** after `gh` auth
+- User asks for kit default shell (six views + Tier-1 columns)
+- `board-bootstrap --check` FAILs views, Tier-1 columns, or empty README
 
 ## Non-negotiable
 
 | Do | Do not |
 |----|--------|
-| **CONSENT GATE** before any shell apply (below) | Create/mutate shell without description + explicit proceed |
-| After `gh` auth, accept Project + repo URLs and propose YAML via `gh project view` / `field-list` | Write YAML without human confirm |
-| Coach humans through TURN PROTOCOL (`views-setup.md` = click reference only) | Dump “follow views-setup.md” and stop; undocumented GraphQL view mutations |
-| Run `board-bootstrap --check` until exit 0 (views + Tier-1 columns) | Mutate Insights / workflows / status updates without approval |
-| Optional `--ensure-fields` / `--apply-readme` **only after** CONSENT GATE (no view-apply CLI; **`--apply-shell` is not shipped**) | Invent field option ids into YAML without discovery |
-| Smoke `create-from-template` | Claim “ready” while `--check` exit 5 or Prioritized backlog lacks **Priority** |
-| Default: coach TURN PROTOCOL (human clicks); **if user asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn | Open browser MCP unprompted; multi-view instruction dumps; undocumented GraphQL view mutations |
+| **CONSENT GATE** before shell apply | Mutate shell without description + explicit proceed |
+| Accept Project + repo URLs; propose YAML via `gh project view` / `field-list` | Write YAML without human confirm |
+| Coach **TURN PROTOCOL** — one turn at a time | Dump “follow views-setup.md” and stop |
+| Run `board-bootstrap --check` until exit 0 | Undocumented GraphQL view mutations |
+| `--ensure-fields` / `--apply-readme` only after CONSENT | Invent field option ids without discovery |
+| Smoke `create-from-template` | Claim ready while `--check` exit 5 |
+| Browser MCP only when user asks | Open browser unprompted |
 
-## CONSENT GATE (mandatory — every first-run shell) 
+Click reference: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md) § Browser assist map.
 
-**Before** TURN PROTOCOL, `--ensure-fields`, `--apply-readme`, or any future `--apply-shell`, stop and ask the human **both** questions in one message. Do **not** proceed until answered.
+## CONSENT GATE (mandatory — every first-run shell)
+
+**Before** TURN PROTOCOL, `--ensure-fields`, `--apply-readme`, or any future `--apply-shell`, stop and ask **both** questions in one message. Do **not** proceed until answered.
 
 ### Q1 — Board description (README blurb)
 
@@ -52,9 +56,9 @@ What short description should appear on this Project board?
 (Reply with 1–3 sentences for the Project README, or say "use template default".)
 ```
 
-- If they give text → keep it for README placeholders / `--apply-readme` body merge.
-- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (board brief; title/repo filled from YAML).
-- If README already non-empty and they say keep it → record that; skip overwrite unless they ask.
+- Custom text → keep for `--apply-readme` body merge.
+- `use template default` → `.ai_infra/templates/project-board/project-readme.md`.
+- README already non-empty + keep → record; skip overwrite unless asked.
 
 ### Q2 — Proceed to create / coach the default shell?
 
@@ -65,9 +69,9 @@ May I proceed to set up the kit default Playground board shell on this Project
 (six views + Tier-1 columns + README)? Reply "yes" or "no".
 ```
 
-- **`yes`** → continue Entry check + TURN PROTOCOL (and/or approved CLI flags).
-- **`no`** → stop. Do not coach views, do not `--apply-readme` / `--ensure-fields`. Offer day-to-day triage only if shell already green.
-- Ambiguous reply → ask again. Never assume yes.
+- **`yes`** → Entry check + TURN PROTOCOL (and/or approved CLI flags).
+- **`no`** → stop. Offer day-to-day triage only if shell already green.
+- Ambiguous → ask again. Never assume yes.
 
 Print after answers:
 
@@ -79,120 +83,63 @@ Only `proceed=yes` unlocks the rest of this skill.
 
 ## Entry
 
-0. Run **CONSENT GATE** (Q1 + Q2). If `proceed=no` → Exit with consent line only.
-1. If board ids missing and human provided URLs: propose collaboration YAML, confirm, save. After wire, print:
+0. Run **CONSENT GATE**. If `proceed=no` → Exit with consent line only.
+1. If board ids missing and human provided URLs: propose collaboration YAML, confirm, save. Print:
 
 ```text
 board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
 ```
 
-**Automation boundary:** API automates YAML, field defs, README; **UI required** for six views + Tier-1 column visibility (GitHub has no public view mutation API).
+**Automation boundary:** API automates YAML, field defs, README. **UI required** for six views + Tier-1 column visibility (no public view mutation API).
 
 2. `python3 -m agent_colony project status`
 3. `python3 -m agent_colony project doctor`
-4. Load desired state:
-   - Overlay if present: `.local/user_settings/board-shell.schema.yaml`
-   - Else: `.ai_infra/templates/project-board/board-shell.schema.yaml`
+4. Load schema: overlay `.local/user_settings/board-shell.schema.yaml` or template `.ai_infra/templates/project-board/board-shell.schema.yaml`
 5. `python3 -m agent_colony project board-bootstrap --check`
 
-## Loop (refuse ready until default shell passes)
+## Loop
 
 ```text
 CONSENT GATE → doctor → board-bootstrap --check → (gaps?) → TURN PROTOCOL → re-check → smoke → ready
 ```
 
-**Read FAIL lines literally:** `FAIL — missing minimum view 'Status board'` (etc.) / `WARN — rename default view 'View 1'` → human UI until official apply CLI ships. Empty README / `--apply-readme` is a **separate** fix after consent — never tell the user a view-missing FAIL is “only README”.
+Read FAIL lines literally. Empty README is a **separate** fix after consent — never call a view-missing FAIL “only README”.
 
-### WARN vs FAIL (schema check)
+### WARN vs FAIL
 
 | Outcome | Typical cause | Coach action |
 |---------|---------------|--------------|
-| **FAIL** (exit non-zero) | Missing a **default** Playground view; empty README | Enter **TURN PROTOCOL** below — do not stop after one sentence |
-| **WARN** (exit 0) | Missing Tier-1 **columns** on primary views | Now **FAIL (exit 5)** — coach Turn H until green |
-| **WARN** (exit 0) | Leftover `View N`; layout mismatch | Coach rename/columns until cleared |
-| **PASS** | Six views + README + `board-bootstrap --check` exit 0 | Smoke card → day-to-day Pattern A |
+| **FAIL** (exit non-zero) | Missing default Playground view; empty README | **TURN PROTOCOL** — one turn, re-check |
+| **WARN** (exit 0) | Missing Tier-1 columns on primary views | Now **FAIL (exit 5)** — coach until green |
+| **WARN** (exit 0) | Leftover `View N`; layout mismatch | Rename/columns until cleared |
+| **PASS** | Six views + README + `--check` exit 0 | Smoke card → Pattern A |
 
-### TURN PROTOCOL (mandatory when views FAIL) — do not skip
+### TURN PROTOCOL (mandatory when views FAIL)
 
-You **must** run this conversation loop. **Forbidden:** “follow views-setup.md”, “rename View 1”, or “add columns” as a single dump then waiting forever. **Required:** one concrete UI turn, wait for human “done”, then next turn.
+**Required:** one concrete UI turn → wait for human `done` → re-check → next turn.
 
-**Default:** human performs clicks in GitHub UI; you coach one turn at a time.
+**Forbidden:** single dump of views-setup.md then wait forever.
 
-**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers. Follow **Browser assist map** below (same targets as `views-setup.md`).
+**Default:** human clicks in GitHub UI; you coach one turn.
 
-**Open:** Project URL from `project status` (e.g. `https://github.com/users/…/projects/N`).
+**Opt-in browser assist:** When user explicitly asks (e.g. “use cursor-ide-browser”), you may use browser MCP for **that turn only**. Stop on login/2FA/permission blockers. Targets: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md) § Browser assist map.
 
-### Browser assist map (universal click targets — opt-in only)
+**Open:** Project URL from `project status`.
 
-Use this when driving **cursor-ide-browser** (or when coaching clicks). Prefer **minimal 2-view** path unless the user asked for six-view Playground. After each turn: `board-bootstrap --check`.
+| Turn | Goal | Done when |
+|------|------|-----------|
+| A | Rename **View 1** → **Status board**; Board layout; Group by **Status**; Tier-1 columns | Human replies `done`; fewer FAILs |
+| B | **+ New view** → Table → **Prioritized backlog** + Tier-1 columns | `done`; re-check |
+| C | **+ New view** → Roadmap → **Roadmap** | `done`; re-check |
+| D | **+ New view** → Table → **Bugs**; filter title `[BUG]` | `done`; re-check |
+| E | **+ New view** → Table → **In review**; filter Status = In review | `done`; re-check |
+| F | **+ New view** → Table → **My items**; filter Assignees = `@me` | `done`; re-check |
+| G | README via `--apply-readme` or paste `project-readme.md` | README non-empty; re-check |
+| H | Clear Tier-1 column FAILs on Status board / Prioritized backlog | `--check` exits **0** |
 
-| Goal | Where to go (GitHub Project UI) | Done when |
-|------|----------------------------------|-----------|
-| Open project | Navigate to Project URL from `project status` | Project header + view tabs visible |
-| Select a view | Click the **view tab** by exact name (`Status board`, `Prioritized backlog`, …) | That view is active |
-| Rename view | Active tab → **⋯** (or right-click / View menu) → **Rename** → type kit name → confirm | Tab label matches schema |
-| New view | **+ New view** (or **New view**) → pick layout → name it | New tab exists with correct name |
-| Layout | View menu / **⋯** → **Layout** → **Board** / **Table** / **Roadmap** | Layout matches turn |
-| Group by (required) | View menu / toolbar **Group by** → **Status** (Status board) | Board columns are Status groups |
-| Show Tier-1 columns | Active view → **+** / field picker / **Fields** / **View settings → Fields** → enable **Priority**, **Size**, **Estimate**, **Start date**, **End date** | `--check` no longer FAILs those columns on that view |
-| Clear Slice by (if set by mistake) | View menu → **Slice by** → **No slicing** (or clear) | No slice chips; groups only if Group by set |
-| Save view | If UI shows unsaved / **Save** on the view | Changes persist after reload |
-| README | Prefer CLI `--apply-readme` after consent; else Project **⋯** / Settings → **README** | README non-empty; `--check` OK |
+**Fast minimal path:** Turn A → Turn B → Turn G → Turn H if needed → exit **0**.
 
-**Fast minimal path (browser):** Turn A (Status board rename/layout/Group by Status + Tier-1 fields) → Turn B (Prioritized backlog Table + Tier-1 fields) → Turn G (README) → Turn H only if `--check` still FAILs columns → exit when `--check` **0**.
-
-**Optional polish (not a bootstrap gate):** on **Prioritized backlog** → **Group by** → **Priority** (P0/P1/P2 sections). Empty boards may hide empty group headers until cards have Priority set. Do **not** block “ready for agents” on this.
-
-**Browser stop conditions:** login / 2FA / permission / CAPTCHA / “can’t find control after 2 tries” → hand back to human with the same turn table row; do not invent GraphQL view mutations.
-
-**Turn A — kill `View 1` → Status board**
-
-1. Tell human: open the Project → click the view tab named **View 1** (or similar).
-2. Rename it to **Status board**.
-3. Layout = **Board**; Group by = **Status**.
-4. Show fields/columns: Title, Assignees, Status, **Priority**, **Size**, **Estimate**, **Start date**, **End date**, Linked pull requests.
-5. Ask: reply `done` when Status board exists. Then re-run `--check` (expect fewer FAILs).
-
-**Turn B — Prioritized backlog (new Table view)**
-
-1. **+ New view** → Table → name **Prioritized backlog**.
-2. Show same Tier-1 columns as Status board (**Priority** required).
-3. Wait for `done` → re-check.
-
-**Turn C — Roadmap**
-
-1. **+ New view** → Roadmap layout → name **Roadmap**.
-2. Wait for `done` → re-check.
-
-**Turn D — Bugs**
-
-1. **+ New view** → Table → name **Bugs** (emoji optional).
-2. Filter: title contains `[BUG]`.
-3. Wait for `done` → re-check.
-
-**Turn E — In review**
-
-1. **+ New view** → Table → name **In review**.
-2. Filter: Status = **In review**.
-3. Wait for `done` → re-check.
-
-**Turn F — My items**
-
-1. **+ New view** → Table → name **My items**.
-2. Filter: Assignees = `@me`.
-3. Wait for `done` → re-check.
-
-**Turn G — README**
-
-```bash
-python3 -m agent_colony project board-bootstrap --check --apply-readme
-```
-
-Or paste contents of `project-readme.md` into Project README settings. Re-check.
-
-**Turn H — clear Tier-1 column FAILs**
-
-If `--check` still FAILs missing Priority/Size/Estimate/Start date/End date on Status board or Prioritized backlog: open that view → **+** field picker → show the missing columns. Re-check until `board-bootstrap --check` exits **0** (no view FAIL and no Tier-1 column FAILs). Leftover `View N` WARNs are cosmetic and can be cleared separately.
+**Optional polish:** Group by Priority on Prioritized backlog — not a bootstrap gate.
 
 Between every turn print:
 
@@ -200,7 +147,7 @@ Between every turn print:
 board-shell turn: A|B|C|D|E|F|G|H · waiting=human · next=<view or column>
 ```
 
-Use checklist: `.ai_infra/templates/project-board/views-checklist.md`. Canon clicks: `.ai_infra/templates/project-board/views-setup.md`.
+Checklist: `.ai_infra/templates/project-board/views-checklist.md`. Canon clicks: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md).
 
 ### Optional automation (official API only)
 
@@ -209,51 +156,37 @@ python3 -m agent_colony project board-bootstrap --check --ensure-fields
 python3 -m agent_colony project board-bootstrap --check --apply-readme
 ```
 
-- `--ensure-fields`: create missing **field definitions** by name; print suggested YAML field ids (human confirms before editing collaboration.yaml). Does **not** create views.
-- `--apply-readme`: push templated README via `updateProjectV2` (opt-in; user approval).
+- `--ensure-fields`: create missing field definitions; print suggested YAML ids. Does **not** create views.
+- `--apply-readme`: push templated README via `updateProjectV2` (opt-in).
 
 Respect GraphQL quota / outbox — never retry-loop.
 
-### Smoke card (prove Tier-1)
+### Smoke card
 
 ```bash
 python3 -m agent_colony project create-from-template \
   --title "[LIVE-SMOKE] board shell onboard" --template slice \
   --status ready --priority p2 --size xs --estimate 0.5 --agent board
 python3 -m agent_colony project validate-item --last
-# cleanup: delete smoke item or set Done with Notes "smoke cleanup"
 ```
 
 ## Customization
 
-### Minimal 2-view overlay
+**Minimal 2-view:** copy `board-shell.schema.minimal.yaml` exemplar → `.local/user_settings/board-shell.schema.yaml`. Coach Turns A + B only. Re-check after each turn.
 
-When the user asks for a **simple board** (Status board + Prioritized backlog only):
-
-1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
-2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
-3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F. Optional: **Group by Priority** on Prioritized backlog (polish; not a `--check` gate).
-4. Re-run `board-bootstrap --check` after each turn until exit **0**.
-
-### Playground default (six views)
-
-- Edit overlay `.local/user_settings/board-shell.schema.yaml` only if your team intentionally drops a Playground view (expect FAIL→WARN tradeoffs).
-- **Safe:** Insights, Iteration columns, filters. (End date is Tier-1 — keep visible on Status board / Prioritized backlog.)
-- **Unsafe:** remove Status / Priority / Size / Estimate / Start date / End date fields, or hide **Priority** on Prioritized backlog.
+**Playground default (six views):** edit overlay only if team intentionally drops a view. **Unsafe:** remove Tier-1 fields or hide Priority on Prioritized backlog.
 
 ## Exit
-
-Print:
 
 ```text
 board-shell: minimum=pass|fail · recommended=N missing · schema=<path> · next=day-to-day Pattern A
 ```
 
-Only say **ready for agents** when `board-bootstrap --check` exits **0** (no view FAIL, no Tier-1 column FAIL on Status board / Prioritized backlog, README non-empty).
+Say **ready for agents** only when `board-bootstrap --check` exits **0**.
 
 ## Canon
 
 - Schema: `.ai_infra/templates/project-board/board-shell.schema.yaml`
-- Click map: `.ai_infra/templates/project-board/views-setup.md` § Browser assist map
-- Day-to-day cards: `.cursor/skills/board-ssot/SKILL.md`
-- ADR-008: no view API; coach + check by default; browser MCP only when user asks
+- Clicks: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md)
+- Day-to-day: `.cursor/skills/board-ssot/SKILL.md`
+- ADR-008: coach + check by default; browser MCP only when user asks

--- a/payload/.cursor/skills/canvas-artifacts/SKILL.md
+++ b/payload/.cursor/skills/canvas-artifacts/SKILL.md
@@ -5,6 +5,8 @@ description: Three-tier canvas and plan snapshot workflow via agent_colony canva
 
 # Canvas and plan artifacts (Pattern A)
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 - Editing kit canvases in `canvases/` and needing IDE preview
@@ -32,15 +34,15 @@ python3 -m agent_colony canvas save --slug billing-review --agent implementer
 ```
 
 - Use `export default function NameCanvas()` in `.canvas.tsx` files.
-- `sync --all` requires `--force` (avoid silent overwrite).
+- `sync --all` requires `--force`.
 
 ## Plan CLI
 
 ```bash
 python3 -m agent_colony plan snapshot --slug slice-170 --agent implementer --board-item PVTI_xxx
 python3 -m agent_colony plan list
-python3 -m agent_colony plan open --slug slice-170          # human Build bridge
-python3 -m agent_colony plan open --slug slice-170 --force  # overwrite Cursor twin
+python3 -m agent_colony plan open --slug slice-170
+python3 -m agent_colony plan open --slug slice-170 --force
 python3 -m agent_colony plan snapshot --slug my-plan --from cursor-plan:my-plan.plan.md
 ```
 
@@ -49,21 +51,21 @@ Never treat `.local/plans/` as active backlog under `board_only`.
 ## Agent rituals
 
 1. **Product canvas:** edit repo → `canvas sync --name …` → Open Canvas in IDE.
-2. **Ephemeral canvas:** write via Cursor canvas skill to managed path → `canvas save --slug …`.
+2. **Ephemeral canvas:** write via Cursor canvas skill → `canvas save --slug …`.
 3. **Plan mode exit:** `plan snapshot --slug …` with board item id when known.
 
-### Consumer plans (agent build — Path A)
+### Consumer plans (Path A)
 
-Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
+Agents **never depend on** the IDE Build button:
 
-1. `plan list` — discover slugs under `.local/plans/`
-2. Read `.local/plans/<latest>-<slug>.plan.md` (+ sibling `.meta.yaml`)
-3. Execute todos / acceptance as implementer (no Build required)
-4. **Human-only:** `plan open --slug …` → Plans UI → Build (copies latest snapshot to `~/.cursor/plans/<slug>.plan.md`)
-5. After plan-mode work in Cursor: `plan snapshot --from cursor-plan:…` to re-anchor history in `.local/plans/`
+1. `plan list` — discover slugs
+2. Read `.local/plans/<latest>-<slug>.plan.md` (+ `.meta.yaml`)
+3. Execute todos as implementer
+4. **Human-only:** `plan open --slug …` → Plans UI → Build
+5. After plan-mode work: `plan snapshot --from cursor-plan:…`
 
-`plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
+`plan snapshot` preserves YAML frontmatter (`name` / `overview` / `todos`) for Build.
 
-**Indexing:** only `*.plan.md` (+ sibling `*.meta.yaml`) appear in `plan list` / `index.md`. Plain `.md` files dropped under `.local/plans/` are orphans — remove or re-snapshot via `plan snapshot --from <path>`.
+**Indexing:** only `*.plan.md` (+ `*.meta.yaml`) in `plan list`. Orphans → re-snapshot or remove.
 
 Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/payload/.cursor/skills/integrator-protocol/SKILL.md
+++ b/payload/.cursor/skills/integrator-protocol/SKILL.md
@@ -5,177 +5,105 @@ description: Procedural integration of new agents, skills, MCP servers, and kit 
 
 # Integrator protocol
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Integrate **new agents, skills, MCP servers, scripts, or docs** into the kit so the user gets the same **unpack + personal settings** experience: full consumer infrastructure from the plugin, human completes `.local/user_settings/`, everything else stays **procedural, deterministic, and enterprise-grade**.
+Integrate **new agents, skills, MCP servers, scripts, or docs** for unpack + personal settings. Keep work procedural and deterministic.
 
-**Canonical ops mirror:** `.ai_infra/docs/operations/mas-infrastructure-integration.md`
-
-## When to use
-
-- User adds a **new Cursor agent** or **skill**
-- User connects an **external MCP server** for multiple agents
-- User expands **manifest / install contract / plugin payload**
-- User asks to merge a **standalone agent** into the MAS pipeline (or keep independent but governed)
-
-**Agent card:** `.cursor/agents/integrator.md`
+**Canonical ops:** [mas-infrastructure-integration.md](../../.ai_infra/docs/operations/mas-infrastructure-integration.md) · **Agent:** `.cursor/agents/integrator.md`
 
 ## Evidence contract
 
-- Every integration claim cites a **repo path** or **command output**.
-- If not inspected: label **Unknown** — do not invent file layout or gate behavior.
-- No narrative without a checklist row or script result backing it.
+- Every claim cites **repo path** or **command output**.
+- Not inspected → **Unknown**. No invented layout or gate behavior.
 
----
+## Phase 0 — Intake
 
-## Phase 0 — Intake (classify)
+| Type | Examples | Outputs |
+|------|----------|---------|
+| **Agent** | `my-domain-agent.md` | `.cursor/agents/`, registry |
+| **Skill** | `.cursor/skills/` or `.agents/skills/` | SKILL.md, plugin sync |
+| **MCP** | GitHub, browser, DB | `mcp.user.json`, registry |
+| **Infrastructure** | script, gate | `.ai_infra/`, manifest, tests |
+| **Doc-only** | runbook | `.ai_infra/docs/` |
 
-| Type | Examples | Primary outputs |
-|------|----------|-----------------|
-| **Agent** | `my-domain-agent.md` | `.cursor/agents/`, registry, optional pipeline |
-| **Skill** | `.cursor/skills/foo/` or `.agents/skills/` | SKILL.md, cross-links, plugin sync |
-| **MCP external** | GitHub, browser, DB | `mcp.user.json`, registry, `mcp.agents.yaml` worksheet |
-| **Infrastructure** | new script, gate, template dir | `.ai_infra/`, manifest, tests |
-| **Doc-only** | runbook, charter | `.ai_infra/docs/` |
+Ask: MAS-integrated vs independent (ADR-006)? Architecture/manifest touch → plan `auditor`. Consumer-visible → `manifest.yaml` + `install-contract.json`. Research pack → read `AGENT_BRIEF.md`.
 
-Ask (or infer from request):
+## Phase 1 — Read base workflow
 
-1. **MAS-integrated** or **independent contract**? (see ADR-006: `.ai_infra/docs/decisions/ADR-006-agent-integration-model.md`)
-2. Touches **architecture / manifest / workflows**? → plan `auditor` before merge prep.
-3. **Consumer-visible** (copied on install)? → update `manifest.yaml` + `install-contract.json`.
-4. Research pack cited? → read `_research_results/sources/<slug>/AGENT_BRIEF.md` before classifying.
+`workflow-architecture.md` · `agent-workflow-procedures.md` · `local-workspace-layout.md` · `github.collaboration.yaml` · similar agent/skill as template.
 
----
+## Phase 2 — Templates
 
-## Phase 1 — Read base workflow (do not skip)
-
-Minimum read set:
-
-1. `.ai_infra/docs/architecture/workflow-architecture.md` — three planes
-2. `.ai_infra/docs/operations/agent-workflow-procedures.md` — Pattern A
-3. `.ai_infra/docs/operations/local-workspace-layout.md` — `.local/` contract
-4. `.local/user_settings/github.collaboration.yaml` — pipelines + attribution
-5. Target area already in repo (similar agent/skill as template)
-
----
-
-## Phase 2 — Apply templates
-
-Copy and edit from **`.ai_infra/templates/agent-integration/`**:
+From `.ai_infra/templates/agent-integration/`:
 
 | Template | Use |
 |----------|-----|
-| `AGENT.template.md` | New `.cursor/agents/<id>.md` |
-| `SKILL.template.md` | New skill under `.cursor/skills/<name>/` |
-| `INTEGRATION-CHECKLIST.md` | Track slice; when `project_ssot.enabled` + `board_only`, attach to the **board card** body/Notes; else attach to `work-tracker.md` |
+| `AGENT.template.md` | `.cursor/agents/<id>.md` |
+| `SKILL.template.md` | `.cursor/skills/<name>/` |
+| `INTEGRATION-CHECKLIST.md` | Board card or `work-tracker.md` |
 
-**Agent file rules:**
+**Agent:** frontmatter; **Anchor**; **Read first**; **MCP integration**. Board SSOT when enabled; else `session-pointer.md`. Independent agents: omit pipelines unless PR phase owner.
 
-- YAML frontmatter: `name`, `model`, `description`
-- **Anchor** block (Entry/Exit) — same discipline as `implementer.md`
-- **Read first** — bounded file set; no whole-repo loads
-- **MCP integration** section — required (governance scanner)
-- Procedural exits: when `project_ssot.enabled` + `board_only`, **Entry/Exit** on Project (`project status` → `set-status` / Notes); update `change-index.md`. `session-pointer.md` is offline fallback / session pointer only — not Status SSOT. When SSOT disabled/offline: update `session-pointer.md`, `change-index.md`
+## Phase 3 — Wire surfaces
 
-**Independent agent:** still includes Anchor + universal rules; omit from `github.collaboration.yaml` pipelines unless it participates in PR phases.
-
----
-
-## Phase 3 — Wire integration surfaces
-
-### A. MAS-integrated agent (multi-agent system)
+### MAS-integrated
 
 | Step | Action |
 |------|--------|
-| 1 | Add `.cursor/agents/<id>.md` from template |
-| 2 | Add skill if procedural steps are non-trivial |
-| 3 | Update `.cursor/mcp.registry.yaml` (+ example): list agent under `agent-colony-mcp` or external server |
-| 4 | Update `.local/user_settings/mcp.agents.yaml` worksheet + exemplar under `templates/user-settings/` |
-| 5 | Add to `github.collaboration.yaml` pipeline if it runs in PR/slice flow (or rely on `--agents-from-session` via `change-index`) |
-| 6 | If consumer-installed: add paths to `manifest.yaml` / `install-contract.json` when new dirs ship |
-| 7 | If marketplace: `make sync-plugin` + `make check-plugin` |
-| 8 | Add tests under `tests/modules/` if new scripts |
+| 1–2 | Agent + skill if non-trivial |
+| 3–4 | `mcp.registry.yaml` + `mcp.agents.yaml` worksheet |
+| 5 | `github.collaboration.yaml` pipeline if PR/slice |
+| 6–7 | `manifest.yaml` / `install-contract.json`; `make sync-plugin` + `check-plugin` |
+| 8 | `tests/modules/` if new scripts |
 
-### B. Independent agent (governed, not in MAS pipeline)
+### Independent
 
-| Step | Action |
-|------|--------|
-| 1 | Agent + skill with explicit **boundaries** (what it must not do) |
-| 2 | Registry: optional MCP servers scoped to that agent id only |
-| 3 | **Do not** add to core PR pipelines unless it owns a maintainer phase |
-| 4 | Document handoff to `implementer` / `integrator` when work crosses into kit infrastructure |
+Agent + skill with **boundaries**; optional scoped MCP; no core PR pipeline unless maintainer phase; document handoff when crossing kit infra.
 
-### C. External MCP server
+### External MCP
 
-Follow `.ai_infra/docs/operations/connect-external-mcp.md` plus:
+[connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md): `mcp.agents.yaml` row → `mcp.user.json` fragment → `mcp.registry.yaml` → `mcp validate`.
 
-1. Row in `.local/user_settings/mcp.agents.yaml`
-2. Fragment in `.cursor/mcp.user.json` (gitignored)
-3. Keys in `.cursor/mcp.registry.yaml` — `agents: [...]` per server
-4. `python -m agent_colony mcp validate`
+### Canvases / plans (ADR-010)
 
-### D. Canvases / plans (ADR-010)
+`.cursor/skills/canvas-artifacts/SKILL.md`. `.local/plans/` = snapshots only.
 
-When touching `canvases/`, `.local/canvases/`, or `.local/plans/`:
+### Maintainer script
 
-1. Read `.cursor/skills/canvas-artifacts/SKILL.md` and [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md).
-2. Repo `canvases/` = git SSOT → `canvas sync` → optional `canvas save` to `.local/canvases/`.
-3. `.local/plans/` = snapshot history only; live plan stays on board card / `plan.md` — wire `plan snapshot|list|open` in docs/agent cards as needed.
-4. After canvas edits: `python3 -m agent_colony canvas sync --name <stem>` (+ `canvas doctor` smoke).
+`.ai_infra/scripts/` only; never duplicate `GATES` outside `prepare.py`; file header on new Python; thin MCP wrapper in `agent_colony_mcp/server.py`.
 
-### E. New maintainer script
-
-- Lives under `.ai_infra/scripts/` — never duplicate `GATES` outside `prepare.py`
-- File header per `file-docstring-header-relations.mdc`
-- Wire MCP tool in `agent_colony_mcp/server.py` only as thin wrapper (Pattern A)
-
----
-
-## Phase 4 — Verify (commands, not prose)
-
-Run applicable subset:
+## Phase 4 — Verify
 
 ```bash
 python -m agent_colony contributors validate
 python -m agent_colony integrate validate
-python .ai_infra/scripts/architecture/check_governance_consistency.py   # if .cursor/ or workflows changed
+python .ai_infra/scripts/architecture/check_governance_consistency.py   # if .cursor/ changed
 pytest -q tests/modules/<relevant>/
-make gates                    # kit dev
-make check-plugin             # if agents/rules/skills/payload touched
-make install-dry-run          # if manifest / scaffold changed
-python -m agent_colony health --directory .
+make gates && make check-plugin    # if payload touched
+make install-dry-run               # if manifest changed
 ```
 
-Record PASS/FAIL in `change-index.md` and `updates-log.md`.
-
----
+Say *prepare gates green* or paste failing stderr. Record in `change-index.md` + `updates-log.md`.
 
 ## Phase 5 — Handoff
 
-| Outcome | Next agent |
-|---------|------------|
-| Needs product code / tests | `implementer` + `test-runner` |
-| Architecture-impacting | `auditor` → alignment artifacts |
-| Ready for PR | maintainer `review-pr` with `--pipeline` + `--agents-from-session` |
+| Outcome | Next |
+|---------|------|
+| Product code / tests | `implementer` + `test-runner` |
+| Architecture-impacting | `auditor` |
+| Ready for PR | `review-pr` with `--pipeline` + `--agents-from-session` |
 
----
+## Anti-patterns
 
-## Anti-patterns (reject)
-
-- Duplicating `prepare.py` GATES in skills or agent prose
-- New agents without Anchor / MCP integration section
-- Skipping `change-index.md` Agent column (breaks PR `--agents-from-session`)
-- `Made-with:` or fake human sign-off in commits
-- Loading entire `.local/` or megadocs when a checklist suffices
-- Independent agents that bypass governance scripts
-
----
+Duplicate GATES in prose · agents without Anchor/MCP · skip `change-index.md` Agent column · `Made-with:` · load entire `.local/` · independent agents bypass governance.
 
 ## Exit criteria
 
-- [ ] Integration type documented (MAS vs independent)
-- [ ] Templates filled; file headers present on new Python
-- [ ] Registry / user_settings exemplars updated if MCP or pipelines affected
-- [ ] Manifest + install-contract if consumer tree changed
-- [ ] Verification commands run; failures fixed or logged as blockers
-- [ ] Board Status/Notes updated when `project_ssot.enabled` + `board_only`; else `session-pointer.md` updated. `change-index.md` always updated
+- [ ] Type documented (MAS vs independent)
+- [ ] Templates + file headers on new Python
+- [ ] Registry/exemplars if MCP/pipelines touched
+- [ ] Manifest if consumer tree changed
+- [ ] Verify commands run; blockers logged
+- [ ] Board Notes when `board_only`; `change-index.md` always

--- a/payload/.cursor/skills/mcp-connect/SKILL.md
+++ b/payload/.cursor/skills/mcp-connect/SKILL.md
@@ -5,6 +5,8 @@ description: Connect external MCP servers to Agent Colony agents via mcp.user.js
 
 # MCP connect
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom APIs) alongside built-in `agent-colony-mcp`.
@@ -13,22 +15,20 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 
 ### 1. Enable DeepWiki (default zero-auth)
 
-Consumer activate already seeds DeepWiki when `mcp.user.json` / registry keys are missing. On an existing workspace:
-
 ```bash
 python3 -m agent_colony mcp seed --deepwiki
 python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp smoke --server deepwiki
 ```
 
-Optional: `--force-registry-agents` to reset `deepwiki.agents` to the seven Pattern A agents.
+Optional: `--force-registry-agents` to reset `deepwiki.agents` to seven Pattern A agents.
 
 ### 2. Link custom (auth or private)
 
 ```bash
 python3 -m agent_colony mcp link --name my-api --file .cursor/mcp.d/my-api.json
 # edit .cursor/mcp.registry.yaml — map agents
-python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN   # if needed
+python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN
 python3 -m agent_colony mcp validate
 ```
 
@@ -38,41 +38,34 @@ python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp doctor
 python3 -m agent_colony mcp smoke --server agent-colony-mcp
 python3 -m agent_colony mcp smoke --server deepwiki
-# DeepWiki live call (repoName; repo must be indexed on deepwiki.com):
 python3 -m agent_colony mcp call --server deepwiki --tool ask_question \
   --args-json '{"repoName":"karpathy/nanochat","question":"What is nanochat in one sentence?"}'
 ```
 
-### Agent contract — DeepWiki
+### DeepWiki agent contract
 
 | Do | Do not |
 |----|--------|
-| `list-tools --server deepwiki` before inventing args | Guess `repo` — the tool wants **`repoName`** |
-| Pass `owner/repo` as `repoName` (same slug as GitHub) | Pass a deepwiki.com URL as the MCP arg |
-| Prefer indexed smoke targets (e.g. `karpathy/nanochat`) | Treat “Repository not found” as a kit bug — index on deepwiki.com first |
-| Use GitHub URL / `github:` for `research init\|fetch` | Use DeepWiki MCP as a substitute for cloning the corpus |
+| `list-tools --server deepwiki` before inventing args | Guess `repo` — tool wants **`repoName`** |
+| Pass `owner/repo` as `repoName` | Pass deepwiki.com URL as MCP arg |
+| Prefer indexed smoke targets (e.g. `karpathy/nanochat`) | Treat “Repository not found” as kit bug |
+| Use GitHub URL / `github:` for `research init\|fetch` | Use DeepWiki as substitute for cloning corpus |
 
-## Steps (<5 min) — first-time worksheets
+## First-time setup (<5 min)
 
-1. Copy `.cursor/mcp.registry.yaml.example` → `.cursor/mcp.registry.yaml` (if live missing and you did not activate)
-2. Copy `.cursor/mcp.user.example.json` → `.cursor/mcp.user.json` (gitignored) — or prefer `mcp seed --deepwiki`
-3. Or link a fragment:
-
-```bash
-python3 -m agent_colony mcp link --name my-api --file .cursor/mcp.d/my-api.json
-```
-
-4. Map the server to agents in `mcp.registry.yaml`
-5. Merge and validate:
+1. Copy `.cursor/mcp.registry.yaml.example` → `.cursor/mcp.registry.yaml` (if missing)
+2. Copy `.cursor/mcp.user.example.json` → `.cursor/mcp.user.json` — or `mcp seed --deepwiki`
+3. Map server to agents in `mcp.registry.yaml`
+4. Validate:
 
 ```bash
 python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp doctor
 ```
 
-6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
+5. Optional: enable MCP in Cursor settings (`CallMcpTool` convenience).
 
-**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+**Pattern A (canonical):** agents call MCP via CLI:
 
 ```bash
 python3 -m agent_colony mcp list-tools --server agent-colony-mcp
@@ -81,17 +74,17 @@ python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN
 python3 -m agent_colony mcp smoke --server agent-colony-mcp
 ```
 
-Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
+Walkthrough: [connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md) § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `python3 -m agent_colony mcp validate` exits 0
-- `python3 -m agent_colony mcp doctor` shows configured vs host-loaded
+- `mcp validate` exits 0
+- `mcp doctor` shows configured vs host-loaded
 - `mcp list-tools` / `mcp call` work for allowlisted servers
-- Target agent markdown includes the server under **MCP integration**
+- Target agent markdown includes server under **MCP integration**
 
 ## Reference
 
-- `.ai_infra/docs/operations/connect-external-mcp.md`
-- `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
-- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`
+- [connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md)
+- [ADR-004](../../.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md)
+- [ADR-009](../../.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md)

--- a/payload/.cursor/skills/research-corpus/SKILL.md
+++ b/payload/.cursor/skills/research-corpus/SKILL.md
@@ -5,124 +5,95 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 # Research corpus
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-- External research: user chat, another agent’s handoff/Notes, or a board research card names a source.
-- Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` when present under `_research_results/`.
+- External research: user chat, peer handoff/Notes, or board research card names a source
+- Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` under `_research_results/`
 
-**Not for:** product code changes, PR merge, `.local/` implementation — use `implementer` / `.agents/skills/pr-workflow/SKILL.md`.
+**Not for:** product code, PR merge, `.local/` implementation — use `implementer` / `pr-workflow`.
 
-## Agent
-
-**`.cursor/agents/researcher.md`**. Hub: `.agents/skills/RESEARCH_WORKFLOW.md`.
+**Agent:** `.cursor/agents/researcher.md` · Hub: `.agents/skills/RESEARCH_WORKFLOW.md`
 
 ## Read first
 
-1. This skill (intake → rounds)
+1. This skill
 2. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
-3. Incoming chat / board card / peer handoff (see Intake)
+3. Incoming chat / board card / peer handoff
 4. Pack `BRIEF.md` when continuing a slug
 
-## Intake (adapt — do not require a formal paste)
+## Intake
 
-Build a Brief from **any** of:
-
-1. **User chat** — including terse forms like `/researcher https://github.com/owner/repo`
-2. **Peer agents** — board Notes, handoff line, cited `AGENT_BRIEF.md` / pack path, implementer/integrator ask
-3. **Board card** — `create-from-template --template research --priority p2` body Brief table
-4. **Existing** `sources/<slug>/BRIEF.md`
+Build a Brief from user chat, peer Notes/handoff, board card, or existing `BRIEF.md`.
 
 ### Normalize source
 
 | Input | Normalized |
 |-------|------------|
-| `https://github.com/owner/repo` | OK for CLI; also record `github:owner/repo` |
-| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` (CLI accepts HTTPS tree URLs) |
+| `https://github.com/owner/repo` | OK; also `github:owner/repo` |
+| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` |
 | `github:owner/repo[@ref]` | Canonical |
 | Local path | `path:…` or bare path |
 
-**DeepWiki is not a research source locator.** Packs clone from GitHub/`path:`. Optional wiki Q&A uses MCP `deepwiki` with **`repoName":"owner/repo"`** (must be indexed on [deepwiki.com](https://deepwiki.com)) — see `researcher` MCP section and `/mcp-connect`. Do not pass a deepwiki.com URL to `research init --source`.
+**DeepWiki is not a research source locator.** Packs clone from GitHub/`path:`. Optional wiki Q&A: MCP `deepwiki` with `repoName":"owner/repo"` — see `mcp-connect`. Do not pass deepwiki.com URL to `research init --source`.
 
 ### Defaults (terse chat)
 
-If only a link/path is given:
+If only a link/path:
 
-- **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
+- **question:** Map architecture, entrypoints, patterns for MAS kit; produce `AGENT_BRIEF`.
 - **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
-- **slug:** repo (or directory) name, lowercase with hyphens
-- **consumers:** implementer, integrator (plus the requesting agent if known)
+- **slug:** repo name, lowercase hyphens
+- **consumers:** implementer, integrator (+ requester if known)
 - **rounds_max:** 6
 
-Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
+Refuse only when no source and no `mode: self`. Missing question → use default; state in Notes.
 
 ### GitHub access
 
-| Visibility | Requirement |
-|------------|-------------|
-| Public | Network + `gh` or `git` clone |
-| Private | Same, plus consumer auth (`gh auth login` / git credentials that can clone the URL) |
+Public: network + `gh` or `git`. Private: + consumer auth. Clone failure → report once; stop.
 
-Clone failures: report once and stop — no retry loop.
-
-### Brief contract (persisted)
-
-Write via `research init` into `BRIEF.md`:
-
-```text
-source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
-question: <what MAS / requesting agent needs>
-lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
-rounds_max: 6
-consumers: [implementer, integrator, …]
-slug: <derived or explicit>
-```
-
-## Procedural setup
+### Brief contract
 
 ```bash
 python3 -m agent_colony research init --slug <slug> --source '…' --question '…'
 python3 -m agent_colony research fetch --slug <slug> --source '…'
 ```
 
-`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch prefers `gh repo clone` (private-friendly), else `git clone --depth 1` into `_research_results/cache/<slug>/`. Re-fetch requires `--force`.
+`--source`: HTTPS GitHub, `github:…`, `path:…`, or local path. Re-fetch needs `--force`.
 
 ## Anti-loop (hard stop)
 
 | Rule | Behavior |
 |------|----------|
-| Cap | Deepen ≤ `rounds_max` (default 6); never round 7+ |
-| Idempotent init/fetch | Existing pack / `SOURCE.md` → refuse unless `--force` |
-| Closed pack | `INDEX.status=complete` + validate PASS → **exit**; do not deepen again unless user reopens |
-| Failures | One clone attempt; surface error; stop |
-| Gaps | Remaining questions → document gaps; set `blocked` or complete with gaps — do not spin |
+| Cap | ≤ `rounds_max` (default 6) |
+| Idempotent | Existing pack → refuse unless `--force` |
+| Closed pack | `INDEX.status=complete` + validate PASS → **exit** |
+| Failures | One clone attempt; stop |
+| Gaps | Document; set `blocked` or complete with gaps |
 
-## Multi-round loop (active)
+## Multi-round loop
 
-Work only under `_research_results/sources/<slug>/`. Read foreign trees read-only.
+Work under `_research_results/sources/<slug>/` only. Foreign trees read-only.
 
-1. **Scout** — confirm `SOURCE.md` pin (SHA/path); note languages/size.
-2. **Map** — write `MAP.md` (entrypoints, layout, docs).
-3. **Extract** — for each lens in Brief, fill `findings/<lens>.md` with path + line evidence.
-4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`). **Stop deepening when N == rounds_max.**
-5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
-6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed` ≤ `rounds_max`).
-7. **Validate** — `python3 -m agent_colony research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known). **Then stop.**
+1. **Scout** — confirm `SOURCE.md` pin
+2. **Map** — `MAP.md`
+3. **Extract** — `findings/<lens>.md` with path + line evidence
+4. **Deepen** — `rounds/round-N.md` (N ≤ `rounds_max`)
+5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`
+6. **Pack** — `AGENT_BRIEF.md` + `INDEX.json`
+7. **Validate** — `research validate --slug <slug>`
+8. **Exit** — board Done + Notes; handoff to consumer; **stop**
 
-## Mode: self (optional)
+## Mode: self
 
-If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only.
+One backlog ID per session when `DEPTH_BACKLOG.md` exists and user asks.
 
-## Lenses (default)
-
-`architecture` · `cli` · `agents` · `skills` · `tests` · `decisions` · `patterns`
-
-## Output format
+## Output
 
 ```text
 slug · mode · rounds · curated_count · AGENT_BRIEF path · validate PASS/FAIL · next consumer
 ```
 
-## Status
-
-**Agent shipped/proven** (2026-07-19): live external pack (`flexiai-toolsmith`, 18 curated, validate PASS) + verifier Claim A (efficiency) / Claim B (correctness) VERIFIED. Corpus remains **opt-in** after first `research init` — not an incomplete agent. Canvas: `canvases/agent-researcher.canvas.tsx`.
+Canvas: `canvases/agent-researcher.canvas.tsx`.

--- a/payload/.cursor/skills/test-coverage/SKILL.md
+++ b/payload/.cursor/skills/test-coverage/SKILL.md
@@ -5,6 +5,8 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 
 # Test coverage
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 `src/**` or `scripts/**` behavior change; coverage or regression requests; medium/high risk before merge.
@@ -13,16 +15,16 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 
 1. Target modules/symbols; matrix: valid / boundary / invalid, lifecycle, failure/recovery.
 2. Tests under `tests/modules/<module>/`.
-3. Update `.local/index-and-planning/current/test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
-4. Run: `pytest` scoped to module → broader as needed. Before merge path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (see `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
-5. For coverage evidence, install `dev` extras (`pip install -e ".[dev]"`) then run `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing --cov-report=json -q` (writes **`coverage.json` only** — do not invent alternate names). Prefer `grep`/`python` over `rg` when filtering shell output — `rg` is often absent from the user PATH. Record gaps in board card Notes when `project_ssot.enabled` + `board_only`, else `work-tracker.md`; always one line in `updates-log.md` per `implementation-workflow-governance.mdc`. **Scope:** this metric tracks the installable kit import surface (`.ai_infra/**` modules imported during tests + `agent_colony/**`); subprocess-only scanners (`check_governance_consistency.py`, `check_debrand.py`, etc.) are validated via their own module tests but excluded from `--cov` by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
-6. **After scoped coverage reaches 100%** (or any coverage-closure slice): mandatory doc reality sync — update `IMPLEMENTATION-STATUS.md` **Tests:** + coverage scope numbers, regenerate `.local/index-and-planning/current/coverage-index.md` via `make coverage-index`, run `make doc-validate`, sync related README/AGENTS/repository-map claims, then `make sync-plugin` when skills/docs payload copies change.
-7. Report: modules • edges added • gaps • tracker edits.
+3. Update `test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
+4. Run scoped `pytest` → broader as needed. Before merge: **`check_testing_artifacts.py`** (via `prepare.py` `resolve_gates()`).
+5. Coverage evidence: `pip install -e ".[dev]"` then `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing --cov-report=json -q` (writes **`coverage.json`** only). Record gaps in board Notes when `board_only`, else `work-tracker.md`; one line in `updates-log.md`. Scope: kit import surface; subprocess scanners excluded by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
+6. **After 100% scoped coverage:** sync `IMPLEMENTATION-STATUS.md`, regenerate `coverage-index.md` via `make coverage-index`, `make doc-validate`, sync README/AGENTS claims, `make sync-plugin` when payload copies change.
+7. Report: modules · edges added · gaps · tracker edits.
 
 ## Themes (when relevant)
 
-Validation boundaries • error/reason codes • retry/replay on risky flows • async cleanup • policy negative paths.
+Validation boundaries · error/reason codes · retry/replay · async cleanup · policy negative paths.
 
 ## Output
 
-`Coverage summary` → `Tests added/updated` → `Edge cases` → `Gaps` → `Index/plan updates` (paths in backticks).
+`Coverage summary` → `Tests added/updated` → `Edge cases` → `Gaps` → `Index/plan updates`.

--- a/payload/.cursor/skills/update-agent-colony/SKILL.md
+++ b/payload/.cursor/skills/update-agent-colony/SKILL.md
@@ -19,53 +19,45 @@ Notes:
 
 # Update Agent Colony
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-User already ran **`/workflow-activate`** in **their app**, then updated the **Agent Colony** plugin (or kit tag) and needs kit-managed files refreshed.
+User ran **`/workflow-activate`** in **their app**, then updated the Agent Colony plugin and needs kit-managed files refreshed.
 
 **Not for first install** — use [workflow-activate](workflow-activate/SKILL.md) when `.ai_infra/` is missing.
 
 ## Guide the user
 
-1. Confirm the open folder is **their activated app**, not the kit product repo.
-2. Prefer Agent chat **`/update-agent-colony`**, or the Pattern A command below.
-3. Explain version gate briefly:
+1. Confirm folder is **their activated app**, not kit-dev repo.
+2. Prefer **`/update-agent-colony`** or Pattern A command below.
+3. Version gate:
    - **same / newer installed** → light heal (dashboards, `.gitignore`, `STARTER-001`, missing `.venv`)
    - **source newer** or **`--force`** → full overwrite of kit-managed agents/rules/skills/scripts
 4. After upgrade: `health` + `mcp validate`.
 
-## One command
+## Commands
 
 ```bash
 source .venv/bin/activate
 python3 -m agent_colony update --directory .
+python3 -m agent_colony update --directory . --check      # no writes
+python3 -m agent_colony update --directory . --force      # full refresh
 ```
 
-**Check only (no writes):**
-
-```bash
-python3 -m agent_colony update --directory . --check
-```
-
-**Force full refresh** (even when versions match):
-
-```bash
-python3 -m agent_colony update --directory . --force
-```
-
-**Source resolution** matches activate: `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
+**Source resolution:** `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
 
 ## What update does
 
 | Condition | Action |
 |-----------|--------|
-| No `.ai_infra/` or missing `.kit-version` | Fail — tell user to run `/workflow-activate` |
-| `installed == available` (and not `--force`) | Light heal only |
-| `available > installed` or `--force` | Full scaffold refresh (same as `activate --force`) |
+| No `.ai_infra/` or missing `.kit-version` | Fail — run `/workflow-activate` |
+| `installed == available` (not `--force`) | Light heal only |
+| `available > installed` or `--force` | Full scaffold refresh |
 
-**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, existing trackers.
+**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, trackers.
 
-**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI copy, `.kit-version`, kit-managed dashboards.
+**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI, `.kit-version`, dashboards.
 
 ## Post-update
 
@@ -78,6 +70,6 @@ Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.
 
 ## Anti-patterns
 
-- Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
-- Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
-- Do **not** run `update --force` inside the **kit-dev product repo** (`agent-colony`) — scaffold treats it as a consumer install and fails (`forbidden in slim install: full kit tests tree`). Kit-dev workflow: edit sources → `make sync-plugin` → commit. Use `update` only in **activated consumer apps**.
+- Re-run plain `/workflow-activate` expecting agents/skills refresh — heals only when planes ready.
+- Overwrite consumer `user_settings` or invent second Status writer under `board_only`.
+- Run `update --force` in **kit-dev repo** — fails (`forbidden in slim install`). Kit-dev: edit sources → `make sync-plugin` → commit.

--- a/skills/audit-alignment/SKILL.md
+++ b/skills/audit-alignment/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Audit alignment (deprecated stub — retire pending)
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Do not use this file as the primary workflow.** The canonical audit agent is **`auditor`**.
 
 - **Agent:** `.cursor/agents/auditor.md`

--- a/skills/audit-module-map/SKILL.md
+++ b/skills/audit-module-map/SKILL.md
@@ -3,73 +3,52 @@ name: audit-module-map
 description: Builds a deep per-module workflow map with importance, goals, and visual architecture output.
 ---
 
-# Audit Module Map (Advisory-Only)
+# Audit module map (advisory-only)
+
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
 ## Relationship to audits
 
-This is a **depth tool** for **`auditor`**, not a separate audit authority. Run it when the enterprise architecture audit (or a focused alignment pass) needs HTML/topology evidence; fold outputs into the parent audit’s citations.
+Depth tool for **`auditor`**, not a separate audit authority. Run when enterprise audit (or focused alignment pass) needs HTML/topology evidence. Fold outputs into parent audit citations.
 
-## Goal
+## When
 
-Produce a module-by-module audit that explains workflow, behavior, importance, and intended goal, with a visual architecture map and detailed results.
+- **`auditor`** requests deep module topology or `module-audit.html` export
+- Team needs current module map before architecture reconciliation
+- Documentation drift suspected across module boundaries
 
-## When to Use
+## Required sources
 
-- **`auditor`** requests deep module topology or `module-audit.html` export.
-- Team needs a current module map before architecture reconciliation.
-- Documentation drift is suspected across module boundaries and ownership.
+- `README.md`, `AGENTS.md`
+- Project strategy/plan docs (when consumer defines them)
+- `tests/modules/*`
+- `.cursor/rules/*`, `.cursor/skills/*`
+- `.agents/skills/*` (maintainer context)
 
-## Required Sources
+## Constraints
 
-- `README.md` and `AGENTS.md`
-- Project strategy/plan docs (when the consumer repo defines them)
-- `tests/modules/*` (or project test tree)
-- `.cursor/rules/*` and `.cursor/skills/*`
-- `.agents/skills/*` (maintainer workflow context)
+1. Advisory-only: do not auto-remediate during this audit.
+2. Evidence-backed statements only; concrete file paths per claim.
+3. Distinguish canonical docs from archival/historical docs.
+4. Uncertain ownership → `TBD` + follow-up callout.
 
-## Mandatory Constraints
+## Steps
 
-1. Advisory-only: do not auto-remediate findings during this audit.
-2. Use evidence-backed statements only; include concrete file paths for each claim.
-3. Distinguish canonical current-state docs from archival/historical docs.
-4. Mark uncertain ownership as `TBD` and call out required follow-up.
-
-## Execution Steps
-
-1. Inventory module roots under `src/` and map corresponding test ownership under `tests/modules/`.
-2. For each module, document:
-   - goal
-   - workflow/how it works (entrypoints, key contracts, control flow)
-   - importance (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`) with rationale
-   - key dependencies and key dependents
-3. Build an architecture-layer graphic showing module placement and directional data/control flow.
-4. Identify drift/gaps in:
-   - module-to-test mapping
-   - module documentation coverage
-   - rules/skill guidance needed for repeatable audits
+1. Inventory module roots under `src/`; map test ownership under `tests/modules/`.
+2. Per module document: goal, workflow (entrypoints, contracts, control flow), importance (`CRITICAL`|`HIGH`|`MEDIUM`|`LOW`) + rationale, dependencies, dependents.
+3. Build architecture-layer graphic (placement + data/control flow).
+4. Identify drift/gaps: module-to-test mapping, doc coverage, rules/skill guidance.
 5. Emit:
-   - `.local/module-map.md` (detailed module catalog)
-   - `.local/agents-control-center/audits/module-audit.html` (visual report with architecture graphic and per-module cards)
-   - Optional reconciliation findings appended into `.local/workflow-artifacts/alignment/alignment-audit.md` and `.local/workflow-artifacts/alignment/alignment-todos.md`
+   - `.local/module-map.md`
+   - `.local/agents-control-center/audits/module-audit.html`
+   - Optional: append to `alignment-audit.md` + `alignment-todos.md`
 
-## Output Contract
+## Output contract (per module)
 
-For each module entry, include:
+`module_name` · `source_paths` · `test_paths` · `importance` · `goal` · `workflow` · `key_contracts` · `dependencies` · `dependents` · `evidence` · `gaps_or_risks`
 
-- `module_name`
-- `source_paths`
-- `test_paths`
-- `importance`
-- `goal`
-- `workflow`
-- `key_contracts`
-- `dependencies`
-- `dependents`
-- `evidence`
-- `gaps_or_risks`
+## Exit criteria
 
-## Exit Criteria
-
-- Every production module has an explicit ownership/mapping entry (or `TBD` with rationale).
-- The architecture graphic and module deep-dive results are generated and readable.
-- Any accuracy-improving updates needed for rules/skills/agents are explicitly listed with evidence.
+- Every production module has ownership entry (or `TBD` + rationale).
+- Architecture graphic and module deep-dive are readable.
+- Rules/skills/agent updates listed with evidence when needed.

--- a/skills/audit-orchestration/SKILL.md
+++ b/skills/audit-orchestration/SKILL.md
@@ -20,16 +20,18 @@ Notes:
 
 # Audit orchestration
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Run a **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts and apply approved fixes — without one agent re-running every shell command.
+Run **full audit closure** efficiently: scripts establish facts first; specialized agents write artifacts — without one agent re-running every shell command.
 
 ## Cadence
 
 | Trigger | Auditor depth | Drift |
 |---------|---------------|-------|
-| **Architecture-impacting PR** | Focused alignment + scoped CHK-* tick table | `drift validate` via prepare; optional drift-guard artifacts |
-| **Quarterly / kit release readiness** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
+| **Architecture-impacting PR** | Focused alignment + scoped CHK-* | `drift validate` via prepare; optional drift-guard |
+| **Quarterly / kit release** | Full EA report + **all CHK-*** | drift-guard goal pulse after implementer |
 | **Ad-hoc full audit** | Same as quarterly | Same |
 
 Do **not** run full CHK-* scorecard on every PR.
@@ -46,36 +48,34 @@ Run **once**; capture JSON for downstream agents:
 
 ```bash
 make verify-all
-# or with artifacts for agents:
+# or with artifacts:
 python -m agent_colony verify all --write-preflight
 python -m agent_colony doc validate --write-preflight
 python -m agent_colony drift validate --directory .
 ```
 
-**MCP (preferred in Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
+**MCP (Cursor):** `workflow_verify_all`, `workflow_doc_facts_validate`, `workflow_drift_validate`, `workflow_integrate_validate`, `workflow_activate`.
 
-**Read:** `.local/workflow-artifacts/audit/preflight.json` and `doc-facts-preflight.json` if present.
+**Read:** `.local/workflow-artifacts/audit/preflight.json`, `doc-facts-preflight.json` if present.
 
-**Stop on P0** from doc validate or drift; hand to **implementer** only for mechanical fixes the user approved.
+**Stop on P0** from doc validate or drift; hand to **implementer** only for approved mechanical fixes.
 
 ## Phase 1 — Parallel discovery (Task delegation)
 
-Launch concurrently:
-
 | Subagent | Mode | Deliverable |
 |----------|------|-------------|
-| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + **CHK-* tick table**. PR-scoped: alignment artifacts only |
-| `audit-module-map` skill (optional) | artifact-write (`.local/` only) | `.local/module-map.md` summary for audit §3 |
+| `auditor` | artifact-write (`.local/` only) | Full: `enterprise-architecture-audit.md` + actions + CHK-* table. PR-scoped: alignment only |
+| `audit-module-map` (optional) | artifact-write | `.local/module-map.md` summary for audit §3 |
 
-Parent **does not** duplicate inventory searches — consumes subagent outputs + preflight JSON.
+Parent consumes subagent outputs + preflight JSON — no duplicate inventory searches.
 
 ## Phase 2 — Mechanical remediation (user-approved only)
 
-When `enterprise-audit-actions.md` or doc validate lists **DOC-*** / doc-sync items:
+When `enterprise-audit-actions.md` or doc validate lists **DOC-*** items:
 
 | Subagent | Scope |
 |----------|-------|
-| `implementer` | Tracked doc/template fixes only; no scope creep |
+| `implementer` | Tracked doc/template fixes only |
 
 After edits:
 
@@ -89,22 +89,22 @@ make doc-validate
 
 | Subagent | When |
 |----------|------|
-| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift findings |
+| `drift-guard` | After tracker/doc edits; goal pulse + DRIFT-011; P0/P1 drift |
 | `verifier` | Spot-check top audit claims vs preflight + repo paths |
 
 ## Phase 4 — Maintainer PR
 
-Human or maintainer agent: `review-pr` → `prepare-pr` → `merge-pr` on a `feature/` or `chore/` branch.
+Human or maintainer: `review-pr` → `prepare-pr` → `merge-pr` on `feature/` or `chore/` branch.
 
 ## Delegation rules
 
-1. **Scripts before agents** — never let an agent re-run five gates if preflight JSON is fresh (<1 session).
-2. **One primary `in_progress`** during implementer slice: when `project_ssot.enabled` + `sync_policy: board_only`, Status lives on the **Project board** (`project status` → claim with `set-status --to in_progress`); do **not** dual-write tracker `in_progress`. When SSOT is disabled or offline fallback is active, one primary `in_progress` in `work-tracker.md`.
-3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`. Under `board_only`, do not auto-edit board card body or local `plan.md` / `work-tracker.md`; offline fallback: do not auto-edit `plan.md` / `work-tracker.md`.
+1. **Scripts before agents** — do not re-run five gates if preflight JSON is fresh (<1 session).
+2. **One primary `in_progress`:** board SSOT when enabled; else `work-tracker.md`. No dual-write under `board_only`.
+3. **Do not auto-edit** slice scope from audit agents — propose in `enterprise-audit-actions.md`.
 4. **Canvases** — optional IDE artifacts; not merge gates.
-5. **Token efficiency** — cite preflight pass/fail in chat; paste failing command output only.
-6. **Ownership** — continuous plan/agent-doctrine coherence = `drift-guard`; deep CHK-* = `auditor`. No new trash agents.
+5. **Token efficiency** — cite preflight pass/fail; paste failing stderr only.
+6. **Ownership** — plan/agent-doctrine = `drift-guard`; deep CHK-* = `auditor`.
 
 ## Handoff format
 
-Preflight exit • audit artifact paths • CHK-* gaps • P0/P1 counts • branch name • suggested next: implementer | drift-guard | verifier | maintainer PR
+Preflight exit · audit artifact paths · CHK-* gaps · P0/P1 counts · branch name · next: implementer | drift-guard | verifier | maintainer PR

--- a/skills/board-shell/SKILL.md
+++ b/skills/board-shell/SKILL.md
@@ -20,28 +20,32 @@ Notes:
 
 # Board shell
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-- Fresh consumer after `/workflow-activate` + identity in `github.collaboration.yaml` (board ids may still be empty)
-- Human pastes **Project URL + repo URL** after `gh` auth — help wire `project_ssot` / `default_repo` before shell check
-- User asks to apply the **kit default** board shell (Playground parity: six views + Tier-1 columns)
-- `board-bootstrap --check` FAILs missing default views or **FAILs** Tier-1 columns on Status board / Prioritized backlog / empty README
+- Fresh consumer after `/workflow-activate` + identity in `github.collaboration.yaml`
+- Human pastes **Project URL + repo URL** after `gh` auth
+- User asks for kit default shell (six views + Tier-1 columns)
+- `board-bootstrap --check` FAILs views, Tier-1 columns, or empty README
 
 ## Non-negotiable
 
 | Do | Do not |
 |----|--------|
-| **CONSENT GATE** before any shell apply (below) | Create/mutate shell without description + explicit proceed |
-| After `gh` auth, accept Project + repo URLs and propose YAML via `gh project view` / `field-list` | Write YAML without human confirm |
-| Coach humans through TURN PROTOCOL (`views-setup.md` = click reference only) | Dump “follow views-setup.md” and stop; undocumented GraphQL view mutations |
-| Run `board-bootstrap --check` until exit 0 (views + Tier-1 columns) | Mutate Insights / workflows / status updates without approval |
-| Optional `--ensure-fields` / `--apply-readme` **only after** CONSENT GATE (no view-apply CLI; **`--apply-shell` is not shipped**) | Invent field option ids into YAML without discovery |
-| Smoke `create-from-template` | Claim “ready” while `--check` exit 5 or Prioritized backlog lacks **Priority** |
-| Default: coach TURN PROTOCOL (human clicks); **if user asks** for browser help on views/columns → use **browser MCP** / cursor-ide-browser for that turn | Open browser MCP unprompted; multi-view instruction dumps; undocumented GraphQL view mutations |
+| **CONSENT GATE** before shell apply | Mutate shell without description + explicit proceed |
+| Accept Project + repo URLs; propose YAML via `gh project view` / `field-list` | Write YAML without human confirm |
+| Coach **TURN PROTOCOL** — one turn at a time | Dump “follow views-setup.md” and stop |
+| Run `board-bootstrap --check` until exit 0 | Undocumented GraphQL view mutations |
+| `--ensure-fields` / `--apply-readme` only after CONSENT | Invent field option ids without discovery |
+| Smoke `create-from-template` | Claim ready while `--check` exit 5 |
+| Browser MCP only when user asks | Open browser unprompted |
 
-## CONSENT GATE (mandatory — every first-run shell) 
+Click reference: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md) § Browser assist map.
 
-**Before** TURN PROTOCOL, `--ensure-fields`, `--apply-readme`, or any future `--apply-shell`, stop and ask the human **both** questions in one message. Do **not** proceed until answered.
+## CONSENT GATE (mandatory — every first-run shell)
+
+**Before** TURN PROTOCOL, `--ensure-fields`, `--apply-readme`, or any future `--apply-shell`, stop and ask **both** questions in one message. Do **not** proceed until answered.
 
 ### Q1 — Board description (README blurb)
 
@@ -52,9 +56,9 @@ What short description should appear on this Project board?
 (Reply with 1–3 sentences for the Project README, or say "use template default".)
 ```
 
-- If they give text → keep it for README placeholders / `--apply-readme` body merge.
-- If `use template default` → use `.ai_infra/templates/project-board/project-readme.md` as-is (board brief; title/repo filled from YAML).
-- If README already non-empty and they say keep it → record that; skip overwrite unless they ask.
+- Custom text → keep for `--apply-readme` body merge.
+- `use template default` → `.ai_infra/templates/project-board/project-readme.md`.
+- README already non-empty + keep → record; skip overwrite unless asked.
 
 ### Q2 — Proceed to create / coach the default shell?
 
@@ -65,9 +69,9 @@ May I proceed to set up the kit default Playground board shell on this Project
 (six views + Tier-1 columns + README)? Reply "yes" or "no".
 ```
 
-- **`yes`** → continue Entry check + TURN PROTOCOL (and/or approved CLI flags).
-- **`no`** → stop. Do not coach views, do not `--apply-readme` / `--ensure-fields`. Offer day-to-day triage only if shell already green.
-- Ambiguous reply → ask again. Never assume yes.
+- **`yes`** → Entry check + TURN PROTOCOL (and/or approved CLI flags).
+- **`no`** → stop. Offer day-to-day triage only if shell already green.
+- Ambiguous → ask again. Never assume yes.
 
 Print after answers:
 
@@ -79,120 +83,63 @@ Only `proceed=yes` unlocks the rest of this skill.
 
 ## Entry
 
-0. Run **CONSENT GATE** (Q1 + Q2). If `proceed=no` → Exit with consent line only.
-1. If board ids missing and human provided URLs: propose collaboration YAML, confirm, save. After wire, print:
+0. Run **CONSENT GATE**. If `proceed=no` → Exit with consent line only.
+1. If board ids missing and human provided URLs: propose collaboration YAML, confirm, save. Print:
 
 ```text
 board-onboard status: api=complete · shell=incomplete · views=ui-only · next=/board CONSENT+TURN
 ```
 
-**Automation boundary:** API automates YAML, field defs, README; **UI required** for six views + Tier-1 column visibility (GitHub has no public view mutation API).
+**Automation boundary:** API automates YAML, field defs, README. **UI required** for six views + Tier-1 column visibility (no public view mutation API).
 
 2. `python3 -m agent_colony project status`
 3. `python3 -m agent_colony project doctor`
-4. Load desired state:
-   - Overlay if present: `.local/user_settings/board-shell.schema.yaml`
-   - Else: `.ai_infra/templates/project-board/board-shell.schema.yaml`
+4. Load schema: overlay `.local/user_settings/board-shell.schema.yaml` or template `.ai_infra/templates/project-board/board-shell.schema.yaml`
 5. `python3 -m agent_colony project board-bootstrap --check`
 
-## Loop (refuse ready until default shell passes)
+## Loop
 
 ```text
 CONSENT GATE → doctor → board-bootstrap --check → (gaps?) → TURN PROTOCOL → re-check → smoke → ready
 ```
 
-**Read FAIL lines literally:** `FAIL — missing minimum view 'Status board'` (etc.) / `WARN — rename default view 'View 1'` → human UI until official apply CLI ships. Empty README / `--apply-readme` is a **separate** fix after consent — never tell the user a view-missing FAIL is “only README”.
+Read FAIL lines literally. Empty README is a **separate** fix after consent — never call a view-missing FAIL “only README”.
 
-### WARN vs FAIL (schema check)
+### WARN vs FAIL
 
 | Outcome | Typical cause | Coach action |
 |---------|---------------|--------------|
-| **FAIL** (exit non-zero) | Missing a **default** Playground view; empty README | Enter **TURN PROTOCOL** below — do not stop after one sentence |
-| **WARN** (exit 0) | Missing Tier-1 **columns** on primary views | Now **FAIL (exit 5)** — coach Turn H until green |
-| **WARN** (exit 0) | Leftover `View N`; layout mismatch | Coach rename/columns until cleared |
-| **PASS** | Six views + README + `board-bootstrap --check` exit 0 | Smoke card → day-to-day Pattern A |
+| **FAIL** (exit non-zero) | Missing default Playground view; empty README | **TURN PROTOCOL** — one turn, re-check |
+| **WARN** (exit 0) | Missing Tier-1 columns on primary views | Now **FAIL (exit 5)** — coach until green |
+| **WARN** (exit 0) | Leftover `View N`; layout mismatch | Rename/columns until cleared |
+| **PASS** | Six views + README + `--check` exit 0 | Smoke card → Pattern A |
 
-### TURN PROTOCOL (mandatory when views FAIL) — do not skip
+### TURN PROTOCOL (mandatory when views FAIL)
 
-You **must** run this conversation loop. **Forbidden:** “follow views-setup.md”, “rename View 1”, or “add columns” as a single dump then waiting forever. **Required:** one concrete UI turn, wait for human “done”, then next turn.
+**Required:** one concrete UI turn → wait for human `done` → re-check → next turn.
 
-**Default:** human performs clicks in GitHub UI; you coach one turn at a time.
+**Forbidden:** single dump of views-setup.md then wait forever.
 
-**Opt-in browser assist:** If the user **explicitly** asks you to open the browser / use browser MCP / click views or columns for them (e.g. “help me in the browser”, “do Turn H for me”, “use cursor-ide-browser”), you **may** use **browser MCP** / cursor-ide-browser for **that** turn only. Still one turn → re-check → next. Do **not** open the browser unprompted. Stop and hand back to the human on login/2FA/permission blockers. Follow **Browser assist map** below (same targets as `views-setup.md`).
+**Default:** human clicks in GitHub UI; you coach one turn.
 
-**Open:** Project URL from `project status` (e.g. `https://github.com/users/…/projects/N`).
+**Opt-in browser assist:** When user explicitly asks (e.g. “use cursor-ide-browser”), you may use browser MCP for **that turn only**. Stop on login/2FA/permission blockers. Targets: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md) § Browser assist map.
 
-### Browser assist map (universal click targets — opt-in only)
+**Open:** Project URL from `project status`.
 
-Use this when driving **cursor-ide-browser** (or when coaching clicks). Prefer **minimal 2-view** path unless the user asked for six-view Playground. After each turn: `board-bootstrap --check`.
+| Turn | Goal | Done when |
+|------|------|-----------|
+| A | Rename **View 1** → **Status board**; Board layout; Group by **Status**; Tier-1 columns | Human replies `done`; fewer FAILs |
+| B | **+ New view** → Table → **Prioritized backlog** + Tier-1 columns | `done`; re-check |
+| C | **+ New view** → Roadmap → **Roadmap** | `done`; re-check |
+| D | **+ New view** → Table → **Bugs**; filter title `[BUG]` | `done`; re-check |
+| E | **+ New view** → Table → **In review**; filter Status = In review | `done`; re-check |
+| F | **+ New view** → Table → **My items**; filter Assignees = `@me` | `done`; re-check |
+| G | README via `--apply-readme` or paste `project-readme.md` | README non-empty; re-check |
+| H | Clear Tier-1 column FAILs on Status board / Prioritized backlog | `--check` exits **0** |
 
-| Goal | Where to go (GitHub Project UI) | Done when |
-|------|----------------------------------|-----------|
-| Open project | Navigate to Project URL from `project status` | Project header + view tabs visible |
-| Select a view | Click the **view tab** by exact name (`Status board`, `Prioritized backlog`, …) | That view is active |
-| Rename view | Active tab → **⋯** (or right-click / View menu) → **Rename** → type kit name → confirm | Tab label matches schema |
-| New view | **+ New view** (or **New view**) → pick layout → name it | New tab exists with correct name |
-| Layout | View menu / **⋯** → **Layout** → **Board** / **Table** / **Roadmap** | Layout matches turn |
-| Group by (required) | View menu / toolbar **Group by** → **Status** (Status board) | Board columns are Status groups |
-| Show Tier-1 columns | Active view → **+** / field picker / **Fields** / **View settings → Fields** → enable **Priority**, **Size**, **Estimate**, **Start date**, **End date** | `--check` no longer FAILs those columns on that view |
-| Clear Slice by (if set by mistake) | View menu → **Slice by** → **No slicing** (or clear) | No slice chips; groups only if Group by set |
-| Save view | If UI shows unsaved / **Save** on the view | Changes persist after reload |
-| README | Prefer CLI `--apply-readme` after consent; else Project **⋯** / Settings → **README** | README non-empty; `--check` OK |
+**Fast minimal path:** Turn A → Turn B → Turn G → Turn H if needed → exit **0**.
 
-**Fast minimal path (browser):** Turn A (Status board rename/layout/Group by Status + Tier-1 fields) → Turn B (Prioritized backlog Table + Tier-1 fields) → Turn G (README) → Turn H only if `--check` still FAILs columns → exit when `--check` **0**.
-
-**Optional polish (not a bootstrap gate):** on **Prioritized backlog** → **Group by** → **Priority** (P0/P1/P2 sections). Empty boards may hide empty group headers until cards have Priority set. Do **not** block “ready for agents” on this.
-
-**Browser stop conditions:** login / 2FA / permission / CAPTCHA / “can’t find control after 2 tries” → hand back to human with the same turn table row; do not invent GraphQL view mutations.
-
-**Turn A — kill `View 1` → Status board**
-
-1. Tell human: open the Project → click the view tab named **View 1** (or similar).
-2. Rename it to **Status board**.
-3. Layout = **Board**; Group by = **Status**.
-4. Show fields/columns: Title, Assignees, Status, **Priority**, **Size**, **Estimate**, **Start date**, **End date**, Linked pull requests.
-5. Ask: reply `done` when Status board exists. Then re-run `--check` (expect fewer FAILs).
-
-**Turn B — Prioritized backlog (new Table view)**
-
-1. **+ New view** → Table → name **Prioritized backlog**.
-2. Show same Tier-1 columns as Status board (**Priority** required).
-3. Wait for `done` → re-check.
-
-**Turn C — Roadmap**
-
-1. **+ New view** → Roadmap layout → name **Roadmap**.
-2. Wait for `done` → re-check.
-
-**Turn D — Bugs**
-
-1. **+ New view** → Table → name **Bugs** (emoji optional).
-2. Filter: title contains `[BUG]`.
-3. Wait for `done` → re-check.
-
-**Turn E — In review**
-
-1. **+ New view** → Table → name **In review**.
-2. Filter: Status = **In review**.
-3. Wait for `done` → re-check.
-
-**Turn F — My items**
-
-1. **+ New view** → Table → name **My items**.
-2. Filter: Assignees = `@me`.
-3. Wait for `done` → re-check.
-
-**Turn G — README**
-
-```bash
-python3 -m agent_colony project board-bootstrap --check --apply-readme
-```
-
-Or paste contents of `project-readme.md` into Project README settings. Re-check.
-
-**Turn H — clear Tier-1 column FAILs**
-
-If `--check` still FAILs missing Priority/Size/Estimate/Start date/End date on Status board or Prioritized backlog: open that view → **+** field picker → show the missing columns. Re-check until `board-bootstrap --check` exits **0** (no view FAIL and no Tier-1 column FAILs). Leftover `View N` WARNs are cosmetic and can be cleared separately.
+**Optional polish:** Group by Priority on Prioritized backlog — not a bootstrap gate.
 
 Between every turn print:
 
@@ -200,7 +147,7 @@ Between every turn print:
 board-shell turn: A|B|C|D|E|F|G|H · waiting=human · next=<view or column>
 ```
 
-Use checklist: `.ai_infra/templates/project-board/views-checklist.md`. Canon clicks: `.ai_infra/templates/project-board/views-setup.md`.
+Checklist: `.ai_infra/templates/project-board/views-checklist.md`. Canon clicks: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md).
 
 ### Optional automation (official API only)
 
@@ -209,51 +156,37 @@ python3 -m agent_colony project board-bootstrap --check --ensure-fields
 python3 -m agent_colony project board-bootstrap --check --apply-readme
 ```
 
-- `--ensure-fields`: create missing **field definitions** by name; print suggested YAML field ids (human confirms before editing collaboration.yaml). Does **not** create views.
-- `--apply-readme`: push templated README via `updateProjectV2` (opt-in; user approval).
+- `--ensure-fields`: create missing field definitions; print suggested YAML ids. Does **not** create views.
+- `--apply-readme`: push templated README via `updateProjectV2` (opt-in).
 
 Respect GraphQL quota / outbox — never retry-loop.
 
-### Smoke card (prove Tier-1)
+### Smoke card
 
 ```bash
 python3 -m agent_colony project create-from-template \
   --title "[LIVE-SMOKE] board shell onboard" --template slice \
   --status ready --priority p2 --size xs --estimate 0.5 --agent board
 python3 -m agent_colony project validate-item --last
-# cleanup: delete smoke item or set Done with Notes "smoke cleanup"
 ```
 
 ## Customization
 
-### Minimal 2-view overlay
+**Minimal 2-view:** copy `board-shell.schema.minimal.yaml` exemplar → `.local/user_settings/board-shell.schema.yaml`. Coach Turns A + B only. Re-check after each turn.
 
-When the user asks for a **simple board** (Status board + Prioritized backlog only):
-
-1. Explain: agent runtime uses CLI/API fields — extra Playground views are optional human UI.
-2. Offer copy from `.ai_infra/templates/user-settings/exemplars/board-shell.schema.minimal.yaml` → `.local/user_settings/board-shell.schema.yaml`.
-3. Coach **Turn A** (Status board) + **Turn B** (Prioritized backlog) only — skip Turns C–F. Optional: **Group by Priority** on Prioritized backlog (polish; not a `--check` gate).
-4. Re-run `board-bootstrap --check` after each turn until exit **0**.
-
-### Playground default (six views)
-
-- Edit overlay `.local/user_settings/board-shell.schema.yaml` only if your team intentionally drops a Playground view (expect FAIL→WARN tradeoffs).
-- **Safe:** Insights, Iteration columns, filters. (End date is Tier-1 — keep visible on Status board / Prioritized backlog.)
-- **Unsafe:** remove Status / Priority / Size / Estimate / Start date / End date fields, or hide **Priority** on Prioritized backlog.
+**Playground default (six views):** edit overlay only if team intentionally drops a view. **Unsafe:** remove Tier-1 fields or hide Priority on Prioritized backlog.
 
 ## Exit
-
-Print:
 
 ```text
 board-shell: minimum=pass|fail · recommended=N missing · schema=<path> · next=day-to-day Pattern A
 ```
 
-Only say **ready for agents** when `board-bootstrap --check` exits **0** (no view FAIL, no Tier-1 column FAIL on Status board / Prioritized backlog, README non-empty).
+Say **ready for agents** only when `board-bootstrap --check` exits **0**.
 
 ## Canon
 
 - Schema: `.ai_infra/templates/project-board/board-shell.schema.yaml`
-- Click map: `.ai_infra/templates/project-board/views-setup.md` § Browser assist map
-- Day-to-day cards: `.cursor/skills/board-ssot/SKILL.md`
-- ADR-008: no view API; coach + check by default; browser MCP only when user asks
+- Clicks: [views-setup.md](../../.ai_infra/templates/project-board/views-setup.md)
+- Day-to-day: `.cursor/skills/board-ssot/SKILL.md`
+- ADR-008: coach + check by default; browser MCP only when user asks

--- a/skills/canvas-artifacts/SKILL.md
+++ b/skills/canvas-artifacts/SKILL.md
@@ -5,6 +5,8 @@ description: Three-tier canvas and plan snapshot workflow via agent_colony canva
 
 # Canvas and plan artifacts (Pattern A)
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 - Editing kit canvases in `canvases/` and needing IDE preview
@@ -32,15 +34,15 @@ python3 -m agent_colony canvas save --slug billing-review --agent implementer
 ```
 
 - Use `export default function NameCanvas()` in `.canvas.tsx` files.
-- `sync --all` requires `--force` (avoid silent overwrite).
+- `sync --all` requires `--force`.
 
 ## Plan CLI
 
 ```bash
 python3 -m agent_colony plan snapshot --slug slice-170 --agent implementer --board-item PVTI_xxx
 python3 -m agent_colony plan list
-python3 -m agent_colony plan open --slug slice-170          # human Build bridge
-python3 -m agent_colony plan open --slug slice-170 --force  # overwrite Cursor twin
+python3 -m agent_colony plan open --slug slice-170
+python3 -m agent_colony plan open --slug slice-170 --force
 python3 -m agent_colony plan snapshot --slug my-plan --from cursor-plan:my-plan.plan.md
 ```
 
@@ -49,21 +51,21 @@ Never treat `.local/plans/` as active backlog under `board_only`.
 ## Agent rituals
 
 1. **Product canvas:** edit repo → `canvas sync --name …` → Open Canvas in IDE.
-2. **Ephemeral canvas:** write via Cursor canvas skill to managed path → `canvas save --slug …`.
+2. **Ephemeral canvas:** write via Cursor canvas skill → `canvas save --slug …`.
 3. **Plan mode exit:** `plan snapshot --slug …` with board item id when known.
 
-### Consumer plans (agent build — Path A)
+### Consumer plans (Path A)
 
-Agents **never depend on** the IDE Build button. Execute from `.local/plans/`:
+Agents **never depend on** the IDE Build button:
 
-1. `plan list` — discover slugs under `.local/plans/`
-2. Read `.local/plans/<latest>-<slug>.plan.md` (+ sibling `.meta.yaml`)
-3. Execute todos / acceptance as implementer (no Build required)
-4. **Human-only:** `plan open --slug …` → Plans UI → Build (copies latest snapshot to `~/.cursor/plans/<slug>.plan.md`)
-5. After plan-mode work in Cursor: `plan snapshot --from cursor-plan:…` to re-anchor history in `.local/plans/`
+1. `plan list` — discover slugs
+2. Read `.local/plans/<latest>-<slug>.plan.md` (+ `.meta.yaml`)
+3. Execute todos as implementer
+4. **Human-only:** `plan open --slug …` → Plans UI → Build
+5. After plan-mode work: `plan snapshot --from cursor-plan:…`
 
-`plan snapshot` from a Cursor plan preserves YAML frontmatter (`name` / `overview` / `todos`) needed for Build.
+`plan snapshot` preserves YAML frontmatter (`name` / `overview` / `todos`) for Build.
 
-**Indexing:** only `*.plan.md` (+ sibling `*.meta.yaml`) appear in `plan list` / `index.md`. Plain `.md` files dropped under `.local/plans/` are orphans — remove or re-snapshot via `plan snapshot --from <path>`.
+**Indexing:** only `*.plan.md` (+ `*.meta.yaml`) in `plan list`. Orphans → re-snapshot or remove.
 
 Canon: [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md)

--- a/skills/full-pr-workflow/SKILL.md
+++ b/skills/full-pr-workflow/SKILL.md
@@ -6,7 +6,9 @@ disable-model-invocation: true
 
 # Full PR workflow (maintainer)
 
-**Goal:** Merge a PR and then clean up the repo (sync `main`, delete local + remote feature branches) with a dedicated **finalize** phase.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+**Goal:** Merge a PR and clean up the repo (sync `main`, delete branches) via **finalize**.
 
 ## Order
 

--- a/skills/integrator-protocol/SKILL.md
+++ b/skills/integrator-protocol/SKILL.md
@@ -5,177 +5,105 @@ description: Procedural integration of new agents, skills, MCP servers, and kit 
 
 # Integrator protocol
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## Goal
 
-Integrate **new agents, skills, MCP servers, scripts, or docs** into the kit so the user gets the same **unpack + personal settings** experience: full consumer infrastructure from the plugin, human completes `.local/user_settings/`, everything else stays **procedural, deterministic, and enterprise-grade**.
+Integrate **new agents, skills, MCP servers, scripts, or docs** for unpack + personal settings. Keep work procedural and deterministic.
 
-**Canonical ops mirror:** `.ai_infra/docs/operations/mas-infrastructure-integration.md`
-
-## When to use
-
-- User adds a **new Cursor agent** or **skill**
-- User connects an **external MCP server** for multiple agents
-- User expands **manifest / install contract / plugin payload**
-- User asks to merge a **standalone agent** into the MAS pipeline (or keep independent but governed)
-
-**Agent card:** `.cursor/agents/integrator.md`
+**Canonical ops:** [mas-infrastructure-integration.md](../../.ai_infra/docs/operations/mas-infrastructure-integration.md) · **Agent:** `.cursor/agents/integrator.md`
 
 ## Evidence contract
 
-- Every integration claim cites a **repo path** or **command output**.
-- If not inspected: label **Unknown** — do not invent file layout or gate behavior.
-- No narrative without a checklist row or script result backing it.
+- Every claim cites **repo path** or **command output**.
+- Not inspected → **Unknown**. No invented layout or gate behavior.
 
----
+## Phase 0 — Intake
 
-## Phase 0 — Intake (classify)
+| Type | Examples | Outputs |
+|------|----------|---------|
+| **Agent** | `my-domain-agent.md` | `.cursor/agents/`, registry |
+| **Skill** | `.cursor/skills/` or `.agents/skills/` | SKILL.md, plugin sync |
+| **MCP** | GitHub, browser, DB | `mcp.user.json`, registry |
+| **Infrastructure** | script, gate | `.ai_infra/`, manifest, tests |
+| **Doc-only** | runbook | `.ai_infra/docs/` |
 
-| Type | Examples | Primary outputs |
-|------|----------|-----------------|
-| **Agent** | `my-domain-agent.md` | `.cursor/agents/`, registry, optional pipeline |
-| **Skill** | `.cursor/skills/foo/` or `.agents/skills/` | SKILL.md, cross-links, plugin sync |
-| **MCP external** | GitHub, browser, DB | `mcp.user.json`, registry, `mcp.agents.yaml` worksheet |
-| **Infrastructure** | new script, gate, template dir | `.ai_infra/`, manifest, tests |
-| **Doc-only** | runbook, charter | `.ai_infra/docs/` |
+Ask: MAS-integrated vs independent (ADR-006)? Architecture/manifest touch → plan `auditor`. Consumer-visible → `manifest.yaml` + `install-contract.json`. Research pack → read `AGENT_BRIEF.md`.
 
-Ask (or infer from request):
+## Phase 1 — Read base workflow
 
-1. **MAS-integrated** or **independent contract**? (see ADR-006: `.ai_infra/docs/decisions/ADR-006-agent-integration-model.md`)
-2. Touches **architecture / manifest / workflows**? → plan `auditor` before merge prep.
-3. **Consumer-visible** (copied on install)? → update `manifest.yaml` + `install-contract.json`.
-4. Research pack cited? → read `_research_results/sources/<slug>/AGENT_BRIEF.md` before classifying.
+`workflow-architecture.md` · `agent-workflow-procedures.md` · `local-workspace-layout.md` · `github.collaboration.yaml` · similar agent/skill as template.
 
----
+## Phase 2 — Templates
 
-## Phase 1 — Read base workflow (do not skip)
-
-Minimum read set:
-
-1. `.ai_infra/docs/architecture/workflow-architecture.md` — three planes
-2. `.ai_infra/docs/operations/agent-workflow-procedures.md` — Pattern A
-3. `.ai_infra/docs/operations/local-workspace-layout.md` — `.local/` contract
-4. `.local/user_settings/github.collaboration.yaml` — pipelines + attribution
-5. Target area already in repo (similar agent/skill as template)
-
----
-
-## Phase 2 — Apply templates
-
-Copy and edit from **`.ai_infra/templates/agent-integration/`**:
+From `.ai_infra/templates/agent-integration/`:
 
 | Template | Use |
 |----------|-----|
-| `AGENT.template.md` | New `.cursor/agents/<id>.md` |
-| `SKILL.template.md` | New skill under `.cursor/skills/<name>/` |
-| `INTEGRATION-CHECKLIST.md` | Track slice; when `project_ssot.enabled` + `board_only`, attach to the **board card** body/Notes; else attach to `work-tracker.md` |
+| `AGENT.template.md` | `.cursor/agents/<id>.md` |
+| `SKILL.template.md` | `.cursor/skills/<name>/` |
+| `INTEGRATION-CHECKLIST.md` | Board card or `work-tracker.md` |
 
-**Agent file rules:**
+**Agent:** frontmatter; **Anchor**; **Read first**; **MCP integration**. Board SSOT when enabled; else `session-pointer.md`. Independent agents: omit pipelines unless PR phase owner.
 
-- YAML frontmatter: `name`, `model`, `description`
-- **Anchor** block (Entry/Exit) — same discipline as `implementer.md`
-- **Read first** — bounded file set; no whole-repo loads
-- **MCP integration** section — required (governance scanner)
-- Procedural exits: when `project_ssot.enabled` + `board_only`, **Entry/Exit** on Project (`project status` → `set-status` / Notes); update `change-index.md`. `session-pointer.md` is offline fallback / session pointer only — not Status SSOT. When SSOT disabled/offline: update `session-pointer.md`, `change-index.md`
+## Phase 3 — Wire surfaces
 
-**Independent agent:** still includes Anchor + universal rules; omit from `github.collaboration.yaml` pipelines unless it participates in PR phases.
-
----
-
-## Phase 3 — Wire integration surfaces
-
-### A. MAS-integrated agent (multi-agent system)
+### MAS-integrated
 
 | Step | Action |
 |------|--------|
-| 1 | Add `.cursor/agents/<id>.md` from template |
-| 2 | Add skill if procedural steps are non-trivial |
-| 3 | Update `.cursor/mcp.registry.yaml` (+ example): list agent under `agent-colony-mcp` or external server |
-| 4 | Update `.local/user_settings/mcp.agents.yaml` worksheet + exemplar under `templates/user-settings/` |
-| 5 | Add to `github.collaboration.yaml` pipeline if it runs in PR/slice flow (or rely on `--agents-from-session` via `change-index`) |
-| 6 | If consumer-installed: add paths to `manifest.yaml` / `install-contract.json` when new dirs ship |
-| 7 | If marketplace: `make sync-plugin` + `make check-plugin` |
-| 8 | Add tests under `tests/modules/` if new scripts |
+| 1–2 | Agent + skill if non-trivial |
+| 3–4 | `mcp.registry.yaml` + `mcp.agents.yaml` worksheet |
+| 5 | `github.collaboration.yaml` pipeline if PR/slice |
+| 6–7 | `manifest.yaml` / `install-contract.json`; `make sync-plugin` + `check-plugin` |
+| 8 | `tests/modules/` if new scripts |
 
-### B. Independent agent (governed, not in MAS pipeline)
+### Independent
 
-| Step | Action |
-|------|--------|
-| 1 | Agent + skill with explicit **boundaries** (what it must not do) |
-| 2 | Registry: optional MCP servers scoped to that agent id only |
-| 3 | **Do not** add to core PR pipelines unless it owns a maintainer phase |
-| 4 | Document handoff to `implementer` / `integrator` when work crosses into kit infrastructure |
+Agent + skill with **boundaries**; optional scoped MCP; no core PR pipeline unless maintainer phase; document handoff when crossing kit infra.
 
-### C. External MCP server
+### External MCP
 
-Follow `.ai_infra/docs/operations/connect-external-mcp.md` plus:
+[connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md): `mcp.agents.yaml` row → `mcp.user.json` fragment → `mcp.registry.yaml` → `mcp validate`.
 
-1. Row in `.local/user_settings/mcp.agents.yaml`
-2. Fragment in `.cursor/mcp.user.json` (gitignored)
-3. Keys in `.cursor/mcp.registry.yaml` — `agents: [...]` per server
-4. `python -m agent_colony mcp validate`
+### Canvases / plans (ADR-010)
 
-### D. Canvases / plans (ADR-010)
+`.cursor/skills/canvas-artifacts/SKILL.md`. `.local/plans/` = snapshots only.
 
-When touching `canvases/`, `.local/canvases/`, or `.local/plans/`:
+### Maintainer script
 
-1. Read `.cursor/skills/canvas-artifacts/SKILL.md` and [ADR-010](../../.ai_infra/docs/decisions/ADR-010-canvas-plan-local-artifacts.md).
-2. Repo `canvases/` = git SSOT → `canvas sync` → optional `canvas save` to `.local/canvases/`.
-3. `.local/plans/` = snapshot history only; live plan stays on board card / `plan.md` — wire `plan snapshot|list|open` in docs/agent cards as needed.
-4. After canvas edits: `python3 -m agent_colony canvas sync --name <stem>` (+ `canvas doctor` smoke).
+`.ai_infra/scripts/` only; never duplicate `GATES` outside `prepare.py`; file header on new Python; thin MCP wrapper in `agent_colony_mcp/server.py`.
 
-### E. New maintainer script
-
-- Lives under `.ai_infra/scripts/` — never duplicate `GATES` outside `prepare.py`
-- File header per `file-docstring-header-relations.mdc`
-- Wire MCP tool in `agent_colony_mcp/server.py` only as thin wrapper (Pattern A)
-
----
-
-## Phase 4 — Verify (commands, not prose)
-
-Run applicable subset:
+## Phase 4 — Verify
 
 ```bash
 python -m agent_colony contributors validate
 python -m agent_colony integrate validate
-python .ai_infra/scripts/architecture/check_governance_consistency.py   # if .cursor/ or workflows changed
+python .ai_infra/scripts/architecture/check_governance_consistency.py   # if .cursor/ changed
 pytest -q tests/modules/<relevant>/
-make gates                    # kit dev
-make check-plugin             # if agents/rules/skills/payload touched
-make install-dry-run          # if manifest / scaffold changed
-python -m agent_colony health --directory .
+make gates && make check-plugin    # if payload touched
+make install-dry-run               # if manifest changed
 ```
 
-Record PASS/FAIL in `change-index.md` and `updates-log.md`.
-
----
+Say *prepare gates green* or paste failing stderr. Record in `change-index.md` + `updates-log.md`.
 
 ## Phase 5 — Handoff
 
-| Outcome | Next agent |
-|---------|------------|
-| Needs product code / tests | `implementer` + `test-runner` |
-| Architecture-impacting | `auditor` → alignment artifacts |
-| Ready for PR | maintainer `review-pr` with `--pipeline` + `--agents-from-session` |
+| Outcome | Next |
+|---------|------|
+| Product code / tests | `implementer` + `test-runner` |
+| Architecture-impacting | `auditor` |
+| Ready for PR | `review-pr` with `--pipeline` + `--agents-from-session` |
 
----
+## Anti-patterns
 
-## Anti-patterns (reject)
-
-- Duplicating `prepare.py` GATES in skills or agent prose
-- New agents without Anchor / MCP integration section
-- Skipping `change-index.md` Agent column (breaks PR `--agents-from-session`)
-- `Made-with:` or fake human sign-off in commits
-- Loading entire `.local/` or megadocs when a checklist suffices
-- Independent agents that bypass governance scripts
-
----
+Duplicate GATES in prose · agents without Anchor/MCP · skip `change-index.md` Agent column · `Made-with:` · load entire `.local/` · independent agents bypass governance.
 
 ## Exit criteria
 
-- [ ] Integration type documented (MAS vs independent)
-- [ ] Templates filled; file headers present on new Python
-- [ ] Registry / user_settings exemplars updated if MCP or pipelines affected
-- [ ] Manifest + install-contract if consumer tree changed
-- [ ] Verification commands run; failures fixed or logged as blockers
-- [ ] Board Status/Notes updated when `project_ssot.enabled` + `board_only`; else `session-pointer.md` updated. `change-index.md` always updated
+- [ ] Type documented (MAS vs independent)
+- [ ] Templates + file headers on new Python
+- [ ] Registry/exemplars if MCP/pipelines touched
+- [ ] Manifest if consumer tree changed
+- [ ] Verify commands run; blockers logged
+- [ ] Board Notes when `board_only`; `change-index.md` always

--- a/skills/mcp-connect/SKILL.md
+++ b/skills/mcp-connect/SKILL.md
@@ -5,6 +5,8 @@ description: Connect external MCP servers to Agent Colony agents via mcp.user.js
 
 # MCP connect
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom APIs) alongside built-in `agent-colony-mcp`.
@@ -13,22 +15,20 @@ User wants kit agents to use **external** MCP tools (Slack, DB, GitHub, custom A
 
 ### 1. Enable DeepWiki (default zero-auth)
 
-Consumer activate already seeds DeepWiki when `mcp.user.json` / registry keys are missing. On an existing workspace:
-
 ```bash
 python3 -m agent_colony mcp seed --deepwiki
 python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp smoke --server deepwiki
 ```
 
-Optional: `--force-registry-agents` to reset `deepwiki.agents` to the seven Pattern A agents.
+Optional: `--force-registry-agents` to reset `deepwiki.agents` to seven Pattern A agents.
 
 ### 2. Link custom (auth or private)
 
 ```bash
 python3 -m agent_colony mcp link --name my-api --file .cursor/mcp.d/my-api.json
 # edit .cursor/mcp.registry.yaml — map agents
-python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN   # if needed
+python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN
 python3 -m agent_colony mcp validate
 ```
 
@@ -38,41 +38,34 @@ python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp doctor
 python3 -m agent_colony mcp smoke --server agent-colony-mcp
 python3 -m agent_colony mcp smoke --server deepwiki
-# DeepWiki live call (repoName; repo must be indexed on deepwiki.com):
 python3 -m agent_colony mcp call --server deepwiki --tool ask_question \
   --args-json '{"repoName":"karpathy/nanochat","question":"What is nanochat in one sentence?"}'
 ```
 
-### Agent contract — DeepWiki
+### DeepWiki agent contract
 
 | Do | Do not |
 |----|--------|
-| `list-tools --server deepwiki` before inventing args | Guess `repo` — the tool wants **`repoName`** |
-| Pass `owner/repo` as `repoName` (same slug as GitHub) | Pass a deepwiki.com URL as the MCP arg |
-| Prefer indexed smoke targets (e.g. `karpathy/nanochat`) | Treat “Repository not found” as a kit bug — index on deepwiki.com first |
-| Use GitHub URL / `github:` for `research init\|fetch` | Use DeepWiki MCP as a substitute for cloning the corpus |
+| `list-tools --server deepwiki` before inventing args | Guess `repo` — tool wants **`repoName`** |
+| Pass `owner/repo` as `repoName` | Pass deepwiki.com URL as MCP arg |
+| Prefer indexed smoke targets (e.g. `karpathy/nanochat`) | Treat “Repository not found” as kit bug |
+| Use GitHub URL / `github:` for `research init\|fetch` | Use DeepWiki as substitute for cloning corpus |
 
-## Steps (<5 min) — first-time worksheets
+## First-time setup (<5 min)
 
-1. Copy `.cursor/mcp.registry.yaml.example` → `.cursor/mcp.registry.yaml` (if live missing and you did not activate)
-2. Copy `.cursor/mcp.user.example.json` → `.cursor/mcp.user.json` (gitignored) — or prefer `mcp seed --deepwiki`
-3. Or link a fragment:
-
-```bash
-python3 -m agent_colony mcp link --name my-api --file .cursor/mcp.d/my-api.json
-```
-
-4. Map the server to agents in `mcp.registry.yaml`
-5. Merge and validate:
+1. Copy `.cursor/mcp.registry.yaml.example` → `.cursor/mcp.registry.yaml` (if missing)
+2. Copy `.cursor/mcp.user.example.json` → `.cursor/mcp.user.json` — or `mcp seed --deepwiki`
+3. Map server to agents in `mcp.registry.yaml`
+4. Validate:
 
 ```bash
 python3 -m agent_colony mcp validate
 python3 -m agent_colony mcp doctor
 ```
 
-6. Optional: enable MCP in Cursor settings for the workspace (`CallMcpTool` convenience).
+5. Optional: enable MCP in Cursor settings (`CallMcpTool` convenience).
 
-**Pattern A (canonical):** agents call MCP via CLI — not Cursor host loading:
+**Pattern A (canonical):** agents call MCP via CLI:
 
 ```bash
 python3 -m agent_colony mcp list-tools --server agent-colony-mcp
@@ -81,17 +74,17 @@ python3 -m agent_colony mcp auth --server my-api --token-env MY_TOKEN
 python3 -m agent_colony mcp smoke --server agent-colony-mcp
 ```
 
-Full walkthrough: `.ai_infra/docs/operations/connect-external-mcp.md` § Worked example: DeepWiki. Canon: ADR-009.
+Walkthrough: [connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md) § Worked example: DeepWiki. Canon: ADR-009.
 
 ## Success
 
-- `python3 -m agent_colony mcp validate` exits 0
-- `python3 -m agent_colony mcp doctor` shows configured vs host-loaded
+- `mcp validate` exits 0
+- `mcp doctor` shows configured vs host-loaded
 - `mcp list-tools` / `mcp call` work for allowlisted servers
-- Target agent markdown includes the server under **MCP integration**
+- Target agent markdown includes server under **MCP integration**
 
 ## Reference
 
-- `.ai_infra/docs/operations/connect-external-mcp.md`
-- `.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md`
-- `.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md`
+- [connect-external-mcp.md](../../.ai_infra/docs/operations/connect-external-mcp.md)
+- [ADR-004](../../.ai_infra/docs/decisions/ADR-004-user-mcp-registry.md)
+- [ADR-009](../../.ai_infra/docs/decisions/ADR-009-mcp-pattern-a-cli.md)

--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Merge PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Merge only when artifacts + gates are satisfied.
 
 ## Steps

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -6,9 +6,11 @@ disable-model-invocation: true
 
 # PR workflow (maintainer)
 
-**Implementer work:** when `project_ssot.enabled` + `board_only`, slice status lives on the **GitHub Project** (Entry/Exit continuation). Local `.local/index-and-planning/current/*` is offline fallback only — see ADR-008 and `project-ssot-precedence.mdc`. Slice closure: `.ai_infra/docs/operations/workflow-complete.md` §F.
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
-This skill is the **merge path** only: **review → prepare → merge** (slash skills: `review-pr`, `prepare-pr`, `merge-pr`).
+**Implementer work:** board SSOT when `project_ssot.enabled` + `board_only`; local trackers are offline fallback (ADR-008). Slice closure: `workflow-complete.md` §F.
+
+**Merge path only:** review → prepare → merge (`review-pr`, `prepare-pr`, `merge-pr`).
 
 ## Order
 

--- a/skills/prepare-pr/SKILL.md
+++ b/skills/prepare-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Prepare PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Green gates + documented evidence in `prep.md`.
 
 ## Steps

--- a/skills/research-corpus/SKILL.md
+++ b/skills/research-corpus/SKILL.md
@@ -5,124 +5,95 @@ description: Brief-driven multi-round research into _research_results packs (ext
 
 # Research corpus
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-- External research: user chat, another agent’s handoff/Notes, or a board research card names a source.
-- Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` when present under `_research_results/`.
+- External research: user chat, peer handoff/Notes, or board research card names a source
+- Host deepening (`mode: self`): optional `DEPTH_BACKLOG.md` under `_research_results/`
 
-**Not for:** product code changes, PR merge, `.local/` implementation — use `implementer` / `.agents/skills/pr-workflow/SKILL.md`.
+**Not for:** product code, PR merge, `.local/` implementation — use `implementer` / `pr-workflow`.
 
-## Agent
-
-**`.cursor/agents/researcher.md`**. Hub: `.agents/skills/RESEARCH_WORKFLOW.md`.
+**Agent:** `.cursor/agents/researcher.md` · Hub: `.agents/skills/RESEARCH_WORKFLOW.md`
 
 ## Read first
 
-1. This skill (intake → rounds)
+1. This skill
 2. `_research_results/RESEARCH_BOUNDARIES.md` (via `research init` if missing)
-3. Incoming chat / board card / peer handoff (see Intake)
+3. Incoming chat / board card / peer handoff
 4. Pack `BRIEF.md` when continuing a slug
 
-## Intake (adapt — do not require a formal paste)
+## Intake
 
-Build a Brief from **any** of:
-
-1. **User chat** — including terse forms like `/researcher https://github.com/owner/repo`
-2. **Peer agents** — board Notes, handoff line, cited `AGENT_BRIEF.md` / pack path, implementer/integrator ask
-3. **Board card** — `create-from-template --template research --priority p2` body Brief table
-4. **Existing** `sources/<slug>/BRIEF.md`
+Build a Brief from user chat, peer Notes/handoff, board card, or existing `BRIEF.md`.
 
 ### Normalize source
 
 | Input | Normalized |
 |-------|------------|
-| `https://github.com/owner/repo` | OK for CLI; also record `github:owner/repo` |
-| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` (CLI accepts HTTPS tree URLs) |
+| `https://github.com/owner/repo` | OK; also `github:owner/repo` |
+| `https://github.com/owner/repo/tree/ref/...` | `github:owner/repo@ref` |
 | `github:owner/repo[@ref]` | Canonical |
 | Local path | `path:…` or bare path |
 
-**DeepWiki is not a research source locator.** Packs clone from GitHub/`path:`. Optional wiki Q&A uses MCP `deepwiki` with **`repoName":"owner/repo"`** (must be indexed on [deepwiki.com](https://deepwiki.com)) — see `researcher` MCP section and `/mcp-connect`. Do not pass a deepwiki.com URL to `research init --source`.
+**DeepWiki is not a research source locator.** Packs clone from GitHub/`path:`. Optional wiki Q&A: MCP `deepwiki` with `repoName":"owner/repo"` — see `mcp-connect`. Do not pass deepwiki.com URL to `research init --source`.
 
 ### Defaults (terse chat)
 
-If only a link/path is given:
+If only a link/path:
 
-- **question:** Map architecture, entrypoints, and patterns useful to our MAS kit; produce `AGENT_BRIEF` for implementer/integrator.
+- **question:** Map architecture, entrypoints, patterns for MAS kit; produce `AGENT_BRIEF`.
 - **lenses:** architecture, cli, agents, skills, tests, decisions, patterns
-- **slug:** repo (or directory) name, lowercase with hyphens
-- **consumers:** implementer, integrator (plus the requesting agent if known)
+- **slug:** repo name, lowercase hyphens
+- **consumers:** implementer, integrator (+ requester if known)
 - **rounds_max:** 6
 
-Refuse **only** when there is no source and no `mode: self` ask. Missing question → use default and state it in board Notes / chat.
+Refuse only when no source and no `mode: self`. Missing question → use default; state in Notes.
 
 ### GitHub access
 
-| Visibility | Requirement |
-|------------|-------------|
-| Public | Network + `gh` or `git` clone |
-| Private | Same, plus consumer auth (`gh auth login` / git credentials that can clone the URL) |
+Public: network + `gh` or `git`. Private: + consumer auth. Clone failure → report once; stop.
 
-Clone failures: report once and stop — no retry loop.
-
-### Brief contract (persisted)
-
-Write via `research init` into `BRIEF.md`:
-
-```text
-source: github:owner/repo@ref | https://github.com/… | path:/abs/or/rel
-question: <what MAS / requesting agent needs>
-lenses: [architecture, cli, agents, skills, tests, decisions, patterns]
-rounds_max: 6
-consumers: [implementer, integrator, …]
-slug: <derived or explicit>
-```
-
-## Procedural setup
+### Brief contract
 
 ```bash
 python3 -m agent_colony research init --slug <slug> --source '…' --question '…'
 python3 -m agent_colony research fetch --slug <slug> --source '…'
 ```
 
-`--source` accepts HTTPS GitHub URLs, `github:…`, `path:…`, or bare local path. Fetch prefers `gh repo clone` (private-friendly), else `git clone --depth 1` into `_research_results/cache/<slug>/`. Re-fetch requires `--force`.
+`--source`: HTTPS GitHub, `github:…`, `path:…`, or local path. Re-fetch needs `--force`.
 
 ## Anti-loop (hard stop)
 
 | Rule | Behavior |
 |------|----------|
-| Cap | Deepen ≤ `rounds_max` (default 6); never round 7+ |
-| Idempotent init/fetch | Existing pack / `SOURCE.md` → refuse unless `--force` |
-| Closed pack | `INDEX.status=complete` + validate PASS → **exit**; do not deepen again unless user reopens |
-| Failures | One clone attempt; surface error; stop |
-| Gaps | Remaining questions → document gaps; set `blocked` or complete with gaps — do not spin |
+| Cap | ≤ `rounds_max` (default 6) |
+| Idempotent | Existing pack → refuse unless `--force` |
+| Closed pack | `INDEX.status=complete` + validate PASS → **exit** |
+| Failures | One clone attempt; stop |
+| Gaps | Document; set `blocked` or complete with gaps |
 
-## Multi-round loop (active)
+## Multi-round loop
 
-Work only under `_research_results/sources/<slug>/`. Read foreign trees read-only.
+Work under `_research_results/sources/<slug>/` only. Foreign trees read-only.
 
-1. **Scout** — confirm `SOURCE.md` pin (SHA/path); note languages/size.
-2. **Map** — write `MAP.md` (entrypoints, layout, docs).
-3. **Extract** — for each lens in Brief, fill `findings/<lens>.md` with path + line evidence.
-4. **Deepen** — open questions only → `rounds/round-N.md` (N ≤ `rounds_max`). **Stop deepening when N == rounds_max.**
-5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`.
-6. **Pack** — `AGENT_BRIEF.md` (1–2 pages) + update `INDEX.json` (`status: complete`, findings array, `curated_count`, `rounds_completed` ≤ `rounds_max`).
-7. **Validate** — `python3 -m agent_colony research validate --slug <slug>`.
-8. **Exit** — board Done + Notes with pack paths; handoff to named consumer (requesting agent if known). **Then stop.**
+1. **Scout** — confirm `SOURCE.md` pin
+2. **Map** — `MAP.md`
+3. **Extract** — `findings/<lens>.md` with path + line evidence
+4. **Deepen** — `rounds/round-N.md` (N ≤ `rounds_max`)
+5. **Curate** — `CURATED.md` rows `verified: path; ~Lnn; note: …`
+6. **Pack** — `AGENT_BRIEF.md` + `INDEX.json`
+7. **Validate** — `research validate --slug <slug>`
+8. **Exit** — board Done + Notes; handoff to consumer; **stop**
 
-## Mode: self (optional)
+## Mode: self
 
-If `DEPTH_BACKLOG.md` exists and user asks for host deepening: one backlog ID per session; same hard stop; still write under `_research_results/` only.
+One backlog ID per session when `DEPTH_BACKLOG.md` exists and user asks.
 
-## Lenses (default)
-
-`architecture` · `cli` · `agents` · `skills` · `tests` · `decisions` · `patterns`
-
-## Output format
+## Output
 
 ```text
 slug · mode · rounds · curated_count · AGENT_BRIEF path · validate PASS/FAIL · next consumer
 ```
 
-## Status
-
-**Agent shipped/proven** (2026-07-19): live external pack (`flexiai-toolsmith`, 18 curated, validate PASS) + verifier Claim A (efficiency) / Claim B (correctness) VERIFIED. Corpus remains **opt-in** after first `research init` — not an incomplete agent. Canvas: `canvases/agent-researcher.canvas.tsx`.
+Canvas: `canvases/agent-researcher.canvas.tsx`.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Review PR
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 **Goal:** Decide if the PR is ready for `/prepare-pr`.
 
 ## Steps

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -5,6 +5,8 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 
 # Test coverage
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
 `src/**` or `scripts/**` behavior change; coverage or regression requests; medium/high risk before merge.
@@ -13,16 +15,16 @@ description: Module-focused tests and coverage evidence for workflow scripts and
 
 1. Target modules/symbols; matrix: valid / boundary / invalid, lifecycle, failure/recovery.
 2. Tests under `tests/modules/<module>/`.
-3. Update `.local/index-and-planning/current/test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
-4. Run: `pytest` scoped to module → broader as needed. Before merge path: **`python .ai_infra/scripts/pr/check_testing_artifacts.py`** (see `.ai_infra/scripts/pr/prepare.py` `resolve_gates()`).
-5. For coverage evidence, install `dev` extras (`pip install -e ".[dev]"`) then run `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing --cov-report=json -q` (writes **`coverage.json` only** — do not invent alternate names). Prefer `grep`/`python` over `rg` when filtering shell output — `rg` is often absent from the user PATH. Record gaps in board card Notes when `project_ssot.enabled` + `board_only`, else `work-tracker.md`; always one line in `updates-log.md` per `implementation-workflow-governance.mdc`. **Scope:** this metric tracks the installable kit import surface (`.ai_infra/**` modules imported during tests + `agent_colony/**`); subprocess-only scanners (`check_governance_consistency.py`, `check_debrand.py`, etc.) are validated via their own module tests but excluded from `--cov` by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
-6. **After scoped coverage reaches 100%** (or any coverage-closure slice): mandatory doc reality sync — update `IMPLEMENTATION-STATUS.md` **Tests:** + coverage scope numbers, regenerate `.local/index-and-planning/current/coverage-index.md` via `make coverage-index`, run `make doc-validate`, sync related README/AGENTS/repository-map claims, then `make sync-plugin` when skills/docs payload copies change.
-7. Report: modules • edges added • gaps • tracker edits.
+3. Update `test-index.md` and `test-plan.md`; drop obsolete tests when contracts change.
+4. Run scoped `pytest` → broader as needed. Before merge: **`check_testing_artifacts.py`** (via `prepare.py` `resolve_gates()`).
+5. Coverage evidence: `pip install -e ".[dev]"` then `pytest --cov=.ai_infra --cov=agent_colony --cov-report=term-missing --cov-report=json -q` (writes **`coverage.json`** only). Record gaps in board Notes when `board_only`, else `work-tracker.md`; one line in `updates-log.md`. Scope: kit import surface; subprocess scanners excluded by design — see `IMPLEMENTATION-STATUS.md` § Coverage scope.
+6. **After 100% scoped coverage:** sync `IMPLEMENTATION-STATUS.md`, regenerate `coverage-index.md` via `make coverage-index`, `make doc-validate`, sync README/AGENTS claims, `make sync-plugin` when payload copies change.
+7. Report: modules · edges added · gaps · tracker edits.
 
 ## Themes (when relevant)
 
-Validation boundaries • error/reason codes • retry/replay on risky flows • async cleanup • policy negative paths.
+Validation boundaries · error/reason codes · retry/replay · async cleanup · policy negative paths.
 
 ## Output
 
-`Coverage summary` → `Tests added/updated` → `Edge cases` → `Gaps` → `Index/plan updates` (paths in backticks).
+`Coverage summary` → `Tests added/updated` → `Edge cases` → `Gaps` → `Index/plan updates`.

--- a/skills/update-agent-colony/SKILL.md
+++ b/skills/update-agent-colony/SKILL.md
@@ -19,53 +19,45 @@ Notes:
 
 # Update Agent Colony
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
 ## When
 
-User already ran **`/workflow-activate`** in **their app**, then updated the **Agent Colony** plugin (or kit tag) and needs kit-managed files refreshed.
+User ran **`/workflow-activate`** in **their app**, then updated the Agent Colony plugin and needs kit-managed files refreshed.
 
 **Not for first install** — use [workflow-activate](workflow-activate/SKILL.md) when `.ai_infra/` is missing.
 
 ## Guide the user
 
-1. Confirm the open folder is **their activated app**, not the kit product repo.
-2. Prefer Agent chat **`/update-agent-colony`**, or the Pattern A command below.
-3. Explain version gate briefly:
+1. Confirm folder is **their activated app**, not kit-dev repo.
+2. Prefer **`/update-agent-colony`** or Pattern A command below.
+3. Version gate:
    - **same / newer installed** → light heal (dashboards, `.gitignore`, `STARTER-001`, missing `.venv`)
    - **source newer** or **`--force`** → full overwrite of kit-managed agents/rules/skills/scripts
 4. After upgrade: `health` + `mcp validate`.
 
-## One command
+## Commands
 
 ```bash
 source .venv/bin/activate
 python3 -m agent_colony update --directory .
+python3 -m agent_colony update --directory . --check      # no writes
+python3 -m agent_colony update --directory . --force      # full refresh
 ```
 
-**Check only (no writes):**
-
-```bash
-python3 -m agent_colony update --directory . --check
-```
-
-**Force full refresh** (even when versions match):
-
-```bash
-python3 -m agent_colony update --directory . --force
-```
-
-**Source resolution** matches activate: `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
+**Source resolution:** `WORKFLOW_KIT_PAYLOAD` → `./payload/` → kit/plugin `payload/` → `--source`.
 
 ## What update does
 
 | Condition | Action |
 |-----------|--------|
-| No `.ai_infra/` or missing `.kit-version` | Fail — tell user to run `/workflow-activate` |
-| `installed == available` (and not `--force`) | Light heal only |
-| `available > installed` or `--force` | Full scaffold refresh (same as `activate --force`) |
+| No `.ai_infra/` or missing `.kit-version` | Fail — run `/workflow-activate` |
+| `installed == available` (not `--force`) | Light heal only |
+| `available > installed` or `--force` | Full scaffold refresh |
 
-**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, existing trackers.
+**Preserved:** `AGENTS.md` (if present), `mcp.user.json`, `.local/user_settings/`, trackers.
 
-**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI copy, `.kit-version`, kit-managed dashboards.
+**Overwritten on upgrade:** `.cursor/agents|rules|skills`, `.ai_infra/scripts`, `agent_colony/` CLI, `.kit-version`, dashboards.
 
 ## Post-update
 
@@ -78,6 +70,6 @@ Optional: `integrate validate`, `canvas doctor`. Breaking renames: [upgrade-kit.
 
 ## Anti-patterns
 
-- Do not tell users to re-run plain `/workflow-activate` expecting agents/skills to refresh — that path only heals when planes are ready.
-- Do not overwrite consumer `user_settings` or invent a second Status writer under `board_only`.
-- Do **not** run `update --force` inside the **kit-dev product repo** (`agent-colony`) — scaffold treats it as a consumer install and fails (`forbidden in slim install: full kit tests tree`). Kit-dev workflow: edit sources → `make sync-plugin` → commit. Use `update` only in **activated consumer apps**.
+- Re-run plain `/workflow-activate` expecting agents/skills refresh — heals only when planes ready.
+- Overwrite consumer `user_settings` or invent second Status writer under `board_only`.
+- Run `update --force` in **kit-dev repo** — fails (`forbidden in slim install`). Kit-dev: edit sources → `make sync-plugin` → commit.


### PR DESCRIPTION
## Summary

- Add **Use ASD-STE100** banner to nine `.cursor/skills` and six `.agents/skills` maintainer slash skills
- Thin `board-shell` (259→192 lines) and `integrator-protocol` (181→109 lines); link `views-setup.md` and `mas-infrastructure-integration.md` instead of pasting long procedures
- Extend `token-efficiency.md` skill thin-index; add maintainer slash row to `asd-ste100-prose.md`
- Sync plugin bundle mirrors (`make sync-plugin`; `check-plugin` green)

## Metrics

| Skill | Before | After |
|-------|--------|-------|
| board-shell | 259 | 192 |
| integrator-protocol | 181 | 109 |

## Test plan

- [x] `make sync-plugin` + `make check-plugin`
- [x] `check_governance_consistency.py`
- [x] `make doc-validate`
- [x] `make gates` (1508 passed)
- [x] Every `.cursor/skills/*/SKILL.md` and `.agents/skills/*/SKILL.md` contains `Use ASD-STE100`

Board-Item: PVTI_lAHOBl46-84A9KZxzg3edeQ