### PR TITLE
fix: board Entry false-offline + --last validation

### DIFF
--- a/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/.ai_infra/docs/architecture/workflow-architecture.md
@@ -13,6 +13,9 @@ Notes:
 
 # Workflow architecture (Agent Colony)
 
+**Use ASD-STE100:** [../operations/asd-ste100-prose.md](../operations/asd-ste100-prose.md) · [token-efficiency.md](../operations/token-efficiency.md)
+
+
 ## Three planes
 
 | Plane | Path | Purpose |

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -15,6 +15,11 @@ Notes:
 
 # Implementation status (Agent Colony)
 
+**Use ASD-STE100:** [../operations/asd-ste100-prose.md](../operations/asd-ste100-prose.md)
+
+Agent prose: [token-efficiency.md](../operations/token-efficiency.md).
+
+
 **Last updated:** 2026-08-09 (board End date on Done; kit 0.6.3)
 **Product:** `agent-colony` · CLI: `agent-colony` 0.6.3 · **Tests:** 1510
 

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -21,7 +21,7 @@ Agent prose: [token-efficiency.md](../operations/token-efficiency.md).
 
 
 **Last updated:** 2026-08-09 (board End date on Done; kit 0.6.3)
-**Product:** `agent-colony` · CLI: `agent-colony` 0.6.3 · **Tests:** 1510
+**Product:** `agent-colony` · CLI: `agent-colony` 0.6.3 · **Tests:** 1514
 
 ## Shipped (confirmed in repo)
 
@@ -62,7 +62,7 @@ Agent prose: [token-efficiency.md](../operations/token-efficiency.md).
 | Marketplace plugin | ADR-001 Option B | `.cursor-plugin/`, `sync_plugin_bundle.py` |
 | Researcher agent (corpus) | **Shipped / proven** — adaptive Brief; anti-loop ≤6; CLI `research init\|fetch\|validate`; live E2E flexiai-toolsmith (18 curated, validate PASS) + verifier Claim A+B VERIFIED 2026-07-19; corpus **opt-in** after first `research init` | `.cursor/agents/researcher.md` · `research-corpus` · `canvases/agent-researcher.canvas.tsx` · Issue #74 |
 | Kit version on install | `kit_version` 0.6.3 | `.ai_infra/manifest.yaml`, `.ai_infra/.kit-version` |
-| Tests | 1510 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
+| Tests | 1514 collected (intentional live-smoke skips on full green run) | `tests/modules/` |
 
 ## Coverage scope (shipped source)
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -50,7 +50,7 @@ agent-colony/
 ├── agent_colony/            SSOT — thin CLI shim (also copied to consumer)
 ├── schemas/                    Legacy gate.json stub (`resolve_gates()` in prepare.py; `GATES` = alias)
 ├── .local/                     Kit-dev runtime (gitignored); CI seed fixture — not consumer exemplars
-├── tests/                      Kit-dev only — full pytest suite (1510; see IMPLEMENTATION-STATUS)
+├── tests/                      Kit-dev only — full pytest suite (1514; see IMPLEMENTATION-STATUS)
 ├── Makefile, pyproject.toml    Kit-dev only
 ├── overlays/                   Optional product rules source (`overlays/rules/project-ssot-precedence.mdc`); this product payload ships **7** rules (6 kit + SSOT precedence)
 ├── project-rules/              Deprecated alias → use overlays/rules/
