### PR TITLE
Align STE docs with STEMG AI guidance

### DIFF
--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -20,7 +20,7 @@ Notes:
 Agent prose: [token-efficiency.md](../operations/token-efficiency.md).
 
 
-**Last updated:** 2026-08-21 (ASD-STE100 + board Entry reliability; kit 0.6.4)
+**Last updated:** 2026-08-21 (STEMG-aligned AI and STE prose; kit 0.6.4)
 **Product:** `agent-colony` · CLI: `agent-colony` 0.6.4 · **Tests:** 1514
 
 ## Shipped (confirmed in repo)
@@ -44,7 +44,7 @@ Agent prose: [token-efficiency.md](../operations/token-efficiency.md).
 | Board CLI subcommands | **27** leaf commands (incl. `entry`, `heal-cards`; full table in ops doc) | [project-board-collaboration.md](../operations/project-board-collaboration.md) § Project CLI subcommands |
 | Board Status + Tier-1 heal | `create-from-template` Status default `ready`; `heal-cards`; validate empty Status; close-issue Done gate; merge outbox queue | `project_handlers.run_heal_cards` · `project_atomics.collect_validate_item_problems` · PR #217 |
 | Board End date on Done | UTC End date when Status→done if empty (`set_end_date_on_done`); validate/heal; Tier-1 column | `ensure_end_date_if_done` · board-shell · kit 0.6.3 |
-| ASD-STE100 agent prose | Use ASD-STE100 banners on agents/skills/rules; governance enforces; token-efficiency contract | `asd-ste100-prose.md` · `token-efficiency.md` · `check_governance_consistency.py` · PRs #223–#226 |
+| ASD-STE100 agent prose | Use ASD-STE100 banners; § AI and STE (assist, human review, no STEMG endorsement); governance enforces; token-efficiency contract | `asd-ste100-prose.md` · `token-efficiency.md` · `check_governance_consistency.py` · PRs #223–#226 |
 | Board Entry + `--last` safety | Entry retry/conserve on rate-limit probe error (no false offline); reject corrupt `--last` PVTI_; Day-0/Day-N heal playbook | `project_cli.py` · `project_atomics.py` · board-ssot · PR #227 |
 | GraphQL-efficient Entry | `project entry` live \| conserve \| offline_artifacts; `export --reuse-if-fresh` | `project_cli.py` · `project_ssot.efficiency` |
 | EA-001 residual thin CLI | `project_cli.py` facade (~660 LOC) + parser/handlers split; board CLI modules under `.ai_infra/install/agent_colony/`: `project_cli.py`, `project_parser.py`, `project_handlers.py`, `project_atomics.py`, `gh_project_adapter.py`, `project_recipes.py`, `project_outbox.py` | PR #36 |

--- a/.ai_infra/docs/operations/README.md
+++ b/.ai_infra/docs/operations/README.md
@@ -31,7 +31,7 @@ Depends On:
 - [`upgrade-kit.md`](upgrade-kit.md) — reinstall / semver upgrade
 - [`project-config.md`](project-config.md) — optional `project.config.yaml` metadata
 - [`token-efficiency.md`](token-efficiency.md) — agent read/write contract
-- [`asd-ste100-prose.md`](asd-ste100-prose.md) — **Use ASD-STE100** (free prose guide; token-efficiency research)
+- [`asd-ste100-prose.md`](asd-ste100-prose.md) — **Use ASD-STE100** (free prose guide; not compliance; AI assists, human reviews)
 - [`logging-and-errors.md`](logging-and-errors.md) — logging baseline
 - [`abbreviations-notepad.md`](abbreviations-notepad.md) — shared abbreviations
 

--- a/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -50,10 +50,12 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **con
 | UI | GitHub Project / settings UI (humans); agents prefer CLI |
 | PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes — see [permissions-and-prerequisites](permissions-and-prerequisites.md) |
 | ASD-STE100 | Simplified Technical English (ASD). Kit: **Use ASD-STE100** → [asd-ste100-prose.md](asd-ste100-prose.md) (free principles; no dictionary; not compliance) |
+| STEMG | Simplified Technical English Maintenance Group — maintains ASD-STE100. This kit does **not** endorse STEMG or claim STE compliance |
 | GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
 | KISS | Keep It Simple — incremental, reversible slices |
 | DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |
