### PR TITLE
Add universal evidence-first doctrine (skill 15)

### DIFF
--- a/.ai_infra/docs/governance/rules-overlap-matrix.md
+++ b/.ai_infra/docs/governance/rules-overlap-matrix.md
@@ -18,7 +18,7 @@ Notes:
 | Rule file | Purpose | Overlap with | Posture |
 |-----------|---------|--------------|---------|
 | `pr-workflow-enforcement.mdc` | PR-first, artifacts, merge gates | `workflow-complete.md`, `pr-workflow/SKILL.md` | **Short pointer** to `local_workflow_paths.py` + `prepare.py` `resolve_gates()` (`GATES` = 2-gate alias) |
-| `implementation-workflow-governance.mdc` | Slice lifecycle, planning discipline, testing, anchoring | `implementer.md`, `token-efficiency.md` | **Keep** |
+| `implementation-workflow-governance.mdc` | Slice lifecycle, planning discipline, testing, evidence-first | `implementer.md`, `token-efficiency.md`, `evidence-first` | **Keep** |
 | `advisory-audit-alignment-enforcement.mdc` | Alignment artifacts (authored via `auditor`) | `agent-workflow-procedures.md` | **Keep** |
 | `commit-trailer-format.mdc` | Required commit trailers + optional `Assisted-by` (no `Made-with:`) | `README.md`, `AGENTS.md` § Commits | **Keep separate** |
 | `file-docstring-header-relations.mdc` | File headers | All new source files | **Keep** |