@@ -100,7 +100,7 @@ my-app/
 └── .local/                         Scaffolded trackers + artifact buckets (gitignored)
 ```
 
-**Not installed:** kit `tests/modules/` (1510; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
+**Not installed:** kit `tests/modules/` (1514; see IMPLEMENTATION-STATUS), `Makefile`, `docs/handoff/`, `docs/maintainer/`, `.ai_infra/scripts/ci/`, `.ai_infra/scripts/release/`, this `repository-map.md`, `IMPLEMENTATION-STATUS.md`, repo-root `agents/rules/skills/`.
 
 Consumer tree detail: [PLUGIN-ARCHITECTURE.md § Installed consumer project](PLUGIN-ARCHITECTURE.md).
 

--- a/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -16,6 +16,9 @@ Notes:
 
 # Agent Colony · Plugin User Guide
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **From the [kit README](https://github.com/SavinRazvan/agent-colony):** public landing lives on GitHub. Prefer the short path? [consumer-quickstart.md](consumer-quickstart.md). This guide is the full consumer manual.
 
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.

--- a/.ai_infra/docs/operations/connect-external-mcp.md
+++ b/.ai_infra/docs/operations/connect-external-mcp.md
@@ -1,5 +1,8 @@
 # Connect external MCP (<5 min)
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 Link **any** MCP server to kit agents without forking agent prompts.
 
 ## Prerequisites

--- a/.ai_infra/docs/operations/documentation-maintenance-checklist.md
+++ b/.ai_infra/docs/operations/documentation-maintenance-checklist.md
@@ -13,6 +13,9 @@ Notes:
 
 # Documentation Maintenance Checklist
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **Kit maintainers only — not copied to consumer projects.** Filtered by `consumer_bundle_paths.py` (`OPERATIONS_MAINTAINER_ONLY`). Consumers use [PLUGIN-USER-GUIDE.md](PLUGIN-USER-GUIDE.md) and [consumer-quickstart.md](consumer-quickstart.md).
 
 ## Trigger

--- a/.ai_infra/docs/operations/gate-matrix.md
+++ b/.ai_infra/docs/operations/gate-matrix.md
@@ -12,6 +12,9 @@ Depends On:
 
 # Gate matrix
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **Consumer installs:** use `agent-colony install --verify` or `python .ai_infra/scripts/install/scaffold.py --target … --verify` (4 steps). Do **not** use a `agent_colony scaffold` subcommand — it does not exist. `agent-colony gates` is a separate **5**-step maintainer hygiene command (adds doc facts). Sections mentioning `make gates`, `make verify-all`, `kit-quality.yml`, or `IMPLEMENTATION-STATUS.md` apply to **kit repository maintainers** only.
 
 Three gate surfaces exist by design (Pattern A).

--- a/.ai_infra/docs/operations/install-dry-run.md
+++ b/.ai_infra/docs/operations/install-dry-run.md
@@ -14,6 +14,9 @@ Notes:
 
 # Install dry-run (manual or automated)
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 Verify the kit installs into an empty or greenfield project **without** product-specific rule contamination in core `.cursor/rules/`.
 
 **Consumer path:** [`consumer-quickstart.md`](consumer-quickstart.md) — recommended first read.

--- a/.ai_infra/docs/operations/logging-and-errors.md
+++ b/.ai_infra/docs/operations/logging-and-errors.md
@@ -12,6 +12,9 @@ Notes:
 
 # Logging and error handling (Agent Colony)
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 ## Kit scripts
 
 - PR workflow scripts (`prepare.py`, `merge.py`, etc.) return non-zero exit codes on failure.

--- a/.ai_infra/docs/operations/mas-infrastructure-integration.md
+++ b/.ai_infra/docs/operations/mas-infrastructure-integration.md
@@ -14,6 +14,9 @@ Notes:
 
 # MAS infrastructure integration
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 ## Product model
 
 1. **Plugin + activate** unpacks consumer infrastructure (agents, scripts, `.local/` skeleton, optional MCP).

--- a/.ai_infra/docs/operations/permissions-and-prerequisites.md
+++ b/.ai_infra/docs/operations/permissions-and-prerequisites.md
@@ -20,6 +20,9 @@ Notes:
 
 # What you need — permissions & prerequisites
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **Read this before `/implementer`.** It lists everything you must have on your machine and what you must approve on GitHub so the **Cursor plugin**, **agents**, and **board SSOT** behave as documented.
 >
 > Install path: [consumer-quickstart](consumer-quickstart.md) · Full manual: [PLUGIN-USER-GUIDE](PLUGIN-USER-GUIDE.md)

--- a/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/.ai_infra/docs/operations/project-board-collaboration.md
@@ -40,6 +40,20 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 - **Verify:** `python3 -m agent_colony project board-bootstrap --check` (FAIL if a default Playground view is missing; **FAIL (exit 5)** on missing Tier-1 columns; WARN on leftover `View N` / layout mismatch).
 - **Optional API:** `--ensure-fields` (create missing field definitions + print suggested YAML ids); `--apply-readme` (push README). Views stay human UI (ADR-008).
 
+## Day-0 / Day-N playbook (no confusion)
+
+| Who | Day-0 | Day-N |
+|-----|-------|-------|
+| **Human** | `/board` wire YAML → CONSENT → TURN → `board-bootstrap --check` exit **0** | Ready order, views, Insights, README |
+| **Agent** | Refuse day-to-day claim until bootstrap exit 0 | `project entry` → one card → Exit Status + Notes |
+| **Both** | Fill Acceptance/Rollback before In review / Done | `heal-cards --check` = inventory WARN only |
+
+**Incomplete cards WARN:** `doctor` / `heal-cards --check` often flag **Done** cards missing **End date** (historical hygiene). That is **not** blocked Ready work. Repair with human consent: `heal-cards --apply` (sets End date on Done). Use `--fill-tier1` only when you want Priority→p2 / Size defaults on gaps. Do **not** invent Acceptance/Rollback on old Done cards. Empty Ready → `create-from-template` + `claim`.
+
+**Entry modes:** Prefer `project entry` (or `--digest`). `live` / `conserve` when GraphQL works; `offline_artifacts` only when remaining is known-low or no usable snapshot. On EXIT_QUEUED (6): `outbox flush` after quota recovers — do not retry-loop.
+
+**`--last`:** Use after create/claim. If guide prints `(invalid …)`, clear `.local/generated-data/project-last-item.json` and recreate — never paste docs placeholders as `--id`.
+
 ## Surfaces — who may write
 
 | Surface | Human | Agents | GitHub |

--- a/.ai_infra/docs/operations/project-config.md
+++ b/.ai_infra/docs/operations/project-config.md
@@ -13,6 +13,9 @@ Notes:
 
 # Optional `project.config.yaml`
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 The **Agent Colony** ships **`.ai_infra/project.config.yaml.example`**. After install, copy it to `project.config.yaml` in the project root and fill in metadata.
 
 ## What it is for

--- a/.ai_infra/install/agent_colony/project_atomics.py
+++ b/.ai_infra/install/agent_colony/project_atomics.py
@@ -256,7 +256,7 @@ def load_last_item_id(root: Path) -> str | None:
     iid = str(data.get("item_id") or "").strip()
     return iid or None
 def is_placeholder_item_id(raw: str) -> bool:
-    """True for docs ellipsis / truncated ids agents must never paste."""
+    """True for docs ellipsis / truncated / corrupted ids agents must never paste."""
     s = (raw or "").strip()
     if not s:
         return True
@@ -272,7 +272,17 @@ def is_placeholder_item_id(raw: str) -> bool:
         return True
     if re.match(r"^DI_", s) and len(s) < 12:
         return True
+    # Corrupted session files (e.g. …sect01 from set-section path bugs)
+    if re.search(r"sect\d+$", s, re.IGNORECASE):
+        return True
+    # Must look like a real node id (alphanumeric + _/- only after prefix)
+    if re.match(r"^PVTI_", s) and not re.match(r"^PVTI_[A-Za-z0-9_-]{16,}$", s):
+        return True
+    if re.match(r"^DI_", s) and not re.match(r"^DI_[A-Za-z0-9_-]{8,}$", s):
+        return True
     return False
+
+
 def resolve_item_id_arg(
     root: Path, args: argparse.Namespace, cmd: str
 ) -> tuple[str | None, int]:
@@ -288,6 +298,13 @@ def resolve_item_id_arg(
                 cmd,
                 EXIT_USAGE,
                 "no last item — run create-from-template (or claim) first, then --last",
+            )
+        if is_placeholder_item_id(lid):
+            return None, fail(
+                cmd,
+                EXIT_USAGE,
+                f"invalid last item_id {lid!r} — recreate with create-from-template "
+                f"or pass a real --id (clear .local/generated-data/project-last-item.json)",
             )
         return lid, EXIT_OK
     if not raw:

--- a/.ai_infra/install/agent_colony/project_cli.py
+++ b/.ai_infra/install/agent_colony/project_cli.py
@@ -1327,6 +1327,12 @@ def cmd_last(args: argparse.Namespace) -> int:
     lid = load_last_item_id(root)
     if not lid:
         return fail("last", EXIT_USAGE, "no last item — create-from-template first")
+    if is_placeholder_item_id(lid):
+        return fail(
+            "last",
+            EXIT_USAGE,
+            f"invalid last item_id {lid!r} — recreate (clear project-last-item.json)",
+        )
     print(lid)
     return EXIT_OK
 def cmd_mention_pr(args: argparse.Namespace) -> int:
@@ -1340,9 +1346,15 @@ def cmd_guide(args: argparse.Namespace) -> int:
     root = Path(args.directory).resolve()
     agent = (getattr(args, "agent", None) or "implementer").strip()
     nxt = (getattr(args, "next", None) or "verifier").strip()
-    lid = load_last_item_id(root) or "(none — create first)"
+    lid = load_last_item_id(root)
+    if not lid:
+        lid_disp = "(none — create first)"
+    elif is_placeholder_item_id(lid):
+        lid_disp = f"(invalid {lid!r} — recreate; do not use --last)"
+    else:
+        lid_disp = lid
     print("# Safe board recipes — use --last; never paste docs placeholders as --id")
-    print(f"# last item_id: {lid}")
+    print(f"# last item_id: {lid_disp}")
     print("python3 -m agent_colony project doctor")
     print("python3 -m agent_colony project outbox status")
     print(
@@ -1614,15 +1626,30 @@ def cmd_entry(args: argparse.Namespace) -> int:
 
     rl = _outbox.graphql_rate_limit()
     rem_raw = rl.get("remaining")
+    probe_err = rl.get("error")
     rem: int | None
     try:
-        rem = int(rem_raw) if rem_raw is not None and "error" not in rl else None
+        # Only treat as error when error is a non-empty truthy value (key may be None).
+        rem = int(rem_raw) if rem_raw is not None and not probe_err else None
     except (TypeError, ValueError):
         rem = None
-    if "error" in rl and rem is None:
-        # Forbidden / probe failure → treat as offline_artifacts (safe degrade)
-        mode = "offline_artifacts"
-        rem_disp = "error"
+    if probe_err and rem is None:
+        # One retry — intermittent gh rate_limit probe failures should not false-offline.
+        rl = _outbox.graphql_rate_limit()
+        rem_raw = rl.get("remaining")
+        probe_err = rl.get("error")
+        try:
+            rem = int(rem_raw) if rem_raw is not None and not probe_err else None
+        except (TypeError, ValueError):
+            rem = None
+    if probe_err and rem is None:
+        # Prefer conserve (fresh snapshot) over offline when we have local artifacts.
+        if snap.is_file() and not force_live:
+            mode = "conserve"
+            rem_disp = "probe_error"
+        else:
+            mode = "offline_artifacts"
+            rem_disp = "error"
     elif rem is None:
         mode = "live"
         rem_disp = "?"

--- a/.ai_infra/scripts/architecture/check_governance_consistency.py
+++ b/.ai_infra/scripts/architecture/check_governance_consistency.py
@@ -347,6 +347,25 @@ def _collect_integration_validate_violations() -> list[str]:
     return violations
 
 
+def _collect_asd_ste100_banner_violations() -> list[str]:
+    """Every agent card and cursor skill must declare Use ASD-STE100."""
+    needle = "Use ASD-STE100"
+    violations: list[str] = []
+    agents = ROOT / ".cursor" / "agents"
+    if agents.is_dir():
+        for path in sorted(agents.glob("*.md")):
+            text = _read_text(path)
+            if needle not in text:
+                violations.append(f"ASD-STE100 missing: {path.relative_to(ROOT)}")
+    skills = ROOT / ".cursor" / "skills"
+    if skills.is_dir():
+        for path in sorted(skills.glob("*/SKILL.md")):
+            text = _read_text(path)
+            if needle not in text:
+                violations.append(f"ASD-STE100 missing: {path.relative_to(ROOT)}")
+    return violations
+
+
 def main() -> int:
     violations = _collect_banned_reference_violations()
     violations.extend(_collect_contract_parity_violations())
@@ -357,6 +376,7 @@ def main() -> int:
     violations.extend(_collect_agent_mcp_block_violations())
     violations.extend(_collect_owner_path_violations())
     violations.extend(_collect_file_header_violations())
+    violations.extend(_collect_asd_ste100_banner_violations())
     violations.extend(_collect_integration_validate_violations())
     if violations:
         print("Governance consistency check failed:")

--- a/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
+++ b/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
@@ -12,6 +12,9 @@ Notes:
 
 # Integration checklist — {{SLICE_ID}}
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+
 | Field | Value |
 |-------|--------|
 | **Type** | agent \| skill \| mcp \| script \| doc |

--- a/.ai_infra/templates/agent-integration/README.md
+++ b/.ai_infra/templates/agent-integration/README.md
@@ -1,5 +1,8 @@
 # Agent integration templates
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+
 Copy from here when **`integrator`** adds agents or skills.
 
 | File | Purpose |

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -143,7 +143,15 @@ Plain `project create` needs follow-up `set-field` for Priority/Size/Estimate. E
 
 **Issue vs board Status:** independent by default. Opt-in bridge: `conventions.close_linked_issue_on_cleanup` → `finalize.py` closes linked Issue after merge cleanup. CLI: `project close-linked-issue --pr N` (requires Status=Done first).
 
-**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` flags missing Status/Tier-1 · `outbox flush` if QUEUED.
+**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` · `outbox flush` if QUEUED.
+
+| WARN | Meaning | Action |
+|------|---------|--------|
+| Done + missing End date | Historical hygiene | `heal-cards --apply` (consent) |
+| Ready / In progress missing Tier-1 | Active card incomplete | Fill on own card; `--fill-tier1` only if defaults OK |
+| Empty Ready | No work queued | `create-from-template` → `set-section` → `claim` |
+
+**Day-0 / Day-N:** Human owns views + Ready order. Agent: `entry` → one card → Exit Status+Notes. Fill Acceptance/Rollback before In review/Done. Canon: `project-board-collaboration.md` § Day-0 / Day-N.
 
 **Rules:** one In progress per human assignee; Acceptance/Rollback/Notes on card body; no dual-mirror under `board_only` (DRIFT-009); read-only `export` never writes Status; post-merge Done via `merge.py`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | | |
 |--|--|
-| **Version** | [`0.6.3`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1510 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
+| **Version** | [`0.6.3`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1514 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
 | **Reference board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 
 ---
@@ -27,7 +27,7 @@ Agent chats lose Status. Trackers and docs drift. Teams re-explain the same slic
 
 **Agent Colony** installs a full Cursor kit into *your* app repo (not this kit repo). When Project SSOT is on, the **GitHub Project** is the only writable place for backlog and Status — agents **enter** by reading the board and **exit** by updating Status and Notes. Local `.local/` holds gates, audits, and evidence — not a second Status writer.
 
-**Proof:** 1510 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
+**Proof:** 1514 tests · 8 agents · reference layout on [Playground #3](https://github.com/users/SavinRazvan/projects/3).
 
 ---
 

--- a/payload/.ai_infra/docs/architecture/workflow-architecture.md
+++ b/payload/.ai_infra/docs/architecture/workflow-architecture.md
@@ -13,6 +13,9 @@ Notes:
 
 # Workflow architecture (Agent Colony)
 
+**Use ASD-STE100:** [../operations/asd-ste100-prose.md](../operations/asd-ste100-prose.md) · [token-efficiency.md](../operations/token-efficiency.md)
+
+
 ## Three planes
 
 | Plane | Path | Purpose |

--- a/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
+++ b/payload/.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md
@@ -16,6 +16,9 @@ Notes:
 
 # Agent Colony · Plugin User Guide
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **From the [kit README](https://github.com/SavinRazvan/agent-colony):** public landing lives on GitHub. Prefer the short path? [consumer-quickstart.md](consumer-quickstart.md). This guide is the full consumer manual.
 
 Single entry point for **installing**, **activating**, and **using** the kit in your project. Deeper runbooks are linked as chapters — you do not need the kit maintainer repo open.

--- a/payload/.ai_infra/docs/operations/connect-external-mcp.md
+++ b/payload/.ai_infra/docs/operations/connect-external-mcp.md
@@ -1,5 +1,8 @@
 # Connect external MCP (<5 min)
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 Link **any** MCP server to kit agents without forking agent prompts.
 
 ## Prerequisites

--- a/payload/.ai_infra/docs/operations/gate-matrix.md
+++ b/payload/.ai_infra/docs/operations/gate-matrix.md
@@ -12,6 +12,9 @@ Depends On:
 
 # Gate matrix
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **Consumer installs:** use `agent-colony install --verify` or `python .ai_infra/scripts/install/scaffold.py --target … --verify` (4 steps). Do **not** use a `agent_colony scaffold` subcommand — it does not exist. `agent-colony gates` is a separate **5**-step maintainer hygiene command (adds doc facts). Sections mentioning `make gates`, `make verify-all`, `kit-quality.yml`, or `IMPLEMENTATION-STATUS.md` apply to **kit repository maintainers** only.
 
 Three gate surfaces exist by design (Pattern A).

--- a/payload/.ai_infra/docs/operations/install-dry-run.md
+++ b/payload/.ai_infra/docs/operations/install-dry-run.md
@@ -14,6 +14,9 @@ Notes:
 
 # Install dry-run (manual or automated)
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 Verify the kit installs into an empty or greenfield project **without** product-specific rule contamination in core `.cursor/rules/`.
 
 **Consumer path:** [`consumer-quickstart.md`](consumer-quickstart.md) — recommended first read.

--- a/payload/.ai_infra/docs/operations/logging-and-errors.md
+++ b/payload/.ai_infra/docs/operations/logging-and-errors.md
@@ -12,6 +12,9 @@ Notes:
 
 # Logging and error handling (Agent Colony)
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 ## Kit scripts
 
 - PR workflow scripts (`prepare.py`, `merge.py`, etc.) return non-zero exit codes on failure.

--- a/payload/.ai_infra/docs/operations/mas-infrastructure-integration.md
+++ b/payload/.ai_infra/docs/operations/mas-infrastructure-integration.md
@@ -14,6 +14,9 @@ Notes:
 
 # MAS infrastructure integration
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 ## Product model
 
 1. **Plugin + activate** unpacks consumer infrastructure (agents, scripts, `.local/` skeleton, optional MCP).

--- a/payload/.ai_infra/docs/operations/permissions-and-prerequisites.md
+++ b/payload/.ai_infra/docs/operations/permissions-and-prerequisites.md
@@ -20,6 +20,9 @@ Notes:
 
 # What you need — permissions & prerequisites
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 > **Read this before `/implementer`.** It lists everything you must have on your machine and what you must approve on GitHub so the **Cursor plugin**, **agents**, and **board SSOT** behave as documented.
 >
 > Install path: [consumer-quickstart](consumer-quickstart.md) · Full manual: [PLUGIN-USER-GUIDE](PLUGIN-USER-GUIDE.md)

--- a/payload/.ai_infra/docs/operations/project-board-collaboration.md
+++ b/payload/.ai_infra/docs/operations/project-board-collaboration.md
@@ -40,6 +40,20 @@ When `project_ssot.enabled` and `sync_policy: board_only`, the **GitHub Project 
 - **Verify:** `python3 -m agent_colony project board-bootstrap --check` (FAIL if a default Playground view is missing; **FAIL (exit 5)** on missing Tier-1 columns; WARN on leftover `View N` / layout mismatch).
 - **Optional API:** `--ensure-fields` (create missing field definitions + print suggested YAML ids); `--apply-readme` (push README). Views stay human UI (ADR-008).
 
+## Day-0 / Day-N playbook (no confusion)
+
+| Who | Day-0 | Day-N |
+|-----|-------|-------|
+| **Human** | `/board` wire YAML → CONSENT → TURN → `board-bootstrap --check` exit **0** | Ready order, views, Insights, README |
+| **Agent** | Refuse day-to-day claim until bootstrap exit 0 | `project entry` → one card → Exit Status + Notes |
+| **Both** | Fill Acceptance/Rollback before In review / Done | `heal-cards --check` = inventory WARN only |
+
+**Incomplete cards WARN:** `doctor` / `heal-cards --check` often flag **Done** cards missing **End date** (historical hygiene). That is **not** blocked Ready work. Repair with human consent: `heal-cards --apply` (sets End date on Done). Use `--fill-tier1` only when you want Priority→p2 / Size defaults on gaps. Do **not** invent Acceptance/Rollback on old Done cards. Empty Ready → `create-from-template` + `claim`.
+
+**Entry modes:** Prefer `project entry` (or `--digest`). `live` / `conserve` when GraphQL works; `offline_artifacts` only when remaining is known-low or no usable snapshot. On EXIT_QUEUED (6): `outbox flush` after quota recovers — do not retry-loop.
+
+**`--last`:** Use after create/claim. If guide prints `(invalid …)`, clear `.local/generated-data/project-last-item.json` and recreate — never paste docs placeholders as `--id`.
+
 ## Surfaces — who may write
 
 | Surface | Human | Agents | GitHub |

--- a/payload/.ai_infra/docs/operations/project-config.md
+++ b/payload/.ai_infra/docs/operations/project-config.md
@@ -13,6 +13,9 @@ Notes:
 
 # Optional `project.config.yaml`
 
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+
 The **Agent Colony** ships **`.ai_infra/project.config.yaml.example`**. After install, copy it to `project.config.yaml` in the project root and fill in metadata.
 
 ## What it is for

--- a/payload/.ai_infra/install/agent_colony/project_atomics.py
+++ b/payload/.ai_infra/install/agent_colony/project_atomics.py
@@ -256,7 +256,7 @@ def load_last_item_id(root: Path) -> str | None:
     iid = str(data.get("item_id") or "").strip()
     return iid or None
 def is_placeholder_item_id(raw: str) -> bool:
-    """True for docs ellipsis / truncated ids agents must never paste."""
+    """True for docs ellipsis / truncated / corrupted ids agents must never paste."""
     s = (raw or "").strip()
     if not s:
         return True
@@ -272,7 +272,17 @@ def is_placeholder_item_id(raw: str) -> bool:
         return True
     if re.match(r"^DI_", s) and len(s) < 12:
         return True
+    # Corrupted session files (e.g. …sect01 from set-section path bugs)
+    if re.search(r"sect\d+$", s, re.IGNORECASE):
+        return True
+    # Must look like a real node id (alphanumeric + _/- only after prefix)
+    if re.match(r"^PVTI_", s) and not re.match(r"^PVTI_[A-Za-z0-9_-]{16,}$", s):
+        return True
+    if re.match(r"^DI_", s) and not re.match(r"^DI_[A-Za-z0-9_-]{8,}$", s):
+        return True
     return False
+
+
 def resolve_item_id_arg(
     root: Path, args: argparse.Namespace, cmd: str
 ) -> tuple[str | None, int]:
@@ -288,6 +298,13 @@ def resolve_item_id_arg(
                 cmd,
                 EXIT_USAGE,
                 "no last item — run create-from-template (or claim) first, then --last",
+            )
+        if is_placeholder_item_id(lid):
+            return None, fail(
+                cmd,
+                EXIT_USAGE,
+                f"invalid last item_id {lid!r} — recreate with create-from-template "
+                f"or pass a real --id (clear .local/generated-data/project-last-item.json)",
             )
         return lid, EXIT_OK
     if not raw:

--- a/payload/.ai_infra/install/agent_colony/project_cli.py
+++ b/payload/.ai_infra/install/agent_colony/project_cli.py
@@ -1327,6 +1327,12 @@ def cmd_last(args: argparse.Namespace) -> int:
     lid = load_last_item_id(root)
     if not lid:
         return fail("last", EXIT_USAGE, "no last item — create-from-template first")
+    if is_placeholder_item_id(lid):
+        return fail(
+            "last",
+            EXIT_USAGE,
+            f"invalid last item_id {lid!r} — recreate (clear project-last-item.json)",
+        )
     print(lid)
     return EXIT_OK
 def cmd_mention_pr(args: argparse.Namespace) -> int:
@@ -1340,9 +1346,15 @@ def cmd_guide(args: argparse.Namespace) -> int:
     root = Path(args.directory).resolve()
     agent = (getattr(args, "agent", None) or "implementer").strip()
     nxt = (getattr(args, "next", None) or "verifier").strip()
-    lid = load_last_item_id(root) or "(none — create first)"
+    lid = load_last_item_id(root)
+    if not lid:
+        lid_disp = "(none — create first)"
+    elif is_placeholder_item_id(lid):
+        lid_disp = f"(invalid {lid!r} — recreate; do not use --last)"
+    else:
+        lid_disp = lid
     print("# Safe board recipes — use --last; never paste docs placeholders as --id")
-    print(f"# last item_id: {lid}")
+    print(f"# last item_id: {lid_disp}")
     print("python3 -m agent_colony project doctor")
     print("python3 -m agent_colony project outbox status")
     print(
@@ -1614,15 +1626,30 @@ def cmd_entry(args: argparse.Namespace) -> int:
 
     rl = _outbox.graphql_rate_limit()
     rem_raw = rl.get("remaining")
+    probe_err = rl.get("error")
     rem: int | None
     try:
-        rem = int(rem_raw) if rem_raw is not None and "error" not in rl else None
+        # Only treat as error when error is a non-empty truthy value (key may be None).
+        rem = int(rem_raw) if rem_raw is not None and not probe_err else None
     except (TypeError, ValueError):
         rem = None
-    if "error" in rl and rem is None:
-        # Forbidden / probe failure → treat as offline_artifacts (safe degrade)
-        mode = "offline_artifacts"
-        rem_disp = "error"
+    if probe_err and rem is None:
+        # One retry — intermittent gh rate_limit probe failures should not false-offline.
+        rl = _outbox.graphql_rate_limit()
+        rem_raw = rl.get("remaining")
+        probe_err = rl.get("error")
+        try:
+            rem = int(rem_raw) if rem_raw is not None and not probe_err else None
+        except (TypeError, ValueError):
+            rem = None
+    if probe_err and rem is None:
+        # Prefer conserve (fresh snapshot) over offline when we have local artifacts.
+        if snap.is_file() and not force_live:
+            mode = "conserve"
+            rem_disp = "probe_error"
+        else:
+            mode = "offline_artifacts"
+            rem_disp = "error"
     elif rem is None:
         mode = "live"
         rem_disp = "?"

--- a/payload/.ai_infra/scripts/architecture/check_governance_consistency.py
+++ b/payload/.ai_infra/scripts/architecture/check_governance_consistency.py
@@ -347,6 +347,25 @@ def _collect_integration_validate_violations() -> list[str]:
     return violations
 
 
+def _collect_asd_ste100_banner_violations() -> list[str]:
+    """Every agent card and cursor skill must declare Use ASD-STE100."""
+    needle = "Use ASD-STE100"
+    violations: list[str] = []
+    agents = ROOT / ".cursor" / "agents"
+    if agents.is_dir():
+        for path in sorted(agents.glob("*.md")):
+            text = _read_text(path)
+            if needle not in text:
+                violations.append(f"ASD-STE100 missing: {path.relative_to(ROOT)}")
+    skills = ROOT / ".cursor" / "skills"
+    if skills.is_dir():
+        for path in sorted(skills.glob("*/SKILL.md")):
+            text = _read_text(path)
+            if needle not in text:
+                violations.append(f"ASD-STE100 missing: {path.relative_to(ROOT)}")
+    return violations
+
+
 def main() -> int:
     violations = _collect_banned_reference_violations()
     violations.extend(_collect_contract_parity_violations())
@@ -357,6 +376,7 @@ def main() -> int:
     violations.extend(_collect_agent_mcp_block_violations())
     violations.extend(_collect_owner_path_violations())
     violations.extend(_collect_file_header_violations())
+    violations.extend(_collect_asd_ste100_banner_violations())
     violations.extend(_collect_integration_validate_violations())
     if violations:
         print("Governance consistency check failed:")

--- a/payload/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
+++ b/payload/.ai_infra/templates/agent-integration/INTEGRATION-CHECKLIST.md
@@ -12,6 +12,9 @@ Notes:
 
 # Integration checklist — {{SLICE_ID}}
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+
 | Field | Value |
 |-------|--------|
 | **Type** | agent \| skill \| mcp \| script \| doc |

--- a/payload/.ai_infra/templates/agent-integration/README.md
+++ b/payload/.ai_infra/templates/agent-integration/README.md
@@ -1,5 +1,8 @@
 # Agent integration templates
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+
 Copy from here when **`integrator`** adds agents or skills.
 
 | File | Purpose |

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -143,7 +143,15 @@ Plain `project create` needs follow-up `set-field` for Priority/Size/Estimate. E
 
 **Issue vs board Status:** independent by default. Opt-in bridge: `conventions.close_linked_issue_on_cleanup` → `finalize.py` closes linked Issue after merge cleanup. CLI: `project close-linked-issue --pr N` (requires Status=Done first).
 
-**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` flags missing Status/Tier-1 · `outbox flush` if QUEUED.
+**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` · `outbox flush` if QUEUED.
+
+| WARN | Meaning | Action |
+|------|---------|--------|
+| Done + missing End date | Historical hygiene | `heal-cards --apply` (consent) |
+| Ready / In progress missing Tier-1 | Active card incomplete | Fill on own card; `--fill-tier1` only if defaults OK |
+| Empty Ready | No work queued | `create-from-template` → `set-section` → `claim` |
+
+**Day-0 / Day-N:** Human owns views + Ready order. Agent: `entry` → one card → Exit Status+Notes. Fill Acceptance/Rollback before In review/Done. Canon: `project-board-collaboration.md` § Day-0 / Day-N.
 
 **Rules:** one In progress per human assignee; Acceptance/Rollback/Notes on card body; no dual-mirror under `board_only` (DRIFT-009); read-only `export` never writes Status; post-merge Done via `merge.py`.
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,6 +13,9 @@ Notes:
 
 # Schemas
 
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+
 | File | Purpose |
 |------|---------|
 | [`gate.json`](gate.json) | Shape of one `GATES` entry (string argv array) |

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -143,7 +143,15 @@ Plain `project create` needs follow-up `set-field` for Priority/Size/Estimate. E
 
 **Issue vs board Status:** independent by default. Opt-in bridge: `conventions.close_linked_issue_on_cleanup` → `finalize.py` closes linked Issue after merge cleanup. CLI: `project close-linked-issue --pr N` (requires Status=Done first).
 
-**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` flags missing Status/Tier-1 · `outbox flush` if QUEUED.
+**Repair:** `project doctor` · `heal-cards --check|--apply [--fill-tier1]` · `validate-item` · `outbox flush` if QUEUED.
+
+| WARN | Meaning | Action |
+|------|---------|--------|
+| Done + missing End date | Historical hygiene | `heal-cards --apply` (consent) |
+| Ready / In progress missing Tier-1 | Active card incomplete | Fill on own card; `--fill-tier1` only if defaults OK |
+| Empty Ready | No work queued | `create-from-template` → `set-section` → `claim` |
+
+**Day-0 / Day-N:** Human owns views + Ready order. Agent: `entry` → one card → Exit Status+Notes. Fill Acceptance/Rollback before In review/Done. Canon: `project-board-collaboration.md` § Day-0 / Day-N.
 
 **Rules:** one In progress per human assignee; Acceptance/Rollback/Notes on card body; no dual-mirror under `board_only` (DRIFT-009); read-only `export` never writes Status; post-merge Done via `merge.py`.
 