-| AI | Artificial intelligence — optional `Assisted-by:` trailer when AI materially shaped a change |
+| AI | Artificial intelligence — assists authors; does not replace human review. Optional `Assisted-by:` when AI materially shaped a change. See [asd-ste100-prose.md](asd-ste100-prose.md) § AI and STE |
+| Assisted-by | Git commit trailer for AI disclosure (`Assisted-by: <tool>[:<model>]`); not a STEMG or ASD endorsement |
 | TBD | To Be Determined — placeholder in file headers / relations |
 | DAG | Directed Acyclic Graph — agent **handoff** edges (canvases); no cycles |
 | ACC | Agents Control Center — `.local/agents-control-center/` (folder name) |

--- a/.ai_infra/docs/operations/agent-workflow-procedures.md
+++ b/.ai_infra/docs/operations/agent-workflow-procedures.md
@@ -56,7 +56,7 @@ Notes:
 
 ## 3b) Commit message provenance (git, not PR artifacts)
 
-**Git commits** use **`.cursor/rules/commit-trailer-format.mdc`**: required `Author:` + `GitHub-User:`; optional `Assisted-by:` when disclosure applies. No **`Made-with:`**.
+**Git commits** use **`.cursor/rules/commit-trailer-format.mdc`**: required `Author:` + `GitHub-User:`; optional `Assisted-by:` when AI materially shaped the change. No **`Made-with:`**. The human author reviews and validates. AI assists; it does not replace review. See [asd-ste100-prose.md](asd-ste100-prose.md) § AI and STE.
 
 **PR phase markdown** uses `Action-By` / `GitHub-User` / `Agent/s` per **`.agents/skills/pr-workflow/SKILL.md`**.
 

--- a/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -11,6 +11,7 @@ Depends On:
  - token-efficiency.md
 Notes:
  - Inspired by ASD-STE100 writing principles. No ASD dictionary. No purchase. Not a compliance claim.
+ - AI assists; human reviews. No STEMG / ASD / AI-vendor endorsement.
 -->
 
 # Use ASD-STE100
@@ -49,6 +50,18 @@ Research goal: clearer prose → fewer tokens → measure before/after byte and 
 | Board SSOT | GitHub Project writable Status when enabled | Local tracker Status under `board_only` |
 | Tier-1 | Status, Priority, Size, Estimate, dates, Assignee, PR link | “All the fields” without the skill |
 | EXIT_QUEUED | Exit code 6 — outbox; flush later | Retry loops on GraphQL throttle |
+
+## AI and STE
+
+AI can write clear text that looks like STE. That is not verified STE compliance.
+
+| Do | Do not |
+|----|--------|
+| Use AI to draft; human reviews | Ship AI text as STE-compliant |
+| Keep this guide as the kit reference | Claim ASD or STEMG endorsement |
+| Add `Assisted-by:` when AI shaped the change | Hide AI use on material commits |
+
+STEMG maintains ASD-STE100. This kit is not STEMG software.
 
 ## When agents write
 

--- a/.ai_infra/docs/operations/documentation-maintenance-checklist.md
+++ b/.ai_infra/docs/operations/documentation-maintenance-checklist.md
@@ -36,6 +36,7 @@ Run when a PR changes kit architecture, install manifest, governance, workflow p
 - [ ] If ADRs change: update `.ai_infra/docs/decisions/README.md` index.
 - [ ] Verify no contradictions against `.cursor/rules/*.mdc` and `.agents/skills/pr-workflow/SKILL.md`.
 - [ ] Run `python .ai_infra/scripts/architecture/check_governance_consistency.py`.
+- [ ] If `asd-ste100-prose.md` or STE banners change: keep anti-compliance wording, § AI and STE (human oversight; no STEMG/ASD/AI-vendor endorsement), and sync payload via `make sync-plugin`.
 
 ## Ownership and Cadence
 

--- a/.ai_infra/docs/operations/token-efficiency.md
+++ b/.ai_infra/docs/operations/token-efficiency.md
@@ -12,11 +12,12 @@ Notes:
  - When project_ssot.enabled: pair with board Status + card Notes for resume-without-chat.
  - Else: session-pointer.md + change-index.md.
  - Use ASD-STE100: see asd-ste100-prose.md (free principles; no ASD dictionary).