--- a/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/.ai_infra/docs/governance/workflow-source-owners.md
@@ -24,7 +24,7 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `full-pr-workflow` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (14 folders) | Plugin sync, agents |
+| Canonical Cursor skills | `.cursor/skills/` (15 folders) | Plugin sync, agents |
 | Maintainer slash skills | `.agents/skills/` (6 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |
@@ -33,6 +33,7 @@ Notes:
 | Alignment finding shape | `.ai_infra/docs/roadmap/alignment-audit-schema.md` | `auditor` focused pass |
 | Full enterprise audit outputs | `.cursor/skills/auditor-protocol/SKILL.md` → `.local/workflow-artifacts/enterprise-architecture-audit/` | Deep audits |
 | Focused alignment outputs | Same skill § focused pass → `.local/workflow-artifacts/alignment/` | Architecture-impacting PRs |
+| Universal agent doctrine (facts → evidence → action) | `.ai_infra/docs/operations/evidence-first.md` + `.cursor/skills/evidence-first/` | All agents, rules |
 | Always-on enforcement | `.cursor/rules/*.mdc` | Cursor agents |
 | Git **commit** trailers | `.cursor/rules/commit-trailer-format.mdc` | `AGENTS.md` § Commits, implementer skills |
 | Governance drift scan | `.ai_infra/scripts/architecture/check_governance_consistency.py` | CI + local policy edits |

--- a/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
+++ b/.ai_infra/docs/handoff/IMPLEMENTATION-STATUS.md
@@ -29,7 +29,7 @@ Agent prose: [token-efficiency.md](../operations/token-efficiency.md).
 |------|--------|----------|
 | Universal rules | 7 `.mdc` | `.cursor/rules/` **and** `payload/.cursor/rules/` (6 kit + `project-ssot-precedence`) |
 | Agents | 8 core; `model: auto`; audit agents write `.local/` artifacts only (no `readonly`) | `.cursor/agents/` |
-| Canonical skills | 14 folders | `.cursor/skills/` |
+| Canonical skills | 15 folders | `.cursor/skills/` |
 | Maintainer skills | 6 folders (additive plugin merge; includes `full-pr-workflow`) | `.agents/skills/` |
 | Cursor skill merge | Canonical wins in plugin sync | `sync_plugin_bundle.py` |
 | workflow-activate skill | Kit dev + plugin | `.cursor/skills/workflow-activate/` |

--- a/.ai_infra/docs/handoff/marketplace-publish.md
+++ b/.ai_infra/docs/handoff/marketplace-publish.md
@@ -40,7 +40,7 @@ Use the kit venv interpreter (`.venv/bin/python`) or `python3` — bare `python`
 
 ## Versioning
 
-**Current release:** `0.6.5` (git tag [`v0.6.5`](https://github.com/SavinRazvan/agent-colony/releases/tag/v0.6.5) when published).
+**Current release:** `0.6.5` (git tag [`v0.6.5`](https://github.com/SavinRazvan/agent-colony/releases/tag/v0.6.5)).
 
 **Superseded:** `v0.3.0` (`1f16af1`) predates `PLUGIN-FLATTEN` (#15) — its tagged tree has **zero**
 files under `agents/`, `rules/`, `skills/`, `payload/` (the gitignore bug #15 fixed). Do not
@@ -240,6 +240,8 @@ Pre-filled values for [Become a plugin publisher](https://cursor.com/marketplace
 **Listing copy refresh (2026-08-09 board End date on Done):** Agents set End date (UTC) on Status→Done; validate/heal/board-shell Tier-1; `set_end_date_on_done`; **1510** tests; **8** / **14** / **7**; kit version **0.6.3**.
 
 **Listing copy refresh (2026-08-21 ASD-STE100 + board Entry reliability):** ASD-STE100 banners + governance; Entry false-offline fix; `--last` PVTI_ validation; heal Day-N playbook; **1514** tests; **8** / **14** / **7**; kit version **0.6.4**.
+
+**Listing copy refresh (2026-08-22 consumer update `.kit-version` stamp):** Scaffold + `update` stamp from source manifest; CLI `ensure_kit_version_stamp` fallback; STEMG STE docs (0.6.4); **1516** tests; **8** / **14** / **7**; kit version **0.6.5**.
 
 **Listing copy refresh (2026-07-20 DOC-CANVAS-ALIGN):** Canvases re-aligned to live CLI (**22** leaves incl. `board-bootstrap`), board-shell day-0 story, test-runner `coverage.json` + post-100% doc sync, VERIFIED **2026-07-20**; metrics unchanged (**1178** / **7089** / **100%**; **8** / **12** / **7**).
 

--- a/.ai_infra/docs/handoff/repository-map.md
+++ b/.ai_infra/docs/handoff/repository-map.md
@@ -69,9 +69,9 @@ Deep dive: [PLUGIN-ARCHITECTURE.md](PLUGIN-ARCHITECTURE.md).
 |------|------|------------|
 | `.cursor/agents/*.md` | 8 agent cards | **Here** |
 | `.cursor/rules/*.mdc` | 7 kit-dev rules | **Here** |
-| `.cursor/skills/*/` | 14 canonical protocols | **Here** |
+| `.cursor/skills/*/` | 15 canonical protocols | **Here** |
 | `.agents/skills/*/` | Maintainer slash skills | **Here** |
-| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (20 skill folders = 14 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
+| `agents/`, `rules/`, `skills/` (repo root) | Marketplace discovery (21 skill folders = 15 canonical + 6 maintainer PR slash skills, incl. `full-pr-workflow`) | `make sync-plugin` from `.cursor/` + `.agents/skills/` |
 | `payload/` | Consumer install bundle | `make sync-plugin` from above + manifest |
 | `skills/audit-alignment/` | Deprecated stub in merged `skills/` | `.agents/skills/audit-alignment/` |
 
@@ -87,7 +87,7 @@ my-app/
 ├── .cursor/
 │   ├── agents/                     8 agents (from payload; incl. board)
 │   ├── rules/                      7 rules (6 kit + project-ssot-precedence)
-│   └── skills/                     14 canonical skills only (no repo-root skills/ merge)
+│   └── skills/                     15 canonical skills only (no repo-root skills/ merge)
 ├── .agents/skills/                 6 maintainer slash folders (incl. full-pr-workflow; + audit-alignment stub)
 ├── .ai_infra/                      Slim bundle (manifest copy_ai_infra only)
 │   ├── scripts/pr|architecture|integration|workflow|install/
@@ -141,10 +141,11 @@ Filter SSOT: `.ai_infra/scripts/architecture/consumer_bundle_paths.py` (e.g. exc
 
 ## Skills
 
-### Canonical — `.cursor/skills/` (14) → consumer `.cursor/skills/`
+### Canonical — `.cursor/skills/` (15) → consumer `.cursor/skills/`
 
 | Skill | Paired agent |
 |-------|----------------|
+| `evidence-first` | All agents (universal doctrine) |
 | `auditor-protocol` | `auditor` (full audit + **focused alignment pass**) |
 | `audit-module-map` | `auditor` (depth tool) |
 | `audit-orchestration` | Parent orchestration |
@@ -175,7 +176,7 @@ Also under `.agents/skills/`: `README.md`, `PR_WORKFLOW.md` (legacy redirect), `
 
 ### Repo-root `skills/` — Marketplace plugin mirror only
 
-Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (14) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
+Cursor loads repo-root `agents/`, `rules/`, and `skills/` from the GitHub plugin URL. Those trees are **generated mirrors** of `.cursor/` + `.agents/skills/` (via `sync_plugin_bundle.py`) — **not** a second authoring SSOT. Edit canonical `.cursor/skills/` (15) and `.agents/skills/` (6); then `make sync-plugin`. Consumers receive skills under `.cursor/skills/` and `.agents/skills/` via `payload/` after activate — never as a single root `skills/` tree on disk.
 
 ---
 

--- a/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -75,6 +75,7 @@ STEMG maintains ASD-STE100. This kit is not STEMG software.
 
 ## Related
 
+- [evidence-first.md](evidence-first.md) — facts → evidence → responsible action
 - [token-efficiency.md](token-efficiency.md) — read/write contract
 - [board-ssot skill](../../../.cursor/skills/board-ssot/SKILL.md) — Tier-1 and Continuation
 - Official standard (reference only): [asd-ste100.org](https://asd-ste100.org/)

--- a/.ai_infra/docs/operations/evidence-first.md
+++ b/.ai_infra/docs/operations/evidence-first.md
@@ -1,0 +1,73 @@
+<!--
+File: evidence-first.md
+Path: .ai_infra/docs/operations/evidence-first.md
+Role: Universal doctrine — facts, evidence, responsible action before claims of done.
+Used By:
+ - .cursor/rules/implementation-workflow-governance.mdc
+ - .cursor/skills/evidence-first/SKILL.md
+ - AGENTS.md
+ - .cursor/agents/*.md
+Depends On:
+ - docs/governance/workflow-source-owners.md
+Notes:
+ - Complements ASD-STE100 (writing) and verifier falsify (disproof). Not a substitute for gates or board SSOT.
+-->
+
+# Evidence-first (agent doctrine)
+
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+## Principle
+
+**We always use facts, check for evidence, then take responsible action based on evidence.**
+
+Do not tell the user a task is complete, a version is bumped everywhere, or a fix is shipped until **fresh evidence** supports the claim — or you label the gap explicitly (**Partial**, **Unknown**, **Not verified**).
+
+## Three-step ladder
+
+| Step | Action | Fail if |
+|------|--------|---------|
+| 1. **Facts** | Restate the claim in testable terms. List surfaces that must be true (repo paths, tags, releases, consumer cache, CLI output). | Claim is vague or untestable |
+| 2. **Evidence** | Run commands or open files **now** (not from chat memory). Record path, command, and outcome. | No command output or path cited |
+| 3. **Responsible action** | Act on evidence: fix gaps, downgrade the claim, or document deferrals with owner. | Action contradicts evidence or hides known gaps |
+
+## What counts as evidence
+
+1. **Repository paths** — repo-relative; opened or searched in this session
+2. **Command output** — exact command + outcome (exit code, key lines)
+3. **External surfaces** — GitHub release/tag, plugin cache manifest, board CLI JSON (when relevant)
+4. **User context** — label **`Context:`**; never treat as **Confirmed** for repo or shipped state
+
+## Labels (shared vocabulary)
+
+| Label | Meaning |
+|-------|---------|
+| **Verified** | Evidence supports the claim for all required surfaces |
+| **Partial** | Some surfaces verified; known gaps listed |
+| **Not verified** | Claim not supported or evidence missing |
+| **Unknown** | Not inspected — say so; do not guess |
+| **Confirmed / Probable / Unknown** | Drift and audit artifacts (see specialized skills) |
+
+## Anti-patterns (mandatory avoid)
+
+- **Repo vs shipped conflation** — Bumping SSOT in `main` ≠ tag, GitHub Release, or Cursor plugin cache updated. Check all three when the user cares about “version shipped”.
+- **Memory claims** — “Tests passed earlier” without re-run when challenged or before merge/release.
+- **Complete without surfaces** — “Bump everywhere” must match [marketplace-publish.md](../handoff/marketplace-publish.md) Versioning table + publish path when release is in scope.
+- **Chat-only approval** — Written deliverables (audits, PR artifacts, alignment) need paths or commands, not opinion.
+
+## Role pointers
+
+| Role | Canon |
+|------|--------|
+| All agents | This doc + `.cursor/skills/evidence-first/SKILL.md` |
+| `verifier` | Disproof loop — `.cursor/agents/verifier.md` § Work |
+| `auditor` | Falsify column — `auditor-protocol` § Evidence contract |
+| `drift-guard` | Script output + labels — `drift-audit` § Evidence contract |
+| `integrator` | Path/command cites — `integrator-protocol` |
+| `implementer` | Lifecycle step `evidence` before “done” — `implementation-workflow-governance.mdc` |
+
+## Related
+
+- [token-efficiency.md](token-efficiency.md) — what to read/write; prefer CLI digests
+- [marketplace-publish.md](../handoff/marketplace-publish.md) — version SSOT + release checklist
+- [workflow-source-owners.md](../governance/workflow-source-owners.md) — executable behavior wins over prose

--- a/.ai_infra/docs/operations/token-efficiency.md
+++ b/.ai_infra/docs/operations/token-efficiency.md
@@ -25,6 +25,7 @@ Load the section you need. Do not load whole skills by default.
 
 | Skill | Read when | Prefer |
 |-------|-----------|--------|
+| `evidence-first` | Any done/complete/shipped claim; user challenges prior answer | Universal contract + role § |
 | `board-ssot` | Mutating Status / Tier-1 | § Continuation · § Tier-1 |
 | `board-shell` | First-run shell / bootstrap FAIL | § CONSENT GATE · § TURN PROTOCOL |
 | `implementer-loop` | Implement slice | Full skill (short) |

--- a/.ai_infra/templates/agent-integration/AGENT.template.md
+++ b/.ai_infra/templates/agent-integration/AGENT.template.md
@@ -10,6 +10,8 @@ description: {{ONE_LINE_DESCRIPTION}}
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If `project_ssot.enabled`: `project entry`, then claim one card. Else: `.local/index-and-planning/current/session-pointer.md`, then {{SKILL_OR_DOC_PATH}}.
 
 **Exit:** Board Status + Notes when SSOT on (no dual-write to trackers). Else update `session-pointer.md`, append `change-index.md` (Agent: `{{AGENT_ID}}`), one line in `history/updates-log.md`.

--- a/.cursor/agents/auditor.md
+++ b/.cursor/agents/auditor.md
@@ -14,6 +14,8 @@ Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is 
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status`. If no audit card: `create-from-template` `[AUDIT]` → `claim --last --agent auditor`. Else `session-pointer.md`.
 
 **Exit:** Write audit artifacts. Status → `in_review`/`done`. Put paths in Notes. No dual-write under `board_only`.
@@ -22,7 +24,7 @@ Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is 
 
 **Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `auditor-protocol` skill.
+**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `evidence-first` + `auditor-protocol` skill.
 
 ## Read first
 

--- a/.cursor/agents/board.md
+++ b/.cursor/agents/board.md
@@ -10,6 +10,8 @@ description: board Agent Colony — Wire Project SSOT, triage cards, and coach f
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** Read `github.collaboration.yaml` → `project_ssot`. Run `project entry`. Wire-from-URLs: propose YAML; human confirms. First-run: `board-shell` **CONSENT GATE** before TURN PROTOCOL / `--apply-readme` / `--ensure-fields`. Refuse ready until `board-bootstrap --check` exit 0.
 
 **Exit:** Update Status via CLI. Append `change-index.md`. One line in `updates-log.md`. Print handoff. No dual-write under `board_only`.

--- a/.cursor/agents/drift-guard.md
+++ b/.cursor/agents/drift-guard.md
@@ -14,6 +14,8 @@ Goal/plan/agent-doctrine/docs coherence + DRIFT-001…012 (script-first). Not de
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project entry` (must). Prefer `export --reuse-if-fresh` before drift validate. Else `session-pointer.md`.
 
 **Exit:** Write `.local/workflow-artifacts/drift/`. Set drift-pass card → `done` or `in_review`. Remediations via Notes/Ready — never silent tracker dual-write. One line in `updates-log.md`.

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -10,6 +10,8 @@ description: implementer Agent Colony — Disciplined implementation slices with
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** Read `github.collaboration.yaml` → `project_ssot`. If enabled: `project entry`, then claim or create. Skill: `board-ssot` § Continuation. Else: `session-pointer.md`.
 
 **Exit:** Fill Acceptance/Rollback, then `handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Promote or `mention-pr` before shippable PR. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`. Say *prepare gates green*.

--- a/.cursor/agents/integrator.md
+++ b/.cursor/agents/integrator.md
@@ -14,6 +14,8 @@ Wire new agents, skills, MCP, and kit surfaces. Do not invent workflow steps. Us
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` + `integrator-protocol`. Claim/create integration card. Else `session-pointer.md`.
 
 **Exit:** Status → `done` or `in_review`. Notes with validate outcomes. `change-index.md` + `updates-log.md`. No dual-write under `board_only`.

--- a/.cursor/agents/researcher.md
+++ b/.cursor/agents/researcher.md
@@ -10,6 +10,8 @@ description: researcher Agent Colony — Brief-driven multi-round research (GitH
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` (+ research card). Else `session-pointer.md`.
 
 **Exit:** Packs under `_research_results/sources/<slug>/`. Research card → `done` + paths in Notes. No dual-write under `board_only`.

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -10,6 +10,8 @@ description: test-runner Agent Colony — Module-focused tests, regressions, cov
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` / claim; read Acceptance/Notes. Else `session-pointer.md`. Read `test-index.md` when tests change.
 
 **Exit:** `handoff --last` / claim. Status → `in_review` if tests gate PR, else `done`. Update `change-index.md`, `test-index.md` / `test-plan.md`. No dual-write under `board_only`.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -10,6 +10,8 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project entry` + card Acceptance/Rollback/Notes. Else `session-pointer.md`.
 
 **Exit:** `validate-item --last` before `done`. Refuse placeholder Acceptance/Rollback. Status → `done` or leave `in_review` with failure Notes. No dual-write under `board_only`.
@@ -21,6 +23,8 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 **Lifecycle:** Consume only. Evidence only — do not implement fixes.
 
 ## Work
+
+Canon: `.cursor/skills/evidence-first/SKILL.md` § Role extensions · disproof loop below.
 
 1. Restate the claim.
 2. Cite files or command output.

--- a/.cursor/rules/implementation-workflow-governance.mdc
+++ b/.cursor/rules/implementation-workflow-governance.mdc
@@ -7,6 +7,14 @@ alwaysApply: true
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
+## Evidence-first
+
+**We always use facts, check for evidence, then take responsible action based on evidence.**
+
+- Before “done”, “complete”, “shipped”, or “bumped everywhere”: gather **fresh** path/command evidence or label **Partial** / **Not verified**.
+- Do not conflate **repo SSOT** with **published** surfaces (git tag, GitHub Release, plugin cache) — check both when release matters.
+- Canon: [evidence-first.md](.ai_infra/docs/operations/evidence-first.md) · skill `evidence-first`.
+
 ## Lifecycle
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.

--- a/.cursor/skills/auditor-protocol/SKILL.md
+++ b/.cursor/skills/auditor-protocol/SKILL.md
@@ -25,6 +25,8 @@ Produce a **step-by-step, facts-first** enterprise architecture assessment of **
 
 ## Evidence contract (mandatory)
 
+**Universal canon:** `.cursor/skills/evidence-first/SKILL.md` · `.ai_infra/docs/operations/evidence-first.md`. Below adds **auditor-specific** labels and scorecard rules.
+
 Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in written deliverables.
 
 **What counts as evidence (priority order)**

--- a/.cursor/skills/board-ssot/SKILL.md
+++ b/.cursor/skills/board-ssot/SKILL.md
@@ -197,6 +197,8 @@ When `board_only`, do **not** mark the same slice `in_progress` in `work-tracker
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Board-specific:
+
 Cite CLI output or `gh project` JSON. Label **Unknown** when board unreachable → `fallback: local_trackers` only.
 
 ## Exit criteria

--- a/.cursor/skills/drift-audit/SKILL.md
+++ b/.cursor/skills/drift-audit/SKILL.md
@@ -58,6 +58,8 @@ Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Drift-specific labels:
+
 | Label | Meaning |
 |-------|---------|
 | Confirmed | Script output + file path cited |

--- a/.cursor/skills/evidence-first/SKILL.md
+++ b/.cursor/skills/evidence-first/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: evidence-first
+description: Universal facts → evidence → responsible action doctrine; shared labels; role extensions for all Agent Colony agents.
+---
+<!--
+File: SKILL.md
+Path: .cursor/skills/evidence-first/SKILL.md
+Role: Procedural SSOT for evidence-first agent behavior across all kit agents.
+Used By:
+ - .cursor/agents/*.md
+ - .cursor/rules/implementation-workflow-governance.mdc
+Depends On:
+ - .ai_infra/docs/operations/evidence-first.md
+Notes:
+ - Specialized skills link here; do not duplicate full contract blocks elsewhere.
+-->
+
+# Evidence-first
+
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+**Doctrine:** `.ai_infra/docs/operations/evidence-first.md`
+
+## When (every agent)
+
+- Before claiming **done**, **complete**, **green**, **shipped**, or **bumped everywhere**
+- When the user challenges a prior answer (“I still see X”)
+- Before merge prep, release tag, or “consumer can upgrade now”
+- When writing `.local/workflow-artifacts/**` (PR, drift, alignment, audit)
+
+## Universal contract
+
+1. **Restate** the claim in testable terms.
+2. **Gather** fresh evidence (paths + commands). Prefer smallest disproof first.
+3. **Label** outcome: Verified | Partial | Not verified. List gaps with severity.
+4. **Act** on evidence — fix, defer with owner, or correct the claim. Never hide a known gap.
+
+**Not inspected → Unknown.** Do not infer from chat history alone.
+
+## Evidence checklist (version / release example)
+
+When scope includes **version bump** or **release**:
+
+| Surface | Example check |
+|---------|----------------|
+| Repo SSOT | `grep` / read paths in marketplace-publish § Versioning |
+| Payload mirror | `make check-plugin` |
+| Git tag | `git tag -l 'v*'` · `gh release view vX.Y.Z` |
+| Published artifact | GitHub **Latest** release; plugin cache `manifest.yaml` |
+| Consumer | `update --check` on a real consumer app |
+
+**Partial** is honest: e.g. repo at 0.6.5 but release still 0.6.4.
+
+## Role extensions
+
+| Agent | Extension |
+|-------|-----------|
+| **verifier** | Canonical disproof executor — try to disprove; smallest checks first; no code fixes |
+| **auditor** | Confirmed / Probable + **Falsify** column — `auditor-protocol` |
+| **drift-guard** | Confirmed / Probable / Unknown from `drift validate` output — `drift-audit` |
+| **integrator** | Every integration claim cites path or command — `integrator-protocol` |
+| **board** | Cite CLI or `gh project` JSON — `board-ssot` § Evidence contract |
+| **implementer** | Slice closes with evidence step before docs; say *prepare gates green* only after run |
+| **test-runner** | Cite pytest command + pass/fail counts from this run |
+| **researcher** | Pack rows need source refs — `research-corpus` |
+
+## Handoff line (optional)
+
+```text
+Evidence: Verified | Partial | Not verified — <one-line gap or next check>
+```

--- a/.cursor/skills/implementer-loop/SKILL.md
+++ b/.cursor/skills/implementer-loop/SKILL.md
@@ -7,6 +7,8 @@ description: Disciplined implementation slices with board SSOT continuation and 
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
+**Evidence-first:** `.cursor/skills/evidence-first/SKILL.md` — verify with fresh evidence before “done” or release claims.
+
 ## When
 
 New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slices.

--- a/.cursor/skills/integrator-protocol/SKILL.md
+++ b/.cursor/skills/integrator-protocol/SKILL.md
@@ -15,6 +15,8 @@ Integrate **new agents, skills, MCP servers, scripts, or docs** for unpack + per
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Integrator-specific:
+
 - Every claim cites **repo path** or **command output**.
 - Not inspected → **Unknown**. No invented layout or gate behavior.
 

--- a/.cursor/skills/workflow-activate/SKILL.md
+++ b/.cursor/skills/workflow-activate/SKILL.md
@@ -52,7 +52,7 @@ Do **not** dump gate lists or maintainer `make` commands.
 
 ## One command
 
-From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 14 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
+From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 15 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
 
 ```bash
 python3 -m agent_colony activate --directory .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Shippable cards as **Issues** (`item_kind_default: issue`). Draft is scratch-only.
 - Fill **Tier-1** fields: Status, Priority, Size/Estimate, Start/End dates, Assignee, Linked PR (`mention-pr`).
 - EXIT_QUEUED (6) → `project outbox`; outbox is not SSOT.
+- **Evidence-first:** use facts, check fresh evidence, then act — [evidence-first.md](.ai_infra/docs/operations/evidence-first.md) · skill `evidence-first`. Do not claim complete without evidence or explicit **Partial** gaps.
 
 **Consumer install:** plugin + `/workflow-activate` — see [PLUGIN-USER-GUIDE](.ai_infra/docs/operations/PLUGIN-USER-GUIDE.md#product-promise).
 
@@ -82,7 +83,7 @@ PR artifacts: `Action-By` / `GitHub-User` / `Agent/s` via `--pipeline` (`.agents
 | Root | Role |
 |------|------|
 | `.cursor/agents/` | 8 agent cards — `auditor`, `board`, `drift-guard`, `implementer`, `integrator`, `researcher`, `test-runner`, `verifier` |
-| `.cursor/skills/` | 14 canonical protocols — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
+| `.cursor/skills/` | 15 canonical protocols — see [repository-map](.ai_infra/docs/handoff/repository-map.md) |
 | `.agents/skills/` | 6 maintainer slash skills (PR workflow) |
 | `.cursor/rules/` | 7 `alwaysApply` rules |
 
@@ -93,7 +94,7 @@ PR artifacts: `Action-By` / `GitHub-User` / `Agent/s` via `--pipeline` (`.agents
 | Implement | `implementer` + `implementer-loop` |
 | Integrate | `integrator` + `integrator-protocol` |
 | Tests | `test-runner` + `test-coverage` |
-| Verify | `verifier` (evidence only) |
+| Verify | `verifier` (evidence only) + `evidence-first` |
 | Drift | `drift-guard` + `drift-audit` |
 | Audit | `auditor` + `auditor-protocol` |
 | Research | `researcher` + `research-corpus` |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | | |
 |--|--|
-| **Version** | [`0.6.5`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1516 · **Agents** · 8 · **Skills** · 14 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
+| **Version** | [`0.6.5`](https://github.com/SavinRazvan/agent-colony/releases) · **Tests** · 1516 · **Agents** · 8 · **Skills** · 15 · **Rules** · **7 universal** · **License** · [Apache-2.0](LICENSE) |
 | **Reference board** | [AI Project Playground](https://github.com/users/SavinRazvan/projects/3) |
 
 ---

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -14,6 +14,8 @@ Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is 
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status`. If no audit card: `create-from-template` `[AUDIT]` → `claim --last --agent auditor`. Else `session-pointer.md`.
 
 **Exit:** Write audit artifacts. Status → `in_review`/`done`. Put paths in Notes. No dual-write under `board_only`.
@@ -22,7 +24,7 @@ Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is 
 
 **Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `auditor-protocol` skill.
+**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `evidence-first` + `auditor-protocol` skill.
 
 ## Read first
 

--- a/agents/board.md
+++ b/agents/board.md
@@ -10,6 +10,8 @@ description: board Agent Colony — Wire Project SSOT, triage cards, and coach f
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** Read `github.collaboration.yaml` → `project_ssot`. Run `project entry`. Wire-from-URLs: propose YAML; human confirms. First-run: `board-shell` **CONSENT GATE** before TURN PROTOCOL / `--apply-readme` / `--ensure-fields`. Refuse ready until `board-bootstrap --check` exit 0.
 
 **Exit:** Update Status via CLI. Append `change-index.md`. One line in `updates-log.md`. Print handoff. No dual-write under `board_only`.

--- a/agents/drift-guard.md
+++ b/agents/drift-guard.md
@@ -14,6 +14,8 @@ Goal/plan/agent-doctrine/docs coherence + DRIFT-001…012 (script-first). Not de
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project entry` (must). Prefer `export --reuse-if-fresh` before drift validate. Else `session-pointer.md`.
 
 **Exit:** Write `.local/workflow-artifacts/drift/`. Set drift-pass card → `done` or `in_review`. Remediations via Notes/Ready — never silent tracker dual-write. One line in `updates-log.md`.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -10,6 +10,8 @@ description: implementer Agent Colony — Disciplined implementation slices with
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** Read `github.collaboration.yaml` → `project_ssot`. If enabled: `project entry`, then claim or create. Skill: `board-ssot` § Continuation. Else: `session-pointer.md`.
 
 **Exit:** Fill Acceptance/Rollback, then `handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Promote or `mention-pr` before shippable PR. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`. Say *prepare gates green*.

--- a/agents/integrator.md
+++ b/agents/integrator.md
@@ -14,6 +14,8 @@ Wire new agents, skills, MCP, and kit surfaces. Do not invent workflow steps. Us
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` + `integrator-protocol`. Claim/create integration card. Else `session-pointer.md`.
 
 **Exit:** Status → `done` or `in_review`. Notes with validate outcomes. `change-index.md` + `updates-log.md`. No dual-write under `board_only`.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -10,6 +10,8 @@ description: researcher Agent Colony — Brief-driven multi-round research (GitH
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` (+ research card). Else `session-pointer.md`.
 
 **Exit:** Packs under `_research_results/sources/<slug>/`. Research card → `done` + paths in Notes. No dual-write under `board_only`.

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -10,6 +10,8 @@ description: test-runner Agent Colony — Module-focused tests, regressions, cov
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` / claim; read Acceptance/Notes. Else `session-pointer.md`. Read `test-index.md` when tests change.
 
 **Exit:** `handoff --last` / claim. Status → `in_review` if tests gate PR, else `done`. Update `change-index.md`, `test-index.md` / `test-plan.md`. No dual-write under `board_only`.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -10,6 +10,8 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project entry` + card Acceptance/Rollback/Notes. Else `session-pointer.md`.
 
 **Exit:** `validate-item --last` before `done`. Refuse placeholder Acceptance/Rollback. Status → `done` or leave `in_review` with failure Notes. No dual-write under `board_only`.
@@ -21,6 +23,8 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 **Lifecycle:** Consume only. Evidence only — do not implement fixes.
 
 ## Work
+
+Canon: `.cursor/skills/evidence-first/SKILL.md` § Role extensions · disproof loop below.
 
 1. Restate the claim.
 2. Cite files or command output.

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -16,7 +16,7 @@
  *  - Roster scorecard 2026-08-04 (AA-ROSTER-001…008) mirrored on Stack/Future views.
  *  - Intentional non-renames: artifact dir enterprise-architecture-audit/, ops doc
  *    project-board-collaboration.md, snapshot project-board-snapshot.json.
- *  - CLI/MCP stack (renames v0.6.0/v0.6.1; current kit 0.6.4): agent_colony / agent-colony console;
+ *  - CLI/MCP stack (renames v0.6.0/v0.6.1; current kit 0.6.5): agent_colony / agent-colony console;
  *    agent_colony_mcp package; Cursor server id agent-colony-mcp unchanged.
  *  - Avoid "star-slash" globs in this block comment — they terminate the comment early.
  */
@@ -1121,8 +1121,8 @@ export default function NamingRosterAuditCanvas() {
             auditor · drift-guard · researcher. KEEP all 8 — residual score debt
             (drift-guard 16 / auditor 17) is naming debt, not redundancy.
           </Callout>
-          <Callout tone="neutral" title="CLI / MCP stack (kit 0.6.4)">
-            Renames landed in v0.6.0 (CLI) / v0.6.1 (MCP). Current kit 0.6.4:
+          <Callout tone="neutral" title="CLI / MCP stack (kit 0.6.5)">
+            Renames landed in v0.6.0 (CLI) / v0.6.1 (MCP). Current kit 0.6.5:
             Python module agent_colony · console agent-colony · MCP package
             agent_colony_mcp · Cursor server id agent-colony-mcp (unchanged).
           </Callout>

--- a/canvases/naming-roster-audit.canvas.tsx
+++ b/canvases/naming-roster-audit.canvas.tsx
@@ -856,7 +856,7 @@ export default function NamingRosterAuditCanvas() {
             B-safe SHIPPED
           </Pill>
           <Pill tone="neutral" size="sm">
-            8 agents · 14 skills
+            8 agents · 15 skills
           </Pill>
         </Row>
         <Text tone="secondary" size="small">
@@ -897,7 +897,7 @@ export default function NamingRosterAuditCanvas() {
       {view === "plan" ? (
         <Stack gap={16}>
           <Callout tone="success" title="B-safe rename SHIPPED — 2026-08-03">
-            Live filesystem roster: 8 agents / 14 canonical skills / 7 rules.
+            Live filesystem roster: 8 agents / 15 canonical skills / 7 rules.
             Agent descriptions prefixed Agent Colony (#153). Shared board-ssot is
             Entry/Exit for all agents. Plan rows below are keep/keep against the
             shipped names — not a pending rename plan.

--- a/payload/.ai_infra/docs/governance/rules-overlap-matrix.md
+++ b/payload/.ai_infra/docs/governance/rules-overlap-matrix.md
@@ -18,7 +18,7 @@ Notes:
 | Rule file | Purpose | Overlap with | Posture |
 |-----------|---------|--------------|---------|
 | `pr-workflow-enforcement.mdc` | PR-first, artifacts, merge gates | `workflow-complete.md`, `pr-workflow/SKILL.md` | **Short pointer** to `local_workflow_paths.py` + `prepare.py` `resolve_gates()` (`GATES` = 2-gate alias) |
-| `implementation-workflow-governance.mdc` | Slice lifecycle, planning discipline, testing, anchoring | `implementer.md`, `token-efficiency.md` | **Keep** |
+| `implementation-workflow-governance.mdc` | Slice lifecycle, planning discipline, testing, evidence-first | `implementer.md`, `token-efficiency.md`, `evidence-first` | **Keep** |
 | `advisory-audit-alignment-enforcement.mdc` | Alignment artifacts (authored via `auditor`) | `agent-workflow-procedures.md` | **Keep** |
 | `commit-trailer-format.mdc` | Required commit trailers + optional `Assisted-by` (no `Made-with:`) | `README.md`, `AGENTS.md` § Commits | **Keep separate** |
 | `file-docstring-header-relations.mdc` | File headers | All new source files | **Keep** |

--- a/payload/.ai_infra/docs/governance/workflow-source-owners.md
+++ b/payload/.ai_infra/docs/governance/workflow-source-owners.md
@@ -24,7 +24,7 @@ Notes:
 | Merge preconditions | `.ai_infra/scripts/pr/merge.py` | `merge-pr` skill |
 | Post-merge cleanup | `.ai_infra/scripts/pr/finalize.py` | `full-pr-workflow` skill |
 | Maintainer narrative order | `.agents/skills/pr-workflow/SKILL.md` (slash `/pr-workflow`; redirect stub: `PR_WORKFLOW.md`) | Humans |
-| Canonical Cursor skills | `.cursor/skills/` (14 folders) | Plugin sync, agents |
+| Canonical Cursor skills | `.cursor/skills/` (15 folders) | Plugin sync, agents |
 | Maintainer slash skills | `.agents/skills/` (6 folders; no name overlap with `.cursor/skills/`) | Plugin sync additive merge |
 | Kit subagent model policy | `.cursor/agents/*.md` frontmatter `model: auto` | Task delegation cost control |
 | Durable maintainer checklist | `.ai_infra/docs/operations/workflow-complete.md` | Everyone (versioned) |
@@ -33,6 +33,7 @@ Notes:
 | Alignment finding shape | `.ai_infra/docs/roadmap/alignment-audit-schema.md` | `auditor` focused pass |
 | Full enterprise audit outputs | `.cursor/skills/auditor-protocol/SKILL.md` → `.local/workflow-artifacts/enterprise-architecture-audit/` | Deep audits |
 | Focused alignment outputs | Same skill § focused pass → `.local/workflow-artifacts/alignment/` | Architecture-impacting PRs |
+| Universal agent doctrine (facts → evidence → action) | `.ai_infra/docs/operations/evidence-first.md` + `.cursor/skills/evidence-first/` | All agents, rules |
 | Always-on enforcement | `.cursor/rules/*.mdc` | Cursor agents |
 | Git **commit** trailers | `.cursor/rules/commit-trailer-format.mdc` | `AGENTS.md` § Commits, implementer skills |
 | Governance drift scan | `.ai_infra/scripts/architecture/check_governance_consistency.py` | CI + local policy edits |

--- a/payload/.ai_infra/docs/operations/asd-ste100-prose.md
+++ b/payload/.ai_infra/docs/operations/asd-ste100-prose.md
@@ -75,6 +75,7 @@ STEMG maintains ASD-STE100. This kit is not STEMG software.
 
 ## Related
 
+- [evidence-first.md](evidence-first.md) — facts → evidence → responsible action
 - [token-efficiency.md](token-efficiency.md) — read/write contract
 - [board-ssot skill](../../../.cursor/skills/board-ssot/SKILL.md) — Tier-1 and Continuation
 - Official standard (reference only): [asd-ste100.org](https://asd-ste100.org/)

--- a/payload/.ai_infra/docs/operations/evidence-first.md
+++ b/payload/.ai_infra/docs/operations/evidence-first.md
@@ -1,0 +1,73 @@
+<!--
+File: evidence-first.md
+Path: .ai_infra/docs/operations/evidence-first.md
+Role: Universal doctrine — facts, evidence, responsible action before claims of done.
+Used By:
+ - .cursor/rules/implementation-workflow-governance.mdc
+ - .cursor/skills/evidence-first/SKILL.md
+ - AGENTS.md
+ - .cursor/agents/*.md
+Depends On:
+ - docs/governance/workflow-source-owners.md
+Notes:
+ - Complements ASD-STE100 (writing) and verifier falsify (disproof). Not a substitute for gates or board SSOT.
+-->
+
+# Evidence-first (agent doctrine)
+
+**Use ASD-STE100:** [asd-ste100-prose.md](asd-ste100-prose.md)
+
+## Principle
+
+**We always use facts, check for evidence, then take responsible action based on evidence.**
+
+Do not tell the user a task is complete, a version is bumped everywhere, or a fix is shipped until **fresh evidence** supports the claim — or you label the gap explicitly (**Partial**, **Unknown**, **Not verified**).
+
+## Three-step ladder
+
+| Step | Action | Fail if |
+|------|--------|---------|
+| 1. **Facts** | Restate the claim in testable terms. List surfaces that must be true (repo paths, tags, releases, consumer cache, CLI output). | Claim is vague or untestable |
+| 2. **Evidence** | Run commands or open files **now** (not from chat memory). Record path, command, and outcome. | No command output or path cited |
+| 3. **Responsible action** | Act on evidence: fix gaps, downgrade the claim, or document deferrals with owner. | Action contradicts evidence or hides known gaps |
+
+## What counts as evidence
+
+1. **Repository paths** — repo-relative; opened or searched in this session
+2. **Command output** — exact command + outcome (exit code, key lines)
+3. **External surfaces** — GitHub release/tag, plugin cache manifest, board CLI JSON (when relevant)
+4. **User context** — label **`Context:`**; never treat as **Confirmed** for repo or shipped state
+
+## Labels (shared vocabulary)
+
+| Label | Meaning |
+|-------|---------|
+| **Verified** | Evidence supports the claim for all required surfaces |
+| **Partial** | Some surfaces verified; known gaps listed |
+| **Not verified** | Claim not supported or evidence missing |
+| **Unknown** | Not inspected — say so; do not guess |
+| **Confirmed / Probable / Unknown** | Drift and audit artifacts (see specialized skills) |
+
+## Anti-patterns (mandatory avoid)
+
+- **Repo vs shipped conflation** — Bumping SSOT in `main` ≠ tag, GitHub Release, or Cursor plugin cache updated. Check all three when the user cares about “version shipped”.
+- **Memory claims** — “Tests passed earlier” without re-run when challenged or before merge/release.
+- **Complete without surfaces** — “Bump everywhere” must match [marketplace-publish.md](../handoff/marketplace-publish.md) Versioning table + publish path when release is in scope.
+- **Chat-only approval** — Written deliverables (audits, PR artifacts, alignment) need paths or commands, not opinion.
+
+## Role pointers
+
+| Role | Canon |
+|------|--------|
+| All agents | This doc + `.cursor/skills/evidence-first/SKILL.md` |
+| `verifier` | Disproof loop — `.cursor/agents/verifier.md` § Work |
+| `auditor` | Falsify column — `auditor-protocol` § Evidence contract |
+| `drift-guard` | Script output + labels — `drift-audit` § Evidence contract |
+| `integrator` | Path/command cites — `integrator-protocol` |
+| `implementer` | Lifecycle step `evidence` before “done” — `implementation-workflow-governance.mdc` |
+
+## Related
+
+- [token-efficiency.md](token-efficiency.md) — what to read/write; prefer CLI digests
+- [marketplace-publish.md](../handoff/marketplace-publish.md) — version SSOT + release checklist
+- [workflow-source-owners.md](../governance/workflow-source-owners.md) — executable behavior wins over prose

--- a/payload/.ai_infra/docs/operations/token-efficiency.md
+++ b/payload/.ai_infra/docs/operations/token-efficiency.md
@@ -25,6 +25,7 @@ Load the section you need. Do not load whole skills by default.
 
 | Skill | Read when | Prefer |
 |-------|-----------|--------|
+| `evidence-first` | Any done/complete/shipped claim; user challenges prior answer | Universal contract + role § |
 | `board-ssot` | Mutating Status / Tier-1 | § Continuation · § Tier-1 |
 | `board-shell` | First-run shell / bootstrap FAIL | § CONSENT GATE · § TURN PROTOCOL |
 | `implementer-loop` | Implement slice | Full skill (short) |

--- a/payload/.ai_infra/templates/agent-integration/AGENT.template.md
+++ b/payload/.ai_infra/templates/agent-integration/AGENT.template.md
@@ -10,6 +10,8 @@ description: {{ONE_LINE_DESCRIPTION}}
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If `project_ssot.enabled`: `project entry`, then claim one card. Else: `.local/index-and-planning/current/session-pointer.md`, then {{SKILL_OR_DOC_PATH}}.
 
 **Exit:** Board Status + Notes when SSOT on (no dual-write to trackers). Else update `session-pointer.md`, append `change-index.md` (Agent: `{{AGENT_ID}}`), one line in `history/updates-log.md`.

--- a/payload/.cursor/agents/auditor.md
+++ b/payload/.cursor/agents/auditor.md
@@ -14,6 +14,8 @@ Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is 
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status`. If no audit card: `create-from-template` `[AUDIT]` → `claim --last --agent auditor`. Else `session-pointer.md`.
 
 **Exit:** Write audit artifacts. Status → `in_review`/`done`. Put paths in Notes. No dual-write under `board_only`.
@@ -22,7 +24,7 @@ Evidence-only architecture audit (CHK-*). Not continuous plan pulse — that is 
 
 **Tier-1:** Fill Status, Priority, Size, Estimate, dates, Assignee, Linked PR. Canon: `board-ssot` § Tier-1.
 
-**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `auditor-protocol` skill.
+**Write scope:** `.local/workflow-artifacts/` only. Evidence contract: `evidence-first` + `auditor-protocol` skill.
 
 ## Read first
 

--- a/payload/.cursor/agents/board.md
+++ b/payload/.cursor/agents/board.md
@@ -10,6 +10,8 @@ description: board Agent Colony — Wire Project SSOT, triage cards, and coach f
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** Read `github.collaboration.yaml` → `project_ssot`. Run `project entry`. Wire-from-URLs: propose YAML; human confirms. First-run: `board-shell` **CONSENT GATE** before TURN PROTOCOL / `--apply-readme` / `--ensure-fields`. Refuse ready until `board-bootstrap --check` exit 0.
 
 **Exit:** Update Status via CLI. Append `change-index.md`. One line in `updates-log.md`. Print handoff. No dual-write under `board_only`.

--- a/payload/.cursor/agents/drift-guard.md
+++ b/payload/.cursor/agents/drift-guard.md
@@ -14,6 +14,8 @@ Goal/plan/agent-doctrine/docs coherence + DRIFT-001…012 (script-first). Not de
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project entry` (must). Prefer `export --reuse-if-fresh` before drift validate. Else `session-pointer.md`.
 
 **Exit:** Write `.local/workflow-artifacts/drift/`. Set drift-pass card → `done` or `in_review`. Remediations via Notes/Ready — never silent tracker dual-write. One line in `updates-log.md`.

--- a/payload/.cursor/agents/implementer.md
+++ b/payload/.cursor/agents/implementer.md
@@ -10,6 +10,8 @@ description: implementer Agent Colony — Disciplined implementation slices with
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** Read `github.collaboration.yaml` → `project_ssot`. If enabled: `project entry`, then claim or create. Skill: `board-ssot` § Continuation. Else: `session-pointer.md`.
 
 **Exit:** Fill Acceptance/Rollback, then `handoff --last --agent implementer --next verifier --to in_review` (or `--to done`). Promote or `mention-pr` before shippable PR. Append `change-index.md`; one line in `updates-log.md`. No dual-write under `board_only`. Say *prepare gates green*.

--- a/payload/.cursor/agents/integrator.md
+++ b/payload/.cursor/agents/integrator.md
@@ -14,6 +14,8 @@ Wire new agents, skills, MCP, and kit surfaces. Do not invent workflow steps. Us
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` + `integrator-protocol`. Claim/create integration card. Else `session-pointer.md`.
 
 **Exit:** Status → `done` or `in_review`. Notes with validate outcomes. `change-index.md` + `updates-log.md`. No dual-write under `board_only`.

--- a/payload/.cursor/agents/researcher.md
+++ b/payload/.cursor/agents/researcher.md
@@ -10,6 +10,8 @@ description: researcher Agent Colony — Brief-driven multi-round research (GitH
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` (+ research card). Else `session-pointer.md`.
 
 **Exit:** Packs under `_research_results/sources/<slug>/`. Research card → `done` + paths in Notes. No dual-write under `board_only`.

--- a/payload/.cursor/agents/test-runner.md
+++ b/payload/.cursor/agents/test-runner.md
@@ -10,6 +10,8 @@ description: test-runner Agent Colony — Module-focused tests, regressions, cov
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project status` / claim; read Acceptance/Notes. Else `session-pointer.md`. Read `test-index.md` when tests change.
 
 **Exit:** `handoff --last` / claim. Status → `in_review` if tests gate PR, else `done`. Update `change-index.md`, `test-index.md` / `test-plan.md`. No dual-write under `board_only`.

--- a/payload/.cursor/agents/verifier.md
+++ b/payload/.cursor/agents/verifier.md
@@ -10,6 +10,8 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md` · `.ai_infra/docs/operations/token-efficiency.md`
 
+**Evidence-first:** `.ai_infra/docs/operations/evidence-first.md` · skill `evidence-first`
+
 **Entry:** If SSOT on: `project entry` + card Acceptance/Rollback/Notes. Else `session-pointer.md`.
 
 **Exit:** `validate-item --last` before `done`. Refuse placeholder Acceptance/Rollback. Status → `done` or leave `in_review` with failure Notes. No dual-write under `board_only`.
@@ -21,6 +23,8 @@ description: verifier Agent Colony — Check “done” claims against fresh evi
 **Lifecycle:** Consume only. Evidence only — do not implement fixes.
 
 ## Work
+
+Canon: `.cursor/skills/evidence-first/SKILL.md` § Role extensions · disproof loop below.
 
 1. Restate the claim.
 2. Cite files or command output.

--- a/payload/.cursor/rules/implementation-workflow-governance.mdc
+++ b/payload/.cursor/rules/implementation-workflow-governance.mdc
@@ -7,6 +7,14 @@ alwaysApply: true
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
+## Evidence-first
+
+**We always use facts, check for evidence, then take responsible action based on evidence.**
+
+- Before “done”, “complete”, “shipped”, or “bumped everywhere”: gather **fresh** path/command evidence or label **Partial** / **Not verified**.
+- Do not conflate **repo SSOT** with **published** surfaces (git tag, GitHub Release, plugin cache) — check both when release matters.
+- Canon: [evidence-first.md](.ai_infra/docs/operations/evidence-first.md) · skill `evidence-first`.
+
 ## Lifecycle
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.

--- a/payload/.cursor/skills/auditor-protocol/SKILL.md
+++ b/payload/.cursor/skills/auditor-protocol/SKILL.md
@@ -25,6 +25,8 @@ Produce a **step-by-step, facts-first** enterprise architecture assessment of **
 
 ## Evidence contract (mandatory)
 
+**Universal canon:** `.cursor/skills/evidence-first/SKILL.md` · `.ai_infra/docs/operations/evidence-first.md`. Below adds **auditor-specific** labels and scorecard rules.
+
 Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in written deliverables.
 
 **What counts as evidence (priority order)**

--- a/payload/.cursor/skills/board-ssot/SKILL.md
+++ b/payload/.cursor/skills/board-ssot/SKILL.md
@@ -197,6 +197,8 @@ When `board_only`, do **not** mark the same slice `in_progress` in `work-tracker
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Board-specific:
+
 Cite CLI output or `gh project` JSON. Label **Unknown** when board unreachable → `fallback: local_trackers` only.
 
 ## Exit criteria

--- a/payload/.cursor/skills/drift-audit/SKILL.md
+++ b/payload/.cursor/skills/drift-audit/SKILL.md
@@ -58,6 +58,8 @@ Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Drift-specific labels:
+
 | Label | Meaning |
 |-------|---------|
 | Confirmed | Script output + file path cited |

--- a/payload/.cursor/skills/evidence-first/SKILL.md
+++ b/payload/.cursor/skills/evidence-first/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: evidence-first
+description: Universal facts → evidence → responsible action doctrine; shared labels; role extensions for all Agent Colony agents.
+---
+<!--
+File: SKILL.md
+Path: .cursor/skills/evidence-first/SKILL.md
+Role: Procedural SSOT for evidence-first agent behavior across all kit agents.
+Used By:
+ - .cursor/agents/*.md
+ - .cursor/rules/implementation-workflow-governance.mdc
+Depends On:
+ - .ai_infra/docs/operations/evidence-first.md
+Notes:
+ - Specialized skills link here; do not duplicate full contract blocks elsewhere.
+-->
+
+# Evidence-first
+
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+**Doctrine:** `.ai_infra/docs/operations/evidence-first.md`
+
+## When (every agent)
+
+- Before claiming **done**, **complete**, **green**, **shipped**, or **bumped everywhere**
+- When the user challenges a prior answer (“I still see X”)
+- Before merge prep, release tag, or “consumer can upgrade now”
+- When writing `.local/workflow-artifacts/**` (PR, drift, alignment, audit)
+
+## Universal contract
+
+1. **Restate** the claim in testable terms.
+2. **Gather** fresh evidence (paths + commands). Prefer smallest disproof first.
+3. **Label** outcome: Verified | Partial | Not verified. List gaps with severity.
+4. **Act** on evidence — fix, defer with owner, or correct the claim. Never hide a known gap.
+
+**Not inspected → Unknown.** Do not infer from chat history alone.
+
+## Evidence checklist (version / release example)
+
+When scope includes **version bump** or **release**:
+
+| Surface | Example check |
+|---------|----------------|
+| Repo SSOT | `grep` / read paths in marketplace-publish § Versioning |
+| Payload mirror | `make check-plugin` |
+| Git tag | `git tag -l 'v*'` · `gh release view vX.Y.Z` |
+| Published artifact | GitHub **Latest** release; plugin cache `manifest.yaml` |
+| Consumer | `update --check` on a real consumer app |
+
+**Partial** is honest: e.g. repo at 0.6.5 but release still 0.6.4.
+
+## Role extensions
+
+| Agent | Extension |
+|-------|-----------|
+| **verifier** | Canonical disproof executor — try to disprove; smallest checks first; no code fixes |
+| **auditor** | Confirmed / Probable + **Falsify** column — `auditor-protocol` |
+| **drift-guard** | Confirmed / Probable / Unknown from `drift validate` output — `drift-audit` |
+| **integrator** | Every integration claim cites path or command — `integrator-protocol` |
+| **board** | Cite CLI or `gh project` JSON — `board-ssot` § Evidence contract |
+| **implementer** | Slice closes with evidence step before docs; say *prepare gates green* only after run |
+| **test-runner** | Cite pytest command + pass/fail counts from this run |
+| **researcher** | Pack rows need source refs — `research-corpus` |
+
+## Handoff line (optional)
+
+```text
+Evidence: Verified | Partial | Not verified — <one-line gap or next check>
+```

--- a/payload/.cursor/skills/implementer-loop/SKILL.md
+++ b/payload/.cursor/skills/implementer-loop/SKILL.md
@@ -7,6 +7,8 @@ description: Disciplined implementation slices with board SSOT continuation and 
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
+**Evidence-first:** `.cursor/skills/evidence-first/SKILL.md` — verify with fresh evidence before “done” or release claims.
+
 ## When
 
 New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slices.

--- a/payload/.cursor/skills/integrator-protocol/SKILL.md
+++ b/payload/.cursor/skills/integrator-protocol/SKILL.md
@@ -15,6 +15,8 @@ Integrate **new agents, skills, MCP servers, scripts, or docs** for unpack + per
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Integrator-specific:
+
 - Every claim cites **repo path** or **command output**.
 - Not inspected → **Unknown**. No invented layout or gate behavior.
 

--- a/payload/.cursor/skills/workflow-activate/SKILL.md
+++ b/payload/.cursor/skills/workflow-activate/SKILL.md
@@ -52,7 +52,7 @@ Do **not** dump gate lists or maintainer `make` commands.
 
 ## One command
 
-From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 14 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
+From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 15 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
 
 ```bash
 python3 -m agent_colony activate --directory .

--- a/rules/implementation-workflow-governance.mdc
+++ b/rules/implementation-workflow-governance.mdc
@@ -7,6 +7,14 @@ alwaysApply: true
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
+## Evidence-first
+
+**We always use facts, check for evidence, then take responsible action based on evidence.**
+
+- Before “done”, “complete”, “shipped”, or “bumped everywhere”: gather **fresh** path/command evidence or label **Partial** / **Not verified**.
+- Do not conflate **repo SSOT** with **published** surfaces (git tag, GitHub Release, plugin cache) — check both when release matters.
+- Canon: [evidence-first.md](.ai_infra/docs/operations/evidence-first.md) · skill `evidence-first`.
+
 ## Lifecycle
 
 - Sequence: `plan -> interfaces -> implementation -> tests -> evidence -> docs update`.

--- a/skills/auditor-protocol/SKILL.md
+++ b/skills/auditor-protocol/SKILL.md
@@ -25,6 +25,8 @@ Produce a **step-by-step, facts-first** enterprise architecture assessment of **
 
 ## Evidence contract (mandatory)
 
+**Universal canon:** `.cursor/skills/evidence-first/SKILL.md` · `.ai_infra/docs/operations/evidence-first.md`. Below adds **auditor-specific** labels and scorecard rules.
+
 Audits are **evidence-backed** or they fail the contract. Chat-only opinions without traceable repo pointers are not acceptable in written deliverables.
 
 **What counts as evidence (priority order)**

--- a/skills/board-ssot/SKILL.md
+++ b/skills/board-ssot/SKILL.md
@@ -197,6 +197,8 @@ When `board_only`, do **not** mark the same slice `in_progress` in `work-tracker
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Board-specific:
+
 Cite CLI output or `gh project` JSON. Label **Unknown** when board unreachable → `fallback: local_trackers` only.
 
 ## Exit criteria

--- a/skills/drift-audit/SKILL.md
+++ b/skills/drift-audit/SKILL.md
@@ -58,6 +58,8 @@ Does **not** replace `auditor` (CHK-* scorecard) or `verifier`.
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Drift-specific labels:
+
 | Label | Meaning |
 |-------|---------|
 | Confirmed | Script output + file path cited |

--- a/skills/evidence-first/SKILL.md
+++ b/skills/evidence-first/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: evidence-first
+description: Universal facts → evidence → responsible action doctrine; shared labels; role extensions for all Agent Colony agents.
+---
+<!--
+File: SKILL.md
+Path: .cursor/skills/evidence-first/SKILL.md
+Role: Procedural SSOT for evidence-first agent behavior across all kit agents.
+Used By:
+ - .cursor/agents/*.md
+ - .cursor/rules/implementation-workflow-governance.mdc
+Depends On:
+ - .ai_infra/docs/operations/evidence-first.md
+Notes:
+ - Specialized skills link here; do not duplicate full contract blocks elsewhere.
+-->
+
+# Evidence-first
+
+**Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
+
+**Doctrine:** `.ai_infra/docs/operations/evidence-first.md`
+
+## When (every agent)
+
+- Before claiming **done**, **complete**, **green**, **shipped**, or **bumped everywhere**
+- When the user challenges a prior answer (“I still see X”)
+- Before merge prep, release tag, or “consumer can upgrade now”
+- When writing `.local/workflow-artifacts/**` (PR, drift, alignment, audit)
+
+## Universal contract
+
+1. **Restate** the claim in testable terms.
+2. **Gather** fresh evidence (paths + commands). Prefer smallest disproof first.
+3. **Label** outcome: Verified | Partial | Not verified. List gaps with severity.
+4. **Act** on evidence — fix, defer with owner, or correct the claim. Never hide a known gap.
+
+**Not inspected → Unknown.** Do not infer from chat history alone.
+
+## Evidence checklist (version / release example)
+
+When scope includes **version bump** or **release**:
+
+| Surface | Example check |
+|---------|----------------|
+| Repo SSOT | `grep` / read paths in marketplace-publish § Versioning |
+| Payload mirror | `make check-plugin` |
+| Git tag | `git tag -l 'v*'` · `gh release view vX.Y.Z` |
+| Published artifact | GitHub **Latest** release; plugin cache `manifest.yaml` |
+| Consumer | `update --check` on a real consumer app |
+
+**Partial** is honest: e.g. repo at 0.6.5 but release still 0.6.4.
+
+## Role extensions
+
+| Agent | Extension |
+|-------|-----------|
+| **verifier** | Canonical disproof executor — try to disprove; smallest checks first; no code fixes |
+| **auditor** | Confirmed / Probable + **Falsify** column — `auditor-protocol` |
+| **drift-guard** | Confirmed / Probable / Unknown from `drift validate` output — `drift-audit` |
+| **integrator** | Every integration claim cites path or command — `integrator-protocol` |
+| **board** | Cite CLI or `gh project` JSON — `board-ssot` § Evidence contract |
+| **implementer** | Slice closes with evidence step before docs; say *prepare gates green* only after run |
+| **test-runner** | Cite pytest command + pass/fail counts from this run |
+| **researcher** | Pack rows need source refs — `research-corpus` |
+
+## Handoff line (optional)
+
+```text
+Evidence: Verified | Partial | Not verified — <one-line gap or next check>
+```

--- a/skills/implementer-loop/SKILL.md
+++ b/skills/implementer-loop/SKILL.md
@@ -7,6 +7,8 @@ description: Disciplined implementation slices with board SSOT continuation and 
 
 **Use ASD-STE100:** `.ai_infra/docs/operations/asd-ste100-prose.md`
 
+**Evidence-first:** `.cursor/skills/evidence-first/SKILL.md` — verify with fresh evidence before “done” or release claims.
+
 ## When
 
 New or continued `feature/` | `fix/` | `chore/` work; recovery from blocked slices.

--- a/skills/integrator-protocol/SKILL.md
+++ b/skills/integrator-protocol/SKILL.md
@@ -15,6 +15,8 @@ Integrate **new agents, skills, MCP servers, scripts, or docs** for unpack + per
 
 ## Evidence contract
 
+**Universal canon:** `evidence-first` skill · [evidence-first.md](../../.ai_infra/docs/operations/evidence-first.md). Integrator-specific:
+
 - Every claim cites **repo path** or **command output**.
 - Not inspected → **Unknown**. No invented layout or gate behavior.
 

--- a/skills/workflow-activate/SKILL.md
+++ b/skills/workflow-activate/SKILL.md
@@ -52,7 +52,7 @@ Do **not** dump gate lists or maintainer `make` commands.
 
 ## One command
 
-From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 14 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
+From the **open workspace** (Pattern A — one script command). Defaults: **`with_mcp`**, **`.venv`**, **verify gates** — full consumer kit (8 agents, 15 skills, MCP, PR scripts, `.local/` scaffold, runtime `.gitignore`, `STARTER-001`).
 
 ```bash
 python3 -m agent_colony activate --directory .


### PR DESCRIPTION
## Summary
- SSOT doc `evidence-first.md` + universal skill `evidence-first` (15th canonical skill)
- Always-applied rule pointer in `implementation-workflow-governance.mdc`
- Evidence-first anchor on all 8 agent cards; specialized skills link to canon (no duplication)
- Governance/index updates (AGENTS.md, repository-map, workflow-source-owners, token-efficiency)
- Includes chore: v0.6.5 listing copy + canvas kit version (d2b4722)

Architecture-impacting: rules, skills, agent cards, governance docs.

## Test plan
- [x] `make sync-plugin && make check-plugin`
- [x] `check_governance_consistency.py`
- [x] `make doc-validate`
- [x] `drift validate` — 13/13 pass