--- a/tests/modules/install/test_project_entry_efficiency.py
+++ b/tests/modules/install/test_project_entry_efficiency.py
@@ -285,7 +285,62 @@ def test_cmd_entry_offline_artifacts(
     assert "queue" in out
 
 
-def test_cmd_entry_quota_error_offline(
+def test_resolve_last_rejects_corrupt_sect_suffix(tmp_path: Path) -> None:
+    path = tmp_path / ".local" / "generated-data" / "project-last-item.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"item_id": "PVTI_lAHOBl46-84A9KZxsect01", "title": "bad"}),
+        encoding="utf-8",
+    )
+    ns = argparse.Namespace(last=True, id="")
+    iid, code = project_cli.resolve_item_id_arg(tmp_path, ns, "claim")
+    assert iid is None
+    assert code == project_cli.EXIT_USAGE
+    assert project_cli.is_placeholder_item_id("PVTI_lAHOBl46-84A9KZxsect01")
+    assert not project_cli.is_placeholder_item_id("PVTI_lAHOBl46-84A9KZxzgzRDnc")
+
+
+def test_cmd_entry_quota_error_prefers_conserve_with_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Probe error + snapshot → conserve (not false offline)."""
+    ssot = _ssot_with_efficiency(
+        conserve_below_remaining=1500, export_reuse_ttl_seconds=900
+    )
+    snap = tmp_path / ".local" / "generated-data" / "project-board-snapshot.json"
+    snap.parent.mkdir(parents=True)
+    snap.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "id": "PVTI_probe1",
+                        "title": "From snap",
+                        "status": "In Progress",
+                        "status_normalized": "in_progress",
+                    }
+                ],
+                "totalCount": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli._outbox,
+        "graphql_rate_limit",
+        lambda: {"error": "Forbidden", "remaining": None},
+    )
+    args = argparse.Namespace(
+        directory=tmp_path, also_ready=False, force_live=False, limit=None
+    )
+    assert project_cli.cmd_entry(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "mode=conserve" in out
+    assert "PVTI_probe1" in out
+
+
+def test_cmd_entry_quota_error_offline_without_snapshot(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     ssot = _ssot_with_efficiency()
@@ -301,6 +356,52 @@ def test_cmd_entry_quota_error_offline(
     assert project_cli.cmd_entry(args) == project_cli.EXIT_OK
     assert "mode=offline_artifacts" in capsys.readouterr().out
 
+
+def test_cmd_entry_success_with_error_null_key_is_live(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression: error:null in rate_limit payload must not force offline."""
+    ssot = _ssot_with_efficiency()
+    monkeypatch.setattr(project_cli, "load_project_ssot", lambda root: (ssot, []))
+    monkeypatch.setattr(
+        project_cli._outbox,
+        "graphql_rate_limit",
+        lambda: {"remaining": 4000, "limit": 5000, "error": None},
+    )
+    monkeypatch.setattr(
+        project_cli,
+        "fetch_project_items",
+        lambda ssot_arg, *, limit=50: (
+            [
+                {
+                    "id": "PVTI_ok1",
+                    "title": "Work",
+                    "status": "In Progress",
+                }
+            ],
+            None,
+        ),
+    )
+    args = argparse.Namespace(
+        directory=tmp_path,
+        also_ready=False,
+        force_live=False,
+        limit=None,
+        digest=True,
+        json=False,
+    )
+    assert project_cli.cmd_entry(args) == project_cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "mode=live" in out
+    assert "offline_artifacts" not in out
+    assert "PVTI_ok1" in out
+
+
+def test_cmd_entry_quota_error_offline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Back-compat name: probe error + force_live + no snap → offline."""
+    test_cmd_entry_quota_error_offline_without_snapshot(monkeypatch, tmp_path, capsys)
 
 def test_cmd_export_reuse_bad_json_and_json_flag(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/modules/install/test_project_set_section.py
+++ b/tests/modules/install/test_project_set_section.py
@@ -29,7 +29,7 @@ import project_cli  # noqa: E402
 import project_handlers  # noqa: E402
 from test_project_cli import SAMPLE_SSOT  # noqa: E402
 
-VALID = "PVTI_lAHOBl46-84A9KZxsect01"
+VALID = "PVTI_lAHOBl46-84A9KZxzg3edeQ"
 
 
 def _ssot(**overrides):


### PR DESCRIPTION
## Summary
- Fix `project entry` false `offline_artifacts` when `graphql_rate_limit` returns `error: null` (treat truthy error only; retry once; prefer conserve with snapshot).
- Reject corrupt `--last` ids (e.g. `…sect01`); guide prints invalid hint.
- Day-0/Day-N playbook + heal-cards hygiene note (Done missing End date ≠ blocked Ready).

## Test plan
- [x] `pytest tests/modules/install/test_project_entry_efficiency.py` (23 passed)
- [x] Live: `project entry --digest` → `mode=live`
- [ ] CI `quality`