+ - AI and STE: asd-ste100-prose.md § AI and STE (assist; human reviews; no endorsement).
 -->
 
 # Token efficiency (agent contract)
 
-**Use ASD-STE100** for agent-facing prose: [asd-ste100-prose.md](asd-ste100-prose.md).
+**Use ASD-STE100** for agent-facing prose: [asd-ste100-prose.md](asd-ste100-prose.md). For AI-assisted writing limits, read [asd-ste100-prose.md § AI and STE](asd-ste100-prose.md#ai-and-ste).
 
 ## Skill thin-index (intent)
 

--- a/.ai_infra/templates/AGENTS.stub.md
+++ b/.ai_infra/templates/AGENTS.stub.md
@@ -88,7 +88,7 @@ Full walkthrough: [PLUGIN-USER-GUIDE.md](.ai_infra/docs/operations/PLUGIN-USER-G
 
 ## Commits
 
-Required trailers: `.cursor/rules/commit-trailer-format.mdc` — set identity in `github.collaboration.yaml`, then `python3 -m agent_colony contributors validate`.
+Required trailers: `.cursor/rules/commit-trailer-format.mdc` — set identity in `github.collaboration.yaml`, then `python3 -m agent_colony contributors validate`. Human author reviews and validates. Optional `Assisted-by:` when AI shaped the change. See [asd-ste100-prose.md § AI and STE](.ai_infra/docs/operations/asd-ste100-prose.md#ai-and-ste).
 
 ## Quality gates
 

--- a/.cursor/rules/commit-trailer-format.mdc
+++ b/.cursor/rules/commit-trailer-format.mdc
@@ -23,8 +23,11 @@ alwaysApply: true
 
 ## Responsibility
 
+- AI assists authors. It does not replace human review.
 - Human author reviews and validates the change.
+- Do not claim ASD-STE100 compliance or STEMG / ASD / AI-vendor endorsement.
 - Do not insert certification or DCO assertions the person did not intend.
+- See `.ai_infra/docs/operations/asd-ste100-prose.md` § AI and STE.
 
 ## Example tail
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Slice closure: `python3 -m agent_colony drift validate`; hand off `drift-guard` 
 
 ## Commits
 
-Required: `Author:` + `GitHub-User:` (see `commit-trailer-format.mdc`). Render: `python3 -m agent_colony contributors commit-trailers`. Optional `Assisted-by:` when AI materially shaped work; no `Made-with:`.
+Required: `Author:` + `GitHub-User:` (see `commit-trailer-format.mdc`). Render: `python3 -m agent_colony contributors commit-trailers`. Optional `Assisted-by:` when AI materially shaped work; no `Made-with:`. Human author reviews and validates. AI assists; it does not replace review. See [asd-ste100-prose.md § AI and STE](.ai_infra/docs/operations/asd-ste100-prose.md#ai-and-ste).
 
 PR artifacts: `Action-By` / `GitHub-User` / `Agent/s` via `--pipeline` (`.agents/skills/pr-workflow/SKILL.md`).
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Slash skills cover activate, update, board protocols, PR lifecycle (`/review-pr`
 
 **Full checklist:** [What you need — permissions & prerequisites](.ai_infra/docs/operations/permissions-and-prerequisites.md) (Cursor, `gh` scopes, git, MCP)
 
-**For agents:** **Use ASD-STE100** — [asd-ste100-prose.md](.ai_infra/docs/operations/asd-ste100-prose.md) · [token-efficiency.md](.ai_infra/docs/operations/token-efficiency.md)
+**For agents:** **Use ASD-STE100** (inspired by; not compliant) — [asd-ste100-prose.md](.ai_infra/docs/operations/asd-ste100-prose.md) · [token-efficiency.md](.ai_infra/docs/operations/token-efficiency.md)
 
 ---
 

--- a/payload/.ai_infra/docs/operations/README.md
+++ b/payload/.ai_infra/docs/operations/README.md
@@ -31,7 +31,7 @@ Depends On:
 - [`upgrade-kit.md`](upgrade-kit.md) — reinstall / semver upgrade
 - [`project-config.md`](project-config.md) — optional `project.config.yaml` metadata
 - [`token-efficiency.md`](token-efficiency.md) — agent read/write contract
-- [`asd-ste100-prose.md`](asd-ste100-prose.md) — **Use ASD-STE100** (free prose guide; token-efficiency research)
+- [`asd-ste100-prose.md`](asd-ste100-prose.md) — **Use ASD-STE100** (free prose guide; not compliance; AI assists, human reviews)
 - [`logging-and-errors.md`](logging-and-errors.md) — logging baseline
 - [`abbreviations-notepad.md`](abbreviations-notepad.md) — shared abbreviations
 

--- a/payload/.ai_infra/docs/operations/abbreviations-notepad.md
+++ b/payload/.ai_infra/docs/operations/abbreviations-notepad.md
@@ -50,10 +50,12 @@ Quick reference for reading `README.md`, `AGENTS.md`, and kit docs — for **con
 | UI | GitHub Project / settings UI (humans); agents prefer CLI |
 | PAT | Personal Access Token — GitHub auth; fine-grained PATs need Projects + repo scopes — see [permissions-and-prerequisites](permissions-and-prerequisites.md) |
 | ASD-STE100 | Simplified Technical English (ASD). Kit: **Use ASD-STE100** → [asd-ste100-prose.md](asd-ste100-prose.md) (free principles; no dictionary; not compliance) |
+| STEMG | Simplified Technical English Maintenance Group — maintains ASD-STE100. This kit does **not** endorse STEMG or claim STE compliance |
 | GraphQL | GitHub Projects API used by `gh project` / board CLI (rate-limited) |
 | KISS | Keep It Simple — incremental, reversible slices |
 | DCO | Developer Certificate of Origin — do **not** auto-insert DCO-style assertions |
-| AI | Artificial intelligence — optional `Assisted-by:` trailer when AI materially shaped a change |
+| AI | Artificial intelligence — assists authors; does not replace human review. Optional `Assisted-by:` when AI materially shaped a change. See [asd-ste100-prose.md](asd-ste100-prose.md) § AI and STE |
+| Assisted-by | Git commit trailer for AI disclosure (`Assisted-by: <tool>[:<model>]`); not a STEMG or ASD endorsement |
 | TBD | To Be Determined — placeholder in file headers / relations |
 | DAG | Directed Acyclic Graph — agent **handoff** edges (canvases); no cycles |
 | ACC | Agents Control Center — `.local/agents-control-center/` (folder name) |

--- a/payload/.ai_infra/docs/operations/agent-workflow-procedures.md
+++ b/payload/.ai_infra/docs/operations/agent-workflow-procedures.md
@@ -56,7 +56,7 @@ Notes:
 
 ## 3b) Commit message provenance (git, not PR artifacts)
 
-**Git commits** use **`.cursor/rules/commit-trailer-format.mdc`**: required `Author:` + `GitHub-User:`; optional `Assisted-by:` when disclosure applies. No **`Made-with:`**.
+**Git commits** use **`.cursor/rules/commit-trailer-format.mdc`**: required `Author:` + `GitHub-User:`; optional `Assisted-by:` when AI materially shaped the change. No **`Made-with:`**. The human author reviews and validates. AI assists; it does not replace review. See [asd-ste100-prose.md](asd-ste100-prose.md) § AI and STE.
 
 **PR phase markdown** uses `Action-By` / `GitHub-User` / `Agent/s` per **`.agents/skills/pr-workflow/SKILL.md`**.
 

--- a/payload/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/payload/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -11,6 +11,7 @@ Depends On:
  - token-efficiency.md
 Notes:
  - Inspired by ASD-STE100 writing principles. No ASD dictionary. No purchase. Not a compliance claim.
+ - AI assists; human reviews. No STEMG / ASD / AI-vendor endorsement.
 -->
 
 # Use ASD-STE100
@@ -49,6 +50,18 @@ Research goal: clearer prose → fewer tokens → measure before/after byte and 
 | Board SSOT | GitHub Project writable Status when enabled | Local tracker Status under `board_only` |
 | Tier-1 | Status, Priority, Size, Estimate, dates, Assignee, PR link | “All the fields” without the skill |
 | EXIT_QUEUED | Exit code 6 — outbox; flush later | Retry loops on GraphQL throttle |
+
+## AI and STE
+
+AI can write clear text that looks like STE. That is not verified STE compliance.
+
+| Do | Do not |
+|----|--------|
+| Use AI to draft; human reviews | Ship AI text as STE-compliant |
+| Keep this guide as the kit reference | Claim ASD or STEMG endorsement |
+| Add `Assisted-by:` when AI shaped the change | Hide AI use on material commits |
+
+STEMG maintains ASD-STE100. This kit is not STEMG software.
 
 ## When agents write
 

--- a/payload/.ai_infra/docs/operations/token-efficiency.md
+++ b/payload/.ai_infra/docs/operations/token-efficiency.md
@@ -12,11 +12,12 @@ Notes:
  - When project_ssot.enabled: pair with board Status + card Notes for resume-without-chat.
  - Else: session-pointer.md + change-index.md.
  - Use ASD-STE100: see asd-ste100-prose.md (free principles; no ASD dictionary).
+ - AI and STE: asd-ste100-prose.md § AI and STE (assist; human reviews; no endorsement).
 -->
 
 # Token efficiency (agent contract)
 
-**Use ASD-STE100** for agent-facing prose: [asd-ste100-prose.md](asd-ste100-prose.md).
+**Use ASD-STE100** for agent-facing prose: [asd-ste100-prose.md](asd-ste100-prose.md). For AI-assisted writing limits, read [asd-ste100-prose.md § AI and STE](asd-ste100-prose.md#ai-and-ste).
 
 ## Skill thin-index (intent)
 

--- a/payload/.ai_infra/templates/AGENTS.stub.md
+++ b/payload/.ai_infra/templates/AGENTS.stub.md
@@ -88,7 +88,7 @@ Full walkthrough: [PLUGIN-USER-GUIDE.md](.ai_infra/docs/operations/PLUGIN-USER-G
 
 ## Commits
 
-Required trailers: `.cursor/rules/commit-trailer-format.mdc` — set identity in `github.collaboration.yaml`, then `python3 -m agent_colony contributors validate`.
+Required trailers: `.cursor/rules/commit-trailer-format.mdc` — set identity in `github.collaboration.yaml`, then `python3 -m agent_colony contributors validate`. Human author reviews and validates. Optional `Assisted-by:` when AI shaped the change. See [asd-ste100-prose.md § AI and STE](.ai_infra/docs/operations/asd-ste100-prose.md#ai-and-ste).
 
 ## Quality gates
 

--- a/payload/.cursor/rules/commit-trailer-format.mdc
+++ b/payload/.cursor/rules/commit-trailer-format.mdc
@@ -23,8 +23,11 @@ alwaysApply: true
 
 ## Responsibility
 
+- AI assists authors. It does not replace human review.
 - Human author reviews and validates the change.
+- Do not claim ASD-STE100 compliance or STEMG / ASD / AI-vendor endorsement.
 - Do not insert certification or DCO assertions the person did not intend.
+- See `.ai_infra/docs/operations/asd-ste100-prose.md` § AI and STE.
 
 ## Example tail
 

--- a/rules/commit-trailer-format.mdc
+++ b/rules/commit-trailer-format.mdc
@@ -23,8 +23,11 @@ alwaysApply: true
 
 ## Responsibility
 
+- AI assists authors. It does not replace human review.
 - Human author reviews and validates the change.
+- Do not claim ASD-STE100 compliance or STEMG / ASD / AI-vendor endorsement.
 - Do not insert certification or DCO assertions the person did not intend.
+- See `.ai_infra/docs/operations/asd-ste100-prose.md` § AI and STE.
 
 ## Example tail
 


### PR DESCRIPTION
## Summary
- Add **AI and STE** section to `asd-ste100-prose.md` (assist, human review, no STEMG/ASD endorsement)
- Expand abbreviations, commit-trailer Responsibility, AGENTS/README disclosure language
- Sync payload mirrors; keep inspired-by only (not ASD-STE100 compliant)

Closes #229

## Test plan
- [x] `make check-plugin` green
- [x] `check_governance_consistency.py` green
- [x] Drift validate P0=0 (artifacts under `.local/workflow-artifacts/drift/`)
- [ ] Verifier re-check after PR link
- [ ] Auditor focused alignment before prepare-pr