### PR TITLE
feat(settings): enable agent-colony plugin in kit-dev Cursor settings

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -2,6 +2,11 @@
   "plugins": {
     "cursor-team-kit": {
       "enabled": true
+    },
+    "agent-colony/agent-colony": {
+      "enabled": true,
+      "gitUrl": "https://github.com/SavinRazvan/agent-colony",
+      "gitRef": "main"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Enable `agent-colony/agent-colony` plugin in tracked `.cursor/settings.json` for kit-dev
- Point plugin at `https://github.com/SavinRazvan/agent-colony` on `main`

## Test plan
- [x] Open agent-colony repo in Cursor — plugin loads from GitHub ref
- [ ] Merge via PR (main is branch-protected)

## Collaboration
- Action-By: Savin Ionuț Răzvan
- GitHub-User: @SavinRazvan
- Agent/s: review-pr | prepare-pr | merge-pr